### PR TITLE
feat: support custom file extensions via GRAPHIFY_EXTENSION_ALIASES

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,21 @@ GEMINI.md
 docs/translations/ # generated content you don't want in the graph
 ```
 
+**Custom file extensions** — if your project uses non-standard extensions for a language graphify already supports (for example `.pic` files that are valid PHP), register an alias and they'll be classified as code and parsed with the canonical grammar. Set `GRAPHIFY_EXTENSION_ALIASES` before running graphify, or call `register_extension_alias` from Python:
+
+```bash
+# treat .pic as PHP and .foo as Python for this run
+export GRAPHIFY_EXTENSION_ALIASES=".pic:.php,.foo:.py"
+/graphify .
+```
+
+```python
+from graphify.detect import register_extension_alias
+register_extension_alias(".pic", ".php")
+```
+
+The canonical extension must already be a known code or document extension. Aliases flow through file detection, the AST dispatch in `extract`, and `collect_files`.
+
 ## Using `graph.json` with an LLM
 
 `graph.json` is not meant to be pasted into a prompt all at once. The useful

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -25,6 +25,66 @@ IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}
 OFFICE_EXTENSIONS = {'.docx', '.xlsx'}
 VIDEO_EXTENSIONS = {'.mp4', '.mov', '.webm', '.mkv', '.avi', '.m4v', '.mp3', '.wav', '.m4a', '.ogg'}
 
+# User-defined extension aliases: maps a custom extension to a canonical one
+# already supported by graphify. Treats `.pic` files as `.php`, `.foo` as `.py`,
+# etc. Populated by register_extension_alias() and from the
+# GRAPHIFY_EXTENSION_ALIASES env var on import.
+EXTENSION_ALIASES: dict[str, str] = {}
+
+
+def register_extension_alias(custom: str, canonical: str) -> None:
+    """Treat files with extension ``custom`` as if they had extension ``canonical``.
+
+    Useful when a project uses a custom file extension for a language graphify
+    already supports — for example, a codebase that uses ``.pic`` for PHP
+    sources can register ``.pic`` as an alias of ``.php`` so those files are
+    classified as code and parsed with the PHP grammar.
+
+    Both extensions must start with a dot. The canonical extension must already
+    be a known code or document extension.
+
+    Updates ``CODE_EXTENSIONS`` (or ``DOC_EXTENSIONS``) and ``EXTENSION_ALIASES``
+    so downstream callers — ``classify_file``, ``collect_files``, the AST
+    dispatch in ``extract`` — pick up the alias.
+    """
+    if not custom.startswith("."):
+        raise ValueError(f"custom extension must start with '.': {custom!r}")
+    if not canonical.startswith("."):
+        raise ValueError(f"canonical extension must start with '.': {canonical!r}")
+    custom = custom.lower()
+    canonical = canonical.lower()
+    if canonical in CODE_EXTENSIONS:
+        CODE_EXTENSIONS.add(custom)
+    elif canonical in DOC_EXTENSIONS:
+        DOC_EXTENSIONS.add(custom)
+    else:
+        raise ValueError(
+            f"canonical extension {canonical!r} is not a known code or doc extension"
+        )
+    EXTENSION_ALIASES[custom] = canonical
+
+
+def _apply_extension_aliases_from_env() -> None:
+    """Parse ``GRAPHIFY_EXTENSION_ALIASES`` and register each alias.
+
+    Format: ``.pic:.php,.foo:.py`` — comma-separated ``custom:canonical`` pairs.
+    Whitespace is ignored. Malformed pairs and unknown canonical extensions are
+    skipped silently so a bad env var never crashes the pipeline.
+    """
+    raw = os.environ.get("GRAPHIFY_EXTENSION_ALIASES", "").strip()
+    if not raw:
+        return
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if not pair or ":" not in pair:
+            continue
+        custom, canonical = (s.strip() for s in pair.split(":", 1))
+        try:
+            register_extension_alias(custom, canonical)
+        except ValueError:
+            continue
+
+
 CORPUS_WARN_THRESHOLD = 50_000    # words - below this, warn "you may not need a graph"
 CORPUS_UPPER_THRESHOLD = 500_000  # words - above this, warn about token cost
 FILE_COUNT_UPPER = 200             # files - above this, warn about token cost
@@ -828,3 +888,7 @@ def detect_incremental(root: Path, manifest_path: str = _MANIFEST_PATH) -> dict:
     full["new_total"] = new_total
     full["deleted_files"] = deleted_files
     return full
+
+
+# Apply any aliases declared via GRAPHIFY_EXTENSION_ALIASES at module load time
+_apply_extension_aliases_from_env()

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3695,7 +3695,17 @@ def _get_extractor(path: Path) -> Any | None:
     """Return the correct extractor function for a file, or None if unsupported."""
     if path.name.endswith(".blade.php"):
         return extract_blade
-    return _DISPATCH.get(path.suffix)
+    suffix = path.suffix
+    extractor = _DISPATCH.get(suffix)
+    if extractor is not None:
+        return extractor
+    # Honor user-registered extension aliases (e.g. .pic → .php) declared via
+    # GRAPHIFY_EXTENSION_ALIASES or register_extension_alias().
+    from graphify.detect import EXTENSION_ALIASES
+    canonical = EXTENSION_ALIASES.get(suffix.lower())
+    if canonical is not None:
+        return _DISPATCH.get(canonical)
+    return None
 
 
 def _extract_single_file(args: tuple) -> tuple[int, dict]:
@@ -4009,7 +4019,11 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
         ".lua", ".toc", ".zig", ".ps1",
         ".m", ".mm",
     }
-    from graphify.detect import _load_graphifyignore, _is_ignored
+    from graphify.detect import _load_graphifyignore, _is_ignored, EXTENSION_ALIASES
+    # Include any user-registered alias whose canonical is a discoverable code extension
+    for _custom_ext, _canonical_ext in EXTENSION_ALIASES.items():
+        if _canonical_ext in _EXTENSIONS:
+            _EXTENSIONS.add(_custom_ext)
     ignore_root = root if root is not None else target
     patterns = _load_graphifyignore(ignore_root)
 

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4057,9 +4057,9 @@ def collect_files(
     }
     from graphify.detect import EXTENSION_ALIASES, _is_ignored, _load_graphifyignore
 
-    # Include aliases whose canonical extension has an AST extractor.
+    # Include aliases whose canonical extension is already discoverable.
     for _custom_ext, _canonical_ext in EXTENSION_ALIASES.items():
-        if _canonical_ext in _DISPATCH:
+        if _canonical_ext in _EXTENSIONS:
             _EXTENSIONS.add(_custom_ext)
     ignore_root = root if root is not None else target
     patterns = _load_graphifyignore(ignore_root)
@@ -4068,14 +4068,14 @@ def collect_files(
         return bool(patterns and _is_ignored(p, ignore_root, patterns))
 
     if not follow_symlinks:
-        return sorted(
-            p
-            for p in target.rglob("*")
-            if p.is_file()
-            and p.suffix.lower() in _EXTENSIONS
-            and not any(part.startswith(".") for part in p.parts)
-            and not _ignored(p)
-        )
+        results: list[Path] = []
+        for ext in sorted(_EXTENSIONS):
+            results.extend(
+                p for p in target.rglob(f"*{ext}")
+                if not any(part.startswith(".") for part in p.parts)
+                and not _ignored(p)
+            )
+        return sorted(results)
     # Walk with symlink following + cycle detection
     results = []
     for dirpath, dirnames, filenames in os.walk(target, followlinks=True):
@@ -4092,7 +4092,7 @@ def collect_files(
         for fname in filenames:
             p = dp / fname
             if (
-                p.suffix.lower() in _EXTENSIONS
+                p.suffix in _EXTENSIONS
                 and not fname.startswith(".")
                 and not _ignored(p)
             ):

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1650,9 +1650,19 @@ def extract_python(path: Path) -> dict:
     return result
 
 
+def _canonical_suffix(path: Path) -> str:
+    """Return the configured canonical suffix for ``path``."""
+    from graphify.detect import EXTENSION_ALIASES
+
+    suffix = path.suffix.lower()
+    return EXTENSION_ALIASES.get(suffix, suffix)
+
+
 def extract_js(path: Path) -> dict:
     """Extract classes, functions, arrow functions, and imports from a .js/.ts/.tsx file."""
-    config = _TS_CONFIG if path.suffix in (".ts", ".tsx") else _JS_CONFIG
+    config = (
+        _TS_CONFIG if _canonical_suffix(path) in (".ts", ".tsx") else _JS_CONFIG
+    )
     return _extract_generic(path, config)
 
 
@@ -3695,17 +3705,27 @@ def _get_extractor(path: Path) -> Any | None:
     """Return the correct extractor function for a file, or None if unsupported."""
     if path.name.endswith(".blade.php"):
         return extract_blade
-    suffix = path.suffix
+    suffix = path.suffix.lower()
     extractor = _DISPATCH.get(suffix)
     if extractor is not None:
         return extractor
     # Honor user-registered extension aliases (e.g. .pic → .php) declared via
     # GRAPHIFY_EXTENSION_ALIASES or register_extension_alias().
     from graphify.detect import EXTENSION_ALIASES
-    canonical = EXTENSION_ALIASES.get(suffix.lower())
+    canonical = EXTENSION_ALIASES.get(suffix)
     if canonical is not None:
         return _DISPATCH.get(canonical)
     return None
+
+
+def _initialize_worker_extension_aliases(
+    alias_pairs: tuple[tuple[str, str], ...],
+) -> None:
+    """Apply the parent process's extension aliases in a spawned worker."""
+    from graphify.detect import register_extension_alias
+
+    for custom, canonical in alias_pairs:
+        register_extension_alias(custom, canonical)
 
 
 def _extract_single_file(args: tuple) -> tuple[int, dict]:
@@ -3754,10 +3774,17 @@ def _extract_parallel(
 
     root_str = str(effective_root)
     work_items = [(idx, str(path), root_str) for idx, path in uncached_work]
+    from graphify.detect import EXTENSION_ALIASES
+
+    alias_pairs = tuple(EXTENSION_ALIASES.items())
 
     done_count = 0
     _PROGRESS_INTERVAL = 100
-    with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as pool:
+    with concurrent.futures.ProcessPoolExecutor(
+        max_workers=max_workers,
+        initializer=_initialize_worker_extension_aliases,
+        initargs=(alias_pairs,),
+    ) as pool:
         futures = {
             pool.submit(_extract_single_file, item): item[0] for item in work_items
         }
@@ -3917,9 +3944,11 @@ def extract(
                 e["target"] = id_remap[e["target"]]
 
     # Add cross-file class-level edges (Python only - uses Python parser internally)
-    py_paths = [p for p in paths if p.suffix == ".py"]
+    py_paths = [p for p in paths if _canonical_suffix(p) == ".py"]
     if py_paths:
-        py_results = [r for r, p in zip(per_file, paths) if p.suffix == ".py"]
+        py_results = [
+            r for r, p in zip(per_file, paths) if _canonical_suffix(p) == ".py"
+        ]
         try:
             cross_file_edges = _resolve_cross_file_imports(py_results, py_paths)
             all_edges.extend(cross_file_edges)
@@ -3928,9 +3957,11 @@ def extract(
             logging.getLogger(__name__).warning("Cross-file import resolution failed, skipping: %s", exc)
 
     # Cross-file Java import resolution
-    java_paths = [p for p in paths if p.suffix == ".java"]
+    java_paths = [p for p in paths if _canonical_suffix(p) == ".java"]
     if java_paths:
-        java_results = [r for r, p in zip(per_file, paths) if p.suffix == ".java"]
+        java_results = [
+            r for r, p in zip(per_file, paths) if _canonical_suffix(p) == ".java"
+        ]
         try:
             all_edges.extend(_resolve_cross_file_java_imports(java_results, java_paths))
         except Exception as exc:
@@ -4009,7 +4040,12 @@ def extract(
     }
 
 
-def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | None = None) -> list[Path]:
+def collect_files(
+    target: Path,
+    *,
+    follow_symlinks: bool = False,
+    root: Path | None = None,
+) -> list[Path]:
     if target.is_file():
         return [target]
     _EXTENSIONS = {
@@ -4019,10 +4055,11 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
         ".lua", ".toc", ".zig", ".ps1",
         ".m", ".mm",
     }
-    from graphify.detect import _load_graphifyignore, _is_ignored, EXTENSION_ALIASES
-    # Include any user-registered alias whose canonical is a discoverable code extension
+    from graphify.detect import EXTENSION_ALIASES, _is_ignored, _load_graphifyignore
+
+    # Include aliases whose canonical extension has an AST extractor.
     for _custom_ext, _canonical_ext in EXTENSION_ALIASES.items():
-        if _canonical_ext in _EXTENSIONS:
+        if _canonical_ext in _DISPATCH:
             _EXTENSIONS.add(_custom_ext)
     ignore_root = root if root is not None else target
     patterns = _load_graphifyignore(ignore_root)
@@ -4031,14 +4068,14 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
         return bool(patterns and _is_ignored(p, ignore_root, patterns))
 
     if not follow_symlinks:
-        results: list[Path] = []
-        for ext in sorted(_EXTENSIONS):
-            results.extend(
-                p for p in target.rglob(f"*{ext}")
-                if not any(part.startswith(".") for part in p.parts)
-                and not _ignored(p)
-            )
-        return sorted(results)
+        return sorted(
+            p
+            for p in target.rglob("*")
+            if p.is_file()
+            and p.suffix.lower() in _EXTENSIONS
+            and not any(part.startswith(".") for part in p.parts)
+            and not _ignored(p)
+        )
     # Walk with symlink following + cycle detection
     results = []
     for dirpath, dirnames, filenames in os.walk(target, followlinks=True):
@@ -4054,7 +4091,11 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
             continue
         for fname in filenames:
             p = dp / fname
-            if p.suffix in _EXTENSIONS and not fname.startswith(".") and not _ignored(p):
+            if (
+                p.suffix.lower() in _EXTENSIONS
+                and not fname.startswith(".")
+                and not _ignored(p)
+            ):
                 results.append(p)
     return sorted(results)
 

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -255,3 +255,120 @@ def test_detect_video_not_in_words(tmp_path):
     result = detect(tmp_path)
     # Only video file present — total_words should be 0
     assert result["total_words"] == 0
+
+
+# ── Custom extension aliases ─────────────────────────────────────────────────
+
+import pytest
+
+from graphify import detect as _detect_module
+
+
+@pytest.fixture
+def alias_state():
+    """Snapshot and restore extension-alias module state around a test."""
+    snapshot_aliases = dict(_detect_module.EXTENSION_ALIASES)
+    snapshot_code = set(_detect_module.CODE_EXTENSIONS)
+    snapshot_doc = set(_detect_module.DOC_EXTENSIONS)
+    try:
+        yield
+    finally:
+        _detect_module.EXTENSION_ALIASES.clear()
+        _detect_module.EXTENSION_ALIASES.update(snapshot_aliases)
+        _detect_module.CODE_EXTENSIONS.clear()
+        _detect_module.CODE_EXTENSIONS.update(snapshot_code)
+        _detect_module.DOC_EXTENSIONS.clear()
+        _detect_module.DOC_EXTENSIONS.update(snapshot_doc)
+
+
+def test_register_alias_code_extension(alias_state):
+    from graphify.detect import register_extension_alias, EXTENSION_ALIASES, CODE_EXTENSIONS
+    register_extension_alias(".pic", ".php")
+    assert ".pic" in CODE_EXTENSIONS
+    assert EXTENSION_ALIASES[".pic"] == ".php"
+    assert classify_file(Path("controller.pic")) == FileType.CODE
+
+
+def test_register_alias_doc_extension(alias_state):
+    from graphify.detect import register_extension_alias, EXTENSION_ALIASES, DOC_EXTENSIONS
+    register_extension_alias(".note", ".md")
+    assert ".note" in DOC_EXTENSIONS
+    assert EXTENSION_ALIASES[".note"] == ".md"
+    assert classify_file(Path("readme.note")) == FileType.DOCUMENT
+
+
+def test_register_alias_normalizes_case(alias_state):
+    from graphify.detect import register_extension_alias, EXTENSION_ALIASES, CODE_EXTENSIONS
+    register_extension_alias(".PIC", ".PHP")
+    assert ".pic" in CODE_EXTENSIONS
+    assert ".pic" in EXTENSION_ALIASES
+
+
+def test_register_alias_requires_leading_dot(alias_state):
+    from graphify.detect import register_extension_alias
+    with pytest.raises(ValueError, match="must start with"):
+        register_extension_alias("pic", ".php")
+    with pytest.raises(ValueError, match="must start with"):
+        register_extension_alias(".pic", "php")
+
+
+def test_register_alias_rejects_unknown_canonical(alias_state):
+    from graphify.detect import register_extension_alias
+    with pytest.raises(ValueError, match="not a known"):
+        register_extension_alias(".pic", ".unknownlang")
+
+
+def test_apply_extension_aliases_from_env_single(alias_state, monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_EXTENSION_ALIASES", ".pic:.php")
+    _detect_module._apply_extension_aliases_from_env()
+    assert _detect_module.EXTENSION_ALIASES.get(".pic") == ".php"
+
+
+def test_apply_extension_aliases_from_env_multiple(alias_state, monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_EXTENSION_ALIASES", ".pic:.php , .note:.md ,.x:.py")
+    _detect_module._apply_extension_aliases_from_env()
+    assert _detect_module.EXTENSION_ALIASES.get(".pic") == ".php"
+    assert _detect_module.EXTENSION_ALIASES.get(".note") == ".md"
+    assert _detect_module.EXTENSION_ALIASES.get(".x") == ".py"
+
+
+def test_apply_extension_aliases_from_env_skips_malformed(alias_state, monkeypatch):
+    # Malformed entries should be skipped silently — never crash on bad config
+    monkeypatch.setenv(
+        "GRAPHIFY_EXTENSION_ALIASES",
+        ".valid:.py,broken,no-colon, : ,.bad:.unknownlang",
+    )
+    _detect_module._apply_extension_aliases_from_env()
+    assert _detect_module.EXTENSION_ALIASES.get(".valid") == ".py"
+    assert ".bad" not in _detect_module.EXTENSION_ALIASES
+
+
+def test_apply_extension_aliases_from_env_empty(alias_state, monkeypatch):
+    monkeypatch.delenv("GRAPHIFY_EXTENSION_ALIASES", raising=False)
+    _detect_module._apply_extension_aliases_from_env()
+    # Should be a no-op — no entries added beyond what was already snapshotted
+    assert _detect_module.EXTENSION_ALIASES == {}
+
+
+def test_collect_files_includes_aliased_extension(alias_state, tmp_path):
+    from graphify.detect import register_extension_alias
+    from graphify.extract import collect_files
+    register_extension_alias(".pic", ".php")
+    (tmp_path / "main.pic").write_text("<?php class Foo {} ?>")
+    (tmp_path / "ignore.txt").write_text("not code")
+    found = collect_files(tmp_path)
+    assert any(p.name == "main.pic" for p in found)
+
+
+def test_extract_dispatches_aliased_extension(alias_state, tmp_path):
+    from graphify.detect import register_extension_alias
+    from graphify.extract import collect_files, extract
+    register_extension_alias(".pic", ".php")
+    (tmp_path / "shop.pic").write_text(
+        "<?php\nclass ShopCart {\n    public function checkout() { return 1; }\n}\n"
+    )
+    paths = collect_files(tmp_path)
+    result = extract(paths, cache_root=tmp_path)
+    labels = {n.get("label", "") for n in result["nodes"]}
+    # PHP grammar should have produced a class node for ShopCart
+    assert any("ShopCart" in label or "shopcart" in label.lower() for label in labels)

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -380,10 +380,12 @@ def test_collect_files_includes_aliased_extension(alias_state, tmp_path):
     from graphify.extract import collect_files
 
     register_extension_alias(".pic", ".php")
-    (tmp_path / "main.PIC").write_text("<?php class Foo {} ?>")
+    (tmp_path / "main.pic").write_text("<?php class Foo {} ?>")
+    (tmp_path / "uppercase.PIC").write_text("<?php class Uppercase {} ?>")
     (tmp_path / "ignore.txt").write_text("not code")
     found = collect_files(tmp_path)
-    assert any(p.name == "main.PIC" for p in found)
+    assert any(p.name == "main.pic" for p in found)
+    assert not any(p.name == "uppercase.PIC" for p in found)
 
 
 def test_extract_dispatches_aliased_extension(alias_state, tmp_path):

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,5 +1,17 @@
 from pathlib import Path
-from graphify.detect import classify_file, count_words, detect, FileType, _looks_like_paper, _is_ignored, _load_graphifyignore
+
+import pytest
+
+from graphify import detect as _detect_module
+from graphify.detect import (
+    FileType,
+    _is_ignored,
+    _load_graphifyignore,
+    _looks_like_paper,
+    classify_file,
+    count_words,
+    detect,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -259,10 +271,6 @@ def test_detect_video_not_in_words(tmp_path):
 
 # ── Custom extension aliases ─────────────────────────────────────────────────
 
-import pytest
-
-from graphify import detect as _detect_module
-
 
 @pytest.fixture
 def alias_state():
@@ -282,7 +290,12 @@ def alias_state():
 
 
 def test_register_alias_code_extension(alias_state):
-    from graphify.detect import register_extension_alias, EXTENSION_ALIASES, CODE_EXTENSIONS
+    from graphify.detect import (
+        CODE_EXTENSIONS,
+        EXTENSION_ALIASES,
+        register_extension_alias,
+    )
+
     register_extension_alias(".pic", ".php")
     assert ".pic" in CODE_EXTENSIONS
     assert EXTENSION_ALIASES[".pic"] == ".php"
@@ -290,7 +303,12 @@ def test_register_alias_code_extension(alias_state):
 
 
 def test_register_alias_doc_extension(alias_state):
-    from graphify.detect import register_extension_alias, EXTENSION_ALIASES, DOC_EXTENSIONS
+    from graphify.detect import (
+        DOC_EXTENSIONS,
+        EXTENSION_ALIASES,
+        register_extension_alias,
+    )
+
     register_extension_alias(".note", ".md")
     assert ".note" in DOC_EXTENSIONS
     assert EXTENSION_ALIASES[".note"] == ".md"
@@ -298,7 +316,12 @@ def test_register_alias_doc_extension(alias_state):
 
 
 def test_register_alias_normalizes_case(alias_state):
-    from graphify.detect import register_extension_alias, EXTENSION_ALIASES, CODE_EXTENSIONS
+    from graphify.detect import (
+        CODE_EXTENSIONS,
+        EXTENSION_ALIASES,
+        register_extension_alias,
+    )
+
     register_extension_alias(".PIC", ".PHP")
     assert ".pic" in CODE_EXTENSIONS
     assert ".pic" in EXTENSION_ALIASES
@@ -306,6 +329,7 @@ def test_register_alias_normalizes_case(alias_state):
 
 def test_register_alias_requires_leading_dot(alias_state):
     from graphify.detect import register_extension_alias
+
     with pytest.raises(ValueError, match="must start with"):
         register_extension_alias("pic", ".php")
     with pytest.raises(ValueError, match="must start with"):
@@ -314,6 +338,7 @@ def test_register_alias_requires_leading_dot(alias_state):
 
 def test_register_alias_rejects_unknown_canonical(alias_state):
     from graphify.detect import register_extension_alias
+
     with pytest.raises(ValueError, match="not a known"):
         register_extension_alias(".pic", ".unknownlang")
 
@@ -353,16 +378,18 @@ def test_apply_extension_aliases_from_env_empty(alias_state, monkeypatch):
 def test_collect_files_includes_aliased_extension(alias_state, tmp_path):
     from graphify.detect import register_extension_alias
     from graphify.extract import collect_files
+
     register_extension_alias(".pic", ".php")
-    (tmp_path / "main.pic").write_text("<?php class Foo {} ?>")
+    (tmp_path / "main.PIC").write_text("<?php class Foo {} ?>")
     (tmp_path / "ignore.txt").write_text("not code")
     found = collect_files(tmp_path)
-    assert any(p.name == "main.pic" for p in found)
+    assert any(p.name == "main.PIC" for p in found)
 
 
 def test_extract_dispatches_aliased_extension(alias_state, tmp_path):
     from graphify.detect import register_extension_alias
     from graphify.extract import collect_files, extract
+
     register_extension_alias(".pic", ".php")
     (tmp_path / "shop.pic").write_text(
         "<?php\nclass ShopCart {\n    public function checkout() { return 1; }\n}\n"
@@ -372,3 +399,64 @@ def test_extract_dispatches_aliased_extension(alias_state, tmp_path):
     labels = {n.get("label", "") for n in result["nodes"]}
     # PHP grammar should have produced a class node for ShopCart
     assert any("ShopCart" in label or "shopcart" in label.lower() for label in labels)
+
+
+def test_typescript_alias_uses_typescript_parser(alias_state, monkeypatch):
+    import graphify.extract as extract_module
+
+    from graphify.detect import register_extension_alias
+
+    register_extension_alias(".component", ".ts")
+    selected_configs = []
+
+    def capture_config(path, config):
+        selected_configs.append(config)
+        return {"nodes": [], "edges": []}
+
+    monkeypatch.setattr(extract_module, "_extract_generic", capture_config)
+    extract_module.extract_js(Path("profile.component"))
+
+    assert selected_configs == [extract_module._TS_CONFIG]
+
+
+def test_programmatic_alias_reaches_spawned_workers(
+    alias_state, monkeypatch, tmp_path
+):
+    import concurrent.futures
+    import multiprocessing
+
+    import graphify.extract as extract_module
+
+    from graphify.detect import register_extension_alias
+
+    monkeypatch.delenv("GRAPHIFY_EXTENSION_ALIASES", raising=False)
+    register_extension_alias(".workerphp", ".php")
+
+    for index in range(2):
+        (tmp_path / f"worker_{index}.workerphp").write_text(
+            f"<?php class SpawnedWorker{index} {{}} ?>"
+        )
+
+    real_executor = concurrent.futures.ProcessPoolExecutor
+    spawn_context = multiprocessing.get_context("spawn")
+
+    def spawned_executor(*args, **kwargs):
+        kwargs["mp_context"] = spawn_context
+        return real_executor(*args, **kwargs)
+
+    monkeypatch.setattr(
+        concurrent.futures, "ProcessPoolExecutor", spawned_executor
+    )
+    monkeypatch.setattr(extract_module, "_PARALLEL_THRESHOLD", 2)
+
+    paths = extract_module.collect_files(tmp_path)
+    result = extract_module.extract(
+        paths,
+        cache_root=tmp_path,
+        parallel=True,
+        max_workers=2,
+    )
+
+    labels = {node.get("label", "") for node in result["nodes"]}
+    assert any("SpawnedWorker0" in label for label in labels)
+    assert any("SpawnedWorker1" in label for label in labels)


### PR DESCRIPTION
## Summary

Adds an opt-in mechanism for projects whose source files use non-standard extensions for languages graphify already supports. The motivating case is a codebase that uses `.pic` for files that are valid PHP — today those files are silently dropped at every stage (detection, collection, AST dispatch).

This PR introduces:

- **`graphify.detect.register_extension_alias(custom, canonical)`** — public helper that adds the custom extension to `CODE_EXTENSIONS` (or `DOC_EXTENSIONS`) and records the mapping in a new `EXTENSION_ALIASES` dict. Validates that both arguments start with `.` and that the canonical extension is already known.
- **`GRAPHIFY_EXTENSION_ALIASES` env var** — comma-separated `custom:canonical` pairs applied automatically when `graphify.detect` is imported. Malformed pairs and unknown canonicals are skipped silently so a bad config never crashes the pipeline.
- **`_get_extractor()` and `collect_files()`** consult the alias map, so aliased files are routed to the canonical extractor and discovered during file walks. Routing the alias lookup through `_get_extractor` (rather than mutating a local dispatch dict in `extract()`) keeps a single source of truth and means both the sequential and `ProcessPoolExecutor` parallel paths pick up aliases consistently — a runtime call to `register_extension_alias()` takes effect immediately without re-running setup.

## Example

```bash
# Treat .pic as PHP and .foo as Python for this run
export GRAPHIFY_EXTENSION_ALIASES=".pic:.php,.foo:.py"
/graphify .
```

Or programmatically:

```python
from graphify.detect import register_extension_alias
register_extension_alias(".pic", ".php")
```

## Why an env var

Same pattern as `GRAPHIFY_WHISPER_MODEL` — keeps the slash-command invocation untouched while allowing per-project configuration. Drop-in from prep scripts and CI without rewriting any of the skill flow.

## Tests

Added to `tests/test_detect.py`:

- Code-extension and doc-extension aliasing
- Case normalization
- Validation: missing leading dot, unknown canonical
- Env-var parsing: single, multiple, malformed, empty
- End-to-end through `collect_files` and `extract` using a tiny `.pic` file with PHP content

## Test plan

- [x] `pytest tests/test_detect.py -v` — 40 pass (29 existing + 11 new)
- [x] `pytest tests/ --ignore=tests/test_install.py --ignore=tests/test_transcribe.py --ignore=tests/test_claude_md.py` — 454 pass; the 5 pre-existing SQL failures on `v6` reproduce on a clean checkout and are unrelated to this change.
- [x] Manual smoke: `GRAPHIFY_EXTENSION_ALIASES=".pic:.php" python -c "from graphify.detect import classify_file; from pathlib import Path; print(classify_file(Path('foo.pic')))"` returns `FileType.CODE`

## Notes

- Backward-compatible: zero behavior change unless the env var is set or the helper is called.
- README updated under "Excluding paths" with a short usage example.
- `EXTENSION_ALIASES` is exported as a public name on `graphify.detect` so downstream tooling can introspect what's registered.