### PR TITLE
fix(extract): recover <script> imports from .vue Single-File Components

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3752,18 +3752,6 @@ def extract_svelte(path: Path) -> dict:
     return result
 
 
-def extract_vue(path: Path) -> dict:
-    """Extract imports from .vue Single-File Components.
-
-    A ``.vue`` SFC has the same ``<template>``/``<script>``/``<style>`` structure as a
-    ``.svelte`` file, so tree-sitter-javascript fed the whole file produces a top-level
-    ERROR node and the ``import_statement`` nodes inside ``<script>``/``<script setup>``
-    are never reached and silently dropped (#713). The Svelte recovery (static imports in
-    each ``<script>`` block plus dynamic ``import()``) applies identically, so reuse it.
-    """
-    return extract_svelte(path)
-
-
 def extract_astro(path: Path) -> dict:
     """Extract imports from .astro files: frontmatter (TS) + template regex fallback.
 
@@ -10583,7 +10571,12 @@ _DISPATCH: dict[str, Any] = {
     ".F03": extract_fortran,
     ".f08": extract_fortran,
     ".F08": extract_fortran,
-    ".vue": extract_vue,
+    # .vue SFCs share .svelte's <template>/<script>/<style> shape: the JS grammar fed the
+    # whole file yields an ERROR root, so <script> imports are only recoverable via the regex
+    # rescue extract_svelte already performs (#713) -- route .vue through it directly.
+    # (.vue intentionally diverges from .svelte at the JS symbol-resolution bypass; see the
+    # `path.suffix != ".vue"` guard above. That divergence is separate from extraction.)
+    ".vue": extract_svelte,
     ".svelte": extract_svelte,
     ".astro": extract_astro,
     ".dart": extract_dart,

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3752,6 +3752,18 @@ def extract_svelte(path: Path) -> dict:
     return result
 
 
+def extract_vue(path: Path) -> dict:
+    """Extract imports from .vue Single-File Components.
+
+    A ``.vue`` SFC has the same ``<template>``/``<script>``/``<style>`` structure as a
+    ``.svelte`` file, so tree-sitter-javascript fed the whole file produces a top-level
+    ERROR node and the ``import_statement`` nodes inside ``<script>``/``<script setup>``
+    are never reached and silently dropped (#713). The Svelte recovery (static imports in
+    each ``<script>`` block plus dynamic ``import()``) applies identically, so reuse it.
+    """
+    return extract_svelte(path)
+
+
 def extract_astro(path: Path) -> dict:
     """Extract imports from .astro files: frontmatter (TS) + template regex fallback.
 
@@ -10571,7 +10583,7 @@ _DISPATCH: dict[str, Any] = {
     ".F03": extract_fortran,
     ".f08": extract_fortran,
     ".F08": extract_fortran,
-    ".vue": extract_js,
+    ".vue": extract_vue,
     ".svelte": extract_svelte,
     ".astro": extract_astro,
     ".dart": extract_dart,

--- a/tests/test_vue_extraction.py
+++ b/tests/test_vue_extraction.py
@@ -1,0 +1,54 @@
+"""Tests for `.vue` extraction.
+
+A `.vue` Single-File Component has the same ``<template>``/``<script>``/``<style>``
+structure as a ``.svelte`` file: tree-sitter-javascript fed the whole file produces a
+top-level ERROR node (the markup is not valid JS), so the JS AST pass never reaches the
+``import_statement`` nodes inside ``<script>``/``<script setup>`` and they are silently
+dropped. The Svelte regex rescue (#713) recovers them, and ``.vue`` reuses it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify.detect import CODE_EXTENSIONS
+from graphify.extract import _get_extractor, _make_id
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _import_targets(result: dict, *, relation: str | None = None) -> set[str]:
+    return {
+        str(e.get("target") or "")
+        for e in result.get("edges", [])
+        if relation is None or e.get("relation") == relation
+    }
+
+
+def test_vue_is_in_code_extensions():
+    assert ".vue" in CODE_EXTENSIONS
+
+
+def test_extract_vue_picks_up_script_static_imports(tmp_path):
+    page = _write(
+        tmp_path / "src/App.vue",
+        """<script setup>
+import Hero from './components/Hero.vue';
+</script>
+
+<template>
+  <Hero />
+</template>
+""",
+    )
+    # Sibling file so the resolver lands on a real node id, not a phantom.
+    hero = _write(tmp_path / "src/components/Hero.vue", "<template><h1>hi</h1></template>\n")
+
+    extractor = _get_extractor(page)
+    result = extractor(page)
+    targets = _import_targets(result, relation="imports_from")
+    assert _make_id(str(hero)) in targets

--- a/tests/test_vue_extraction.py
+++ b/tests/test_vue_extraction.py
@@ -52,3 +52,45 @@ import Hero from './components/Hero.vue';
     result = extractor(page)
     targets = _import_targets(result, relation="imports_from")
     assert _make_id(str(hero)) in targets
+
+
+def test_extract_vue_picks_up_dynamic_import(tmp_path):
+    page = _write(
+        tmp_path / "src/App.vue",
+        """<script setup>
+const Lazy = await import('./components/Lazy.vue');
+</script>
+
+<template>
+  <Lazy />
+</template>
+""",
+    )
+    lazy = _write(tmp_path / "src/components/Lazy.vue", "<template><h1>lazy</h1></template>\n")
+
+    extractor = _get_extractor(page)
+    result = extractor(page)
+    targets = _import_targets(result, relation="dynamic_import")
+    assert _make_id(str(lazy)) in targets
+
+
+def test_extract_vue_picks_up_lang_ts_script_imports(tmp_path):
+    # The <script> regex matches attributes like `lang="ts"`, so a TypeScript SFC's
+    # static imports are still recovered.
+    page = _write(
+        tmp_path / "src/App.vue",
+        """<script setup lang="ts">
+import Hero from './components/Hero.vue';
+</script>
+
+<template>
+  <Hero />
+</template>
+""",
+    )
+    hero = _write(tmp_path / "src/components/Hero.vue", "<template><h1>hi</h1></template>\n")
+
+    extractor = _get_extractor(page)
+    result = extractor(page)
+    targets = _import_targets(result, relation="imports_from")
+    assert _make_id(str(hero)) in targets


### PR DESCRIPTION
## Summary

`.vue` files were dispatched to `extract_js`, which feeds the **whole** Single-File Component to the JavaScript tree-sitter grammar. A `.vue` file is not valid JS — it is `<template>`/`<script>`/`<style>` — so the parser produces a top-level `ERROR` node and the `import_statement` nodes inside `<script>`/`<script setup>` are never reached. The imports are silently dropped, leaving `.vue` files as disconnected nodes in the knowledge graph.

This is the **same problem already solved for `.svelte`** (#713): the JS grammar fed a full `.svelte` file also produces an ERROR root, so `extract_svelte` recovers imports with a regex pass over each `<script>` block (plus dynamic `import()`). The maintainer awareness is already in the code — `_get_extractor`/symbol-resolution treats `.vue` as non-JS at `extract.py` (`path.suffix != ".vue"` guard) — but the main extraction path still fed the whole SFC to the JS grammar.

## Fix

Add `extract_vue`, which reuses the Svelte SFC recovery (`<script>`-block static imports + dynamic `import()`) since a Vue SFC has the identical structure, and route `.vue` to it.

## Verification

Added `tests/test_vue_extraction.py` (modeled on `tests/test_astro_extraction.py`): a `.vue` SFC whose `<script setup>` statically imports a sibling `.vue` component is extracted through the real dispatch (`_get_extractor`) and the import edge is asserted. Verified it fails before the fix (the import is dropped) and passes after. `tests/test_astro_extraction.py`, `tests/test_js_import_resolution.py`, and `tests/test_import_extension_resolution.py` remain green (the fix is additive — `extract_svelte` is unchanged); `ruff check` clean.