### PR TITLE
feat(llm): add openrouter backend support with configurable API and model options

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -115,6 +115,20 @@ BACKENDS: dict[str, dict] = {
         "temperature": 0,
         "max_tokens": 16384,
     },
+    "openrouter": {
+        # Routes through OpenRouter's OpenAI-compatible API proxy, which can connect to various backends including Kimi and Gemini. 
+        # Honours the same env var overrides as the underlying backend (e.g. GRAPHIFY_OPENROUTER_MODEL) but 
+        # with a separate API key (e.g. OPENROUTER_API_KEY).
+        # Default model is set to qwen/qwen3.6-flash as it's a strong open-source model that performs well on code tasks and 
+        # is widely accessible via OpenRouter, but users can override with any model supported by their OpenRouter account.
+        "base_url": "https://openrouter.ai/api/v1",
+        "default_model": "qwen/qwen3.6-flash",
+        "env_keys": ["OPENROUTER_API_KEY"],
+        "model_env_key": "GRAPHIFY_OPENROUTER_MODEL",
+        "pricing": {"input": 0.0, "output": 0.0},
+        "temperature": 0,
+        "max_tokens": 16384,
+    },
 }
 
 

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -117,15 +117,14 @@ BACKENDS: dict[str, dict] = {
     },
     "openrouter": {
         # Routes through OpenRouter's OpenAI-compatible API proxy, which can connect to various backends including Kimi and Gemini. 
-        # Honours the same env var overrides as the underlying backend (e.g. GRAPHIFY_OPENROUTER_MODEL) but 
-        # with a separate API key (e.g. OPENROUTER_API_KEY).
-        # Default model is set to qwen/qwen3.6-flash as it's a strong open-source model that performs well on code tasks and 
+        # Default model is set to qwen/qwen3.6-flash as it's a cheap and well-performing model with low latency, and 
         # is widely accessible via OpenRouter, but users can override with any model supported by their OpenRouter account.
         "base_url": "https://openrouter.ai/api/v1",
         "default_model": "qwen/qwen3.6-flash",
         "env_keys": ["OPENROUTER_API_KEY"],
         "model_env_key": "GRAPHIFY_OPENROUTER_MODEL",
-        "pricing": {"input": 0.0, "output": 0.0},
+        # Pricing set for default model, others may be different
+        "pricing": {"input": 0.1875, "output": 1.125},
         "temperature": 0,
         "max_tokens": 16384,
     },


### PR DESCRIPTION
This pull request adds support for OpenRouter as a new LLM backend in the `graphify/llm.py` configuration. The main change is the introduction of a configuration block for OpenRouter, allowing users to route requests through OpenRouter's OpenAI-compatible API proxy and select from a variety of models.

New LLM backend support:

* Added an `openrouter` configuration to the LLM backends, setting up default parameters, environment variable keys, and documentation for using OpenRouter's API proxy with a default model of `qwen/qwen3.6-flash`.…options