### PR TITLE
Fix prose-edge over-confidence, generic-name god-nodes, and doc-concept mis-anchoring

### DIFF
--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -92,24 +92,47 @@ def _is_json_key_node(G: nx.Graph, node_id: str) -> bool:
     return label in _JSON_NOISE_LABELS
 
 
+# A label shared by this many or more DISTINCT node ids is a generic-name
+# collision (e.g. `main()` across 95 files, `Settings` across 23), not a single
+# architectural abstraction. Such a label is ambiguous: ranking the one highest-
+# degree instance as a "god node" misleads — the name has no single referent and
+# `explain`/`path` cannot disambiguate it. Excluded from the god-node list (QA
+# defect D2). Genuinely-distinct same-named entities (e.g. two real `AgentSession`
+# classes) stay below this threshold and are kept.
+_LABEL_COLLISION_THRESHOLD = 5
+
+
 def god_nodes(G: nx.Graph, top_n: int = 10) -> list[dict]:
     """Return the top_n most-connected real entities - the core abstractions.
 
     File-level hub nodes are excluded: they accumulate import/contains edges
     mechanically and don't represent meaningful architectural abstractions.
+    Generic-name collisions (one label shared across many distinct nodes) are
+    excluded too: their centrality is a name artifact, not a real hub (QA D2).
     """
+    # Count distinct node ids per label so generic-name collisions can be excluded.
+    _label_id_counts: dict[str, int] = {}
+    for _nid in G.nodes():
+        _lab = G.nodes[_nid].get("label", "")
+        if _lab:
+            _label_id_counts[_lab] = _label_id_counts.get(_lab, 0) + 1
     degree = dict(G.degree())
     sorted_nodes = sorted(degree.items(), key=lambda x: x[1], reverse=True)
     result = []
     for node_id, deg in sorted_nodes:
         if _is_file_node(G, node_id) or _is_concept_node(G, node_id) or _is_json_key_node(G, node_id):
             continue
-        if G.nodes[node_id].get("label", "") in _BUILTIN_NOISE_LABELS:
+        label = G.nodes[node_id].get("label", "")
+        if label in _BUILTIN_NOISE_LABELS:
             continue
+        collision = _label_id_counts.get(label, 1)
+        if collision >= _LABEL_COLLISION_THRESHOLD:
+            continue  # generic-name artifact, not a coherent abstraction
         result.append({
             "id": node_id,
-            "label": G.nodes[node_id].get("label", node_id),
+            "label": label or node_id,
             "degree": deg,
+            "collision_count": collision,  # 1 = unique label; >1 = N distinct same-named nodes
         })
         if len(result) >= top_n:
             break

--- a/graphify/build.py
+++ b/graphify/build.py
@@ -29,6 +29,7 @@ import unicodedata
 from pathlib import Path
 import networkx as nx
 from .validate import validate_extraction
+from .detect import CODE_EXTENSIONS
 
 
 # Synonym mapper for known invalid file_type values that LLM subagents commonly
@@ -249,6 +250,36 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
             tgt_ext = Path(G.nodes[tgt].get("source_file") or "").suffix.lower()
             if src_ext and tgt_ext and _LANG_FAMILY.get(src_ext) != _LANG_FAMILY.get(tgt_ext):
                 continue
+        # Demote prose-derived edges mis-tagged as code facts (QA defect D1).
+        # An EXTRACTED edge with no source_location whose provenance is a
+        # non-code file (markdown, yaml, image, …) is a relationship asserted
+        # in documentation, not verified against code AST. It must not carry the
+        # code-anchored EXTRACTED tag (which downstream treats as confidence 1.0).
+        # Demote to INFERRED, cap the score, and stamp `provenance=documentation`
+        # so the audit trail stays honest. Deterministic, so it survives even if
+        # the LLM subagent mislabels the edge.
+        if attrs.get("confidence") == "EXTRACTED" and not attrs.get("source_location"):
+            prov = attrs.get("source_file") or G.nodes[src].get("source_file") or ""
+            ext = Path(prov).suffix.lower()
+            # Demote only on POSITIVE evidence the provenance is non-code: a
+            # recognized non-code extension, OR no provenance at all from a node
+            # the extractor already typed as documentation/concept. A code edge
+            # that merely lost its location (ext == "" on a code node) is NOT a
+            # prose edge and is left alone.
+            src_ft = G.nodes[src].get("file_type", "")
+            is_doc_provenance = (ext != "" and ext not in CODE_EXTENSIONS) or (
+                ext == "" and src_ft in ("document", "concept", "rationale", "image", "paper")
+            )
+            if is_doc_provenance:
+                attrs["confidence"] = "INFERRED"
+                attrs["provenance"] = "documentation"
+                score = attrs.get("confidence_score")
+                try:
+                    # Coerce (LLM JSON often emits numeric strings) and only ever
+                    # LOWER the score — never raise a legitimately-low doc score.
+                    attrs["confidence_score"] = min(float(score), 0.8)
+                except (TypeError, ValueError):
+                    attrs["confidence_score"] = 0.8
         # Preserve original edge direction - undirected graphs lose it otherwise,
         # causing display functions to show edges backwards.
         attrs["_src"] = src
@@ -267,6 +298,56 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
             ):
                 continue
         G.add_edge(src, tgt, **attrs)
+
+    # Re-anchor doc-concept nodes that actually carry a code module's edge set
+    # (QA defect D3). A node typed `concept`/`rationale` with no source_location
+    # but whose incident edges overwhelmingly originate from ONE code file is a
+    # code module wearing a documentation label (e.g. an "Interactive Mode" concept
+    # from docs/usage.md holding all of interactive-mode.ts's calls/imports). The
+    # ghost-merge above only fires on exact (basename,label) match and misses these.
+    # Re-type to `code` and adopt the dominant code source_file so god-node/community
+    # analysis treats it as the real code entity it structurally is. The node id is
+    # preserved (no merge), so no edges or counts change — only its type/anchor.
+    _CODE_REL = {"calls", "imports", "imports_from", "method", "contains", "extends", "implements", "uses"}
+    for nid in list(G.nodes()):
+        attrs = G.nodes[nid]
+        if attrs.get("file_type") not in ("concept", "rationale"):
+            continue
+        if attrs.get("source_location"):
+            continue
+        cur_ext = Path(str(attrs.get("source_file") or "")).suffix.lower()
+        if cur_ext in CODE_EXTENSIONS:
+            continue  # already code-anchored
+        incident = (
+            list(G.in_edges(nid, data=True)) + list(G.out_edges(nid, data=True))
+            if G.is_directed() else list(G.edges(nid, data=True))
+        )
+        if len(incident) < 3:
+            continue
+        code_srcs: dict[str, int] = {}
+        code_rel_total = 0
+        for *_ends, edata in incident:
+            sf = str(edata.get("source_file") or "")
+            if Path(sf).suffix.lower() in CODE_EXTENSIONS and edata.get("relation") in _CODE_REL:
+                code_srcs[sf] = code_srcs.get(sf, 0) + 1
+                code_rel_total += 1
+        if not code_srcs:
+            continue
+        # Deterministic winner (tie-break on file path, not dict insertion order).
+        dominant, dom_count = max(code_srcs.items(), key=lambda kv: (kv[1], kv[0]))
+        # Two independent gates so a genuinely-conceptual node that merely
+        # references one module heavily is NOT mistyped:
+        #   (a) the node is *mostly* code-relation edges (not concept-edge rich), and
+        #   (b) a single code module dominates those code edges.
+        if (
+            code_rel_total >= 3
+            and code_rel_total / len(incident) >= 0.6
+            and dom_count / code_rel_total >= 0.6
+        ):
+            attrs["file_type"] = "code"
+            attrs["source_file"] = _norm_source_file(dominant, _root)
+            attrs["_reanchored_from"] = "concept"
+
     hyperedges = extraction.get("hyperedges", [])
     if hyperedges:
         G.graph["hyperedges"] = hyperedges


### PR DESCRIPTION
## What

Three related fixes to extraction honesty and graph quality, surfaced by an independent production QA audit of four `graphify --mode deep` knowledge graphs (6.4k / 2.9k / 7.3k / 36.6k nodes). All three are deterministic post-extraction reconciliations so they hold even when the LLM subagent mislabels.

### D1 — prose edges no longer masquerade as code facts (`build.py`)
An `EXTRACTED` edge with no `source_location` whose provenance is a non-code file (`.md`, `.yml`, image, …) is a relationship asserted in prose, not verified against code AST — yet it carried `confidence_score = 1.0`. These are now demoted to `INFERRED`, stamped `provenance="documentation"`, and capped at ≤ 0.8. Numeric-string scores are coerced and only ever **lowered**; demotion requires positive non-code evidence so a code edge that merely lost its location is untouched.

*Audit impact:* 1081 / 496 / 272 / 462 such edges across the four corpora (up to ~11% of all EXTRACTED edges) were carrying code-grade confidence.

### D2 — generic-name god-nodes are no longer surfaced as abstractions (`analyze.py`)
`god_nodes` ranked by degree but was blind to label collisions: `main()` (95 distinct ids), `Settings` (23) etc. were surfaced as single "core abstractions", and `explain`/`path` could not disambiguate them. Labels shared by ≥ `_LABEL_COLLISION_THRESHOLD` (5) distinct nodes are now excluded; survivors carry a `collision_count`. Genuinely-distinct same-named entities (e.g. two real `AgentSession` classes) stay below the threshold and are kept.

### D3 — doc-concept nodes holding a code module's edge set are re-anchored (`build.py`)
A `concept`/`rationale` node with no location whose incident edges are mostly code-relation edges dominated by one code module is a code module wearing a documentation label — the existing ghost-merge only fires on exact `(basename, label)` match and misses these. It is re-typed to `code` with the dominant code `source_file`. Two independent dominance gates (≥60% of incident edges are code relations, and one module is ≥60% of those) prevent mistyping a genuinely-conceptual node.

## Verification
Re-ran the patched `build_from_json` / `god_nodes` on all four real graphs:
- node/edge/community counts preserved (no data dropped);
- prose edges demoted (1081/496/272/462 → INFERRED, 0 remaining EXTRACTED-without-location-from-doc);
- `Interactive Mode` + 2 protocol-handler concepts re-anchored concept→code;
- `main()` / `Settings` / `RpcClient` / `Database` dropped from god-node lists, backfilled with real hubs;
- AST-only `extract` + `cluster-only` runs end-to-end; both files `ast.parse` clean.

Regression-tested the D1 score handling: code edge `1.0` untouched, doc `"0.5"` → 0.5 (not raised), doc `"1.0"` → 0.8.

## Notes
- `_reanchored_from` is an additive audit field that persists in `graph.json`.
- `_LABEL_COLLISION_THRESHOLD` is an absolute 5; on a very small repo it could shorten the god-node list (never crashes — callers already guard empty lists).
