### PR TITLE
Fix: Validate Python interpreter before using for graphify detection

### DIFF
--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -67,31 +67,41 @@ Only when the path is one or more `https://github.com/...` URLs, or several loca
 # Detect the correct Python interpreter (handles uv tool, pipx, venv, system installs)
 PYTHON=""
 GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-# 1. uv tool installs — most reliable on modern Mac/Linux
-if [ -z "$PYTHON" ] && command -v uv >/dev/null 2>&1; then
-    _UV_PY=$(uv tool run graphifyy python -c "import sys; print(sys.executable)" 2>/dev/null)
-    if [ -n "$_UV_PY" ]; then PYTHON="$_UV_PY"; fi
-fi
-# 2. Read shebang from graphify binary (pipx and direct pip installs)
-if [ -z "$PYTHON" ] && [ -n "$GRAPHIFY_BIN" ]; then
+
+# 1. Read shebang from graphify binary FIRST (most reliable - it's the actual install location)
+if [ -n "$GRAPHIFY_BIN" ]; then
     _SHEBANG=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
     case "$_SHEBANG" in
         *[!a-zA-Z0-9/_.-]*) ;;
-        *) "$_SHEBANG" -c "import graphify" 2>/dev/null && PYTHON="$_SHEBANG" ;;
+        *) if "$_SHEBANG" -c "import graphify" 2>/dev/null; then PYTHON="$_SHEBANG"; fi ;;
     esac
 fi
-# 3. Fall back to python3
+
+# 2. Try uv tool as fallback only if shebang didn't work
+if [ -z "$PYTHON" ] && command -v uv >/dev/null 2>&1; then
+    _UV_PY=$(uv tool run graphifyy python -c "import sys; print(sys.executable)" 2>/dev/null)
+    if [ -n "$_UV_PY" ] && "$_UV_PY" -c "import graphify" 2>/dev/null; then PYTHON="$_UV_PY"; fi
+fi
+
+# 3. Fall back to python3 as last resort
 if [ -z "$PYTHON" ]; then PYTHON="python3"; fi
 if ! "$PYTHON" -c "import graphify" 2>/dev/null; then
     if command -v uv >/dev/null 2>&1; then
         uv tool install --upgrade graphifyy -q 2>&1 | tail -3
         _UV_PY=$(uv tool run graphifyy python -c "import sys; print(sys.executable)" 2>/dev/null)
-        if [ -n "$_UV_PY" ]; then PYTHON="$_UV_PY"; fi
+        if [ -n "$_UV_PY" ] && "$_UV_PY" -c "import graphify" 2>/dev/null; then PYTHON="$_UV_PY"; fi
     else
         "$PYTHON" -m pip install graphifyy -q 2>/dev/null \
           || "$PYTHON" -m pip install graphifyy -q --break-system-packages 2>&1 | tail -3
     fi
 fi
+
+# Validate one final time before writing
+if ! "$PYTHON" -c "import graphify" 2>/dev/null; then
+    echo "ERROR: Could not find Python with graphify installed. Try: pip install graphifyy"
+    exit 1
+fi
+
 # Write interpreter path for all subsequent steps (persists across invocations)
 mkdir -p graphify-out
 "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"


### PR DESCRIPTION
## Problem

When graphify is installed via pipx but `uv` is also present on the system, the interpreter detection can return the wrong Python environment. This causes:

1. `.graphify_python` written with wrong Python path
2. `ModuleNotFoundError: No module named 'graphify'` on next run
3. `.graphify_detect.json` becomes empty (0 bytes)
4. Subsequent steps fail silently or regenerate files unexpectedly

## Root Cause

Step 1 checks `uv tool` first without validating that graphify is actually importable from the returned Python. The priority order was:
1. uv tool (no validation) ❌
2. graphify binary shebang (with validation) ✓
3. python3 fallback

## Solution

Reorder to check the most reliable source FIRST:
1. graphify binary shebang (with validation) ✓ — this is the authoritative source
2. uv tool as fallback (with validation) ✓
3. python3 fallback (with validation) ✓

Additionally, add final validation before writing to disk to prevent corrupted `.graphify_python` files.

## Changes

- Reorder interpreter detection priority (shebang first)
- Add validation after each detection method
- Add final validation before writing `.graphify_python`
- Add clear error message if all methods fail

## Testing

- When graphify is in pipx: uses correct pipx Python ✓
- When graphify is in uv tool: uses correct uv Python ✓
- When neither: falls back to system Python ✓
- If all fail: clear error message ✓