### PR TITLE
Add AST-first workflow and graphify extract --code-only flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,45 @@ jobs:
         run: |
           uv run --frozen graphify --help
           uv run --frozen graphify install
+
+  ast-graph:
+    # Guard the AST-first policy: .graphifyignore must keep docs out of
+    # detection so `graphify extract` runs offline with no API key (#1122).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --frozen
+
+      - name: Verify AST-only graph extraction
+        env:
+          GEMINI_API_KEY: ""
+          GOOGLE_API_KEY: ""
+          ANTHROPIC_API_KEY: ""
+          OPENAI_API_KEY: ""
+        run: |
+          set -euo pipefail
+          uv run --frozen graphify extract . --code-only --no-label --no-viz 2>&1 | tee /tmp/graphify-extract.log
+          if grep -E '0 docs, 0 papers, 0 images' /tmp/graphify-extract.log; then
+            echo "AST-only corpus: no docs detected"
+          elif grep -q '--code-only: skipping LLM' /tmp/graphify-extract.log; then
+            echo "AST-only corpus: --code-only skipped semantic extraction"
+          else
+            echo "expected --code-only offline extract (check .graphifyignore)" >&2
+            exit 1
+          fi
+          test -f graphify-out/graph.json
+          uv run --frozen python -c "
+          import json
+          from pathlib import Path
+          data = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+          nodes = data.get('nodes', [])
+          assert nodes, 'graph.json must contain nodes'
+          print(f'AST graph OK: {len(nodes)} nodes')
+          "

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,43 @@
+# AST-first graph policy for this repo.
+#
+# Default extraction indexes Python source and test/fixture code only.
+# Documentation, generated skill bundles, and prose are excluded so
+# `graphify extract` runs offline with no LLM API key.
+#
+# Optional semantic overlay (when prose↔code links matter):
+#   graphify extract ./docs --backend gemini --out ./doc-overlay
+#   graphify merge-graphs graphify-out/graph.json \
+#     doc-overlay/graphify-out/graph.json --out graphify-out/graph.json
+
+# Generated platform skill bundles
+graphify/skills/
+
+# Generated monolith skill files
+graphify/skill-*.md
+graphify/command-*.md
+
+# Skill generator (markdown fragments + golden expected files)
+tools/skillgen/
+
+# Docs, translations, and worked examples
+docs/
+worked/
+
+# CI and tooling config (classified as document, not code)
+.github/
+.pre-commit-config.yaml
+
+# Prose (README, CHANGELOG, ARCHITECTURE, etc.)
+*.md
+*.mdx
+*.txt
+*.rst
+*.html
+
+# Test fixtures still need sample .md for pipeline/integration tests
+!tests/fixtures/
+!tests/fixtures/**
+
+# Query feedback loop — keep agent Q&A memory in the graph when present
+!graphify-out/memory/
+!graphify-out/memory/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,33 @@
 ## graphify
 
-This project has a graphify knowledge graph at graphify-out/.
+This project has a graphify knowledge graph at `graphify-out/`.
 
-Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+### AST-first graph policy
+
+Default graph generation is **code-only** (no LLM). `.graphifyignore` excludes documentation and generated skill markdown so extraction stays offline and deterministic. Or pass **`--code-only`** on `graphify extract` to skip semantic work even when docs are detected.
+
+| Task | Command |
+|------|---------|
+| Full AST rebuild | `graphify extract . --code-only --no-label` |
+| Full AST rebuild (docs already ignored) | `graphify extract . --no-label` |
+| Incremental code update | `graphify update .` (AST-only, no API cost) |
+| Auto-rebuild on commit | `graphify hook install` |
+| Agent retrieval | `graphify query "<question>"` or MCP (`python -m graphify.serve graphify-out/graph.json`) |
+
+Do **not** run `/graphify .` for routine rebuilds — it may dispatch semantic extraction if docs are not excluded. Prefer `graphify extract` or `graphify update`.
+
+**Optional semantic overlay** (docs, community labels, inferred links) — run only on demand:
+
+```bash
+graphify extract ./docs --backend gemini --out ./doc-overlay
+graphify merge-graphs graphify-out/graph.json \
+  doc-overlay/graphify-out/graph.json --out graphify-out/graph.json
+graphify label .   # human-readable community names (one batched LLM call)
+```
+
+### Agent rules
+
+- Before answering architecture or codebase questions, read `graphify-out/GRAPH_REPORT.md` for god nodes and community structure
+- If `graphify-out/wiki/index.md` exists, navigate it instead of reading raw files
 - After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
+- Prefer `graphify query` over grepping or reading many source files when `graphify-out/graph.json` exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## 0.8.36 (2026-06-08)
+
+- Feat: `graphify extract --code-only` skips LLM semantic extraction even when docs, papers, or images are present. Runs AST on code plus structural Markdown extractors (`.md`/`.mdx`/`.qmd`) with no API key — mirrors `graphify update` / watch behavior for headless CI and agent-focused workflows.
+- Docs: README adds an **AST-first graphs** section (`.graphifyignore`, `--code-only`, semantic overlay, hook/update workflow).
+- Chore: This repo adopts an AST-first graph policy — `.graphifyignore` excludes generated skills and prose, `AGENTS.md` documents the workflow, and CI runs an `ast-graph` job that verifies code-only extract needs no API key.
+
 ## 0.8.35 (2026-06-07)
 
 - Feat: CodeBuddy platform support. `graphify codebuddy install` installs the graphify skill to `~/.codebuddy/skills/graphify/SKILL.md`, writes a `CODEBUDDY.md` always-on section, and registers Bash + Read|Glob PreToolUse hooks in `.codebuddy/settings.json` that nudge the agent toward `graphify query` instead of grepping raw files when a graph exists. `graphify install --platform codebuddy` and `graphify codebuddy uninstall` also supported. Thanks to @studyzy (#1136).

--- a/README.md
+++ b/README.md
@@ -299,6 +299,43 @@ See the [full command reference](#full-command-reference) below.
 
 ---
 
+## AST-first graphs (code-only, no LLM)
+
+For AI coding agents, the **structural code graph** (imports, calls, inheritance, type references) is usually enough. You do not need an LLM to build it.
+
+**Three ways to stay offline:**
+
+| Approach | When to use |
+|----------|-------------|
+| **`graphify extract . --code-only`** | Docs exist in the repo but you only want code intelligence now |
+| **`.graphifyignore`** | Permanently exclude docs, generated markdown, RAG corpora (`kb/`, etc.) |
+| **Scoped scan** | `graphify extract ./src` — only index a subdirectory |
+
+Typical workflow:
+
+```bash
+graphify extract . --code-only --no-label   # AST graph, no API key
+graphify cluster-only . --no-label          # GRAPH_REPORT.md + graph.html
+graphify update .                           # incremental AST refresh after edits
+graphify hook install                       # auto-rebuild on git commit
+graphify query "what calls UserService?"
+```
+
+**Optional semantic overlay** (docs, community labels, inferred prose↔code links) — run on demand:
+
+```bash
+graphify extract ./docs --backend gemini --out ./doc-overlay
+graphify merge-graphs graphify-out/graph.json \
+  doc-overlay/graphify-out/graph.json --out graphify-out/graph.json
+graphify label .                            # human-readable community names (one LLM call)
+```
+
+With `--code-only`, Markdown files still get **structural** extraction (headings/sections) when they have a local AST extractor (`.md`, `.mdx`, `.qmd`) — same as `graphify update` / watch mode. PDFs, images, and prose semantics are skipped until you run a separate semantic extract.
+
+This repo dogfoods the pattern: see `.graphifyignore` and `AGENTS.md`.
+
+---
+
 ## Ignoring files
 
 Create a `.graphifyignore` in your project root — same syntax as `.gitignore`, including `!` negation.
@@ -578,6 +615,7 @@ graphify extract ./docs --api-timeout 900      # longer HTTP timeout for slow lo
 graphify extract ./docs --google-workspace     # export .gdoc/.gsheet/.gslides via gws before extraction
 graphify extract ./docs --mode deep            # richer semantic extraction via extended system prompt
 graphify extract ./docs --no-cluster           # raw extraction only, skip clustering
+graphify extract . --code-only                 # AST only — skip LLM even when docs are present
 graphify extract ./docs --force                # overwrite graph.json even if new graph has fewer nodes (use after refactors or to clear ghost duplicates)
 graphify extract ./docs --dedup-llm            # LLM tiebreaker for ambiguous entity pairs (uses same API key)
 graphify extract ./docs --global --as myrepo   # extract and register into the cross-project global graph

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2159,6 +2159,7 @@ def main() -> None:
         print("    --top-k-edges N         per-symbol outbound edges in inspector (default 12)")
         print("    --label NAME            project label in header")
         print("  extract <path>          headless full extraction (AST + semantic LLM) for CI/scripts")
+        print("    --code-only             AST only — skip LLM semantic extraction even when docs are present")
         print("    --backend B             gemini|kimi|claude|openai|deepseek|ollama (default: whichever API key is set)")
         print("    --model M               override backend default model")
         print("    --mode deep             aggressive INFERRED-edge semantic extraction")
@@ -3842,7 +3843,8 @@ def main() -> None:
         # has an API key set.
         if len(sys.argv) < 3:
             print(
-                "Usage: graphify extract <path> [--backend gemini|kimi|claude|openai|deepseek|ollama] "
+                "Usage: graphify extract <path> [--code-only] "
+                "[--backend gemini|kimi|claude|openai|deepseek|ollama] "
                 "[--model M] [--mode deep] [--out DIR] [--google-workspace] [--no-cluster] "
                 "[--max-workers N] [--token-budget N] [--max-concurrency N] "
                 "[--api-timeout S] [--postgres DSN]",
@@ -3867,6 +3869,7 @@ def main() -> None:
         cli_postgres_dsn: str | None = None
         no_cluster = False
         dedup_llm = False
+        code_only = False
         google_workspace = False
         global_merge = False
         global_repo_tag: str | None = None
@@ -3924,6 +3927,8 @@ def main() -> None:
                 out_dir = Path(a.split("=", 1)[1]); i += 1
             elif a == "--no-cluster":
                 no_cluster = True; i += 1
+            elif a == "--code-only":
+                code_only = True; i += 1
             elif a == "--dedup-llm":
                 dedup_llm = True; i += 1
             elif a == "--google-workspace":
@@ -4042,6 +4047,28 @@ def main() -> None:
             unchanged_total = 0
 
         semantic_files = doc_files + paper_files + image_files
+        if code_only:
+            if dedup_llm:
+                print(
+                    "[graphify extract] warning: --dedup-llm ignored with --code-only "
+                    "(no LLM calls)",
+                    file=sys.stderr,
+                )
+                dedup_llm = False
+            skipped = len(semantic_files)
+            if skipped:
+                from graphify.extract import _get_extractor as _get_ast_extractor
+                seen_ast = {str(p) for p in code_files}
+                for doc_path in doc_files:
+                    p = Path(doc_path)
+                    if _get_ast_extractor(p) is not None and str(p) not in seen_ast:
+                        code_files.append(p)
+                        seen_ast.add(str(p))
+                print(
+                    f"[graphify extract] --code-only: skipping LLM semantic extraction "
+                    f"for {skipped} doc/paper/image file(s)"
+                )
+            semantic_files = []
         if incremental_mode:
             print(
                 f"[graphify extract] {len(code_files)} code, {len(doc_files)} docs, "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "graphifyy"
-version = "0.8.35"
+version = "0.8.36"
 description = "AI coding assistant skill (Claude Code, CodeBuddy, Codex, OpenCode, Kilo Code, Cursor, Gemini CLI, Aider, OpenClaw, Factory Droid, Trae, Hermes, Kiro, Pi, Devin CLI, Google Antigravity) - turn any folder of code, docs, papers, images, or videos into a queryable knowledge graph"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_extract_cli.py
+++ b/tests/test_extract_cli.py
@@ -198,3 +198,30 @@ def test_extract_without_key_still_errors_when_docs_present(
     assert "no LLM API key found" in err
     assert "code-only corpus needs no key" in err
     assert not (out_dir / "graphify-out" / "graph.json").exists()
+
+
+def test_extract_code_only_flag_skips_semantic_without_api_key(
+    monkeypatch, tmp_path, capsys,
+):
+    """--code-only must skip LLM semantic work even when Markdown docs are present."""
+    corpus = _make_corpus(tmp_path)  # main.go + README.md
+    out_dir = tmp_path / "out"
+    _clear_backend_keys(monkeypatch)
+    monkeypatch.setattr("graphify.llm.detect_backend", lambda: None)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        mainmod.sys, "argv",
+        ["graphify", "extract", str(corpus), "--out", str(out_dir), "--code-only"],
+    )
+
+    try:
+        mainmod.main()
+    except SystemExit as exc:
+        assert exc.code in (None, 0), f"unexpected exit code {exc.code}"
+
+    out = capsys.readouterr().out
+    assert "--code-only" in out
+    graph = out_dir / "graphify-out" / "graph.json"
+    assert graph.exists(), "--code-only must write graph.json without an API key"
+    import json
+    assert len(json.loads(graph.read_text()).get("nodes", [])) > 0

--- a/uv.lock
+++ b/uv.lock
@@ -1146,7 +1146,7 @@ wheels = [
 
 [[package]]
 name = "graphifyy"
-version = "0.8.35"
+version = "0.8.36"
 source = { editable = "." }
 dependencies = [
     { name = "datasketch" },


### PR DESCRIPTION
## Summary

- Adds `graphify extract --code-only` to skip LLM semantic extraction when docs, papers, or images are present but only structural code intelligence is needed.
- Documents the AST-first workflow in README (`.graphifyignore`, semantic overlay, hooks, query/MCP).
- Dogfoods the pattern in this repo via `.graphifyignore`, `AGENTS.md`, and a new CI `ast-graph` job that verifies offline extract with no API keys.

## Motivation

Mixed code+doc repos (e.g. RAG apps with a large `kb/` corpus) previously required an LLM backend even for code navigation. For AI coding IDEs and agents, AST extraction alone is sufficient:

- imports, calls, inheritance, type references
- `graphify query` / MCP / impact analysis
- incremental updates via `graphify update` and git hooks (no API cost)

`--code-only` mirrors the existing watch/update AST path for headless `graphify extract`, including structural Markdown extractors (`.md`/`.mdx`/`.qmd`) without invoking Gemini or other backends.

## Changes

| Area | What |
|------|------|
| CLI | `--code-only` on `graphify extract`; `--dedup-llm` ignored with a warning |
| Docs | README “AST-first graphs” section; CHANGELOG 0.8.36 |
| Repo policy | `.graphifyignore` (excludes generated skills/prose; keeps `tests/fixtures/`) |
| Agents | `AGENTS.md` AST-first commands |
| CI | `ast-graph` job — extract with keys cleared, graph.json must contain nodes |
| Tests | `test_extract_code_only_flag_skips_semantic_without_api_key` |

## Test plan

- [x] `pytest tests/` — 1973 passed, 1 skipped
- [x] `pytest tests/test_extract_cli.py` — 5/5 passed
- [x] `graphify extract . --code-only --no-label --no-viz` with API keys unset
- [x] Verified on external repo (`thirukkural-rag`: 31 code files, 0 docs, no LLM)

## Usage

```bash
# AST graph, no API key (even when docs exist in the repo)
graphify extract . --code-only --no-label
graphify cluster-only . --no-label
graphify update .

# Optional semantic overlay later
graphify extract ./docs --backend gemini --out ./doc-overlay
graphify merge-graphs graphify-out/graph.json doc-overlay/graphify-out/graph.json --out graphify-out/graph.json