### PR TITLE
test: add extraction regression workflow

### DIFF
--- a/.github/workflows/extraction-regression.yml
+++ b/.github/workflows/extraction-regression.yml
@@ -1,0 +1,47 @@
+name: Extraction Regression
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  extraction-regression:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Graphify
+        run: |
+          pip install -e ".[mcp,pdf,watch,sql]"
+
+      - name: Create tiny fixture corpus
+        run: |
+          mkdir fixture
+          echo "def hello(): return 'world'" > fixture/app.py
+          echo "# Demo Project" > fixture/README.md
+
+      - name: Run graph extraction
+        run: |
+          graphify fixture --no-viz
+
+      - name: Verify graph outputs exist
+        run: |
+          test -f graphify-out/graph.json
+          test -f graphify-out/GRAPH_REPORT.md
+
+      - name: Verify graph contains nodes
+        run: |
+          python -c "
+          import json
+          with open('graphify-out/graph.json') as f:
+              data = json.load(f)
+          assert len(data.get('nodes', [])) > 0
+          print('Graph contains nodes')
+          "

--- a/.github/workflows/extraction-regression.yml
+++ b/.github/workflows/extraction-regression.yml
@@ -2,6 +2,10 @@ name: Extraction Regression
 
 on:
   pull_request:
+    paths:
+      - 'graphify/**'
+      - 'tests/**'
+      - 'pyproject.toml'
   workflow_dispatch:
 
 jobs:
@@ -29,7 +33,7 @@ jobs:
 
       - name: Run graph extraction
         run: |
-          graphify fixture --no-viz
+          graphify extract fixture
 
       - name: Verify graph outputs exist
         run: |
@@ -45,3 +49,4 @@ jobs:
           assert len(data.get('nodes', [])) > 0
           print('Graph contains nodes')
           "
+          


### PR DESCRIPTION
## Summary

Adds a lightweight end-to-end extraction regression workflow that:

* creates a tiny local fixture corpus
* runs graphify extraction
* verifies graph outputs are generated successfully
* checks graph.json contains nodes

## Why

Current CI validates installation and tests, but does not explicitly verify minimal graph extraction behavior end-to-end.

This workflow helps catch silent extraction regressions while remaining lightweight and fully local-first.

## Scope

Intentionally small and low-risk:

* no architecture changes
* no infrastructure additions
* no runtime behavior changes
* minimal fixture footprint