### PR TITLE
[codex] Fix hook status in linked worktrees

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2632,14 +2632,18 @@ def main() -> None:
         )
 
         subcmd = sys.argv[2] if len(sys.argv) > 2 else ""
-        if subcmd == "install":
-            print(hook_install(Path(".")))
-        elif subcmd == "uninstall":
-            print(hook_uninstall(Path(".")))
-        elif subcmd == "status":
-            print(hook_status(Path(".")))
-        else:
-            print("Usage: graphify hook [install|uninstall|status]", file=sys.stderr)
+        try:
+            if subcmd == "install":
+                print(hook_install(Path(".")))
+            elif subcmd == "uninstall":
+                print(hook_uninstall(Path(".")))
+            elif subcmd == "status":
+                print(hook_status(Path(".")))
+            else:
+                print("Usage: graphify hook [install|uninstall|status]", file=sys.stderr)
+                sys.exit(1)
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
             sys.exit(1)
     elif cmd == "query":
         if len(sys.argv) < 3:

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -284,61 +284,120 @@ def _git_root(path: Path) -> Path | None:
     return None
 
 
+def _clean_git_stdout(raw: str) -> str:
+    """Return a single safe git path line, or an empty string."""
+    raw = raw.strip()
+    if not raw or any(c in raw for c in ("\n", "\r", "\x00")):
+        return ""
+    return raw
+
+
+def _path_from_git_output(root: Path, raw: str) -> Path | None:
+    value = _clean_git_stdout(raw)
+    if not value:
+        return None
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = root / path
+    return path.resolve()
+
+
+def _repo_local_hooks_path(root: Path, custom: str) -> Path | None:
+    custom = _clean_git_stdout(custom)
+    if not custom:
+        return None
+    path = Path(custom).expanduser()
+    if not path.is_absolute():
+        path = root / path
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return None
+    return path
+
+
+def _common_git_dir_from_dotgit(root: Path) -> Path | None:
+    dotgit = root / ".git"
+    if dotgit.is_dir():
+        return dotgit.resolve()
+    if not dotgit.is_file():
+        return None
+    try:
+        first_line = dotgit.read_text(encoding="utf-8").splitlines()[0].strip()
+    except (OSError, IndexError):
+        return None
+    prefix = "gitdir:"
+    if not first_line.lower().startswith(prefix):
+        return None
+    git_dir = Path(first_line[len(prefix):].strip()).expanduser()
+    if not git_dir.is_absolute():
+        git_dir = root / git_dir
+    git_dir = git_dir.resolve()
+    if git_dir.parent.name == "worktrees":
+        return git_dir.parent.parent
+    return git_dir
+
+
 def _hooks_dir(root: Path) -> Path:
     """Return the git hooks directory, respecting core.hooksPath if set (e.g. Husky)."""
-    try:
-        cfg = configparser.RawConfigParser()
-        cfg.read(root / ".git" / "config", encoding="utf-8")
-        # configparser lowercases option names; git's hooksPath becomes hookspath
-        custom = cfg.get("core", "hookspath", fallback="").strip()
-        if custom:
-            p = Path(custom).expanduser()
-            if not p.is_absolute():
-                p = root / p
-            # Validate the resolved path stays within the repository root
-            # to prevent supply-chain attacks via malicious core.hooksPath values
-            try:
-                p.resolve().relative_to(root.resolve())
-            except ValueError:
-                pass  # Path escapes repo root; fall through to default .git/hooks
-            else:
-                p.mkdir(parents=True, exist_ok=True)
-                return p
-    except (configparser.Error, OSError) as exc:
-        # Narrow the exception (PR747-NEW-2): a bare `except Exception: pass`
-        # was hiding tampering signals (corrupt .git/config, permission flips
-        # by another tool). Surface them on stderr instead of silently
-        # falling through to the default hooks directory.
-        print(
-            f"[graphify hooks] could not read core.hooksPath from "
-            f"{root / '.git' / 'config'}: {exc}",
-            file=sys.stderr,
-        )
-    # In a linked worktree .git is a file not a directory, so constructing
-    # root/.git/hooks directly fails. Ask git for the real hooks path instead.
-    # NOTE: do NOT pass --path-format=absolute — added in git 2.31; older git
-    # echoes it back as a literal argument, contaminating stdout and causing a
-    # phantom directory to be created (#907). git -C <root> already returns an
-    # absolute path for worktree/external-gitdir cases, and a path relative to
-    # <root> for normal repos — anchoring on root covers both.
     import subprocess as _sp
+
     try:
         res = _sp.run(
-            ["git", "-C", str(root), "rev-parse", "--git-path", "hooks"],
+            ["git", "-C", str(root), "config", "--get", "core.hooksPath"],
             capture_output=True, text=True,
         )
-        raw = res.stdout.strip()
-        # A valid hooks path can never contain newlines or NUL. Their presence
-        # means git echoed an unrecognised flag back (old git behaviour).
-        if res.returncode == 0 and raw and not any(c in raw for c in ("\n", "\r", "\x00")):
-            d = (root / raw).resolve()
-            d.mkdir(parents=True, exist_ok=True)
-            return d
+        if res.returncode == 0:
+            custom = _repo_local_hooks_path(root, res.stdout)
+            if custom is not None:
+                custom.mkdir(parents=True, exist_ok=True)
+                return custom
+    except (OSError, FileNotFoundError):
+        try:
+            cfg = configparser.RawConfigParser()
+            common = _common_git_dir_from_dotgit(root)
+            if common is not None:
+                cfg.read(common / "config", encoding="utf-8")
+                # configparser lowercases option names; git's hooksPath becomes hookspath
+                custom = _repo_local_hooks_path(root, cfg.get("core", "hookspath", fallback=""))
+                if custom is not None:
+                    custom.mkdir(parents=True, exist_ok=True)
+                    return custom
+        except (configparser.Error, OSError) as exc:
+            print(
+                f"[graphify hooks] could not read core.hooksPath from git config: {exc}",
+                file=sys.stderr,
+            )
+
+    try:
+        res = _sp.run(
+            ["git", "-C", str(root), "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True,
+        )
+        if res.returncode == 0:
+            common = _path_from_git_output(root, res.stdout)
+            if common is not None:
+                d = common / "hooks"
+                d.mkdir(parents=True, exist_ok=True)
+                return d
     except (OSError, FileNotFoundError):
         pass
+
+    common = _common_git_dir_from_dotgit(root)
+    if common is not None:
+        d = common / "hooks"
+        try:
+            d.mkdir(parents=True, exist_ok=True)
+            return d
+        except OSError as exc:
+            raise RuntimeError(f"Could not create git hooks directory at {d}: {exc}") from exc
+
     d = root / ".git" / "hooks"
-    d.mkdir(parents=True, exist_ok=True)
-    return d
+    try:
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+    except OSError as exc:
+        raise RuntimeError(f"Could not create git hooks directory at {d}: {exc}") from exc
 
 
 def _install_hook(hooks_dir: Path, name: str, script: str, marker: str) -> str:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -12,6 +12,16 @@ def _make_git_repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def _make_git_repo_with_commit(path: Path) -> Path:
+    repo = _make_git_repo(path)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test User"], check=True)
+    (repo / "README.md").write_text("test\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "initial"], check=True, capture_output=True)
+    return repo
+
+
 def test_install_creates_hook(tmp_path):
     repo = _make_git_repo(tmp_path)
     result = install(repo)
@@ -85,6 +95,22 @@ def test_no_git_repo_raises(tmp_path):
         install(tmp_path / "not_a_repo")
 
 
+@pytest.mark.parametrize("subcmd", ["install", "uninstall"])
+def test_hook_cli_non_git_errors_without_traceback(tmp_path, subcmd):
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "graphify", "hook", subcmd],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "No git repository" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
 def test_install_creates_post_checkout_hook(tmp_path):
     repo = _make_git_repo(tmp_path)
     install(repo)
@@ -120,12 +146,70 @@ def test_status_shows_both_hooks(tmp_path):
     assert result.count("installed") >= 2
 
 
+def test_hooks_dir_regular_repo_uses_git_hooks_dir(tmp_path):
+    repo = _make_git_repo(tmp_path)
+
+    assert _hooks_dir(repo) == (repo / ".git" / "hooks").resolve()
+
+
+def test_hooks_dir_linked_worktree_uses_common_git_hooks_dir(tmp_path):
+    main = _make_git_repo_with_commit(tmp_path / "main")
+    worktree = tmp_path / "linked"
+    subprocess.run(
+        ["git", "-C", str(main), "worktree", "add", str(worktree), "-b", "linked-test"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert (worktree / ".git").is_file()
+    assert _hooks_dir(worktree) == (main / ".git" / "hooks").resolve()
+
+    result = status(worktree)
+    assert "post-commit: not installed" in result
+    assert "post-checkout: not installed" in result
+
+
+def test_hooks_dir_linked_worktree_falls_back_to_gitdir_pointer(tmp_path, monkeypatch):
+    main = _make_git_repo_with_commit(tmp_path / "main")
+    worktree = tmp_path / "linked"
+    subprocess.run(
+        ["git", "-C", str(main), "worktree", "add", str(worktree), "-b", "linked-fallback"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    def git_unavailable(*args, **kwargs):
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr("subprocess.run", git_unavailable)
+
+    assert _hooks_dir(worktree) == (main / ".git" / "hooks").resolve()
+
+
+def test_hooks_dir_respects_core_hooks_path(tmp_path):
+    repo = _make_git_repo(tmp_path)
+    custom_hooks = repo / ".husky"
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "core.hooksPath", ".husky"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert _hooks_dir(repo) == custom_hooks.resolve()
+    assert custom_hooks.is_dir()
+
+
 
 def test_hooks_dir_resolves_relative_git_hooks_path(tmp_path, monkeypatch):
     repo = _make_git_repo(tmp_path)
 
-    def fake_run(*args, **kwargs):
-        return SimpleNamespace(returncode=0, stdout=".git/hooks\n")
+    def fake_run(args, **kwargs):
+        if args[-2:] == ["--get", "core.hooksPath"]:
+            return SimpleNamespace(returncode=1, stdout="")
+        return SimpleNamespace(returncode=0, stdout=".git\n")
 
     monkeypatch.setattr("subprocess.run", fake_run)
 
@@ -135,8 +219,10 @@ def test_hooks_dir_resolves_relative_git_hooks_path(tmp_path, monkeypatch):
 def test_hooks_dir_rejects_multiline_git_output(tmp_path, monkeypatch):
     repo = _make_git_repo(tmp_path)
 
-    def fake_run(*args, **kwargs):
-        return SimpleNamespace(returncode=0, stdout="--path-format=absolute\n.git/hooks\n")
+    def fake_run(args, **kwargs):
+        if args[-2:] == ["--get", "core.hooksPath"]:
+            return SimpleNamespace(returncode=1, stdout="")
+        return SimpleNamespace(returncode=0, stdout="--path-format=absolute\n.git\n")
 
     monkeypatch.setattr("subprocess.run", fake_run)
 
@@ -146,14 +232,16 @@ def test_hooks_dir_rejects_multiline_git_output(tmp_path, monkeypatch):
 
 def test_hooks_dir_accepts_absolute_git_hooks_path(tmp_path, monkeypatch):
     repo = _make_git_repo(tmp_path)
-    hooks = tmp_path / "actual-hooks"
+    git_dir = tmp_path / "actual-git-dir"
 
-    def fake_run(*args, **kwargs):
-        return SimpleNamespace(returncode=0, stdout=f"{hooks}\n")
+    def fake_run(args, **kwargs):
+        if args[-2:] == ["--get", "core.hooksPath"]:
+            return SimpleNamespace(returncode=1, stdout="")
+        return SimpleNamespace(returncode=0, stdout=f"{git_dir}\n")
 
     monkeypatch.setattr("subprocess.run", fake_run)
 
-    assert _hooks_dir(repo) == hooks.resolve()
+    assert _hooks_dir(repo) == (git_dir / "hooks").resolve()
 
 def test_hook_skips_head_on_exe():
     """Hook script must skip shebang extraction for .exe binaries (Windows)."""


### PR DESCRIPTION
## Summary

Fix `graphify hook status` / `install` / `uninstall` inside linked git worktrees.

## Repro

Before this change, linked worktrees have `.git` as a file containing a `gitdir:` pointer, so fallback hook resolution could try `<worktree>/.git/hooks` and raise `NotADirectoryError`.

```sh
git worktree add /tmp/wt-test
cd /tmp/wt-test
graphify hook status
```

## Fix

- Resolve `core.hooksPath` with git config and keep the repo-local safety check.
- Resolve fallback hooks through `git rev-parse --git-common-dir`, then `<common-git-dir>/hooks`.
- Parse `.git` `gitdir:` pointer when git is unavailable, including `.git/worktrees/<name>` back to common `.git`.
- Make non-git hook install/uninstall CLI errors print cleanly instead of tracebacking.

## Tests

- `uv run --frozen pytest tests/test_hooks.py -q --tb=short` passes: 40 passed.
- Manual linked-worktree repro returns hook status instead of traceback.
- `uv run --frozen pytest tests/ -q --tb=short` has 3 unrelated failures in `tests/test_pg_introspect.py`.
