### PR TITLE
fix: use relative paths in manifest, .graphify_root, and cache for cross-platform portability (fixes #777)

### DIFF
--- a/graphify/cache.py
+++ b/graphify/cache.py
@@ -289,6 +289,17 @@ def cache_dir(root: Path = Path("."), kind: str = "ast") -> Path:
     return d
 
 
+def _reanchor_source_file(p: str, root: Path) -> str:
+    """If p is a relative path, resolve it against root; otherwise return as-is."""
+    try:
+        candidate = Path(p)
+        if not candidate.is_absolute():
+            return str((root.resolve() / candidate).resolve())
+    except (OSError, ValueError):
+        pass
+    return p
+
+
 def load_cached(path: Path, root: Path = Path("."), kind: str = "ast") -> dict | None:
     """Return cached extraction for this file if hash matches, else None.
 

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1348,7 +1348,7 @@ def detect_incremental(
         if Path(key).is_absolute():
             reanchored[key] = val
         else:
-            reanchored[os.path.normpath(os.path.join(root_str, key))] = val
+            reanchored[str(Path(root_str) / key)] = val
     manifest = reanchored
 
     if not manifest:

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1341,6 +1341,16 @@ def detect_incremental(
     # against. Legacy absolute-keyed manifests pass through unchanged.
     manifest = load_manifest(manifest_path, root=root)
 
+    # Re-anchor relative manifest keys to absolute paths for comparison with detect() output (#777)
+    root_str = str(root.resolve())
+    reanchored: dict[str, dict] = {}
+    for key, val in manifest.items():
+        if Path(key).is_absolute():
+            reanchored[key] = val
+        else:
+            reanchored[os.path.normpath(os.path.join(root_str, key))] = val
+    manifest = reanchored
+
     if not manifest:
         # No previous run - treat everything as new
         full["incremental"] = True


### PR DESCRIPTION
## Problem
Three artifacts contained absolute machine-specific paths, breaking git-shared graphify-out/ across different machines and platforms:
1. manifest.json keys
2. .graphify_root content
3. cache/ast/*.json source_file fields

## Fix
- save_manifest() — relativizes keys against root via Path.relative_to().as_posix() for POSIX separators
- detect_incremental() — re-anchors relative manifest keys back to absolute using Path() join
- .graphify_root — writes user-provided watch_path (often .) instead of resolved absolute watch_root
- save_cached() / load_cached() — relativize/re-anchor source_file fields in nodes and edges
- _reanchor_source_file() helper in cache.py — handles legacy absolute-path entries
- __main__.py passes root= to save_manifest() calls

All backward compatible: absolute paths that escape root are preserved as-is in each layer.