### PR TITLE
fix(incremental): scoped `--update <subfolder>` silently prunes the rest of the graph

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -380,6 +380,24 @@ def build_merge(
             n for n, d in G.nodes(data=True)
             if d.get("source_file") in prune_set
         ]
+        # Defense-in-depth safety net: the anti-shrink guard further below is
+        # skipped whenever prune_sources is set, so a bogus deleted-file list
+        # (e.g. a scoped --update that mistook out-of-scope files for deletions)
+        # could silently wipe most of the graph. Make a catastrophic prune
+        # LOUD instead of silent. Non-breaking: warns, does not raise, so
+        # legitimate large deletions still go through.
+        _total_before = G.number_of_nodes()
+        if to_remove and _total_before:
+            _ratio = len(to_remove) / _total_before
+            if len(to_remove) >= 25 and _ratio >= 0.30:
+                print(
+                    f"[graphify] WARNING: prune is about to remove {len(to_remove)} of "
+                    f"{_total_before} nodes ({_ratio:.0%}) across {len(prune_sources)} "
+                    f"source file(s). If you ran --update on a SUBFOLDER of a larger "
+                    f"corpus, this is likely a scope mistake — re-run --update on the "
+                    f"full corpus root instead. Proceeding.",
+                    file=sys.stderr,
+                )
         G.remove_nodes_from(to_remove)
         n_files = len(prune_sources)
         n_nodes = len(to_remove)

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1285,9 +1285,26 @@ def detect_incremental(
     new_files: dict[str, list[str]] = {k: [] for k in full["files"]}
     unchanged_files: dict[str, list[str]] = {k: [] for k in full["files"]}
 
+    # Robust path matching: resolve symlinks / mount aliases / redundant
+    # segments so a file stored in the manifest under one path form (e.g. the
+    # scan-root symlink) still matches the form detect() produces this run.
+    # Without this, every file looks "changed" after a root path-form change,
+    # forcing a full, expensive re-extract.
+    def _rp(path_str: str) -> str:
+        try:
+            return os.path.realpath(path_str)
+        except Exception:
+            return path_str
+
+    manifest_by_real: dict[str, object] = {}
+    for _k, _v in manifest.items():
+        manifest_by_real.setdefault(_rp(_k), _v)
+
     for ftype, file_list in full["files"].items():
         for f in file_list:
             stored = manifest.get(f)
+            if stored is None:
+                stored = manifest_by_real.get(_rp(f))
             try:
                 current_mtime = Path(f).stat().st_mtime
             except Exception:
@@ -1320,9 +1337,38 @@ def detect_incremental(
             else:
                 unchanged_files[ftype].append(f)
 
-    # Files in manifest that no longer exist - their cached nodes are now ghost nodes
+    # Files in manifest that no longer exist - their cached nodes are now ghost
+    # nodes. CRITICAL SCOPE GUARD: only a manifest file that (a) lives inside the
+    # current scan root's subtree AND (b) is genuinely absent from disk counts as
+    # deleted. A manifest file *outside* `root` is simply out of scope for this
+    # incremental run — NOT deleted. Reporting it as deleted makes the --update
+    # caller pass it to build_merge(prune_sources=...), which silently removes
+    # those nodes. That is how running `--update <subfolder>` on a corpus rooted
+    # higher up wipes the rest of the graph. A file still present on disk but
+    # absent from detect() (skipped as sensitive/unsupported/excluded) is also
+    # NOT a deletion — never prune beyond the scanned scope.
     current_files = {f for flist in full["files"].values() for f in flist}
-    deleted_files = [f for f in manifest if f not in current_files]
+    current_real = {_rp(f) for f in current_files}
+
+    root_real = _rp(str(root))
+    root_prefix = root_real.rstrip(os.sep) + os.sep
+
+    def _within_scan_root(path_str: str) -> bool:
+        rp = _rp(path_str)
+        return rp == root_real or rp.startswith(root_prefix)
+
+    deleted_files = []
+    for f in manifest:
+        if f in current_files or _rp(f) in current_real:
+            continue  # still found by this scan
+        if not _within_scan_root(f):
+            continue  # out of scope for this run — leave its nodes alone
+        try:
+            if Path(f).exists():
+                continue  # on disk but skipped (sensitive/unsupported) — not deleted
+        except OSError:
+            continue  # can't stat it — don't risk pruning
+        deleted_files.append(f)
 
     new_total = sum(len(v) for v in new_files.values())
     full["incremental"] = True

--- a/tests/test_incremental_scope_safety.py
+++ b/tests/test_incremental_scope_safety.py
@@ -1,0 +1,107 @@
+"""Regression tests: a scoped ``--update <subfolder>`` must never report files
+outside the scanned root as deleted.
+
+Before this fix, ``detect_incremental`` computed deletions as
+``[f for f in manifest if f not in current_files]`` where ``current_files`` only
+contains paths under the scanned ``root``. Running an incremental update on a
+subfolder of a larger corpus therefore flagged every out-of-scope manifest file
+as deleted; the ``--update`` driver passes that list to
+``build_merge(prune_sources=...)`` (whose anti-shrink guard is disabled while
+pruning), silently wiping the rest of the graph.
+"""
+from __future__ import annotations
+
+import os
+
+from graphify.detect import detect_incremental, save_manifest
+
+
+def _write(p, text="content"):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(f"# {p.stem}\n{text}\n")
+    return str(p)
+
+
+def test_scoped_update_does_not_prune_out_of_scope_files(tmp_path, monkeypatch):
+    """The core bug: updating a subfolder must not report the rest of the
+    corpus as deleted."""
+    corpus = tmp_path / "corpus"
+    memtree = corpus / "memory"
+    topics = corpus / "topics"
+    mem = [_write(memtree / f"note_{i}.md") for i in range(3)]
+    _write(topics / "old_topic.md")
+
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+    manifest = "graphify-out/manifest.json"
+    save_manifest({"document": mem + [str(topics / "old_topic.md")]},
+                  manifest, kind="semantic")
+
+    # Add a new topic, then incremental-detect ONLY the topics subfolder.
+    _write(topics / "new_topic.md")
+    res = detect_incremental(topics, manifest, kind="semantic")
+
+    new = [f for v in res["new_files"].values() for f in v]
+    assert res["deleted_files"] == [], (
+        f"scoped update falsely reported deletions: {res['deleted_files']}"
+    )
+    assert any("new_topic" in f for f in new)
+    assert not any("note_" in f for f in new), "out-of-scope files must not appear"
+
+
+def test_genuine_in_scope_deletion_still_detected(tmp_path, monkeypatch):
+    corpus = tmp_path / "corpus"
+    topics = corpus / "topics"
+    keep = _write(topics / "keep.md")
+    gone = _write(topics / "gone.md")
+
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+    manifest = "graphify-out/manifest.json"
+    save_manifest({"document": [keep, gone]}, manifest, kind="semantic")
+
+    os.remove(gone)
+    res = detect_incremental(topics, manifest, kind="semantic")
+    assert any("gone.md" in f for f in res["deleted_files"])
+    assert not any("keep.md" in f for f in res["deleted_files"])
+
+
+def test_full_root_update_prunes_genuinely_deleted(tmp_path, monkeypatch):
+    corpus = tmp_path / "corpus"
+    a = _write(corpus / "memory" / "a.md")
+    b = _write(corpus / "topics" / "b.md")
+
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+    manifest = "graphify-out/manifest.json"
+    save_manifest({"document": [a, b]}, manifest, kind="semantic")
+
+    os.remove(a)
+    res = detect_incremental(corpus, manifest, kind="semantic")
+    assert any("a.md" in f for f in res["deleted_files"])
+    assert not any("b.md" in f for f in res["deleted_files"])
+
+
+def test_on_disk_but_skipped_file_is_not_a_deletion(tmp_path, monkeypatch):
+    """A manifest file still on disk but no longer returned by detect()
+    (e.g. it became excluded/unsupported) must not be pruned."""
+    corpus = tmp_path / "corpus"
+    real = _write(corpus / "real.md")
+    # An entry that exists on disk but detect() won't classify as a doc.
+    skipped = corpus / "data.bin"
+    skipped.parent.mkdir(parents=True, exist_ok=True)
+    skipped.write_bytes(b"\x00\x01\x02")
+
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+    manifest = "graphify-out/manifest.json"
+    save_manifest({"document": [real, str(skipped)]}, manifest, kind="semantic")
+
+    res = detect_incremental(corpus, manifest, kind="semantic")
+    assert not any("data.bin" in f for f in res["deleted_files"]), (
+        "a file still present on disk must never be reported as deleted"
+    )


### PR DESCRIPTION
## The bug

Running `graphify <subfolder> --update` on a subfolder of a corpus that is rooted higher up **silently deletes every node outside that subfolder**.

`detect_incremental()` computes deletions as:

```python
current_files = {f for flist in full["files"].values() for f in flist}
deleted_files = [f for f in manifest if f not in current_files]
```

`current_files` only contains paths under the scanned `root`, so **every manifest entry outside `root` is reported as deleted**. The skill's `--update` flow forwards that list straight to `build_merge(prune_sources=...)`:

```python
deleted = list(incremental.get('deleted_files', []))
G = build_merge([new_extraction], graph_path='graphify-out/graph.json', prune_sources=deleted or None)
```

…and `build_merge`'s anti-shrink safety check (#479) is **explicitly skipped whenever `prune_sources` is set**, so there is no guardrail — the rest of the graph is wiped with no error.

### Repro
A graph built from a corpus root containing `memory/` and `topics/`. Later, `graphify topics/ --update` to fold in one new topic file. Result: all `memory/` nodes are reported deleted and pruned. (Hit this in practice: a scoped update on a topics folder reported ~250 unrelated nodes as deleted.)

## The fix

`detect_incremental()` now treats a manifest entry as deleted **only when it is (a) inside the current scan root's subtree AND (b) genuinely absent from disk**. Out-of-scope entries are simply not part of this incremental run, and entries still on disk but skipped by `detect()` (sensitive / unsupported / excluded) are not deletions either.

Two supporting changes:
- **realpath-based manifest matching** so symlink / mount-alias / `..` path-form drift no longer produces false `changed` or false `deleted`.
- a **loud, non-raising warning** in `build_merge` when a prune would remove a large share of the graph — defense in depth, since the disabled anti-shrink guard is what made the original failure silent.

## Tests

New `tests/test_incremental_scope_safety.py` (4 cases):
- scoped subfolder update reports **no** out-of-scope deletions
- genuine in-scope deletion **is** still detected
- full-root update still prunes genuinely deleted files
- a manifest file still present on disk is never reported deleted

```
tests/test_incremental_scope_safety.py ....                    [100%]
4 passed
```

No regressions: `test_detect.py`, `test_incremental.py`, `test_build.py` → **140 passed**.