### PR TITLE
Fix Lua require file-level edge resolution

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1219,6 +1219,99 @@ def _resolve_js_import_target(raw: str, str_path: str) -> "tuple[str, Path | Non
     return _make_id(module_name), None
 
 
+def _file_node_id(path: Path, root: Path | None = None) -> str:
+    """Return the graph node id for a file path, relative to root when possible."""
+    if root is not None:
+        try:
+            return _make_id(str(path.relative_to(root)))
+        except ValueError:
+            pass
+    return _make_id(str(path))
+
+
+def _iter_lua_requires(path: Path) -> list[tuple[str, int]]:
+    """Collect Lua require() module strings and 1-based line numbers from a file."""
+    try:
+        import tree_sitter_lua as tslua
+        from tree_sitter import Language, Parser
+    except ImportError:
+        return []
+
+    try:
+        source = path.read_bytes()
+    except OSError:
+        return []
+
+    parser = Parser(Language(tslua.language()))
+    try:
+        tree = parser.parse(source)
+    except Exception:
+        return []
+
+    requires: list[tuple[str, int]] = []
+    seen: set[tuple[str, int]] = set()
+
+    def walk(node) -> None:
+        if node.type == "function_call":
+            named_children = [child for child in node.children if child.is_named]
+            callee = named_children[0] if named_children else None
+            if callee is not None and callee.type == "identifier":
+                if source[callee.start_byte:callee.end_byte].decode("utf-8", errors="replace") == "require":
+                    args = next((child for child in node.children if child.type == "arguments"), None)
+                    if args is not None:
+                        for child in args.children:
+                            if child.type != "string":
+                                continue
+                            raw = source[child.start_byte:child.end_byte].decode("utf-8", errors="replace").strip("'\"` ")
+                            if raw:
+                                item = (raw, node.start_point[0] + 1)
+                                if item not in seen:
+                                    requires.append(item)
+                                    seen.add(item)
+                            break
+        for child in node.children:
+            walk(child)
+
+    walk(tree.root_node)
+    return requires
+
+
+def _resolve_lua_module_path(raw: str, source_path: Path, root: Path, path_set: set[Path]) -> Path | None:
+    """Resolve a Lua dotted module path to a file within the extracted corpus."""
+    raw = raw.strip().strip("'\"` ")
+    if not raw:
+        return None
+
+    parts = [part for part in raw.split(".") if part]
+    if not parts:
+        return None
+
+    module_base = Path(*parts)
+    bases: list[Path] = []
+    seen_bases: set[Path] = set()
+    for base in [source_path.parent, *source_path.parents]:
+        if base in seen_bases:
+            continue
+        bases.append(base)
+        seen_bases.add(base)
+        if base == root:
+            break
+    if root not in seen_bases:
+        bases.append(root)
+
+    for base in bases:
+        for candidate in (
+            (base / module_base).with_suffix(".lua"),
+            (base / module_base).with_suffix(".luau"),
+            base / module_base / "init.lua",
+            base / module_base / "init.luau",
+        ):
+            resolved = candidate.resolve()
+            if resolved in path_set:
+                return resolved
+    return None
+
+
 def _import_js(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str) -> None:
     is_reexport = node.type == "export_statement"
     # Only handle export_statement if it has a `from` clause (re-export).
@@ -7274,6 +7367,55 @@ def _merge_swift_extensions(
     all_edges[:] = rewritten
 
 
+def _resolve_cross_file_lua_imports(
+    paths: list[Path],
+    root: Path,
+) -> list[dict]:
+    """Resolve Lua require() calls to file-level imports_from edges.
+
+    This post-pass looks across the extracted corpus so dotted module names like
+    `pkg.mod` can be resolved to actual file nodes such as `pkg/mod.lua`.
+    """
+    lua_paths = [p.resolve() for p in paths if p.suffix in {".lua", ".luau"}]
+    if not lua_paths:
+        return []
+
+    path_set = set(lua_paths)
+    new_edges: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+
+    for path in lua_paths:
+        src_nid = _file_node_id(path, root)
+        try:
+            source_file = str(path.relative_to(root))
+        except ValueError:
+            source_file = str(path)
+        for raw, line in _iter_lua_requires(path):
+            resolved = _resolve_lua_module_path(raw, path, root, path_set)
+            if resolved is None:
+                continue
+            tgt_nid = _file_node_id(resolved, root)
+            if src_nid == tgt_nid:
+                continue
+            key = (src_nid, tgt_nid, "imports_from")
+            if key in seen:
+                continue
+            seen.add(key)
+            new_edges.append({
+                "source": src_nid,
+                "target": tgt_nid,
+                "relation": "imports_from",
+                "context": "import",
+                "confidence": "EXTRACTED",
+                "confidence_score": 1.0,
+                "source_file": source_file,
+                "source_location": f"L{line}",
+                "weight": 1.0,
+            })
+
+    return new_edges
+
+
 def _resolve_cross_file_java_imports(
     per_file: list[dict],
     paths: list[Path],
@@ -10379,6 +10521,15 @@ def extract(
         except Exception as exc:
             import logging
             logging.getLogger(__name__).warning("Java cross-file import resolution failed, skipping: %s", exc)
+
+    # Cross-file Lua require() resolution to file-level dependency edges
+    lua_paths = [p for p in paths if p.suffix in {".lua", ".luau"}]
+    if lua_paths:
+        try:
+            all_edges.extend(_resolve_cross_file_lua_imports(lua_paths, root))
+        except Exception as exc:
+            import logging
+            logging.getLogger(__name__).warning("Lua cross-file import resolution failed, skipping: %s", exc)
 
     # Cross-file call resolution for all languages
     # Each extractor saved unresolved calls in raw_calls. Now that we have all

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1276,8 +1276,19 @@ def _iter_lua_requires(path: Path) -> list[tuple[str, int]]:
     return requires
 
 
-def _resolve_lua_module_path(raw: str, source_path: Path, root: Path, path_set: set[Path]) -> Path | None:
-    """Resolve a Lua dotted module path to a file within the extracted corpus."""
+def _resolve_lua_module_path(
+    raw: str,
+    source_path: Path,
+    root: Path,
+    logical_paths: set[Path],
+    resolved_to_logical: dict[Path, Path],
+) -> Path | None:
+    """Resolve a Lua dotted module path to a file within the extracted corpus.
+
+    Returns the logical corpus path, not the fully resolved filesystem path, so
+    file node ids stay aligned with the rest of extraction even when the corpus
+    contains symlinks.
+    """
     raw = raw.strip().strip("'\"` ")
     if not raw:
         return None
@@ -1306,9 +1317,15 @@ def _resolve_lua_module_path(raw: str, source_path: Path, root: Path, path_set: 
             base / module_base / "init.lua",
             base / module_base / "init.luau",
         ):
-            resolved = candidate.resolve()
-            if resolved in path_set:
-                return resolved
+            if candidate in logical_paths:
+                return candidate
+            try:
+                resolved = candidate.resolve()
+            except OSError:
+                continue
+            logical = resolved_to_logical.get(resolved)
+            if logical is not None:
+                return logical
     return None
 
 
@@ -7376,22 +7393,26 @@ def _resolve_cross_file_lua_imports(
     This post-pass looks across the extracted corpus so dotted module names like
     `pkg.mod` can be resolved to actual file nodes such as `pkg/mod.lua`.
     """
-    lua_paths = [p.resolve() for p in paths if p.suffix in {".lua", ".luau"}]
+    lua_paths = [p for p in paths if p.suffix in {".lua", ".luau"}]
     if not lua_paths:
         return []
 
-    path_set = set(lua_paths)
+    logical_paths = set(lua_paths)
+    resolved_to_logical: dict[Path, Path] = {}
+    for path in lua_paths:
+        try:
+            resolved_to_logical.setdefault(path.resolve(), path)
+        except OSError:
+            pass
+
     new_edges: list[dict] = []
     seen: set[tuple[str, str, str]] = set()
 
     for path in lua_paths:
         src_nid = _file_node_id(path, root)
-        try:
-            source_file = str(path.relative_to(root))
-        except ValueError:
-            source_file = str(path)
+        source_file = str(path)
         for raw, line in _iter_lua_requires(path):
-            resolved = _resolve_lua_module_path(raw, path, root, path_set)
+            resolved = _resolve_lua_module_path(raw, path, root, logical_paths, resolved_to_logical)
             if resolved is None:
                 continue
             tgt_nid = _file_node_id(resolved, root)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -427,6 +427,64 @@ def test_extract_js_arrow_function_still_extracted():
         arrow_fixture.unlink()
 
 
+def test_extract_lua_require_emits_file_level_imports_from(tmp_path):
+    caller = tmp_path / "a.lua"
+    callee = tmp_path / "pkg/b.lua"
+    callee.parent.mkdir(parents=True)
+    caller.write_text(
+        'local b = require("pkg.b")\nreturn b\n',
+        encoding="utf-8",
+    )
+    callee.write_text(
+        'local M = {}\nreturn M\n',
+        encoding="utf-8",
+    )
+
+    result = extract([caller, callee], cache_root=tmp_path)
+    imports_from = [e for e in result["edges"] if e["relation"] == "imports_from"]
+
+    assert any(
+        e["source"] == _make_id("a.lua") and e["target"] == _make_id("pkg/b.lua")
+        for e in imports_from
+    )
+
+
+def test_extract_lua_require_supports_bare_nested_and_chained_forms(tmp_path):
+    caller = tmp_path / "main.lua"
+    files = {
+        "pkg.assigned": tmp_path / "pkg/assigned.lua",
+        "pkg.bare": tmp_path / "pkg/bare.lua",
+        "pkg.nested": tmp_path / "pkg/nested.lua",
+        "pkg.chained": tmp_path / "pkg/chained.lua",
+    }
+    for path in files.values():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('local M = {}\nreturn M\n', encoding="utf-8")
+
+    caller.write_text(
+        'local assigned = require("pkg.assigned")\n'
+        'require("pkg.bare")\n'
+        'some_fn(require("pkg.nested"))\n'
+        'local value = require("pkg.chained").x\n',
+        encoding="utf-8",
+    )
+
+    result = extract([caller, *files.values()], cache_root=tmp_path)
+    imports_from = {
+        (e["source"], e["target"])
+        for e in result["edges"]
+        if e["relation"] == "imports_from"
+    }
+
+    expected = {
+        (_make_id("main.lua"), _make_id("pkg/assigned.lua")),
+        (_make_id("main.lua"), _make_id("pkg/bare.lua")),
+        (_make_id("main.lua"), _make_id("pkg/nested.lua")),
+        (_make_id("main.lua"), _make_id("pkg/chained.lua")),
+    }
+    assert expected.issubset(imports_from)
+
+
 def test_cross_file_call_promoted_to_extracted_with_import_evidence(tmp_path):
     """A cross-file `calls` edge must be EXTRACTED when the caller's file has
     an `imports` or `imports_from` edge linking it to the callee."""

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -442,11 +442,18 @@ def test_extract_lua_require_emits_file_level_imports_from(tmp_path):
 
     result = extract([caller, callee], cache_root=tmp_path)
     imports_from = [e for e in result["edges"] if e["relation"] == "imports_from"]
+    file_nodes = {
+        n["source_file"]: n["id"]
+        for n in result["nodes"]
+        if n["label"].endswith(".lua")
+    }
 
-    assert any(
-        e["source"] == _make_id("a.lua") and e["target"] == _make_id("pkg/b.lua")
-        for e in imports_from
-    )
+    matched = [
+        e for e in imports_from
+        if e["source"] == file_nodes[str(caller)] and e["target"] == file_nodes[str(callee)]
+    ]
+    assert matched
+    assert matched[0]["source_file"] == str(caller)
 
 
 def test_extract_lua_require_supports_bare_nested_and_chained_forms(tmp_path):
@@ -475,14 +482,56 @@ def test_extract_lua_require_supports_bare_nested_and_chained_forms(tmp_path):
         for e in result["edges"]
         if e["relation"] == "imports_from"
     }
+    file_nodes = {
+        n["source_file"]: n["id"]
+        for n in result["nodes"]
+        if n["label"].endswith(".lua")
+    }
 
     expected = {
-        (_make_id("main.lua"), _make_id("pkg/assigned.lua")),
-        (_make_id("main.lua"), _make_id("pkg/bare.lua")),
-        (_make_id("main.lua"), _make_id("pkg/nested.lua")),
-        (_make_id("main.lua"), _make_id("pkg/chained.lua")),
+        (file_nodes[str(caller)], file_nodes[str(files["pkg.assigned"])]),
+        (file_nodes[str(caller)], file_nodes[str(files["pkg.bare"])]),
+        (file_nodes[str(caller)], file_nodes[str(files["pkg.nested"])]),
+        (file_nodes[str(caller)], file_nodes[str(files["pkg.chained"])]),
     }
     assert expected.issubset(imports_from)
+
+
+def test_extract_lua_require_uses_logical_symlink_paths_for_file_edges(tmp_path):
+    import sys
+
+    if sys.platform == "win32":
+        return
+
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    pkg_dir = tmp_path / "pkg"
+    pkg_dir.mkdir()
+    linked_dir = tmp_path / "src"
+    linked_dir.mkdir()
+
+    caller = linked_dir / "a.lua"
+    real_caller = real_dir / "a.lua"
+    callee = pkg_dir / "b.lua"
+
+    real_caller.write_text('local b = require("pkg.b")\nreturn b\n', encoding="utf-8")
+    callee.write_text('local M = {}\nreturn M\n', encoding="utf-8")
+    caller.symlink_to(real_caller)
+
+    result = extract([caller, callee], cache_root=tmp_path)
+    imports_from = [e for e in result["edges"] if e["relation"] == "imports_from"]
+    file_nodes = {
+        n["source_file"]: n["id"]
+        for n in result["nodes"]
+        if n["label"].endswith(".lua")
+    }
+
+    assert any(
+        e["source"] == file_nodes[str(caller)]
+        and e["target"] == file_nodes[str(callee)]
+        and e["source_file"] == str(caller)
+        for e in imports_from
+    )
 
 
 def test_cross_file_call_promoted_to_extracted_with_import_evidence(tmp_path):


### PR DESCRIPTION
## Summary
- add a Lua-specific post-pass that resolves `require()` module strings to file nodes and emits `imports_from` edges
- support bare, nested, assigned, and chained `require()` forms by collecting calls from the Lua AST
- add focused tests covering Lua file-level import edge extraction

## Why
Lua `require()` dependencies were being detected inconsistently at the file graph level, which meant inbound file edges were missing from `graph.json` and downstream consumers could not reliably answer "who imports this file?"

## Validation
- `python3 -m py_compile graphify/extract.py tests/test_extract.py`
- targeted Lua validation script covering assigned, bare, nested, and chained `require()` forms
- verified on a real Lua corpus that the patched extractor emits file-level `imports_from` edges

## Notes
I did not run the full pytest suite in this environment because `pytest` is not installed here.

Refs #1075
