### PR TITLE
perf: eliminate redundant Path.relative_to() calls and cache pure function results

### DIFF
--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -4,6 +4,7 @@ Pipeline: exact normalization → entropy gate → MinHash/LSH blocking →
 Jaro-Winkler verification → same-community boost → union-find merge.
 """
 from __future__ import annotations
+import functools
 import math
 import re
 import unicodedata
@@ -15,6 +16,7 @@ from rapidfuzz.distance import JaroWinkler
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
+@functools.lru_cache(maxsize=None)
 def _norm(label: str | None) -> str:
     """Lowercase + collapse non-alphanumeric runs to space (Unicode-aware)."""
     if not isinstance(label, str):

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -787,6 +787,16 @@ def _is_ignored(path: Path, root: Path, patterns: list[tuple[Path, str]]) -> boo
                     return True
             return False
 
+        # target and root are fixed for this call — hoist relative_to out of
+        # the pattern loop so it isn't recomputed once per pattern per file.
+        try:
+            rel_root: str | None = str(target.relative_to(root)).replace(os.sep, "/")
+        except ValueError:
+            rel_root = None
+        # Multiple patterns can share an anchor (same .graphifyignore file),
+        # so cache anchor-relative strings within this call too.
+        rel_anchor_cache: dict[Path, str | None] = {}
+
         result = False
         for anchor, pattern in patterns:
             negated = pattern.startswith("!")
@@ -798,23 +808,26 @@ def _is_ignored(path: Path, root: Path, patterns: list[tuple[Path, str]]) -> boo
 
             matched = False
             if anchored:
-                try:
-                    rel_anchor = str(target.relative_to(anchor)).replace(os.sep, "/")
-                    matched = _matches(rel_anchor, p, anchored=True)
-                except ValueError:
-                    pass
-            else:
-                try:
-                    rel = str(target.relative_to(root)).replace(os.sep, "/")
-                    matched = _matches(rel, p, anchored=False)
-                except ValueError:
-                    pass
-                if not matched and anchor != root:
+                if anchor not in rel_anchor_cache:
                     try:
-                        rel_anchor = str(target.relative_to(anchor)).replace(os.sep, "/")
-                        matched = _matches(rel_anchor, p, anchored=False)
+                        rel_anchor_cache[anchor] = str(target.relative_to(anchor)).replace(os.sep, "/")
                     except ValueError:
-                        pass
+                        rel_anchor_cache[anchor] = None
+                rel_anchor = rel_anchor_cache[anchor]
+                if rel_anchor is not None:
+                    matched = _matches(rel_anchor, p, anchored=True)
+            else:
+                if rel_root is not None:
+                    matched = _matches(rel_root, p, anchored=False)
+                if not matched and anchor != root:
+                    if anchor not in rel_anchor_cache:
+                        try:
+                            rel_anchor_cache[anchor] = str(target.relative_to(anchor)).replace(os.sep, "/")
+                        except ValueError:
+                            rel_anchor_cache[anchor] = None
+                    rel_anchor = rel_anchor_cache[anchor]
+                    if rel_anchor is not None:
+                        matched = _matches(rel_anchor, p, anchored=False)
 
             if matched:
                 result = not negated  # last match wins; ! flips to un-ignore

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1,6 +1,7 @@
 """Deterministic structural extraction from source code using tree-sitter. Outputs nodes+edges dicts."""
 from __future__ import annotations
 
+import functools
 import importlib
 import json
 import os
@@ -6744,6 +6745,7 @@ def extract_powershell(path: Path) -> dict:
 
 # ── Cross-file import resolution ──────────────────────────────────────────────
 
+@functools.lru_cache(maxsize=None)
 def _source_key(source_file: str, root: Path) -> str:
     if not source_file:
         return ""
@@ -6876,6 +6878,7 @@ def _rewire_unique_stub_nodes(nodes: list[dict], edges: list[dict]) -> None:
     nodes[:] = [node for node in nodes if node.get("id") not in drop_ids]
 
 
+@functools.lru_cache(maxsize=None)
 def _js_source_path(source_file: str, root: Path) -> Path | None:
     if not source_file:
         return None
@@ -11516,17 +11519,21 @@ def extract(
     # Map each node back to its containing file_id so we can ask
     # "did the caller's file import the callee's file?"
     # Use relativized paths to match how file node IDs were remapped above (#502).
+    # Many nodes share the same source_file — cache relative_to per unique path.
+    _sf_to_file_nid: dict[str, str] = {}
     nid_to_file_nid: dict[str, str] = {}
     for n in all_nodes:
         sf = n.get("source_file")
         if not sf:
             continue
-        sf_path = Path(sf)
-        try:
-            sf_rel = sf_path.relative_to(root) if sf_path.is_absolute() else sf_path
-        except ValueError:
-            sf_rel = sf_path
-        nid_to_file_nid[n["id"]] = _file_node_id(sf_rel)
+        if sf not in _sf_to_file_nid:
+            sf_path = Path(sf)
+            try:
+                sf_rel = sf_path.relative_to(root) if sf_path.is_absolute() else sf_path
+            except ValueError:
+                sf_rel = sf_path
+            _sf_to_file_nid[sf] = _file_node_id(sf_rel)
+        nid_to_file_nid[n["id"]] = _sf_to_file_nid[sf]
 
     existing_pairs = {(e["source"], e["target"]) for e in all_edges}
     for rc in all_raw_calls:
@@ -11579,17 +11586,22 @@ def extract(
             })
 
     # Relativize source_file fields so paths are portable across machines (#555)
+    # Many nodes and edges share the same source_file — cache per unique path.
+    _sf_to_posix: dict[str, str] = {}
     for item in all_nodes + all_edges:
         sf = item.get("source_file")
         if not sf:
             continue
-        sf_path = Path(sf)
-        if not sf_path.is_absolute():
-            continue
-        try:
-            item["source_file"] = sf_path.relative_to(root).as_posix()
-        except ValueError:
-            pass
+        if sf not in _sf_to_posix:
+            sf_path = Path(sf)
+            if not sf_path.is_absolute():
+                _sf_to_posix[sf] = sf
+            else:
+                try:
+                    _sf_to_posix[sf] = sf_path.relative_to(root).as_posix()
+                except ValueError:
+                    _sf_to_posix[sf] = sf
+        item["source_file"] = _sf_to_posix[sf]
 
     # Tag AST provenance so the incremental watch rebuild can distinguish
     # AST-extracted nodes from semantic/LLM nodes. On a full re-extraction


### PR DESCRIPTION
Some caching and performance improvements.
My runtime went from 261s -> 139s

Before:
```
[graphify extract] scanning C:\testrepo
[graphify extract] found 2182 code, 0 docs, 0 papers, 0 images
[graphify extract] AST extraction on 2182 code files...
  AST extraction: 100/2182 uncached files (4%) [20 workers]
  AST extraction: 200/2182 uncached files (9%) [20 workers]
  AST extraction: 300/2182 uncached files (13%) [20 workers]
  AST extraction: 400/2182 uncached files (18%) [20 workers]
  AST extraction: 500/2182 uncached files (22%) [20 workers]
  AST extraction: 600/2182 uncached files (27%) [20 workers]
  AST extraction: 700/2182 uncached files (32%) [20 workers]
  AST extraction: 800/2182 uncached files (36%) [20 workers]
  AST extraction: 900/2182 uncached files (41%) [20 workers]
  AST extraction: 1000/2182 uncached files (45%) [20 workers]
  AST extraction: 1100/2182 uncached files (50%) [20 workers]
  AST extraction: 1200/2182 uncached files (54%) [20 workers]
  AST extraction: 1300/2182 uncached files (59%) [20 workers]
  AST extraction: 1400/2182 uncached files (64%) [20 workers]
  AST extraction: 1500/2182 uncached files (68%) [20 workers]
  AST extraction: 1600/2182 uncached files (73%) [20 workers]
  AST extraction: 1700/2182 uncached files (77%) [20 workers]
  AST extraction: 1800/2182 uncached files (82%) [20 workers]
  AST extraction: 1900/2182 uncached files (87%) [20 workers]
  AST extraction: 2000/2182 uncached files (91%) [20 workers]
  AST extraction: 2100/2182 uncached files (96%) [20 workers]
  AST extraction: 2182/2182 files (100%) [20 workers]
[graphify] Deduplicated 37140 node(s) (34785 exact, 1875 fuzzy).
[graphify extract] wrote C:\testrepo\graphify-out\graph.json: 49644 nodes, 103147 edges, 2095 communities
[graphify extract] wrote C:\testrepo\graphify-out\.graphify_analysis.json
[graphify extract] next: run `graphify cluster-only C:\testrepo` to generate GRAPH_REPORT.md and name communities

  _     ._   __/__   _ _  _  _ _/_   Recorded: 14:40:09  Samples:  190054
 /_//_/// /_\ / //_// / //_'/ //     Duration: 245.782   CPU time: 239.859
/   _/                      v5.1.2

Program: graphify .

245.783 <module>  ..\graphify\__main__.py:1
└─ 245.751 main  ..\graphify\__main__.py:2070
   └─ 245.719 main  ..\graphify\__main__.py:2070
      ├─ 113.684 extract  ..\graphify\extract.py:11290
      │  ├─ 56.826 _disambiguate_colliding_node_ids  ..\graphify\extract.py:6757
      │  │  └─ 54.994 _source_key  ..\graphify\extract.py:6747
      │  │     ├─ 33.305 WindowsPath.resolve  pathlib\__init__.py:937
      │  │     │     [2 frames hidden]  <frozen ntpath>, <built-in>
      │  │     └─ 20.559 WindowsPath.relative_to  pathlib\__init__.py:481
      │  │           [10 frames hidden]  <frozen _collections_abc>, pathlib
      │  ├─ 26.074 _augment_symbol_resolution_edges  ..\graphify\extract.py:7824
      │  │  ├─ 14.415 _collect_js_symbol_resolution_facts  ..\graphify\extract.py:7484
      │  │  │  └─ 12.188 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │     └─ 11.532 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │        └─ 10.832 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │           └─ 10.157 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │              └─ 9.473 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                 └─ 8.826 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                    └─ 8.126 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                       └─ 7.382 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                          └─ 6.807 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                             └─ 6.214 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                └─ 5.680 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                   └─ 5.160 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                      └─ 4.641 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                         └─ 4.083 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                            └─ 3.633 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                               └─ 3.218 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                                  └─ 2.785 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  └─ 11.572 _apply_symbol_resolution_facts  ..\graphify\extract.py:6955
      │  │     └─ 8.717 _js_source_path  ..\graphify\extract.py:6879
      │  │        └─ 7.839 WindowsPath.resolve  pathlib\__init__.py:937
      │  │              [2 frames hidden]  <frozen ntpath>, <built-in>
      │  ├─ 18.470 WindowsPath.relative_to  pathlib\__init__.py:481
      │  │     [8 frames hidden]  <frozen _collections_abc>, pathlib
      │  └─ 3.940 _extract_parallel  ..\graphify\extract.py:11170
      │     └─ 3.266 as_completed  concurrent\futures\_base.py:193
      │           [3 frames hidden]  threading, <built-in>
      ├─ 65.597 build  ..\graphify\build.py:276
      │  ├─ 62.123 deduplicate_entities  ..\graphify\dedup.py:131
      │  │  ├─ 54.471 [self]  ..\graphify\dedup.py
      │  │  └─ 3.418 <genexpr>  ..\graphify\dedup.py:237
      │  └─ 3.293 build_from_json  ..\graphify\build.py:107
      ├─ 42.955 detect  ..\graphify\detect.py:984
      │  └─ 41.179 _is_ignored  ..\graphify\detect.py:760
      │     └─ 39.792 _eval  ..\graphify\detect.py:783
      │        ├─ 18.807 _matches  ..\graphify\detect.py:787
      │        │  └─ 16.585 fnmatch  fnmatch.py:22
      │        │        [5 frames hidden]  <frozen ntpath>, <built-in>, fnmatch
      │        └─ 18.783 WindowsPath.relative_to  pathlib\__init__.py:481
      │              [8 frames hidden]  <frozen _collections_abc>, pathlib
      ├─ 13.130 cluster  ..\graphify\cluster.py:86
      │  ├─ 7.804 _partition  ..\graphify\cluster.py:22
      │  │  └─ 5.112 func  networkx\utils\decorators.py:783
      │  │     └─ 5.111 argmap_louvain_communities_5  <class 'networkx.utils.decorators.argmap'> compilation 9:1
      │  │        └─ 5.111 _dispatchable._call_if_no_backends_installed  networkx\utils\backends.py:541
      │  │           └─ 5.111 louvain_communities  networkx\algorithms\community\louvain.py:14
      │  │              └─ 5.104 louvain_partitions  networkx\algorithms\community\louvain.py:133
      │  │                 └─ 2.853 _one_level  networkx\algorithms\community\louvain.py:227
      │  └─ 4.687 _split_community  ..\graphify\cluster.py:191
      │     └─ 4.339 _partition  ..\graphify\cluster.py:22
      │        └─ 2.490 argmap_louvain_communities_5  <class 'networkx.utils.decorators.argmap'> compilation 9:1
      │           └─ 2.487 _dispatchable._call_if_no_backends_installed  networkx\utils\backends.py:541
      │              └─ 2.486 louvain_communities  networkx\algorithms\community\louvain.py:14
      │                 └─ 2.482 louvain_partitions  networkx\algorithms\community\louvain.py:133
      └─ 8.044 to_json  ..\graphify\export.py:484
         └─ 6.963 dump  json\__init__.py:120
               [3 frames hidden]  json

To view this report with different options, run:
    pyinstrument --load-prev 2026-06-10T14-40-09 [options]

Elapsed: 261.4s
```

*After*
```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 14:31:26  Samples:  83276
 /_//_/// /_\ / //_// / //_'/ //     Duration: 133.605   CPU time: 129.953
/   _/                      v5.1.2

Program: graphify .

133.604 <module>  ..\graphify\__main__.py:1
└─ 133.575 main  ..\graphify\__main__.py:2070
   └─ 133.554 main  ..\graphify\__main__.py:2070
      ├─ 60.029 build  ..\graphify\build.py:276
      │  ├─ 56.760 deduplicate_entities  ..\graphify\dedup.py:133
      │  │  ├─ 50.766 [self]  ..\graphify\dedup.py
      │  │  ├─ 3.326 <genexpr>  ..\graphify\dedup.py:239
      │  │  └─ 1.549 _make_minhash  ..\graphify\dedup.py:47
      │  └─ 3.113 build_from_json  ..\graphify\build.py:107
      ├─ 25.516 extract  ..\graphify\extract.py:11293
      │  ├─ 16.280 _augment_symbol_resolution_edges  ..\graphify\extract.py:7827
      │  │  ├─ 14.254 _collect_js_symbol_resolution_facts  ..\graphify\extract.py:7487
      │  │  │  └─ 12.025 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │     └─ 11.388 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │        └─ 10.747 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │           └─ 10.122 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │              └─ 9.459 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                 └─ 8.782 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                    └─ 8.088 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                       └─ 7.445 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                          └─ 6.791 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                             └─ 6.200 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                                └─ 5.633 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                                   └─ 5.034 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                                      └─ 4.532 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                                         └─ 4.043 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                                            └─ 3.573 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                                               └─ 3.150 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                                                  └─ 2.738 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                                                     └─ 2.373 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                                                        └─ 2.033 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                                                           └─ 1.725 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  │                                                              └─ 1.403 _walk_js_tree  ..\graphify\extract.py:7194
      │  │  └─ 1.930 _apply_symbol_resolution_facts  ..\graphify\extract.py:6958
      │  ├─ 3.868 _extract_parallel  ..\graphify\extract.py:11173
      │  │  └─ 3.078 as_completed  concurrent\futures\_base.py:193
      │  │        [3 frames hidden]  threading, <built-in>
      │  ├─ 2.170 load_cached  ..\graphify\cache.py:226
      │  │  └─ 1.348 file_hash  ..\graphify\cache.py:97
      │  └─ 1.596 _disambiguate_colliding_node_ids  ..\graphify\extract.py:6759
      ├─ 24.999 detect  ..\graphify\detect.py:997
      │  └─ 23.360 _is_ignored  ..\graphify\detect.py:760
      │     └─ 21.856 _eval  ..\graphify\detect.py:783
      │        └─ 19.049 _matches  ..\graphify\detect.py:787
      │           ├─ 16.850 fnmatch  fnmatch.py:22
      │           │     [8 frames hidden]  <frozen ntpath>, <built-in>, fnmatch
      │           └─ 1.692 [self]  ..\graphify\detect.py
      ├─ 13.111 cluster  ..\graphify\cluster.py:86
      │  ├─ 7.686 _partition  ..\graphify\cluster.py:22
      │  │  └─ 4.957 func  networkx\utils\decorators.py:783
      │  │     └─ 4.956 argmap_louvain_communities_5  <class 'networkx.utils.decorators.argmap'> compilation 9:1
      │  │        └─ 4.956 _dispatchable._call_if_no_backends_installed  networkx\utils\backends.py:541
      │  │           └─ 4.956 louvain_communities  networkx\algorithms\community\louvain.py:14
      │  │              └─ 4.949 louvain_partitions  networkx\algorithms\community\louvain.py:133
      │  │                 └─ 2.746 _one_level  networkx\algorithms\community\louvain.py:227
      │  └─ 4.794 _split_community  ..\graphify\cluster.py:191
      │     └─ 4.453 _partition  ..\graphify\cluster.py:22
      │        └─ 2.608 argmap_louvain_communities_5  <class 'networkx.utils.decorators.argmap'> compilation 9:1
      │           └─ 2.606 _dispatchable._call_if_no_backends_installed  networkx\utils\backends.py:541
      │              └─ 2.606 louvain_communities  networkx\algorithms\community\louvain.py:14
      │                 └─ 2.601 louvain_partitions  networkx\algorithms\community\louvain.py:133
      └─ 7.757 to_json  ..\graphify\export.py:484
         └─ 6.934 dump  json\__init__.py:120
               [4 frames hidden]  json

To view this report with different options, run:
    pyinstrument --load-prev 2026-06-10T14-31-26 [options]

Elapsed: 139.3s
```