### PR TITLE
fix: block fuzzy-dedup merges of numbered siblings and cross-file rationale boilerplate (#1284, proposals 1+2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 ## Unreleased
 
+- Fix: fuzzy dedup no longer merges numbered siblings or cross-file rationale boilerplate. Two new pass-2 guards (also mirrored in the `--dedup-llm` ambiguous-pair collection): (1) labels whose embedded digit runs differ as zero-padding-insensitive multisets (`ADR 0011` vs `ADR 0013`, `3.1 Product Goals` vs `1.1 Product Goals`, `block3` vs `block13`, `40%+ …` vs `<20% …`) are numbered/versioned siblings and never merge — zero-padding (`09` vs `9`) does not count as a difference; (2) `rationale` nodes are file-anchored like code (#1205's reasoning): parallel modules' near-identical docstring boilerplate ("Django app config for `apps.<name>`. No business logic…") no longer collapses across files, while same-file rationale duplicates still merge. On a real 11.7k-node graph these guards eliminated 30 of 49 destructive different-label merge groups, including a 15-node AppConfig collapse and antonym metric labels. (#1284)
+
 ## 0.8.38 (2026-06-11)
 
 - Fix: LLM-generated `calls` edges now have correct direction. The extraction prompt previously never stated that `source` = caller and `target` = callee; the LLM systematically emitted callee→caller edges. An explicit direction rule was added to the prompt. Separately, ghost-node merge was extended to collapse LLM duplicate nodes (bare-stem IDs) onto AST canonical nodes (parent-qualified IDs) even when the LLM node carries a `source_location` — the old check only caught `source_location=None` ghosts. Post-fix annotation: `calls` precision 100% (n=6), overall INFERRED precision 94% (n=16).

--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -89,6 +89,43 @@ def _short_label_blocked(a: str, b: str, jw_score: float) -> bool:
     return True
 
 
+_DIGIT_RUN = re.compile(r"\d+")
+
+
+def _numeric_tokens_differ(a: str, b: str) -> bool:
+    """True when two labels carry different embedded numbers (#1284).
+
+    Long labels that differ only in their digit runs ("ADR 0011 §D5" vs
+    "ADR 0013 D4", "3.1 Product Goals" vs "1.1 Product Goals", "block3" vs
+    "block13", "40%+ retention" vs "<20% retention") are numbered/versioned
+    siblings, not duplicates — but the long shared boilerplate keeps
+    Jaro-Winkler above _MERGE_THRESHOLD, and _is_variant_pair only covers
+    short trailing suffixes. Digit runs are compared as multisets with
+    leading zeros stripped, so zero-padding ("09" vs "9") does not count as
+    a difference. (String comparison, not int(): a pathological label with a
+    >4300-digit run would crash int() on Python's conversion limit.) Labels
+    with identical numbers, or none at all, are unaffected.
+    """
+    if a == b:
+        return False
+    return sorted(t.lstrip("0") or "0" for t in _DIGIT_RUN.findall(a)) != \
+        sorted(t.lstrip("0") or "0" for t in _DIGIT_RUN.findall(b))
+
+
+def _crossfile_rationale_blocked(node: dict, neighbor: dict) -> bool:
+    """Block label-based merging of rationale nodes across files (#1284).
+
+    Rationale nodes are docstring-derived and as file-anchored as the code
+    they describe (#1205's reasoning, one layer up): parallel modules carry
+    near-identical boilerplate ("Django app config for apps.<name>. No
+    business logic here…") that differs by one word and sails past the JW
+    threshold. Same-file rationale duplicates may still merge.
+    """
+    if node.get("file_type") != "rationale" and neighbor.get("file_type") != "rationale":
+        return False
+    return (node.get("source_file") or "") != (neighbor.get("source_file") or "")
+
+
 # ── union-find ────────────────────────────────────────────────────────────────
 
 class _UF:
@@ -276,6 +313,12 @@ def deduplicate_entities(
                 _lo, _hi = sorted((norm_label, neighbor_norm), key=len)
                 if _hi.startswith(_lo) and _hi != _lo:
                     continue
+                # Numbered/versioned siblings and cross-file rationale
+                # boilerplate are decisively distinct regardless of JW (#1284).
+                if _numeric_tokens_differ(norm_label, neighbor_norm):
+                    continue
+                if _crossfile_rationale_blocked(node, neighbor):
+                    continue
 
                 c1 = communities.get(node_id)
                 c2 = communities.get(neighbor_id)
@@ -407,6 +450,11 @@ def _llm_tiebreak(
                 continue
             _lo, _hi = sorted((norm_i, norm_j), key=len)
             if _hi.startswith(_lo) and _hi != _lo:
+                continue
+            # Mirror pass 2: decisively-distinct pairs never reach the LLM (#1284).
+            if _numeric_tokens_differ(norm_i, norm_j):
+                continue
+            if _crossfile_rationale_blocked(node, neighbor):
                 continue
             c1 = communities.get(node["id"])
             c2 = communities.get(neighbor["id"])

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -268,3 +268,60 @@ def test_prefix_guard_fires_for_extension_pairs():
         assert hi.startswith(lo) and hi != lo, (
             f"Prefix guard should fire for ({a!r}, {b!r}) but did not"
         )
+
+
+# ── #1284: numbered siblings + cross-file rationale ──────────────────────────
+
+def test_numeric_tokens_differ_helper():
+    """_numeric_tokens_differ compares digit runs as integer multisets (#1284)."""
+    from graphify.dedup import _numeric_tokens_differ
+    assert _numeric_tokens_differ("adr 0011 d5 pipeline placement", "adr 0013 d4 pipeline placement")
+    assert _numeric_tokens_differ("3 1 product goals", "1 1 product goals")
+    assert _numeric_tokens_differ("code block3", "code block13")
+    # zero-padding is not a difference
+    assert not _numeric_tokens_differ("phase 09 overview", "phase 9 overview")
+    # identical numbers, different words — not this guard's business
+    assert not _numeric_tokens_differ("module layout wave 3", "module layouts wave 3")
+    # digitless labels are unaffected
+    assert not _numeric_tokens_differ("graph extractor", "graph extractar")
+
+
+def test_dedup_does_not_merge_numbered_siblings():
+    """Long labels differing only in embedded numbers (ADR/section/issue ids)
+    must not merge — they are numbered siblings, not duplicates (#1284)."""
+    nodes = [
+        {"id": "n1", "label": "Pipeline placement — 4 call sites (ADR 0013 D4)",
+         "file_type": "document", "source_file": "docs/index-activity.md"},
+        {"id": "n2", "label": "Pipeline placement — 4 call sites (ADR 0011 §D5)",
+         "file_type": "document", "source_file": "docs/schema-matcher.md"},
+    ]
+    result_nodes, _ = deduplicate_entities(nodes, [], communities={})
+    assert len(result_nodes) == 2, "ADR 0013 and ADR 0011 notes are distinct documents"
+
+
+def test_dedup_does_not_merge_crossfile_rationale_boilerplate():
+    """Rationale nodes are file-anchored like code (#1205): parallel modules'
+    boilerplate docstrings differing by one word must not merge (#1284)."""
+    boiler = ("Django app config for {}. No business logic here. "
+              "Domain services live in services.py and adapters in providers.")
+    nodes = [
+        {"id": "r1", "label": boiler.format("apps.platform.cards"),
+         "file_type": "rationale", "source_file": "apps/platform/cards/apps.py"},
+        {"id": "r2", "label": boiler.format("apps.platform.cores"),
+         "file_type": "rationale", "source_file": "apps/platform/cores/apps.py"},
+    ]
+    result_nodes, _ = deduplicate_entities(nodes, [], communities={})
+    assert len(result_nodes) == 2, "AppConfig docstrings from different apps are distinct"
+
+
+def test_dedup_still_merges_samefile_rationale_duplicates():
+    """The rationale guard only blocks cross-file pairs — near-identical
+    rationale duplicates within one file still merge (#1284 non-regression)."""
+    nodes = [
+        {"id": "r1", "label": "Counts-only metrics export, a read-only aggregation service.",
+         "file_type": "rationale", "source_file": "apps/schemas/metrics.py"},
+        {"id": "r2", "label": "Counts-only metrics export, the read-only aggregation service.",
+         "file_type": "rationale", "source_file": "apps/schemas/metrics.py"},
+    ]
+    result_nodes, _ = deduplicate_entities(nodes, [], communities={})
+    assert len(result_nodes) == 1, "same-file rationale near-duplicates should still merge"


### PR DESCRIPTION
Implements proposals **1 + 2** from #1284. Submitted as a **draft** deliberately — #1284 lists three possible directions and the choice is yours; this PR makes the two least-controversial ones concrete and reviewable. Proposal 3 (restricting cross-file fuzzy merging to `concept` nodes) is intentionally omitted as the more opinionated call.

### Problem (from #1284)

#1205 exempted code symbols from label-based merging and #1046 blocks exact-label cross-file pairs, but non-code nodes (`rationale`/`document`/`concept`) with *near*-identical labels still fuzzy-merge across files. On a real 11.7k-node graph: 49 destructive different-label merge groups, including 15 distinct Django `AppConfig` docstring rationale nodes → 1, antonym metric labels (`40%+ X` absorbed `<20% X`), and ADR/issue-numbered sibling notes.

### Change

Two targeted guards in pass 2 (placed with the existing `_is_variant_pair` / `_short_label_blocked` / prefix-extension guards, and mirrored in `_llm_tiebreak`'s ambiguous-pair collection so decisively-distinct pairs never reach the LLM):

1. **`_numeric_tokens_differ`** — digit runs of the normalized labels compared as zero-padding-insensitive multisets (`"09"` ≡ `"9"`; string-normalized rather than `int()` so a pathological >4300-digit run can't hit Python's int-conversion limit). Any mismatch blocks the merge: `ADR 0011 §D5` vs `ADR 0013 D4`, `3.1 Product Goals` vs `1.1 Product Goals`, `block3` vs `block13`, `40%+ …` vs `<20% …` are numbered siblings, not duplicates. Digitless labels are unaffected.
2. **`_crossfile_rationale_blocked`** — `rationale` nodes are docstring-derived and as file-anchored as the code they describe (#1205's reasoning, one layer up). Label-based merging of a rationale node is allowed only within one file, so parallel modules' boilerplate ("Django app config for `apps.<name>`. No business logic…") no longer collapses; same-file rationale duplicates still merge.

Known false-negative trade-off (accepted): pairs like `OAuth2 flow` / `OAuth 2.0 flow` are now blocked. Given that this engine's observed failure mode is destructive merging, a missed merge is the cheaper error.

### Validation on the real graph that produced #1284

| | upstream `v8` | with this PR |
|---|---|---|
| different-label merge groups | **49** | **19** (−30) |
| benign same-label-same-file groups | 144 | 144 (unchanged) |
| nodes absorbed by fuzzy dedup | 249 | 195 |

All flagship destructive cases eliminated (15× AppConfig, antonym metrics, ADR 0034/0035, VAN-375/376, github/places providers, cross-doc numbered headings). The 19 survivors are predominantly legitimate same-file near-duplicates; the cross-file remainder is the class proposal 3 would address.

### Tests

4 new tests in `tests/test_dedup.py` (helper semantics incl. zero-padding; numbered-siblings blocked; cross-file rationale blocked; same-file rationale control still merges). Both guard tests verified to **fail** against the pre-patch `dedup.py`. Full suite: **2025 passed, 27 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
