### PR TITLE
fix: prune base graph before merging in build_merge so modified files keep their fresh nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 ## Unreleased
 
+- Fix: `build_merge(prune_sources=...)` now prunes the base graph **before** merging new chunks. Pruning previously ran on the merged graph, so an `--update` that passed *modified* (re-extracted) files in `prune_sources` deleted their freshly extracted nodes too — the changed file ended up with zero nodes. With base-first pruning, passing changed files atomically replaces their nodes (stale copies dropped, fresh chunk kept), which also eliminates the stale-symbol ghosts of #1152; genuinely deleted files behave exactly as before. (#1283)
+
 ## 0.8.38 (2026-06-11)
 
 - Fix: LLM-generated `calls` edges now have correct direction. The extraction prompt previously never stated that `source` = caller and `target` = callee; the LLM systematically emitted callee→caller edges. An explicit direction rule was added to the prompt. Separately, ghost-node merge was extended to collapse LLM duplicate nodes (bare-stem IDs) onto AST canonical nodes (parent-qualified IDs) even when the LLM node carries a `source_location` — the old check only caught `source_location=None` ghosts. Post-fix annotation: `calls` precision 100% (n=6), overall INFERRED precision 94% (n=16).

--- a/graphify/build.py
+++ b/graphify/build.py
@@ -390,6 +390,12 @@ def build_merge(
     Never replaces - only grows (or prunes deleted-file nodes via prune_sources).
     Safe to call repeatedly: existing nodes and edges are preserved.
     root: if given, absolute source_file paths in new_chunks are made relative (#932).
+
+    prune_sources is applied to the BASE graph before the merge, so it is safe
+    to pass *modified* files together with their fresh re-extraction in
+    new_chunks: the stale copies are dropped and the fresh nodes survive
+    (atomic per-file replace). Genuinely deleted files (no chunk) are simply
+    removed, as before.
     """
     graph_path = Path(graph_path)
     if graph_path.exists():
@@ -406,15 +412,18 @@ def build_merge(
         links_key = "links" if "links" in data else "edges"
         existing_nodes = list(data.get("nodes", []))
         existing_edges = list(data.get(links_key, []))
-        base = [{"nodes": existing_nodes, "edges": existing_edges}]
     else:
         existing_nodes = []
-        base = []
+        existing_edges = []
 
-    all_chunks = base + list(new_chunks)
-    G = build(all_chunks, directed=directed, dedup=dedup, dedup_llm_backend=dedup_llm_backend, root=root)
-
-    # Prune nodes and edges from deleted source files
+    # Prune nodes and edges of deleted/re-extracted source files from the
+    # BASE graph BEFORE merging new chunks. Pruning used to run on the merged
+    # graph, which also deleted the freshly re-extracted nodes of any
+    # *modified* file passed in prune_sources — an --update could only choose
+    # between ghost nodes (don't pass changed files: stale symbols survive,
+    # #1152) and data loss (pass them: the fresh extraction is wiped too).
+    # Pruning the base removes only the stale copies; chunk nodes always win.
+    # (#1283)
     if prune_sources:
         # Build a set containing both the raw form (matches nodes that kept
         # absolute source_file) and the normalised relative form (matches nodes
@@ -431,36 +440,57 @@ def build_merge(
             norm = _norm_source_file(p, _root_str)
             if norm:
                 prune_set.add(norm)
-        to_remove = [
-            n for n, d in G.nodes(data=True)
-            if d.get("source_file") in prune_set
+
+        def _pruned(sf: str | None) -> bool:
+            # Match the stored form and its normalised form, so legacy
+            # absolute source_file entries are caught when prune paths arrive
+            # relative (the merged graph used to be normalised at build time;
+            # the base JSON is checked as-stored).
+            if not sf:
+                return False
+            return sf in prune_set or _norm_source_file(sf, _root_str) in prune_set
+
+        n_before = len(existing_nodes)
+        # Nodes fall back to the legacy "source" key, which build_from_json
+        # migrates to "source_file" — the old post-build prune saw the
+        # migrated key, so the pre-build filter must match it too. Edges get
+        # no such fallback: their "source" is an endpoint node id, not a path.
+        existing_nodes = [
+            n for n in existing_nodes
+            if not _pruned(n.get("source_file") or n.get("source"))
         ]
-        G.remove_nodes_from(to_remove)
+        n_nodes = n_before - len(existing_nodes)
+        e_before = len(existing_edges)
+        existing_edges = [e for e in existing_edges if not _pruned(e.get("source_file"))]
+        n_edges = e_before - len(existing_edges)
+        # Base edges from unchanged files that pointed at a pruned node become
+        # dangling and are dropped by build() below — same outcome as the old
+        # G.remove_nodes_from(), which removed incident edges implicitly.
+
         n_files = len(prune_sources)
-        n_nodes = len(to_remove)
         if n_nodes:
             print(
                 f"[graphify] Pruned {n_nodes} node(s) from {n_files} deleted source file(s).",
                 file=sys.stderr,
             )
-
-        edges_to_remove = [
-            (u, v) for u, v, d in G.edges(data=True)
-            if d.get("source_file") in prune_set
-        ]
-        if edges_to_remove:
-            G.remove_edges_from(edges_to_remove)
+        if n_edges:
             print(
-                f"[graphify] Pruned {len(edges_to_remove)} edge(s) from deleted source file(s).",
+                f"[graphify] Pruned {n_edges} edge(s) from deleted source file(s).",
                 file=sys.stderr,
             )
-
-        if not n_nodes and not edges_to_remove:
+        if not n_nodes and not n_edges:
             print(
                 f"[graphify] {n_files} source file(s) deleted since last run — "
                 f"no matching nodes or edges in graph, already clean.",
                 file=sys.stderr,
             )
+
+    base = (
+        [{"nodes": existing_nodes, "edges": existing_edges}]
+        if graph_path.exists() else []
+    )
+    all_chunks = base + list(new_chunks)
+    G = build(all_chunks, directed=directed, dedup=dedup, dedup_llm_backend=dedup_llm_backend, root=root)
 
     # Safety check: refuse to shrink the graph silently (#479)
     # Skip when dedup or prune_sources is active — shrinkage is intentional there.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -458,6 +458,110 @@ def test_build_merge_prune_windows_backslash_paths(tmp_path):
     assert "parse_date" not in node_labels, "node should be pruned even with backslash path"
 
 
+def test_build_merge_prune_changed_file_keeps_reextracted_nodes(tmp_path):
+    """prune_sources must prune the BASE graph before merging, so a modified
+    (re-extracted) file passed in prune_sources keeps its fresh chunk nodes.
+    Previously the prune ran on the merged graph and deleted the fresh nodes
+    too — the changed file ended up with zero nodes."""
+    import networkx as nx
+
+    root = tmp_path / "corpus"
+    root.mkdir()
+    graph_path = tmp_path / "graph.json"
+
+    stale = {"nodes": [
+        {"id": "auth_login_v1", "label": "login_v1", "file_type": "code",
+         "source_file": "module_a/auth.py"},
+        {"id": "utils_helper", "label": "helper", "file_type": "code",
+         "source_file": "module_b/utils.py"},
+    ], "edges": [
+        {"source": "auth_login_v1", "target": "utils_helper", "relation": "calls",
+         "confidence": "EXTRACTED", "source_file": "module_a/auth.py", "weight": 1.0},
+    ]}
+    G0 = build([stale], dedup=False)
+    graph_path.write_text(json.dumps(nx.node_link_data(G0, edges="edges")), encoding="utf-8")
+
+    # auth.py was MODIFIED: re-extracted chunk carries its current symbols
+    fresh = {"nodes": [
+        {"id": "auth_login_v2", "label": "login_v2", "file_type": "code",
+         "source_file": "module_a/auth.py"},
+    ], "edges": [
+        {"source": "auth_login_v2", "target": "utils_helper", "relation": "calls",
+         "confidence": "EXTRACTED", "source_file": "module_a/auth.py", "weight": 1.0},
+    ]}
+    changed_abs = [str(root / "module_a" / "auth.py")]
+    G1 = build_merge([fresh], graph_path, prune_sources=changed_abs, dedup=False, root=root)
+
+    node_labels = {d["label"] for _, d in G1.nodes(data=True)}
+    assert "login_v2" in node_labels, \
+        "fresh node from the re-extracted file must survive the prune"
+    assert "login_v1" not in node_labels, \
+        "stale node from the modified file must be pruned (#1152 ghost)"
+    assert "helper" in node_labels, "unrelated node must survive"
+    assert G1.number_of_edges() == 1, \
+        "fresh edge must survive; stale edge from the changed file must be gone"
+
+
+def test_build_merge_prune_changed_file_drops_removed_symbols(tmp_path):
+    """#1152: a symbol deleted from a modified file disappears when the file
+    is passed in prune_sources together with its fresh chunk (atomic per-file
+    replace: prune stale copies, keep only what the new extraction emits)."""
+    import networkx as nx
+
+    root = tmp_path / "corpus"
+    root.mkdir()
+    graph_path = tmp_path / "graph.json"
+
+    stale = {"nodes": [
+        {"id": "auth_login", "label": "login", "file_type": "code",
+         "source_file": "module_a/auth.py"},
+        {"id": "auth_legacy_token", "label": "legacy_token", "file_type": "code",
+         "source_file": "module_a/auth.py"},
+    ], "edges": []}
+    G0 = build([stale], dedup=False)
+    graph_path.write_text(json.dumps(nx.node_link_data(G0, edges="edges")), encoding="utf-8")
+
+    # legacy_token was removed from auth.py; the fresh chunk only has login
+    fresh = {"nodes": [
+        {"id": "auth_login", "label": "login", "file_type": "code",
+         "source_file": "module_a/auth.py"},
+    ], "edges": []}
+    changed_abs = [str(root / "module_a" / "auth.py")]
+    G1 = build_merge([fresh], graph_path, prune_sources=changed_abs, dedup=False, root=root)
+
+    node_labels = {d["label"] for _, d in G1.nodes(data=True)}
+    assert "login" in node_labels
+    assert "legacy_token" not in node_labels, \
+        "symbol removed from the file must not survive as a ghost node"
+
+
+def test_build_merge_prune_matches_legacy_source_keyed_nodes(tmp_path):
+    """Legacy graph.json nodes store their path under "source" instead of
+    "source_file" (build_from_json migrates the key at build time). The old
+    prune ran after that migration; the pre-build prune must fall back to the
+    legacy key so those nodes are still removed."""
+    graph_path = tmp_path / "graph.json"
+
+    legacy = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": "n1", "label": "old_fn", "file_type": "code",
+             "source": "module_a/legacy.py"},   # legacy key, no source_file
+            {"id": "n2", "label": "kept_fn", "file_type": "code",
+             "source_file": "module_b/utils.py"},
+        ],
+        "edges": [],
+    }
+    graph_path.write_text(json.dumps(legacy), encoding="utf-8")
+
+    G1 = build_merge([], graph_path, prune_sources=["module_a/legacy.py"], dedup=False)
+
+    node_labels = {d["label"] for _, d in G1.nodes(data=True)}
+    assert "old_fn" not in node_labels, \
+        "legacy 'source'-keyed node must still be pruned"
+    assert "kept_fn" in node_labels
+
+
 def test_build_merge_rejects_oversized_existing_graph(monkeypatch, tmp_path):
     """#F4: build_merge must refuse to read an existing graph.json that
     exceeds the size cap, rather than json.loads-ing it into memory."""


### PR DESCRIPTION
Fixes #1283.

### Problem

`build_merge()` merged the base graph + `new_chunks` first, then pruned every node/edge whose `source_file` ∈ `prune_sources` from the **merged** graph. For *modified* files — re-extracted into `new_chunks` and passed in `prune_sources` to drop their stale copies — the prune deleted the fresh extraction too: the changed file ended up with zero nodes (`[graphify] Pruned 2 node(s) …` on a 1-node file).

The bundled skill update templates (`graphify/skills/*/references/update.md`) already instruct exactly that flow (`prune = deleted + changed`, added for #1178), so the shipped documentation triggers the data loss on every `--update` with modified files. Not passing changed files isn't an option either — that leaves stale-symbol ghosts (#1152). The API had no correct choice for modified files.

### Fix

Prune the **base** graph (the `existing_nodes` / `existing_edges` loaded from `graph.json`) *before* the merge:

- **Modified files become an atomic per-file replace** — stale copies dropped, fresh chunk nodes always survive. This also gives `--update` flows the mechanism to eliminate the #1152 ghosts (the skill templates' `deleted + changed` prune now does what its comment intends).
- **Genuinely deleted files behave exactly as before** (existing prune tests for #1007 absolute/Windows paths pass unchanged).
- Base edges from unchanged files that pointed at a pruned node become dangling and are dropped inside `build()` — same outcome as the old `G.remove_nodes_from()`'s implicit incident-edge removal (`build_from_json` only adds edges whose endpoints exist).
- The #1007 dual-form matching (raw + `_norm_source_file`) is preserved; since the base JSON is now checked as-stored (the old code compared against build-time-normalised attributes), the filter also falls back to the legacy `"source"` node key that `build_from_json` migrates — without the fallback, legacy-keyed nodes would have escaped the prune. Edges deliberately get no such fallback (their `source` is an endpoint id, not a path).
- The `#479` shrink-guard and all stderr messages are unchanged.

### Tests

Three new regression tests in `tests/test_build.py`:

- `test_build_merge_prune_changed_file_keeps_reextracted_nodes` — fresh node + fresh edge survive; stale node + stale edge pruned; unrelated file untouched (fails on the previous ordering).
- `test_build_merge_prune_changed_file_drops_removed_symbols` — a symbol deleted from a modified file does not survive as a ghost (#1152 scenario).
- `test_build_merge_prune_matches_legacy_source_keyed_nodes` — legacy `"source"`-keyed nodes are still pruned.

Full suite: **2024 passed, 27 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
