### PR TITLE
feat: expose graph diff as graphify diff CLI command

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -648,6 +648,7 @@ def main() -> None:
         print("    --type T                query type: query|path_query|explain (default: query)")
         print("    --nodes N1 N2 ...       source node labels cited in the answer")
         print("    --memory-dir DIR        memory directory (default: graphify-out/memory)")
+        print("  diff <old.json> <new.json>  compare two graph snapshots and print what changed")
         print("  benchmark [graph.json]  measure token reduction vs naive full-corpus approach")
         print("  hook install            install post-commit/post-checkout git hooks (all platforms)")
         print("  hook uninstall          remove git hooks")
@@ -845,6 +846,52 @@ def main() -> None:
             source_nodes=opts.nodes or None,
         )
         print(f"Saved to {out}")
+    elif cmd == "diff":
+        if len(sys.argv) < 4:
+            print("Usage: graphify diff <old-graph.json> <new-graph.json>", file=sys.stderr)
+            sys.exit(1)
+        old_path = Path(sys.argv[2]).resolve()
+        new_path = Path(sys.argv[3]).resolve()
+        for p in (old_path, new_path):
+            if not p.exists():
+                print(f"error: file not found: {p}", file=sys.stderr)
+                sys.exit(1)
+            if p.suffix != ".json":
+                print(f"error: expected a .json file: {p}", file=sys.stderr)
+                sys.exit(1)
+        try:
+            import networkx as _nx
+            from networkx.readwrite import json_graph as _jg
+            def _load_graph(p: Path) -> _nx.Graph:
+                raw = json.loads(p.read_text(encoding="utf-8"))
+                try:
+                    return _jg.node_link_graph(raw, edges="links")
+                except TypeError:
+                    return _jg.node_link_graph(raw)
+            G_old = _load_graph(old_path)
+            G_new = _load_graph(new_path)
+        except Exception as exc:
+            print(f"error: could not load graphs: {exc}", file=sys.stderr)
+            sys.exit(1)
+        from graphify.analyze import graph_diff as _graph_diff
+        diff = _graph_diff(G_old, G_new)
+        print(f"Summary: {diff['summary']}")
+        if diff["new_nodes"]:
+            print(f"\nNew nodes ({len(diff['new_nodes'])}):")
+            for n in diff["new_nodes"]:
+                print(f"  + {n['label']} ({n['id']})")
+        if diff["removed_nodes"]:
+            print(f"\nRemoved nodes ({len(diff['removed_nodes'])}):")
+            for n in diff["removed_nodes"]:
+                print(f"  - {n['label']} ({n['id']})")
+        if diff["new_edges"]:
+            print(f"\nNew edges ({len(diff['new_edges'])}):")
+            for e in diff["new_edges"]:
+                print(f"  + {e['source']} --[{e['relation']}]--> {e['target']}")
+        if diff["removed_edges"]:
+            print(f"\nRemoved edges ({len(diff['removed_edges'])}):")
+            for e in diff["removed_edges"]:
+                print(f"  - {e['source']} --[{e['relation']}]--> {e['target']}")
     elif cmd == "benchmark":
         from graphify.benchmark import run_benchmark, print_benchmark
         graph_path = sys.argv[2] if len(sys.argv) > 2 else "graphify-out/graph.json"

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,108 @@
+"""Tests for the `graphify diff` CLI command."""
+import json
+import sys
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+try:
+    import networkx  # noqa: F401
+    _HAS_NETWORKX = True
+except ImportError:
+    _HAS_NETWORKX = False
+
+requires_networkx = pytest.mark.skipif(not _HAS_NETWORKX, reason="networkx not installed")
+
+
+def _run_main(argv):
+    """Run graphify.__main__.main() with the given argv, capture stdout."""
+    import io
+    from graphify.__main__ import main
+    buf = io.StringIO()
+    exit_code = 0
+    with patch("sys.argv", argv), patch("sys.stdout", buf):
+        try:
+            main()
+        except SystemExit as e:
+            exit_code = e.code or 0
+    return buf.getvalue(), exit_code
+
+
+def _make_graph_json(tmp_path, name, nodes, edges):
+    data = {
+        "directed": False,
+        "multigraph": False,
+        "graph": {},
+        "nodes": [{"id": n, "label": n} for n in nodes],
+        "links": [
+            {"source": s, "target": t, "relation": r, "confidence": "EXTRACTED", "weight": 1.0}
+            for s, t, r in edges
+        ],
+    }
+    p = tmp_path / name
+    p.write_text(json.dumps(data))
+    return p
+
+
+@requires_networkx
+def test_diff_no_changes(tmp_path):
+    """diff of identical graphs reports 'no changes'."""
+    nodes = ["alpha", "beta"]
+    edges = [("alpha", "beta", "calls")]
+    old = _make_graph_json(tmp_path, "old.json", nodes, edges)
+    new = _make_graph_json(tmp_path, "new.json", nodes, edges)
+    out, code = _run_main(["graphify", "diff", str(old), str(new)])
+    assert code == 0
+    assert "no changes" in out
+
+
+@requires_networkx
+def test_diff_new_node(tmp_path):
+    """diff detects a newly added node."""
+    old = _make_graph_json(tmp_path, "old.json", ["alpha"], [])
+    new = _make_graph_json(tmp_path, "new.json", ["alpha", "gamma"], [])
+    out, code = _run_main(["graphify", "diff", str(old), str(new)])
+    assert code == 0
+    assert "gamma" in out
+    assert "New nodes" in out
+
+
+@requires_networkx
+def test_diff_removed_node(tmp_path):
+    """diff detects a removed node."""
+    old = _make_graph_json(tmp_path, "old.json", ["alpha", "beta"], [])
+    new = _make_graph_json(tmp_path, "new.json", ["alpha"], [])
+    out, code = _run_main(["graphify", "diff", str(old), str(new)])
+    assert code == 0
+    assert "beta" in out
+    assert "Removed nodes" in out
+
+
+@requires_networkx
+def test_diff_new_edge(tmp_path):
+    """diff detects a new edge."""
+    old = _make_graph_json(tmp_path, "old.json", ["a", "b"], [])
+    new = _make_graph_json(tmp_path, "new.json", ["a", "b"], [("a", "b", "imports")])
+    out, code = _run_main(["graphify", "diff", str(old), str(new)])
+    assert code == 0
+    assert "New edges" in out
+    assert "imports" in out
+
+
+def test_diff_missing_file(tmp_path):
+    """diff exits with error when a file does not exist."""
+    old = _make_graph_json(tmp_path, "old.json", ["a"], [])
+    with pytest.raises(SystemExit) as exc:
+        with patch("sys.argv", ["graphify", "diff", str(old), str(tmp_path / "missing.json")]):
+            from graphify.__main__ import main
+            main()
+    assert exc.value.code != 0
+
+
+def test_diff_missing_args(tmp_path):
+    """diff with fewer than 2 positional args exits with error."""
+    with pytest.raises(SystemExit) as exc:
+        with patch("sys.argv", ["graphify", "diff", str(tmp_path / "only_one.json")]):
+            from graphify.__main__ import main
+            main()
+    assert exc.value.code != 0


### PR DESCRIPTION
## Summary

Wires the existing `analyze.graph_diff()` function (line 444) to the CLI as `graphify diff <old.json> <new.json>`. Zero new graph logic — this is purely a CLI surface addition.

## Usage

```
$ graphify diff graphify-out/graph-v1.json graphify-out/graph.json
Summary: 2 new nodes, 1 new edge, 1 node removed

New nodes (2):
  + AuthService (authservice)
  + TokenCache (tokencache)

Removed nodes (1):
  - OldAuth (oldauth)

New edges (1):
  + authservice --[imports_from]--> tokencache
```

When nothing changed:
```
$ graphify diff old.json new.json
Summary: no changes
```

## Implementation

- **`graphify/__main__.py`** — new `elif cmd == "diff"` branch + help text entry
- Validates both paths exist and are `.json` files before loading
- Loads graphs via `networkx.readwrite.json_graph.node_link_graph` (same pattern as `graphify query`)
- Calls `analyze.graph_diff()` and pretty-prints the result with `+`/`-` prefixes

## Test plan

- [x] `test_diff_no_changes` — "no changes" for identical graphs
- [x] `test_diff_new_node` — new node label appears in output under "New nodes"
- [x] `test_diff_removed_node` — removed node label appears under "Removed nodes"
- [x] `test_diff_new_edge` — new edge relation appears under "New edges"
- [x] `test_diff_missing_file` — exits non-zero when a file does not exist
- [x] `test_diff_missing_args` — exits non-zero with fewer than 2 positional args

Note: the 4 graph-loading tests are skipped when `networkx` is not installed in the test environment, matching the pattern used for tree-sitter tests elsewhere in the suite.