### PR TITLE
fix: blocklist Python stdlib and JS global names from noise nodes and INFERRED edges

### DIFF
--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -4,16 +4,20 @@ from pathlib import Path
 import networkx as nx
 
 from graphify.build import edge_data
+from graphify.extract import _JS_GLOBAL_BLOCKLIST, _PY_STDLIB_BLOCKLIST
 
 # Builtin/mock names that can appear as annotation-derived nodes in pre-existing
 # graphs. Excluded from god-node ranking so they don't displace real abstractions
-# even if they weren't filtered at extraction time (#1147).
+# even if they weren't filtered at extraction time (#1147). Extended with the
+# Python stdlib and JS global blocklists so stale per-file cache entries
+# (cache keys are content hashes, so old extractions survive upgrades) can't
+# push `Path`/`Any`/`os` reference nodes back into the ranking.
 _BUILTIN_NOISE_LABELS = frozenset({
     "str", "int", "float", "bool", "bytes", "bytearray", "complex", "object",
     "True", "False",
     "MagicMock", "Mock", "AsyncMock", "NonCallableMock",
     "NonCallableMagicMock", "PropertyMock", "patch", "sentinel",
-})
+}) | _PY_STDLIB_BLOCKLIST | _JS_GLOBAL_BLOCKLIST
 
 # Language families — extensions sharing a runtime can legitimately call each other
 _LANG_FAMILY: dict[str, str] = {

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -42,6 +42,33 @@ _LANGUAGE_BUILTIN_GLOBALS: frozenset[str] = frozenset({
     "callable", "getattr", "setattr", "hasattr", "delattr", "vars", "dir",
 })
 
+# JS/Node runtime globals and Node core module names that appear as bare
+# identifier references but are never project-defined symbols. Module-level
+# `const fs = require('fs')` bindings otherwise become a per-file node
+# (`app_fs`, `app_path`, `app_os`, ...) in every file that requires the module,
+# and unresolved bare calls to runtime globals (setTimeout, fetch, require)
+# produce spurious cross-file INFERRED edges whenever a project symbol shares
+# the name. Counterpart to _PY_STDLIB_BLOCKLIST; same pattern as
+# _RUST_TRAIT_METHOD_BLOCKLIST (#908). Extracted function labels carry a "()"
+# suffix and the node-suppression sites below match raw identifiers, so this
+# never shadows extracted project functions.
+_JS_GLOBAL_BLOCKLIST: frozenset[str] = frozenset({
+    # runtime globals not already filtered as call targets by
+    # _LANGUAGE_BUILTIN_GLOBALS
+    "JSON", "Promise", "Math", "console", "process", "require", "module",
+    "exports", "global", "globalThis", "window", "document", "navigator",
+    "Buffer", "setTimeout", "setInterval", "clearTimeout", "clearInterval",
+    "setImmediate", "clearImmediate", "queueMicrotask", "structuredClone",
+    "fetch", "atob", "btoa", "localStorage", "sessionStorage",
+    "performance", "__dirname", "__filename",
+    # Node core modules (`const fs = require('fs')` / `require('node:fs')`)
+    "fs", "path", "os", "http", "https", "net", "url", "util", "events",
+    "stream", "crypto", "zlib", "child_process", "cluster", "dns", "buffer",
+    "querystring", "readline", "assert", "tls", "dgram", "v8", "vm",
+    "worker_threads", "perf_hooks", "async_hooks", "string_decoder",
+    "timers", "tty", "repl", "punycode",
+})
+
 
 def _raise_recursion_limit() -> None:
     if sys.getrecursionlimit() < _RECURSION_LIMIT:
@@ -485,6 +512,86 @@ _PYTHON_ANNOTATION_NOISE = frozenset({
     "NonCallableMagicMock", "PropertyMock", "patch", "sentinel",
 })
 
+# Python stdlib/typing names that appear as bare identifier references —
+# annotations like `def f(p: Path) -> Any` and constructor calls like
+# `Path(x)` — but are never project-defined symbols. Without this filter
+# every referencing file grows a free-floating `Path`/`Any`/`datetime` node
+# (the colliding bare ids are split into per-file ids by
+# _disambiguate_colliding_node_ids), _resolve_cross_file_imports then treats
+# those nodes as importing classes and emits spurious INFERRED `uses` edges
+# (Path --uses--> ProjectClass), and the noise dominates god-node rankings.
+# Applied at the annotation walker (same layer as _PYTHON_ANNOTATION_NOISE,
+# #1147) and at the unresolved-call queue (same pattern as
+# _RUST_TRAIT_METHOD_BLOCKLIST, #908). Matching is on the raw identifier and
+# extracted function labels carry a "()" suffix, so project functions are
+# never shadowed. Tradeoff: a project class that reuses one of these exact
+# names loses its annotation-reference edges — acceptable, same as the Rust
+# blocklist skipping project methods named `new` or `get`.
+_PY_STDLIB_BLOCKLIST: frozenset[str] = frozenset({
+    # typing names not already covered by _PYTHON_TYPE_CONTAINERS
+    "Any", "AnyStr", "NoReturn", "Never", "Self", "TypeAlias", "TypedDict",
+    "NamedTuple", "Protocol", "Generic", "Hashable", "Sized",
+    "IO", "TextIO", "BinaryIO", "Pattern", "Match", "Text",
+    "DefaultDict", "OrderedDict", "Deque", "ChainMap", "Counter",
+    # stdlib modules commonly referenced bare (import os; os.path.join(...))
+    "os", "sys", "re", "io", "json", "csv", "abc", "ast", "math", "time",
+    "enum", "uuid", "copy", "glob", "stat", "errno", "shlex", "shutil",
+    "base64", "bisect", "codecs", "ctypes", "typing", "decimal", "difflib",
+    "fnmatch", "getpass", "hashlib", "heapq", "hmac", "inspect", "logging",
+    "pathlib", "pickle", "platform", "pprint", "queue", "random", "secrets",
+    "select", "signal", "socket", "sqlite3", "string", "struct", "asyncio",
+    "subprocess", "tarfile", "tempfile", "textwrap", "threading",
+    "traceback", "types", "unittest", "urllib", "warnings", "weakref",
+    "zipfile", "zlib", "functools", "itertools", "collections",
+    "contextlib", "dataclasses", "datetime", "argparse", "configparser",
+    "multiprocessing", "importlib", "operator", "statistics", "mimetypes",
+    "calendar", "gzip", "http", "email", "xml", "html",
+    # stdlib classes/callables that show up in annotations and constructor calls
+    "Path", "PurePath", "PosixPath", "WindowsPath", "PathLike",
+    "Enum", "IntEnum", "StrEnum", "Flag", "IntFlag", "auto",
+    "ABC", "ABCMeta", "date", "timedelta", "timezone", "tzinfo",
+    "Decimal", "Fraction", "UUID", "StringIO", "BytesIO",
+    "defaultdict", "deque", "namedtuple", "partial", "dataclass",
+    # builtins / common exceptions
+    "Exception", "BaseException", "ValueError", "TypeError", "KeyError",
+    "IndexError", "AttributeError", "RuntimeError", "NotImplementedError",
+    "FileNotFoundError", "FileExistsError", "OSError", "IOError",
+    "ImportError", "ModuleNotFoundError", "NameError", "ZeroDivisionError",
+    "ArithmeticError", "OverflowError", "PermissionError", "TimeoutError",
+    "ConnectionError", "InterruptedError", "KeyboardInterrupt", "SystemExit",
+    "GeneratorExit", "StopIteration", "StopAsyncIteration", "LookupError",
+    "AssertionError", "RecursionError", "MemoryError", "EOFError",
+    "UnicodeDecodeError", "UnicodeEncodeError", "UnicodeError",
+    "Warning", "DeprecationWarning", "UserWarning", "RuntimeWarning",
+    "FutureWarning", "NotImplemented", "memoryview", "slice", "property",
+    "staticmethod", "classmethod", "frozenset",
+})
+
+# Per-language blocklists for the unresolved-call queue in _extract_generic.
+# Mirrors the Rust blocklist (#908): same-file EXTRACTED matches still
+# resolve, but stdlib/global callee names never enter cross-file resolution,
+# where a unique same-named project symbol would attract spurious INFERRED
+# `calls` edges from every file that touches the stdlib name.
+_UNRESOLVED_CALL_BLOCKLISTS: dict[str, frozenset[str]] = {
+    "tree_sitter_python": _PY_STDLIB_BLOCKLIST,
+    "tree_sitter_javascript": _JS_GLOBAL_BLOCKLIST,
+    "tree_sitter_typescript": _JS_GLOBAL_BLOCKLIST,
+}
+
+
+def _python_type_ref_ok(name: str) -> bool:
+    """True if an annotation identifier should become a reference (node + edge).
+
+    Filters typing containers, scalar-builtin/mock noise (#1147), and bare
+    stdlib/typing names (Path, Any, os, datetime, ...) that would otherwise
+    become free-floating per-file nodes.
+    """
+    return bool(name) and (
+        name not in _PYTHON_TYPE_CONTAINERS
+        and name not in _PYTHON_ANNOTATION_NOISE
+        and name not in _PY_STDLIB_BLOCKLIST
+    )
+
 
 def _python_collect_type_refs(node, source: bytes, generic: bool, out: list[tuple[str, str]]) -> None:
     """Walk a Python type annotation; append (name, role) where role is 'type' or 'generic_arg'.
@@ -502,19 +609,19 @@ def _python_collect_type_refs(node, source: bytes, generic: bool, out: list[tupl
         return
     if t == "identifier":
         name = _read_text(node, source)
-        if name and name not in _PYTHON_TYPE_CONTAINERS and name not in _PYTHON_ANNOTATION_NOISE:
+        if _python_type_ref_ok(name):
             out.append((name, "generic_arg" if generic else "type"))
         return
     if t == "attribute":
         tail = _read_text(node, source).rsplit(".", 1)[-1]
-        if tail and tail not in _PYTHON_TYPE_CONTAINERS and tail not in _PYTHON_ANNOTATION_NOISE:
+        if _python_type_ref_ok(tail):
             out.append((tail, "generic_arg" if generic else "type"))
         return
     if t == "generic_type":
         for c in node.children:
             if c.type == "identifier":
                 container = _read_text(c, source)
-                if container and container not in _PYTHON_TYPE_CONTAINERS and container not in _PYTHON_ANNOTATION_NOISE:
+                if _python_type_ref_ok(container):
                     out.append((container, "generic_arg" if generic else "type"))
             elif c.type == "type_parameter":
                 for sub in c.children:
@@ -1764,6 +1871,13 @@ def _js_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
                         name_node = child.child_by_field_name("name")
                         if name_node:
                             const_name = _read_text(name_node, source)
+                            # `const fs = require('fs')` and friends: the
+                            # imports_from edge from _require_imports_js already
+                            # records the dependency; a per-file `fs`/`path`/`os`
+                            # binding node would only clutter god-node rankings
+                            # (same noise class as _PY_STDLIB_BLOCKLIST).
+                            if const_name in _JS_GLOBAL_BLOCKLIST:
+                                continue
                             line = child.start_point[0] + 1
                             const_nid = _make_id(stem, const_name)
                             add_node_fn(const_nid, const_name, line)
@@ -3303,14 +3417,22 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                             "weight": 1.0,
                         })
                 elif callee_name and not tgt_nid:
-                    # Callee not in this file — save for cross-file resolution in extract()
-                    raw_calls.append({
-                        "caller_nid": caller_nid,
-                        "callee": callee_name,
-                        "is_member_call": is_member_call,
-                        "source_file": str_path,
-                        "source_location": f"L{node.start_point[0] + 1}",
-                    })
+                    # Callee not in this file — save for cross-file resolution
+                    # in extract(). Skip per-language stdlib/global names
+                    # (Path(...), datetime(...), setTimeout(...)) from the
+                    # unresolved-call queue entirely: resolving them cross-file
+                    # attaches spurious INFERRED edges to whatever project
+                    # symbol happens to share the name, the same failure mode
+                    # _RUST_TRAIT_METHOD_BLOCKLIST guards against (#908).
+                    lang_blocklist = _UNRESOLVED_CALL_BLOCKLISTS.get(config.ts_module)
+                    if lang_blocklist is None or callee_name not in lang_blocklist:
+                        raw_calls.append({
+                            "caller_nid": caller_nid,
+                            "callee": callee_name,
+                            "is_member_call": is_member_call,
+                            "source_file": str_path,
+                            "source_location": f"L{node.start_point[0] + 1}",
+                        })
 
             # Helper function calls: config('foo.bar') → uses_config edge to "foo"
             if (callee_name and callee_name in config.helper_fn_names):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1060,3 +1060,174 @@ def test_dart_child_node_ids_are_stem_based(tmp_path):
         )
 
 
+
+# ── Python stdlib / JS global noise blocklists ────────────────────────────────
+
+
+def test_python_stdlib_annotation_names_produce_no_nodes(tmp_path):
+    """Stdlib/typing names referenced in annotations (Path, Any, datetime,
+    os.PathLike) must not become free-floating per-file nodes that
+    _resolve_cross_file_imports then promotes into `uses` god-nodes —
+    same failure mode as the Rust trait-method blocklist (#908)."""
+    models = tmp_path / "models.py"
+    consumer = tmp_path / "consumer.py"
+    models.write_text(
+        "from pathlib import Path\n"
+        "from typing import Any\n"
+        "import datetime\n"
+        "import os\n"
+        "class MemoryIndex:\n"
+        "    def load(self, p: Path, when: datetime.datetime) -> Any:\n"
+        "        return os.path.exists(p)\n"
+    )
+    consumer.write_text(
+        "from pathlib import Path\n"
+        "from typing import Any\n"
+        "from .models import MemoryIndex\n"
+        "class Consumer:\n"
+        "    def run(self, p: Path) -> Any:\n"
+        "        idx = MemoryIndex()\n"
+        "        return idx.load(p, None)\n"
+    )
+
+    result = extract([models, consumer], cache_root=tmp_path)
+    noise_labels = {"Path", "Any", "datetime", "PathLike", "os"}
+    noise_nodes = [n for n in result["nodes"] if n["label"] in noise_labels]
+    assert noise_nodes == [], f"Stdlib names became nodes: {noise_nodes}"
+
+    # No INFERRED `uses` edge may originate from a stdlib-named node.
+    nodes = {n["id"]: n for n in result["nodes"]}
+    bad_uses = [
+        e for e in result["edges"]
+        if e["relation"] == "uses" and nodes.get(e["source"], {}).get("label") in noise_labels
+    ]
+    assert bad_uses == [], f"Stdlib node got a uses edge: {bad_uses}"
+
+
+def test_python_project_import_edges_survive_stdlib_blocklist(tmp_path):
+    """The blocklist must not touch legitimate import edges: file → project
+    module (imports_from), file → imported symbol (imports), and the
+    class-level INFERRED `uses` edge from the importing class."""
+    models = tmp_path / "models.py"
+    consumer = tmp_path / "consumer.py"
+    models.write_text(
+        "from pathlib import Path\n"
+        "class MemoryIndex:\n"
+        "    def load(self, p: Path) -> None:\n"
+        "        return None\n"
+    )
+    consumer.write_text(
+        "from typing import Any\n"
+        "from .models import MemoryIndex\n"
+        "class Consumer:\n"
+        "    def run(self) -> Any:\n"
+        "        return MemoryIndex()\n"
+    )
+
+    result = extract([models, consumer], cache_root=tmp_path)
+    nodes = {n["id"]: n for n in result["nodes"]}
+    labels = {n["label"] for n in result["nodes"]}
+    assert "MemoryIndex" in labels and "Consumer" in labels
+
+    edge_views = [
+        (nodes.get(e["source"], {}).get("label", e["source"]),
+         e["relation"],
+         nodes.get(e["target"], {}).get("label", e["target"]))
+        for e in result["edges"]
+    ]
+    # file-level import of the project module survives
+    assert ("consumer.py", "imports_from", "models.py") in edge_views, edge_views
+    # symbol-level import edge survives
+    assert ("consumer.py", "imports", "MemoryIndex") in edge_views, edge_views
+    # class-level INFERRED uses edge from the real importing class survives
+    assert ("Consumer", "uses", "MemoryIndex") in edge_views, edge_views
+    # stdlib module import edges remain as (dangling, external) file edges
+    stdlib_imports = [
+        e["target"] for e in result["edges"]
+        if e["relation"] in ("imports", "imports_from")
+        and nodes.get(e["source"], {}).get("label") == "consumer.py"
+    ]
+    assert "typing" in stdlib_imports, stdlib_imports
+
+
+def test_python_stdlib_constructor_calls_skip_unresolved_queue():
+    """`Path(...)` / `datetime(...)` bare calls must be skipped from the
+    unresolved-call queue (mirrors _RUST_TRAIT_METHOD_BLOCKLIST, #908),
+    while project-name callees still enqueue."""
+    from graphify.extract import extract_python
+    fixture = FIXTURES / "_stdlib_calls.py"
+    fixture.write_text(
+        "from pathlib import Path\n"
+        "def helper(base):\n"
+        "    p = Path(base)\n"
+        "    return resolve_widget(p)\n"
+    )
+    try:
+        result = extract_python(fixture)
+        callees = [rc["callee"] for rc in result.get("raw_calls", [])]
+        assert "Path" not in callees, callees
+        assert "resolve_widget" in callees, callees
+    finally:
+        fixture.unlink()
+
+
+def test_extract_js_core_module_require_binding_produces_no_node(tmp_path):
+    """`const fs = require('fs')` must keep its imports_from edge but not
+    create a per-file `fs`/`path` binding node; project-named module-level
+    consts are unaffected."""
+    app = tmp_path / "app.js"
+    app.write_text(
+        "const fs = require('fs');\n"
+        "const path = require('path');\n"
+        "const registry = buildRegistry();\n"
+        "function load(p) { return fs.readFileSync(path.join(p)); }\n"
+    )
+    result = extract([app], cache_root=tmp_path)
+    labels = [n["label"] for n in result["nodes"]]
+    assert "fs" not in labels and "path" not in labels, labels
+    assert "registry" in labels, labels
+    assert "load()" in labels, labels
+    import_targets = [
+        e["target"] for e in result["edges"] if e["relation"] == "imports_from"
+    ]
+    assert "fs" in import_targets and "path" in import_targets, import_targets
+
+
+def test_js_global_calls_skip_unresolved_queue():
+    """Bare calls to JS runtime globals (setTimeout, fetch) must not enter the
+    unresolved-call queue where they would attract spurious cross-file
+    INFERRED edges onto same-named project symbols."""
+    from graphify.extract import extract_js
+    fixture = FIXTURES / "_js_global_calls.js"
+    fixture.write_text(
+        "function poll() {\n"
+        "  setTimeout(() => fetch('/x'), 100);\n"
+        "  return renderWidget();\n"
+        "}\n"
+    )
+    try:
+        result = extract_js(fixture)
+        callees = [rc["callee"] for rc in result.get("raw_calls", [])]
+        assert "setTimeout" not in callees, callees
+        assert "fetch" not in callees, callees
+        assert "renderWidget" in callees, callees
+    finally:
+        fixture.unlink()
+
+
+def test_god_nodes_exclude_stdlib_noise_labels():
+    """Defense-in-depth (#1147 pattern): pre-existing graphs with stdlib noise
+    nodes must not rank Path/Any/os in god_nodes."""
+    import networkx as nx
+    from graphify.analyze import god_nodes
+
+    G = nx.DiGraph()
+    G.add_node("util_path", label="Path", source_file="util.py")
+    G.add_node("util_memoryindex", label="MemoryIndex", source_file="util.py")
+    for i in range(5):
+        G.add_node(f"c{i}", label=f"C{i}", source_file=f"c{i}.py")
+        G.add_edge(f"c{i}", "util_path", relation="uses")
+        G.add_edge(f"c{i}", "util_memoryindex", relation="uses")
+    top = [g["label"] for g in god_nodes(G, top_n=5)]
+    assert "Path" not in top, top
+    assert "MemoryIndex" in top, top


### PR DESCRIPTION
## Problem

Python annotation references and JS require-bindings to stdlib/runtime names become free-floating graph nodes. On a real ~25k-node graph, `Path` existed as **174 per-file nodes**, plus `Any` ×77, `os` ×74, `datetime` ×31 — and stdlib names held 3 of the top 5 god-node slots in GRAPH_REPORT.md, masking the project's actual hubs.

## Root cause

Three cooperating layers (traced on 0.8.36):

1. `_python_collect_type_refs` emits nodes for annotation identifiers like `def f(p: Path) -> Any`. `Any` is missing from `_PYTHON_TYPE_CONTAINERS`, and stdlib classes/modules are covered nowhere, so `ensure_named_node` materializes each as a node.
2. `_disambiguate_colliding_node_ids` sees the same bare id from N files and splits it into per-file ids — hence 174 `Path` nodes.
3. `_resolve_cross_file_imports` classifies those nodes as importing classes and emits spurious `Path --uses--> ProjectClass` INFERRED edges from every one.

JS path is separate: `_js_extra_walk` creates a per-file binding node for module-level `const fs = require('fs')`, and runtime globals (`setTimeout`, `fetch`, `require`) enter the unresolved-call queue where they attract cross-file INFERRED `calls` edges.

## Fix

Follows the existing precedents for this exact class of problem:

- **`_PY_STDLIB_BLOCKLIST`** applied in the annotation walker via a new `_python_type_ref_ok()` — the same layer as `_PYTHON_ANNOTATION_NOISE` (#1147), so noise is suppressed before node *or* edge creation.
- **`_JS_GLOBAL_BLOCKLIST`** suppresses the require-binding const node in `_js_extra_walk` (the `imports_from` edge from `_require_imports_js` is preserved).
- **`_UNRESOLVED_CALL_BLOCKLISTS`** gates raw-call queue insertion for Python/JS/TS — mirroring `_RUST_TRAIT_METHOD_BLOCKLIST` (#908): same-file EXTRACTED matches still resolve; only cross-file resolution is skipped.
- **`analyze.py`**: both sets folded into `_BUILTIN_NOISE_LABELS` (defense-in-depth, matching #1147) — this also covers graphs built from stale extraction caches, since cache keys are content-hash only.

Matching is on raw identifiers and extracted function labels carry a `()` suffix, so project functions are never shadowed (verified empirically).

**Tradeoff (same one the Rust blocklist accepts):** a project class literally named `Path`/`Counter`/`json` loses annotation-reference edges and cross-file call resolution. Same-file resolution and `contains`/`method` edges are unaffected. Lists deliberately exclude commonly project-named identifiers (`Event`, `Queue`, `Logger`, `Request`, `Response`, `Thread`, `Task`).

## Tests

- 6 new tests in `tests/test_extract.py`: node suppression, no INFERRED `uses` edges, project import/`uses` edge survival, Python and JS unresolved-queue gates, god_nodes guard.
- `tests/test_extract.py`: 82 passed. Related extraction/resolution suites: 369 passed, 22 skipped.
- Full suite: identical pass/fail profile as the unmodified base tree (the 21 failures are pre-existing environmental ones — missing optional grammars). Zero regressions.

## Release-note suggestion

Existing extraction caches still contain the noise nodes until source files change or the cache is cleared; the `analyze.py` guard covers god-node rankings in the meantime, but raw node counts shrink only after re-extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)