### PR TITLE
fix: prevent bare-name node ID collisions across files (fixes #952)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2056,9 +2056,6 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
 
     def ensure_named_node(name: str, line: int) -> str:
         nid = _make_id(stem, name)
-        if nid in seen_ids:
-            return nid
-        nid = _make_id(name)
         if nid not in seen_ids:
             add_node(nid, name, line)
         return nid
@@ -2114,16 +2111,14 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                             base = _read_text(arg, source)
                             base_nid = _make_id(stem, base)
                             if base_nid not in seen_ids:
-                                base_nid = _make_id(base)
-                                if base_nid not in seen_ids:
-                                    nodes.append({
-                                        "id": base_nid,
-                                        "label": base,
-                                        "file_type": "code",
-                                        "source_file": "",
-                                        "source_location": "",
-                                    })
-                                    seen_ids.add(base_nid)
+                                nodes.append({
+                                    "id": base_nid,
+                                    "label": base,
+                                    "file_type": "code",
+                                    "source_file": "",
+                                    "source_location": "",
+                                })
+                                seen_ids.add(base_nid)
                             add_edge(class_nid, base_nid, "inherits", line)
 
             # Swift-specific: conformance / inheritance
@@ -2187,16 +2182,14 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                         return
                     base_nid = _make_id(stem, base_name)
                     if base_nid not in seen_ids:
-                        base_nid = _make_id(base_name)
-                        if base_nid not in seen_ids:
-                            nodes.append({
-                                "id": base_nid,
-                                "label": base_name,
-                                "file_type": "code",
-                                "source_file": "",
-                                "source_location": "",
-                            })
-                            seen_ids.add(base_nid)
+                        nodes.append({
+                            "id": base_nid,
+                            "label": base_name,
+                            "file_type": "code",
+                            "source_file": "",
+                            "source_location": "",
+                        })
+                        seen_ids.add(base_nid)
                     add_edge(class_nid, base_nid, rel, at_line)
 
                 for child in node.children:
@@ -2253,16 +2246,14 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                             continue
                         base_nid = _make_id(stem, base)
                         if base_nid not in seen_ids:
-                            base_nid = _make_id(base)
-                            if base_nid not in seen_ids:
-                                nodes.append({
-                                    "id": base_nid,
-                                    "label": base,
-                                    "file_type": "code",
-                                    "source_file": "",
-                                    "source_location": "",
-                                })
-                                seen_ids.add(base_nid)
+                            nodes.append({
+                                "id": base_nid,
+                                "label": base,
+                                "file_type": "code",
+                                "source_file": "",
+                                "source_location": "",
+                            })
+                            seen_ids.add(base_nid)
                         add_edge(class_nid, base_nid, relation, line)
                         for arg_child in user_type_node.children:
                             if arg_child.type != "type_arguments":
@@ -2301,16 +2292,14 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                             continue
                         base_nid = _make_id(stem, base)
                         if base_nid not in seen_ids:
-                            base_nid = _make_id(base)
-                            if base_nid not in seen_ids:
-                                nodes.append({
-                                    "id": base_nid,
-                                    "label": base,
-                                    "file_type": "code",
-                                    "source_file": "",
-                                    "source_location": "",
-                                })
-                                seen_ids.add(base_nid)
+                            nodes.append({
+                                "id": base_nid,
+                                "label": base,
+                                "file_type": "code",
+                                "source_file": "",
+                                "source_location": "",
+                            })
+                            seen_ids.add(base_nid)
                         relation = _csharp_classify_base(base, csharp_interface_names)
                         add_edge(class_nid, base_nid, relation, line)
                         if sub.type == "generic_name":
@@ -2334,16 +2323,14 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                         return
                     base_nid = _make_id(stem, base_name)
                     if base_nid not in seen_ids:
-                        base_nid = _make_id(base_name)
-                        if base_nid not in seen_ids:
-                            nodes.append({
-                                "id": base_nid,
-                                "label": base_name,
-                                "file_type": "code",
-                                "source_file": "",
-                                "source_location": "",
-                            })
-                            seen_ids.add(base_nid)
+                        nodes.append({
+                            "id": base_nid,
+                            "label": base_name,
+                            "file_type": "code",
+                            "source_file": "",
+                            "source_location": "",
+                        })
+                        seen_ids.add(base_nid)
                     add_edge(class_nid, base_nid, rel, at_line)
 
                 sup = node.child_by_field_name("superclass")
@@ -2403,16 +2390,14 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                             continue
                         base_nid = _make_id(stem, base)
                         if base_nid not in seen_ids:
-                            base_nid = _make_id(base)
-                            if base_nid not in seen_ids:
-                                nodes.append({
-                                    "id": base_nid,
-                                    "label": base,
-                                    "file_type": "code",
-                                    "source_file": "",
-                                    "source_location": "",
-                                })
-                                seen_ids.add(base_nid)
+                            nodes.append({
+                                "id": base_nid,
+                                "label": base,
+                                "file_type": "code",
+                                "source_file": "",
+                                "source_location": "",
+                            })
+                            seen_ids.add(base_nid)
                         add_edge(class_nid, base_nid, "inherits", line)
 
             # Find body and recurse

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2463,9 +2463,6 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
 
     def ensure_named_node(name: str, line: int) -> str:
         nid = _make_id(stem, name)
-        if nid in seen_ids:
-            return nid
-        nid = _make_id(name)
         if nid not in seen_ids:
             # The name isn't defined in this file, so this is a cross-file reference
             # (e.g. a `Thing` type annotation imported from another module). Emit a
@@ -2556,16 +2553,14 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                             base = _read_text(arg, source)
                             base_nid = _make_id(stem, base)
                             if base_nid not in seen_ids:
-                                base_nid = _make_id(base)
-                                if base_nid not in seen_ids:
-                                    nodes.append({
-                                        "id": base_nid,
-                                        "label": base,
-                                        "file_type": "code",
-                                        "source_file": "",
-                                        "source_location": "",
-                                    })
-                                    seen_ids.add(base_nid)
+                                nodes.append({
+                                    "id": base_nid,
+                                    "label": base,
+                                    "file_type": "code",
+                                    "source_file": "",
+                                    "source_location": "",
+                                })
+                                seen_ids.add(base_nid)
                             add_edge(class_nid, base_nid, "inherits", line)
 
             # Swift-specific: conformance / inheritance
@@ -2629,16 +2624,14 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                         return
                     base_nid = _make_id(stem, base_name)
                     if base_nid not in seen_ids:
-                        base_nid = _make_id(base_name)
-                        if base_nid not in seen_ids:
-                            nodes.append({
-                                "id": base_nid,
-                                "label": base_name,
-                                "file_type": "code",
-                                "source_file": "",
-                                "source_location": "",
-                            })
-                            seen_ids.add(base_nid)
+                        nodes.append({
+                            "id": base_nid,
+                            "label": base_name,
+                            "file_type": "code",
+                            "source_file": "",
+                            "source_location": "",
+                        })
+                        seen_ids.add(base_nid)
                     add_edge(class_nid, base_nid, rel, at_line)
 
                 for child in node.children:
@@ -2695,16 +2688,14 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                             continue
                         base_nid = _make_id(stem, base)
                         if base_nid not in seen_ids:
-                            base_nid = _make_id(base)
-                            if base_nid not in seen_ids:
-                                nodes.append({
-                                    "id": base_nid,
-                                    "label": base,
-                                    "file_type": "code",
-                                    "source_file": "",
-                                    "source_location": "",
-                                })
-                                seen_ids.add(base_nid)
+                            nodes.append({
+                                "id": base_nid,
+                                "label": base,
+                                "file_type": "code",
+                                "source_file": "",
+                                "source_location": "",
+                            })
+                            seen_ids.add(base_nid)
                         add_edge(class_nid, base_nid, relation, line)
                         for arg_child in user_type_node.children:
                             if arg_child.type != "type_arguments":
@@ -2743,16 +2734,14 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                             continue
                         base_nid = _make_id(stem, base)
                         if base_nid not in seen_ids:
-                            base_nid = _make_id(base)
-                            if base_nid not in seen_ids:
-                                nodes.append({
-                                    "id": base_nid,
-                                    "label": base,
-                                    "file_type": "code",
-                                    "source_file": "",
-                                    "source_location": "",
-                                })
-                                seen_ids.add(base_nid)
+                            nodes.append({
+                                "id": base_nid,
+                                "label": base,
+                                "file_type": "code",
+                                "source_file": "",
+                                "source_location": "",
+                            })
+                            seen_ids.add(base_nid)
                         relation = _csharp_classify_base(base, csharp_interface_names)
                         add_edge(class_nid, base_nid, relation, line)
                         if sub.type == "generic_name":
@@ -2776,16 +2765,14 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                         return
                     base_nid = _make_id(stem, base_name)
                     if base_nid not in seen_ids:
-                        base_nid = _make_id(base_name)
-                        if base_nid not in seen_ids:
-                            nodes.append({
-                                "id": base_nid,
-                                "label": base_name,
-                                "file_type": "code",
-                                "source_file": "",
-                                "source_location": "",
-                            })
-                            seen_ids.add(base_nid)
+                        nodes.append({
+                            "id": base_nid,
+                            "label": base_name,
+                            "file_type": "code",
+                            "source_file": "",
+                            "source_location": "",
+                        })
+                        seen_ids.add(base_nid)
                     add_edge(class_nid, base_nid, rel, at_line)
 
                 sup = node.child_by_field_name("superclass")
@@ -2894,16 +2881,14 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                             continue
                         base_nid = _make_id(stem, base)
                         if base_nid not in seen_ids:
-                            base_nid = _make_id(base)
-                            if base_nid not in seen_ids:
-                                nodes.append({
-                                    "id": base_nid,
-                                    "label": base,
-                                    "file_type": "code",
-                                    "source_file": "",
-                                    "source_location": "",
-                                })
-                                seen_ids.add(base_nid)
+                            nodes.append({
+                                "id": base_nid,
+                                "label": base,
+                                "file_type": "code",
+                                "source_file": "",
+                                "source_location": "",
+                            })
+                            seen_ids.add(base_nid)
                         add_edge(class_nid, base_nid, "inherits", line)
 
             # Find body and recurse


### PR DESCRIPTION
## Problem
_extract_generic fell back to _make_id(name) (bare name, no stem qualifier) when the stem-qualified ID was not found in the per-file seen_ids. Two files with the same function or class name in different directories would produce identical bare-name IDs -- NetworkX's add_node silently overwrites duplicates, causing one entity to be lost entirely from the graph.

## Fix
Removed the bare-name fallback in:
1. ensure_named_node() — always uses _make_id(stem, name)
2. Generic superclass resolution in walk()
3. Swift inheritance specifiers
4. C# base type resolution
5. Java _emit_java_parent
6. C++ inheritance specifiers

All symbol nodes now use stem-qualified IDs only. The existing _disambiguate_colliding_node_ids post-pass catches any remaining collisions (e.g., a/b/utils.py vs c/b/utils.py where _file_stem alone is not enough).