### PR TITLE
Add Clojure extraction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ To remove graphify from all platforms at once: `graphify uninstall` (add `--purg
 
 | Type | Extensions |
 |------|-----------|
-| Code (31 languages) | `.py .ts .js .jsx .tsx .mjs .go .rs .java .c .cpp .h .hpp .rb .cs .kt .scala .php .swift .lua .luau .zig .ps1 .ex .exs .m .mm .jl .vue .svelte .astro .groovy .gradle .dart .v .sv .sql .f .f90 .f95 .f03 .f08 .pas .pp .dpr .dpk .lpr .inc .dfm .lfm .lpk .sh .bash .json` |
+| Code (32 languages) | `.py .ts .js .jsx .tsx .mjs .go .rs .java .c .cpp .h .hpp .rb .cs .kt .scala .php .clj .swift .lua .luau .zig .ps1 .ex .exs .m .mm .jl .vue .svelte .astro .groovy .gradle .dart .v .sv .sql .f .f90 .f95 .f03 .f08 .pas .pp .dpr .dpk .lpr .inc .dfm .lfm .lpk .sh .bash .json` |
 | Docs | `.md .mdx .qmd .html .txt .rst .yaml .yml` |
 | Office | `.docx .xlsx` (requires `pip install graphifyy[office]`) |
 | Google Workspace | `.gdoc .gsheet .gslides` (opt-in; requires `gws` auth and `--google-workspace`; Sheets need `pip install graphifyy[google]`) |

--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -19,6 +19,18 @@ def _norm(label: str) -> str:
     return re.sub(r"[^a-z0-9]+", " ", label.lower()).strip()
 
 
+def _exact_label_groups(nodes: list[dict]) -> list[list[dict]]:
+    """Avoid exact-deduping same-file symbols that differ only by case."""
+    labels = [str(node.get("label", node.get("id", ""))) for node in nodes]
+    if len(set(labels)) <= 1 or len({label.lower() for label in labels}) != 1:
+        return [nodes]
+
+    by_label: dict[str, list[dict]] = defaultdict(list)
+    for node, label in zip(nodes, labels, strict=True):
+        by_label[label].append(node)
+    return [group for group in by_label.values() if len(group) > 1]
+
+
 def _entropy(label: str) -> float:
     """Shannon entropy in bits/char of the normalised label."""
     s = _norm(label)
@@ -185,11 +197,13 @@ def deduplicate_entities(
             sf = node.get("source_file") or ""
             by_file[sf].append(node)
         for file_group in by_file.values():
-            if len(file_group) > 1:
-                winner = _pick_winner(file_group)
-                for node in file_group:
+            if len(file_group) <= 1:
+                continue
+            for exact_group in _exact_label_groups(file_group):
+                winner = _pick_winner(exact_group)
+                for node in exact_group:
                     uf.union(winner["id"], node["id"])
-                exact_merges += len(file_group) - 1
+                exact_merges += len(exact_group) - 1
 
     # ── pass 2: MinHash/LSH + Jaro-Winkler (high-entropy nodes only) ─────────
     candidates: list[dict] = []

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -24,7 +24,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json'}
+CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.clj', '.lua', '.luau', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json'}
 DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.txt', '.rst', '.html', '.yaml', '.yml'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -6085,6 +6085,264 @@ def extract_json(path: Path) -> dict:
     return {"nodes": nodes, "edges": edges}
 
 
+def extract_clojure(path: Path) -> dict:
+    """Extract namespaces, definitions, requires/imports, protocol methods, and calls from .clj."""
+    try:
+        import tree_sitter_clojure_orchard as tsclojure
+        from tree_sitter import Language, Parser
+    except ImportError:
+        return {"nodes": [], "edges": [], "error": "tree-sitter-clojure-orchard not installed"}
+
+    try:
+        language = Language(tsclojure.language())
+        parser = Parser(language)
+        source = path.read_bytes()
+        tree = parser.parse(source)
+        root = tree.root_node
+    except Exception as e:
+        return {"nodes": [], "edges": [], "error": str(e)}
+
+    stem = _file_stem(path)
+    str_path = str(path)
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen_ids: set[str] = set()
+    function_bodies: list[tuple[str, list[object]]] = []
+    namespace_name: str | None = None
+    namespace_nid: str | None = None
+
+    definition_heads = {
+        "def", "defonce", "defn", "defn-", "defmacro",
+        "defmulti", "defmethod", "defprotocol", "defrecord", "deftype",
+    }
+    callable_heads = {"defn", "defn-", "defmacro", "defmethod"}
+    type_heads = {"defprotocol", "defrecord", "deftype"}
+    skipped_call_heads = {
+        ".", "..", "and", "case", "catch", "comment", "cond", "cond->", "cond->>",
+        "def", "defmacro", "defmethod", "defmulti", "defn", "defn-", "defonce",
+        "defprotocol", "defrecord", "deftype", "do", "doseq", "fn", "for", "if",
+        "import", "let", "loop", "ns", "or", "quote", "recur", "require", "try",
+        "when", "when-let", "when-not",
+    }
+
+    def node_text(node) -> str:
+        return source[node.start_byte:node.end_byte].decode("utf-8", errors="replace")
+
+    def named_children(node) -> list[object]:
+        return [child for child in node.children if getattr(child, "is_named", False)]
+
+    def form_head(node) -> str | None:
+        if node.type != "list_lit":
+            return None
+        children = named_children(node)
+        if not children:
+            return None
+        first = children[0]
+        if first.type in ("sym_lit", "kwd_lit"):
+            return node_text(first)
+        return None
+
+    def first_symbol(children: list[object], start: int = 0) -> tuple[str, object] | tuple[None, None]:
+        for child in children[start:]:
+            if child.type == "sym_lit":
+                return node_text(child), child
+        return None, None
+
+    def add_node(nid: str, label: str, line: int) -> None:
+        if nid not in seen_ids:
+            seen_ids.add(nid)
+            nodes.append({
+                "id": nid,
+                "label": label,
+                "file_type": "code",
+                "source_file": str_path,
+                "source_location": f"L{line}",
+            })
+
+    def add_edge(src: str, tgt: str, relation: str, line: int,
+                 confidence: str = "EXTRACTED", weight: float = 1.0,
+                 context: str | None = None) -> None:
+        edge = {
+            "source": src,
+            "target": tgt,
+            "relation": relation,
+            "confidence": confidence,
+            "source_file": str_path,
+            "source_location": f"L{line}",
+            "weight": weight,
+        }
+        if context:
+            edge["context"] = context
+        edges.append(edge)
+
+    file_nid = _make_id(str_path)
+    add_node(file_nid, path.name, 1)
+
+    def parent_nid() -> str:
+        return namespace_nid or file_nid
+
+    def add_import_edges(ns_form) -> None:
+        src_nid = parent_nid()
+        for clause in named_children(ns_form)[2:]:
+            if clause.type != "list_lit":
+                continue
+            clause_children = named_children(clause)
+            if not clause_children:
+                continue
+            clause_head = node_text(clause_children[0])
+            if clause_head == ":require":
+                for require_vec in clause_children[1:]:
+                    if require_vec.type == "sym_lit":
+                        module_name, module_node = node_text(require_vec), require_vec
+                    elif require_vec.type == "vec_lit":
+                        module_name, module_node = first_symbol(named_children(require_vec))
+                    else:
+                        continue
+                    if module_name:
+                        add_edge(src_nid, _make_id(module_name), "imports_from",
+                                 module_node.start_point[0] + 1, context="import")
+            elif clause_head == ":import":
+                for import_form in clause_children[1:]:
+                    import_symbols = [
+                        node_text(child)
+                        for child in named_children(import_form)
+                        if child.type == "sym_lit"
+                    ]
+                    if not import_symbols:
+                        continue
+                    package = import_symbols[0]
+                    imported = import_symbols[1:] or [package]
+                    for name in imported:
+                        target = f"{package}.{name}" if name != package else package
+                        add_edge(src_nid, _make_id(target), "imports",
+                                 import_form.start_point[0] + 1, context="import")
+
+    def add_protocol_methods(protocol_nid: str, protocol_form) -> None:
+        for child in named_children(protocol_form)[2:]:
+            if child.type != "list_lit":
+                continue
+            method_name = form_head(child)
+            if not method_name:
+                continue
+            line = child.start_point[0] + 1
+            method_nid = _make_id(protocol_nid, method_name)
+            add_node(method_nid, f".{method_name}()", line)
+            add_edge(protocol_nid, method_nid, "method", line)
+
+    def body_nodes(head: str, children: list[object]) -> list[object]:
+        if head == "defmethod":
+            for index, child in enumerate(children[2:], start=2):
+                if child.type == "vec_lit":
+                    return children[index + 1:]
+            return []
+        if head in callable_heads:
+            for index, child in enumerate(children[2:], start=2):
+                if child.type == "vec_lit":
+                    return children[index + 1:]
+            return children[2:]
+        return []
+
+    def add_definition(form) -> None:
+        children = named_children(form)
+        if len(children) < 2:
+            return
+        head = node_text(children[0])
+        if head not in definition_heads:
+            return
+        name, name_node = first_symbol(children, 1)
+        if not name:
+            return
+
+        line = name_node.start_point[0] + 1
+        if head == "defmethod":
+            dispatch = node_text(children[2]) if len(children) > 2 else ""
+            label = f"{name} {dispatch}".strip()
+            nid = _make_id(stem, name, dispatch)
+        elif head in type_heads:
+            label = name
+            nid = _make_id(stem, name)
+        elif head in callable_heads or head == "defmulti":
+            label = f"{name}()"
+            nid = _make_id(stem, name)
+        else:
+            label = name
+            nid = _make_id(stem, name)
+
+        add_node(nid, label, line)
+        add_edge(parent_nid(), nid, "contains", line)
+
+        if head == "defprotocol":
+            add_protocol_methods(nid, form)
+
+        if head in callable_heads:
+            function_bodies.append((nid, body_nodes(head, children)))
+
+    for child in named_children(root):
+        if child.type != "list_lit":
+            continue
+        if form_head(child) == "ns":
+            ns_children = named_children(child)
+            if len(ns_children) > 1 and ns_children[1].type == "sym_lit":
+                namespace_name = node_text(ns_children[1])
+                namespace_nid = _make_id(stem, namespace_name)
+                add_node(namespace_nid, namespace_name, ns_children[1].start_point[0] + 1)
+                add_edge(file_nid, namespace_nid, "contains", ns_children[1].start_point[0] + 1)
+                add_import_edges(child)
+            continue
+        add_definition(child)
+
+    label_to_nid: dict[str, str] = {}
+    for n in nodes:
+        raw = n["label"]
+        normalised = raw.strip("()").lstrip(".").split(" ", 1)[0]
+        label_to_nid[normalised.casefold()] = n["id"]
+
+    seen_call_pairs: set[tuple[str, str]] = set()
+
+    def callee_from_symbol(raw: str) -> str | None:
+        if raw in skipped_call_heads or raw.startswith(":"):
+            return None
+        if "/" in raw:
+            qualifier, name = raw.rsplit("/", 1)
+            if namespace_name and qualifier == namespace_name:
+                return name
+            return None
+        return raw
+
+    def walk_calls(node, caller_nid: str) -> None:
+        if node.type in ("quoting_lit", "syn_quoting_lit", "var_quoting_lit", "comment"):
+            return
+        if node.type == "list_lit":
+            raw_head = form_head(node)
+            if raw_head in definition_heads or raw_head in {"comment", "quote"}:
+                return
+            if raw_head:
+                callee_name = callee_from_symbol(raw_head)
+                if callee_name:
+                    tgt_nid = label_to_nid.get(callee_name.casefold())
+                    if tgt_nid and tgt_nid != caller_nid:
+                        pair = (caller_nid, tgt_nid)
+                        if pair not in seen_call_pairs:
+                            seen_call_pairs.add(pair)
+                            add_edge(caller_nid, tgt_nid, "calls",
+                                     node.start_point[0] + 1, context="call")
+        for child in named_children(node):
+            walk_calls(child, caller_nid)
+
+    for caller_nid, bodies in function_bodies:
+        for body in bodies:
+            walk_calls(body, caller_nid)
+
+    valid_ids = seen_ids
+    clean_edges = []
+    for edge in edges:
+        src, tgt = edge["source"], edge["target"]
+        if src in valid_ids and (tgt in valid_ids or edge["relation"] in ("imports", "imports_from")):
+            clean_edges.append(edge)
+
+    return {"nodes": nodes, "edges": clean_edges}
+
+
 _DISPATCH: dict[str, Any] = {
     ".py": extract_python,
     ".js": extract_js,
@@ -6109,6 +6367,7 @@ _DISPATCH: dict[str, Any] = {
     ".kts": extract_kotlin,
     ".scala": extract_scala,
     ".php": extract_php,
+    ".clj": extract_clojure,
     ".swift": extract_swift,
     ".lua": extract_lua,
     ".luau": extract_lua,

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -6131,6 +6131,13 @@ def extract_clojure(path: Path) -> dict:
     def named_children(node) -> list[object]:
         return [child for child in node.children if getattr(child, "is_named", False)]
 
+    def make_clojure_id(*parts: str) -> str:
+        combined = "_".join(p.strip("_.") for p in parts if p)
+        combined = unicodedata.normalize("NFKC", combined)
+        cleaned = re.sub(r"[^\w]+", "_", combined, flags=re.UNICODE)
+        cleaned = re.sub(r"_+", "_", cleaned)
+        return cleaned.strip("_")
+
     def form_head(node) -> str | None:
         if node.type != "list_lit":
             return None
@@ -6199,7 +6206,7 @@ def extract_clojure(path: Path) -> dict:
                     else:
                         continue
                     if module_name:
-                        add_edge(src_nid, _make_id(module_name), "imports_from",
+                        add_edge(src_nid, make_clojure_id(module_name), "imports_from",
                                  module_node.start_point[0] + 1, context="import")
             elif clause_head == ":import":
                 for import_form in clause_children[1:]:
@@ -6214,7 +6221,7 @@ def extract_clojure(path: Path) -> dict:
                     imported = import_symbols[1:] or [package]
                     for name in imported:
                         target = f"{package}.{name}" if name != package else package
-                        add_edge(src_nid, _make_id(target), "imports",
+                        add_edge(src_nid, make_clojure_id(target), "imports",
                                  import_form.start_point[0] + 1, context="import")
 
     def add_protocol_methods(protocol_nid: str, protocol_form) -> None:
@@ -6225,7 +6232,7 @@ def extract_clojure(path: Path) -> dict:
             if not method_name:
                 continue
             line = child.start_point[0] + 1
-            method_nid = _make_id(protocol_nid, method_name)
+            method_nid = make_clojure_id(protocol_nid, method_name)
             add_node(method_nid, f".{method_name}()", line)
             add_edge(protocol_nid, method_nid, "method", line)
 
@@ -6257,16 +6264,16 @@ def extract_clojure(path: Path) -> dict:
         if head == "defmethod":
             dispatch = node_text(children[2]) if len(children) > 2 else ""
             label = f"{name} {dispatch}".strip()
-            nid = _make_id(stem, name, dispatch)
+            nid = make_clojure_id(stem, name, dispatch)
         elif head in type_heads:
             label = name
-            nid = _make_id(stem, name)
+            nid = make_clojure_id(stem, name)
         elif head in callable_heads or head == "defmulti":
             label = f"{name}()"
-            nid = _make_id(stem, name)
+            nid = make_clojure_id(stem, name)
         else:
             label = name
-            nid = _make_id(stem, name)
+            nid = make_clojure_id(stem, name)
 
         add_node(nid, label, line)
         add_edge(parent_nid(), nid, "contains", line)
@@ -6284,7 +6291,7 @@ def extract_clojure(path: Path) -> dict:
             ns_children = named_children(child)
             if len(ns_children) > 1 and ns_children[1].type == "sym_lit":
                 namespace_name = node_text(ns_children[1])
-                namespace_nid = _make_id(stem, namespace_name)
+                namespace_nid = make_clojure_id(stem, namespace_name)
                 add_node(namespace_nid, namespace_name, ns_children[1].start_point[0] + 1)
                 add_edge(file_nid, namespace_nid, "contains", ns_children[1].start_point[0] + 1)
                 add_import_edges(child)
@@ -6295,7 +6302,7 @@ def extract_clojure(path: Path) -> dict:
     for n in nodes:
         raw = n["label"]
         normalised = raw.strip("()").lstrip(".").split(" ", 1)[0]
-        label_to_nid[normalised.casefold()] = n["id"]
+        label_to_nid[normalised] = n["id"]
 
     seen_call_pairs: set[tuple[str, str]] = set()
 
@@ -6319,7 +6326,7 @@ def extract_clojure(path: Path) -> dict:
             if raw_head:
                 callee_name = callee_from_symbol(raw_head)
                 if callee_name:
-                    tgt_nid = label_to_nid.get(callee_name.casefold())
+                    tgt_nid = label_to_nid.get(callee_name)
                     if tgt_nid and tgt_nid != caller_nid:
                         pair = (caller_nid, tgt_nid)
                         if pair not in seen_call_pairs:

--- a/graphify/skill-droid.md
+++ b/graphify/skill-droid.md
@@ -791,7 +791,7 @@ import json
 from pathlib import Path
 
 result = json.loads(open('.graphify_incremental.json').read()) if Path('.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts'}
+code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.clj','.cc','.cxx','.hpp','.h','.kts'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
 code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -806,7 +806,7 @@ import json
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
+code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.clj','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
 code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "tree-sitter-kotlin",
     "tree-sitter-scala",
     "tree-sitter-php",
+    "tree-sitter-clojure-orchard",
     "tree-sitter-swift",
     "tree-sitter-lua",
     "tree-sitter-zig",

--- a/tests/fixtures/sample.clj
+++ b/tests/fixtures/sample.clj
@@ -1,0 +1,39 @@
+(ns sample.core
+  (:require [sample.db :as db]
+            [clojure.string :as str]
+            sample.audit)
+  (:import [java.time Instant]))
+
+(defonce default-role :guest)
+
+(defrecord User [id name])
+
+(defprotocol Store
+  (fetch-user [this id]))
+
+(defn normalize-name [name]
+  (str/trim name))
+
+(defn- enrich-user [user]
+  (normalize-name (:name user)))
+
+(defn quoted-example []
+  '(normalize-name "quoted"))
+
+(defn comment-example []
+  (comment
+    (normalize-name "commented"))
+  nil)
+
+(defmacro with-user [binding & body]
+  `(let [~binding (fetch-current)]
+     ~@body))
+
+(defmulti render :type)
+
+(defmethod render :user [user]
+  (enrich-user user))
+
+(defn handle-request [id]
+  (let [user (db/fetch-user id)]
+    (render (assoc user :name (normalize-name (:name user))))))

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -9,6 +9,9 @@ def test_classify_python():
 def test_classify_typescript():
     assert classify_file(Path("bar.ts")) == FileType.CODE
 
+def test_classify_clojure():
+    assert classify_file(Path("core.clj")) == FileType.CODE
+
 def test_classify_markdown():
     assert classify_file(Path("README.md")) == FileType.DOCUMENT
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -6,7 +6,7 @@ from graphify.extract import (
     extract_java, extract_c, extract_cpp, extract_ruby,
     extract_csharp, extract_kotlin, extract_scala, extract_php,
     extract_swift, extract_go, extract_julia, extract_js, extract_fortran,
-    extract_groovy,
+    extract_groovy, extract_clojure,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -17,6 +17,9 @@ def _labels(r):
 
 def _relations(r):
     return {e["relation"] for e in r["edges"]}
+
+def _target_ids(r, relation):
+    return {e["target"] for e in r["edges"] if e["relation"] == relation}
 
 def _calls(r):
     node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
@@ -854,6 +857,82 @@ def test_ts_static_template_literal_resolved():
     targets = {e["target"] for e in r["edges"] if e["relation"] == "imports_from"}
     assert any("statichelper" in t.lower() for t in targets), \
         f"Static template literal import not resolved: {targets}"
+
+
+# ── Clojure ──────────────────────────────────────────────────────────────────
+
+def test_clojure_no_error():
+    r = extract_clojure(FIXTURES / "sample.clj")
+    assert "error" not in r
+
+
+def test_clojure_finds_namespace():
+    r = extract_clojure(FIXTURES / "sample.clj")
+    assert "sample.core" in _labels(r)
+
+
+def test_clojure_finds_common_definitions():
+    r = extract_clojure(FIXTURES / "sample.clj")
+    labels = _labels(r)
+    assert any("User" in l for l in labels)
+    assert any("Store" in l for l in labels)
+    assert any("normalize-name" in l for l in labels)
+    assert any("enrich-user" in l for l in labels)
+    assert any("with-user" in l for l in labels)
+    assert any("render" in l for l in labels)
+    assert any("handle-request" in l for l in labels)
+
+
+def test_clojure_finds_requires_and_imports():
+    r = extract_clojure(FIXTURES / "sample.clj")
+    assert "imports" in _relations(r)
+    assert "imports_from" in _relations(r)
+    assert "sample_audit" in _target_ids(r, "imports_from")
+
+
+def test_clojure_import_edges_have_import_context():
+    r = extract_clojure(FIXTURES / "sample.clj")
+    import_edges = _edges_with_relation(r, "imports", "imports_from")
+    assert import_edges
+    assert all(e.get("context") == "import" for e in import_edges)
+
+
+def test_clojure_emits_same_file_calls():
+    r = extract_clojure(FIXTURES / "sample.clj")
+    calls = _calls(r)
+    assert any("enrich-user" in src and "normalize-name" in tgt for src, tgt in calls)
+    assert any("render" in src and "enrich-user" in tgt for src, tgt in calls)
+    assert any("handle-request" in src and "normalize-name" in tgt for src, tgt in calls)
+
+
+def test_clojure_call_edges_have_call_context():
+    r = extract_clojure(FIXTURES / "sample.clj")
+    call_edges = _edges_with_relation(r, "calls")
+    assert call_edges
+    assert all(e.get("context") == "call" for e in call_edges)
+
+
+def test_clojure_calls_are_extracted():
+    r = extract_clojure(FIXTURES / "sample.clj")
+    for e in r["edges"]:
+        if e["relation"] == "calls":
+            assert e["confidence"] == "EXTRACTED"
+
+
+def test_clojure_skips_calls_inside_quoted_or_commented_forms():
+    r = extract_clojure(FIXTURES / "sample.clj")
+    calls = _calls(r)
+    assert not any("quoted-example" in src for src, _ in calls)
+    assert not any("comment-example" in src for src, _ in calls)
+
+
+def test_clojure_no_dangling_internal_edges():
+    r = extract_clojure(FIXTURES / "sample.clj")
+    node_ids = {n["id"] for n in r["nodes"]}
+    for e in r["edges"]:
+        if e["relation"] in ("contains", "method", "calls"):
+            assert e["source"] in node_ids
+            assert e["target"] in node_ids
 
 
 # ── Markdown ─────────────────────────────────────────────────────────────────

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 import pytest
+from graphify.build import build
 from graphify.extract import (
     extract_java, extract_c, extract_cpp, extract_ruby,
     extract_csharp, extract_kotlin, extract_scala, extract_php,
@@ -903,6 +904,38 @@ def test_clojure_emits_same_file_calls():
     assert any("enrich-user" in src and "normalize-name" in tgt for src, tgt in calls)
     assert any("render" in src and "enrich-user" in tgt for src, tgt in calls)
     assert any("handle-request" in src and "normalize-name" in tgt for src, tgt in calls)
+
+
+def test_clojure_preserves_case_sensitive_symbols(tmp_path):
+    sample = tmp_path / "case_sensitive.clj"
+    sample.write_text(
+        """(ns sample.case)
+(defn Foo [] :upper)
+(defn foo [] :lower)
+(defn call-upper [] (Foo))
+(defn call-lower [] (foo))
+""",
+        encoding="utf-8",
+    )
+
+    r = extract_clojure(sample)
+
+    assert "error" not in r
+    ids_by_label = {n["label"]: n["id"] for n in r["nodes"]}
+    assert "Foo()" in ids_by_label
+    assert "foo()" in ids_by_label
+    assert ids_by_label["Foo()"] != ids_by_label["foo()"]
+
+    calls = _calls(r)
+    assert ("call-upper()", "Foo()") in calls
+    assert ("call-lower()", "foo()") in calls
+    assert ("call-upper()", "foo()") not in calls
+    assert ("call-lower()", "Foo()") not in calls
+
+    G = build([r])
+    built_labels = [data.get("label") for _, data in G.nodes(data=True)]
+    assert "Foo()" in built_labels
+    assert "foo()" in built_labels
 
 
 def test_clojure_call_edges_have_call_context():

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -206,6 +206,7 @@ def test_extract_dispatches_all_languages():
         FIXTURES / "sample.ts",
         FIXTURES / "sample.go",
         FIXTURES / "sample.rs",
+        FIXTURES / "sample.clj",
     ]
     r = extract(files)
     source_files = {n["source_file"] for n in r["nodes"] if n["source_file"]}
@@ -214,6 +215,7 @@ def test_extract_dispatches_all_languages():
     assert any("sample.ts" in f for f in source_files)
     assert any("sample.go" in f for f in source_files)
     assert any("sample.rs" in f for f in source_files)
+    assert any("sample.clj" in f for f in source_files)
 
 
 # ── Cache ─────────────────────────────────────────────────────────────────────

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -36,6 +36,7 @@ def test_watched_extensions_includes_code():
     assert ".ts" in _WATCHED_EXTENSIONS
     assert ".go" in _WATCHED_EXTENSIONS
     assert ".rs" in _WATCHED_EXTENSIONS
+    assert ".clj" in _WATCHED_EXTENSIONS
 
 def test_watched_extensions_includes_docs():
     assert ".md" in _WATCHED_EXTENSIONS


### PR DESCRIPTION
## Summary

Adds tree-sitter backed Clojure .clj extraction to Graphify.

- extracts namespaces, require/import edges, common top-level definitions, protocol methods, and same-file calls
- wires .clj through detection, collection, watch, hooks, docs, and skill metadata
- adds fixture-backed regression coverage for bare requires and quoted/commented non-calls

## Validation

- .venv/bin/python3 -m pytest -q -> 302 passed, 2 warnings
- git diff --check -> clean
