### PR TITLE
feat: extract markdown links as first-class edges

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -14,6 +14,107 @@ def _make_id(*parts: str) -> str:
     return cleaned.strip("_").lower()
 
 
+# Patterns for markdown link / wikilink extraction. Kept conservative:
+#  - _MD_LINK_RE matches [text](target); we then filter out images (![...])
+#    and external URLs (http://, https://, mailto:, ftp://) in code.
+#  - _WIKILINK_RE matches [[Page Name]] and [[Page Name|Display Text]].
+_MD_LINK_RE = re.compile(r"(?<!\!)\[([^\]]+)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+_WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+
+
+def _resolve_md_link(target: str, source: Path) -> Path | None:
+    """Resolve a markdown link target to an existing file in the same directory,
+    trying common extensions. Returns None for external URLs or unresolvable refs.
+    """
+    if not target:
+        return None
+    if re.match(r"^[a-z]+://", target) or target.startswith(("mailto:", "tel:")):
+        return None
+    # Strip anchor
+    target = target.split("#", 1)[0]
+    if not target:
+        return None
+    base = source.parent / target
+    if base.is_file():
+        return base
+    for ext in (".md", ".mdx", ".qmd", ".txt", ".html"):
+        candidate = base.with_suffix(ext) if not base.suffix else base
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def extract_markdown(path: Path) -> dict:
+    """Extract markdown links and wikilinks as links_to edges from a .md/.mdx/.qmd file.
+
+    Emits one file-level node and one links_to edge per resolved reference.
+    Unresolved links (external URLs, broken refs) are silently skipped so the
+    graph only contains EXTRACTED, real cross-references.
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        return {"nodes": [], "edges": [], "error": str(e)}
+
+    file_nid = _make_id(path.stem)
+    nodes: list[dict] = [{
+        "id": file_nid,
+        "label": path.name,
+        "file_type": "doc",
+        "source_file": str(path),
+        "source_location": "L1",
+    }]
+    edges: list[dict] = []
+
+    # Strip fenced code blocks so their [..](..) and [[..]] don't leak as edges
+    in_code = False
+    cleaned_lines: list[str] = []
+    for line in source.splitlines():
+        if line.lstrip().startswith("```"):
+            in_code = not in_code
+            cleaned_lines.append("")
+            continue
+        cleaned_lines.append("" if in_code else line)
+    cleaned = "\n".join(cleaned_lines)
+
+    for line_no, line in enumerate(cleaned.splitlines(), start=1):
+        for m in _MD_LINK_RE.finditer(line):
+            target_str = m.group(2)
+            target = _resolve_md_link(target_str, path)
+            if target is None:
+                continue
+            target_nid = _make_id(target.stem)
+            if target_nid != file_nid:  # don't self-link
+                edges.append({
+                    "source": file_nid,
+                    "target": target_nid,
+                    "relation": "links_to",
+                    "confidence": "EXTRACTED",
+                    "source_file": str(path),
+                    "source_location": f"L{line_no}",
+                    "context": m.group(1),
+                    "weight": 1.0,
+                })
+        for m in _WIKILINK_RE.finditer(line):
+            target = _resolve_md_link(m.group(1).strip() + ".md", path)
+            if target is None:
+                continue
+            target_nid = _make_id(target.stem)
+            if target_nid != file_nid:
+                edges.append({
+                    "source": file_nid,
+                    "target": target_nid,
+                    "relation": "links_to",
+                    "confidence": "EXTRACTED",
+                    "source_file": str(path),
+                    "source_location": f"L{line_no}",
+                    "context": m.group(1).strip(),
+                    "weight": 1.0,
+                })
+
+    return {"nodes": nodes, "edges": edges, "input_tokens": 0, "output_tokens": 0}
+
+
 def extract_python(path: Path) -> dict:
     """Extract classes, functions, and imports from a .py file via tree-sitter AST."""
     try:
@@ -2389,6 +2490,15 @@ def extract(paths: list[Path]) -> dict:
             if "error" not in result:
                 save_cached(path, result, root)
             per_file.append(result)
+        elif path.suffix in {".md", ".mdx", ".qmd"}:
+            cached = load_cached(path, root)
+            if cached is not None:
+                per_file.append(cached)
+                continue
+            result = extract_markdown(path)
+            if "error" not in result:
+                save_cached(path, result, root)
+            per_file.append(result)
 
     all_nodes: list[dict] = []
     all_edges: list[dict] = []
@@ -2417,6 +2527,7 @@ def collect_files(target: Path) -> list[Path]:
         "*.py", "*.js", "*.ts", "*.tsx", "*.go", "*.rs",
         "*.java", "*.c", "*.h", "*.cpp", "*.cc", "*.cxx", "*.hpp",
         "*.rb", "*.cs", "*.kt", "*.kts", "*.scala", "*.php",
+        "*.md", "*.mdx", "*.qmd",
     )
     results: list[Path] = []
     for pattern in _EXTENSIONS:

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -113,17 +113,24 @@ from pathlib import Path
 import json
 
 code_files = []
+markdown_files = []
 detect = json.loads(Path('.graphify_detect.json').read_text())
 for f in detect.get('files', {}).get('code', []):
     code_files.extend(collect_files(Path(f)) if Path(f).is_dir() else [Path(f)])
+for f in detect.get('files', {}).get('docs', []):
+    p = Path(f)
+    if p.suffix in {'.md', '.mdx', '.qmd'}:
+        # Docs are individual files (not code dirs) - skip collect_files globs
+        markdown_files.append(p)
 
-if code_files:
-    result = extract(code_files)
+all_files = code_files + markdown_files
+if all_files:
+    result = extract(all_files)
     Path('.graphify_ast.json').write_text(json.dumps(result, indent=2))
     print(f'AST: {len(result[\"nodes\"])} nodes, {len(result[\"edges\"])} edges')
 else:
     Path('.graphify_ast.json').write_text(json.dumps({'nodes':[],'edges':[],'input_tokens':0,'output_tokens':0}))
-    print('No code files - skipping AST extraction')
+    print('No code or markdown files - skipping AST extraction')
 "
 ```
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -60,7 +60,9 @@ def test_collect_files_from_dir():
     files = collect_files(FIXTURES)
     supported = {".py", ".js", ".ts", ".tsx", ".go", ".rs",
                  ".java", ".c", ".cpp", ".cc", ".cxx", ".rb",
-                 ".cs", ".kt", ".kts", ".scala", ".php", ".h", ".hpp"}
+                 ".cs", ".kt", ".kts", ".scala", ".php", ".h", ".hpp",
+                 # markdown is now collected for first-class link extraction
+                 ".md", ".mdx", ".qmd"}
     assert all(f.suffix in supported for f in files)
     assert len(files) > 0
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -5,6 +5,7 @@ import pytest
 from graphify.extract import (
     extract_java, extract_c, extract_cpp, extract_ruby,
     extract_csharp, extract_kotlin, extract_scala, extract_php,
+    extract_markdown, extract, _resolve_md_link,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -217,3 +218,107 @@ def test_php_finds_function():
 def test_php_finds_imports():
     r = extract_php(FIXTURES / "sample.php")
     assert "imports" in _relations(r)
+
+
+# ── Markdown ───────────────────────────────────────────────────────────────
+
+def test_markdown_emits_file_node(tmp_path):
+    """A .md file produces exactly one file-level node with file_type='doc'."""
+    md = tmp_path / "doc.md"
+    md.write_text("# Hello\n\nWorld.\n", encoding="utf-8")
+    r = extract_markdown(md)
+    assert len(r["nodes"]) == 1
+    assert r["nodes"][0]["file_type"] == "doc"
+    assert r["nodes"][0]["id"] == "doc"
+
+
+def test_markdown_link_produces_links_to_edge(tmp_path):
+    """A [text](other.md) reference to an existing file emits a links_to edge."""
+    src = tmp_path / "src.md"
+    tgt = tmp_path / "tgt.md"
+    tgt.write_text("# Target\n", encoding="utf-8")
+    src.write_text("# Source\n\nSee [the target](tgt.md) for details.\n", encoding="utf-8")
+    r = extract_markdown(src)
+    links = [e for e in r["edges"] if e["relation"] == "links_to"]
+    assert len(links) == 1
+    assert links[0]["source"] == "src"
+    assert links[0]["target"] == "tgt"
+    assert links[0]["context"] == "the target"
+    assert links[0]["confidence"] == "EXTRACTED"
+
+
+def test_markdown_wikilink_produces_links_to_edge(tmp_path):
+    """A [[Page]] reference to an existing .md file emits a links_to edge."""
+    src = tmp_path / "src.md"
+    tgt = tmp_path / "Page.md"
+    tgt.write_text("# Page\n", encoding="utf-8")
+    src.write_text("See [[Page]] for details.\n", encoding="utf-8")
+    r = extract_markdown(src)
+    links = [e for e in r["edges"] if e["relation"] == "links_to"]
+    assert len(links) == 1
+    assert links[0]["target"] == "page"
+
+
+def test_markdown_skips_external_urls(tmp_path):
+    """https:// and mailto: links are not emitted as edges."""
+    md = tmp_path / "doc.md"
+    md.write_text(
+        "# Doc\n\n[site](https://example.com) and [mail](mailto:a@b.com)\n",
+        encoding="utf-8",
+    )
+    r = extract_markdown(md)
+    assert all(e["relation"] != "links_to" for e in r["edges"])
+
+
+def test_markdown_skips_unresolved_links(tmp_path):
+    """Links to non-existent files are silently dropped (no broken edges)."""
+    md = tmp_path / "doc.md"
+    md.write_text("# Doc\n\n[ghost](nonexistent.md)\n", encoding="utf-8")
+    r = extract_markdown(md)
+    assert all(e["relation"] != "links_to" for e in r["edges"])
+
+
+def test_markdown_skips_image_links(tmp_path):
+    """![alt](path) is an image, not a link — no edges emitted."""
+    src = tmp_path / "src.md"
+    src.write_text("# Doc\n\n![pic](other.png)\n", encoding="utf-8")
+    r = extract_markdown(src)
+    assert all(e["relation"] != "links_to" for e in r["edges"])
+
+
+def test_markdown_skips_links_inside_code_blocks(tmp_path):
+    """Fenced code blocks have their [..](..) stripped before edge extraction."""
+    src = tmp_path / "src.md"
+    src.write_text(
+        "# Doc\n\n```\n[not a link](other.md)\n```\n\n[real](other.md)\n",
+        encoding="utf-8",
+    )
+    tgt = tmp_path / "other.md"
+    tgt.write_text("# Other\n", encoding="utf-8")
+    r = extract_markdown(src)
+    links = [e for e in r["edges"] if e["relation"] == "links_to"]
+    assert len(links) == 1
+
+
+def test_resolve_md_link_external_returns_none():
+    """URLs with scheme return None."""
+    assert _resolve_md_link("https://example.com", Path("/tmp/x.md")) is None
+    assert _resolve_md_link("http://github.com/x", Path("/tmp/x.md")) is None
+    assert _resolve_md_link("mailto:user@example.com", Path("/tmp/x.md")) is None
+
+
+def test_extract_dispatches_markdown_files(tmp_path):
+    """The high-level extract() routes .md files to extract_markdown().
+
+    Regression: skill.md's orchestrator relies on this dispatch; without it,
+    the links_to edges from markdown files never reach .graphify_ast.json.
+    """
+    src = tmp_path / "src.md"
+    tgt = tmp_path / "tgt.md"
+    tgt.write_text("# Target\n", encoding="utf-8")
+    src.write_text("[ref](tgt.md)\n", encoding="utf-8")
+    r = extract([src])
+    links = [e for e in r["edges"] if e["relation"] == "links_to"]
+    assert len(links) == 1
+    assert links[0]["source"] == "src"
+    assert links[0]["target"] == "tgt"


### PR DESCRIPTION
Re-implements the markdown link extraction from #1066 on top of current upstream/main, addressing chris-boson's review comment: *"we also need a change here so that we actually run the extraction on markdown files"*.

## What's in this PR

- `graphify/extract.py`: new `extract_markdown(path)` function + dispatch in `extract()` for `.md`/`.mdx`/`.qmd` + extension list update in `collect_files()`. Emits `links_to` (EXTRACTED) edges for resolved `[text](path)` and `[[wikilink]]` references. Filters images, external URLs, unresolved refs, and content inside fenced code blocks.
- `graphify/skill.md`: Part A orchestrator now passes `docs` markdown files alongside `code` files into `extract()`. **This is the actual fix for the review** — without it, the new extractor is never invoked.
- `tests/test_languages.py`: 9 new tests covering file node, link, wikilink, external URL filtering, unresolved link filtering, image link filtering, fenced code block filtering, the resolver unit test, and the high-level `extract()` dispatch.

## Why a new PR instead of fixing #1066

PR #1066's branch (`feat/markdown-link-edges`) is 36 commits behind `upstream/main` AND contains 4 separate PRs' worth of work bundled in (`#1065`/`#1033` file-level node IDs, `#1067` bare-name collisions, `#1069` CI extras, plus the actual #1066 markdown work). A clean rebase is hours of careful work. This PR is a focused, single-commit re-implementation of the review's ask on top of current `upstream/main`.

## Tests

- 9/9 new markdown tests pass
- 47/47 in `tests/test_languages.py` (38 pre-existing + 9 new) — zero regressions
- Pre-existing failures in `test_pipeline.py` and `test_report.py` are missing `graspologic`/`networkx` deps in the test env, unrelated to this change

## Closes

Addresses the review on #1066 from chris-boson.

```
feat: extract markdown links as first-class edges

Adds extract_markdown() to graphify/extract.py and routes .md/.mdx/.qmd
files through it from extract(). For each file, emits:
  - a file-level node (file_type=doc)
  - one links_to edge per resolved [text](path) and [[wikilink]] ref

Unresolved links, image links, external URLs, and content inside fenced
code blocks are all skipped so the graph only contains real, EXTRACTED
cross-references.

Also updates skill.md's Part A orchestrator to pass markdown files
alongside code files into extract(), so the new extractor is actually
invoked by the pipeline (the previous orchestrator only iterated
detect['files']['code']).
```