### PR TITLE
perf: skip MinHash/LSH dedup for AST-located nodes

### DIFF
--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -200,13 +200,19 @@ def deduplicate_entities(
                 exact_merges += len(file_group) - 1
 
     # ── pass 2: MinHash/LSH + Jaro-Winkler (high-entropy nodes only) ─────────
+    # AST-extracted nodes carry source_location (e.g. "L42") and are keyed by
+    # file+position, so they never need fuzzy cross-node merging.  Only include
+    # nodes WITHOUT source_location (semantic/LLM-generated) whose names may be
+    # inconsistently cased or spelled across extraction chunks.  This keeps the
+    # candidate set near-zero for pure-AST runs.
     candidates: list[dict] = []
     seen_norms: set[str] = set()
     for node in unique_nodes:
         key = _norm(node.get("label", node.get("id", "")))
         if key and key not in seen_norms:
             seen_norms.add(key)
-            if _entropy(node.get("label", "")) >= _ENTROPY_THRESHOLD:
+            if (_entropy(node.get("label", "")) >= _ENTROPY_THRESHOLD
+                    and not node.get("source_location")):
                 candidates.append(node)
 
     fuzzy_merges = 0

--- a/tests/after.py
+++ b/tests/after.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Dedup benchmark: AFTER changes.
+
+Runs with source_location intact so AST nodes bypass the MinHash/LSH pipeline.
+
+Run standalone for profiling:
+    uv run python tests/after.py
+    uv run pyinstrument tests/after.py
+    uv run pyinstrument tests/after.py --n-ast 200000 --n-semantic 10000
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import random
+import string
+import sys
+import time
+from pathlib import Path
+
+_project_root = Path(__file__).resolve().parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+from graphify.dedup import deduplicate_entities
+
+_SEED = 42
+
+
+def make_dataset(
+    n_ast: int,
+    n_semantic: int,
+    near_dup_pct: float = 0.08,
+) -> tuple[list[dict], list[dict]]:
+    """Return (nodes, edges) with a mix of AST nodes (source_location) and semantic nodes."""
+    rng = random.Random(_SEED)
+    nodes: list[dict] = []
+    files = [f"src/module_{i}.ts" for i in range(100)]
+
+    for i in range(n_ast):
+        label = _rand_label(rng)
+        file = rng.choice(files)
+        nodes.append({
+            "id": f"ast_{i}",
+            "label": label,
+            "kind": rng.choice(["function", "class", "variable", "type"]),
+            "source_file": file,
+            "source_location": f"{file}:{rng.randint(1, 800)}:{rng.randint(0, 80)}",
+        })
+
+    sem_labels = [_rand_label(rng) for _ in range(n_semantic)]
+    for i, label in enumerate(sem_labels):
+        nodes.append({"id": f"sem_{i}", "label": label, "kind": "concept"})
+
+    n_near_dups = max(1, int(n_semantic * near_dup_pct))
+    alpha = string.ascii_lowercase
+    for i in range(n_near_dups):
+        base = sem_labels[i % len(sem_labels)]
+        if len(base) < 2:
+            continue
+        pos = rng.randint(0, len(base) - 1)
+        replacement = rng.choice(alpha.replace(base[pos], "") or alpha)
+        mutated = base[:pos] + replacement + base[pos + 1:]
+        nodes.append({"id": f"nd_{i}", "label": mutated, "kind": "concept"})
+
+    ids = [n["id"] for n in nodes]
+    edges: list[dict] = []
+    for _ in range(len(nodes) * 2):
+        src, tgt = rng.sample(ids, 2)
+        edges.append({"source": src, "target": tgt, "relation": "depends_on"})
+
+    return nodes, edges
+
+
+def _rand_label(rng: random.Random) -> str:
+    n_parts = rng.randint(1, 3)
+    parts = ["".join(rng.choices(string.ascii_lowercase, k=rng.randint(4, 10))) for _ in range(n_parts)]
+    return rng.choice(["", "_"]).join(parts)
+
+
+def _run_once(nodes: list[dict], edges: list[dict]) -> float:
+    t0 = time.perf_counter()
+    with contextlib.redirect_stdout(io.StringIO()):
+        deduplicate_entities(list(nodes), list(edges), communities={})
+    return time.perf_counter() - t0
+
+
+def run_bench(nodes: list[dict], edges: list[dict], runs: int = 2) -> list[float]:
+    """Time deduplicate_entities with source_location intact. Returns per-run elapsed times."""
+    elapsed = _run_once(nodes, edges)
+    print(f"  after   dry : {elapsed:.3f}s  (discarded)", flush=True)
+    times = []
+    for i in range(runs):
+        elapsed = _run_once(nodes, edges)
+        times.append(elapsed)
+        print(f"  after   run {i + 1}/{runs}: {elapsed:.3f}s", flush=True)
+    return times
+
+
+def _print_stats(times: list[float]) -> None:
+    s = sorted(times)
+    median = s[len(s) // 2]
+    print(f"  min: {s[0]:.3f}s   median: {median:.3f}s   mean: {sum(s)/len(s):.3f}s")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--n-ast",        type=int,   default=100_000)
+    ap.add_argument("--n-semantic",   type=int,   default=5_000)
+    ap.add_argument("--runs",         type=int,   default=2)
+    ap.add_argument("--near-dup-pct", type=float, default=0.08)
+    args = ap.parse_args()
+
+    nodes, edges = make_dataset(args.n_ast, args.n_semantic, args.near_dup_pct)
+    print(f"AFTER  ({args.n_ast:,} AST + {args.n_semantic:,} semantic, {args.runs} runs)")
+    times = run_bench(nodes, edges, args.runs)
+    _print_stats(times)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/before.py
+++ b/tests/before.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Dedup benchmark: BEFORE changes
+
+Simulates pre-optimization behavior by stripping source_location from all nodes
+so every high-entropy node enters the MinHash/LSH pipeline regardless of origin.
+
+Run standalone for profiling:
+    uv run python tests/before.py
+    uv run pyinstrument tests/before.py
+    uv run pyinstrument tests/before.py --n-ast 200000 --n-semantic 10000
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import random
+import string
+import sys
+import time
+from pathlib import Path
+
+_project_root = Path(__file__).resolve().parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+from graphify.dedup import deduplicate_entities
+
+_SEED = 42
+
+
+def make_dataset(
+    n_ast: int,
+    n_semantic: int,
+    near_dup_pct: float = 0.08,
+) -> tuple[list[dict], list[dict]]:
+    """Return (nodes, edges) with a mix of AST nodes (source_location) and semantic nodes."""
+    rng = random.Random(_SEED)
+    nodes: list[dict] = []
+    files = [f"src/module_{i}.ts" for i in range(100)]
+
+    for i in range(n_ast):
+        label = _rand_label(rng)
+        file = rng.choice(files)
+        nodes.append({
+            "id": f"ast_{i}",
+            "label": label,
+            "kind": rng.choice(["function", "class", "variable", "type"]),
+            "source_file": file,
+            "source_location": f"{file}:{rng.randint(1, 800)}:{rng.randint(0, 80)}",
+        })
+
+    sem_labels = [_rand_label(rng) for _ in range(n_semantic)]
+    for i, label in enumerate(sem_labels):
+        nodes.append({"id": f"sem_{i}", "label": label, "kind": "concept"})
+
+    n_near_dups = max(1, int(n_semantic * near_dup_pct))
+    alpha = string.ascii_lowercase
+    for i in range(n_near_dups):
+        base = sem_labels[i % len(sem_labels)]
+        if len(base) < 2:
+            continue
+        pos = rng.randint(0, len(base) - 1)
+        replacement = rng.choice(alpha.replace(base[pos], "") or alpha)
+        mutated = base[:pos] + replacement + base[pos + 1:]
+        nodes.append({"id": f"nd_{i}", "label": mutated, "kind": "concept"})
+
+    ids = [n["id"] for n in nodes]
+    edges: list[dict] = []
+    for _ in range(len(nodes) * 2):
+        src, tgt = rng.sample(ids, 2)
+        edges.append({"source": src, "target": tgt, "relation": "depends_on"})
+
+    return nodes, edges
+
+
+def _rand_label(rng: random.Random) -> str:
+    n_parts = rng.randint(1, 3)
+    parts = ["".join(rng.choices(string.ascii_lowercase, k=rng.randint(4, 10))) for _ in range(n_parts)]
+    return rng.choice(["", "_"]).join(parts)
+
+
+def _strip_source_location(nodes: list[dict]) -> list[dict]:
+    return [{k: v for k, v in n.items() if k != "source_location"} if "source_location" in n else n for n in nodes]
+
+
+def _run_once(nodes: list[dict], edges: list[dict]) -> float:
+    t0 = time.perf_counter()
+    with contextlib.redirect_stdout(io.StringIO()):
+        deduplicate_entities(list(nodes), list(edges), communities={})
+    return time.perf_counter() - t0
+
+
+def run_bench(nodes: list[dict], edges: list[dict], runs: int = 2) -> list[float]:
+    """Strip source_location and time deduplicate_entities. Returns per-run elapsed times."""
+    stripped = _strip_source_location(nodes)
+    elapsed = _run_once(stripped, edges)
+    print(f"  before  dry : {elapsed:.3f}s  (discarded)", flush=True)
+    times = []
+    for i in range(runs):
+        elapsed = _run_once(stripped, edges)
+        times.append(elapsed)
+        print(f"  before  run {i + 1}/{runs}: {elapsed:.3f}s", flush=True)
+    return times
+
+
+def _print_stats(times: list[float]) -> None:
+    s = sorted(times)
+    median = s[len(s) // 2]
+    print(f"  min: {s[0]:.3f}s   median: {median:.3f}s   mean: {sum(s)/len(s):.3f}s")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--n-ast",        type=int,   default=100_000)
+    ap.add_argument("--n-semantic",   type=int,   default=5_000)
+    ap.add_argument("--runs",         type=int,   default=2)
+    ap.add_argument("--near-dup-pct", type=float, default=0.08)
+    args = ap.parse_args()
+
+    nodes, edges = make_dataset(args.n_ast, args.n_semantic, args.near_dup_pct)
+    print(f"BEFORE  ({args.n_ast:,} AST + {args.n_semantic:,} semantic, {args.runs} runs)")
+    times = run_bench(nodes, edges, args.runs)
+    _print_stats(times)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bench_dedup.py
+++ b/tests/bench_dedup.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Benchmark: before vs after changes.
+
+Imports before.py and after.py, generates a shared dataset, runs both, and
+prints a side-by-side comparison.  Run before.py / after.py standalone to
+attach a profiler to each scenario individually.
+
+Usage:
+    uv run python tests/bench_dedup.py
+    uv run python tests/bench_dedup.py --n-ast 200000 --n-semantic 10000 --runs 3
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_tests_dir = Path(__file__).resolve().parent
+if str(_tests_dir) not in sys.path:
+    sys.path.insert(0, str(_tests_dir))
+
+_project_root = _tests_dir.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+import before as _before
+import after as _after
+from graphify.dedup import _ENTROPY_THRESHOLD, _entropy, _norm
+
+
+def _count_candidates(nodes: list[dict]) -> int:
+    seen: set[str] = set()
+    count = 0
+    for n in nodes:
+        key = _norm(n.get("label", n.get("id", "")))
+        if key and key not in seen:
+            seen.add(key)
+            if _entropy(n.get("label", "")) >= _ENTROPY_THRESHOLD and not n.get("source_location"):
+                count += 1
+    return count
+
+
+def _stats(times: list[float]) -> dict[str, float]:
+    s = sorted(times)
+    return {"min": s[0], "median": s[len(s) // 2], "mean": sum(s) / len(s)}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--n-ast",        type=int,   default=100_000)
+    ap.add_argument("--n-semantic",   type=int,   default=5_000)
+    ap.add_argument("--runs",         type=int,   default=2)
+    ap.add_argument("--near-dup-pct", type=float, default=0.08)
+    args = ap.parse_args()
+
+    print("=== bench_dedup: MinHash/LSH skip optimization ===\n")
+    print(
+        f"Generating dataset: {args.n_ast:,} AST nodes "
+        f"+ {args.n_semantic:,} semantic nodes "
+        f"(~{int(args.n_semantic * args.near_dup_pct)} near-dups)...",
+        flush=True,
+    )
+
+    # Both scripts use the same seed so the datasets are identical.
+    nodes, edges = _before.make_dataset(args.n_ast, args.n_semantic, args.near_dup_pct)
+
+    cands_before = _count_candidates(_before._strip_source_location(nodes))
+    cands_after  = _count_candidates(nodes)
+
+    print(f"  Total: {len(nodes):,} nodes, {len(edges):,} edges")
+    print(f"  MinHash candidates before : {cands_before:,}  (all high-entropy nodes)")
+    print(f"  MinHash candidates after  : {cands_after:,}  (semantic-only)")
+    print()
+
+    # Warm the _norm lru_cache with all labels before timing so neither scenario
+    # pays a cold-cache penalty.
+    for n in nodes:
+        _norm(n.get("label", ""))
+
+    print(f"Running 1 dry run + {args.runs} timed iterations per scenario...\n")
+
+    before_times = _before.run_bench(nodes, edges, args.runs)
+    print()
+    after_times  = _after.run_bench(nodes, edges, args.runs)
+    print()
+
+    bs  = _stats(before_times)
+    as_ = _stats(after_times)
+    speedup  = bs["median"] / as_["median"] if as_["median"] > 0 else float("inf")
+    saved_ms = (bs["median"] - as_["median"]) * 1000
+    reduction = 100 * (1 - cands_after / cands_before) if cands_before else 0.0
+
+    print("=== Results ===")
+    print(f"  Before  --  min: {bs['min']:.3f}s   median: {bs['median']:.3f}s   mean: {bs['mean']:.3f}s")
+    print(f"  After   --  min: {as_['min']:.3f}s   median: {as_['median']:.3f}s   mean: {as_['mean']:.3f}s")
+    print()
+    print(f"  Candidate reduction : {cands_before:,} -> {cands_after:,}  ({reduction:.1f}% fewer)")
+    print(f"  Speedup             : {speedup:.2f}x")
+    print(f"  Saved               : {saved_ms:.0f}ms per run (median)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
AST-extracted nodes carry source_location (e.g. "L42") and are uniquely keyed by file path + position, so cross-node fuzzy merging via MinHash/JW is both unnecessary and harmful (same function name in two files = two distinct symbols).

Excluding source_location nodes from the pass-2 candidate set reduces candidates by 94.9% (91,268 → 4,670 on a 100k AST + 5k semantic dataset), yielding a 6.35x wall-clock speedup (10.7s → 1.7s median). Mixed AST+semantic runs are also faster since only the small pool of LLM-generated nodes without source_location goes through MinHash.

I included before/after benchmark on this:
```
> uv run python tests/bench_dedup.py
=== bench_dedup: MinHash/LSH skip optimization ===

Generating dataset: 100,000 AST nodes + 5,000 semantic nodes (~400 near-dups)...
  Total: 105,400 nodes, 210,800 edges
  MinHash candidates before : 91,268  (all high-entropy nodes)
  MinHash candidates after  : 4,670  (semantic-only)

Running 1 dry run + 2 timed iterations per scenario...

  before  dry : 10.684s  (discarded)
  before  run 1/2: 10.712s
  before  run 2/2: 10.460s

  after   dry : 1.650s  (discarded)
  after   run 1/2: 1.687s
  after   run 2/2: 1.588s

=== Results ===
  Before  --  min: 10.460s   median: 10.712s   mean: 10.586s
  After   --  min: 1.588s   median: 1.687s   mean: 1.638s

  Candidate reduction : 91,268 -> 4,670  (94.9% fewer)
  Speedup             : 6.35x
  Saved               : 9025ms per run (median)
```