### PR TITLE
fix(build): replace stale source graph content

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2121,6 +2121,8 @@ def main() -> None:
         print("                            (default follows JSON directed flag;")
         print("                             raw extraction with no flag defaults directed)")
         print("    --extract-path PATH     extractor source for suppression scan")
+        print("  diagnose quality       report low-confidence, dangling, and stale-output risks")
+        print("    --graph <path>          path to graph.json (default graphify-out/graph.json)")
         print("  clone <github-url>      clone a GitHub repo locally and print its path for /graphify")
         print("  merge-driver <base> <current> <other>  git merge driver: union-merge two graph.json files (set up via hook install)")
         print("  merge-graphs <g1> <g2>  merge two or more graph.json files into one cross-repo graph")
@@ -2983,11 +2985,73 @@ def main() -> None:
 
     elif cmd == "diagnose":
         subcmd = sys.argv[2] if len(sys.argv) > 2 else ""
+        if subcmd == "quality":
+            graph_path = Path(_default_graph_path())
+            json_output = False
+            max_examples = 10
+            low_confidence_threshold = 0.5
+
+            i = 3
+            while i < len(sys.argv):
+                arg = sys.argv[i]
+                if arg == "--graph":
+                    i += 1
+                    if i >= len(sys.argv):
+                        print("error: --graph requires a path", file=sys.stderr)
+                        sys.exit(1)
+                    graph_path = Path(sys.argv[i])
+                elif arg == "--json":
+                    json_output = True
+                elif arg == "--max-examples":
+                    i += 1
+                    if i >= len(sys.argv):
+                        print("error: --max-examples requires an integer", file=sys.stderr)
+                        sys.exit(1)
+                    try:
+                        max_examples = int(sys.argv[i])
+                    except ValueError:
+                        print("error: --max-examples requires an integer", file=sys.stderr)
+                        sys.exit(1)
+                    if max_examples < 0:
+                        print("error: --max-examples must be >= 0", file=sys.stderr)
+                        sys.exit(1)
+                elif arg == "--low-confidence-threshold":
+                    i += 1
+                    if i >= len(sys.argv):
+                        print("error: --low-confidence-threshold requires a number", file=sys.stderr)
+                        sys.exit(1)
+                    try:
+                        low_confidence_threshold = float(sys.argv[i])
+                    except ValueError:
+                        print("error: --low-confidence-threshold requires a number", file=sys.stderr)
+                        sys.exit(1)
+                else:
+                    print(f"error: unknown diagnose quality option {arg}", file=sys.stderr)
+                    sys.exit(1)
+                i += 1
+
+            from graphify.diagnostics import diagnose_quality_file, format_quality_report
+
+            try:
+                summary = diagnose_quality_file(
+                    graph_path,
+                    low_confidence_threshold=low_confidence_threshold,
+                    max_examples=max_examples,
+                )
+            except Exception as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                sys.exit(1)
+
+            if json_output:
+                print(json.dumps(summary, indent=2, ensure_ascii=False))
+            else:
+                print(format_quality_report(summary))
+            return
+
         if subcmd != "multigraph":
             print(
-                "Usage: graphify diagnose multigraph "
-                "[--graph path] [--json] [--max-examples N] "
-                "[--directed] [--undirected] [--extract-path path]",
+                "Usage: graphify diagnose [multigraph|quality] "
+                "[--graph path] [--json] [--max-examples N]",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -4459,10 +4523,12 @@ def main() -> None:
         from graphify.analyze import god_nodes as _god_nodes, surprising_connections as _surprising
         dedup_backend = backend if dedup_llm else None
         if incremental_mode:
+            changed_files = [str(p) for p in code_files + semantic_files]
             G = _build_merge(
                 [merged],
                 graph_path=existing_graph_path,
                 prune_sources=deleted_files or None,
+                replace_sources=changed_files or None,
                 dedup=True,
                 dedup_llm_backend=dedup_backend,
                 root=target,

--- a/graphify/build.py
+++ b/graphify/build.py
@@ -83,6 +83,80 @@ def _norm_source_file(p: str | None, root: str | None = None) -> str | None:
     return p
 
 
+_GENERIC_SYMBOL_LABELS = {
+    "str",
+    "Any",
+    "int",
+    "bool",
+    "float",
+    "Path",
+    "Connection",
+    "Namespace",
+    "main()",
+    "Check",
+    "Report",
+    "HealthReport",
+}
+_LOW_CONF_GENERIC_RELATIONS = {
+    "calls",
+    "uses",
+    "references",
+    "depends_on",
+    "imports",
+    "implements",
+}
+
+
+def _source_match_set(sources: list[str] | None, root: str | Path | None = None) -> set[str]:
+    """Return raw and normalized source_file values for source-scoped pruning."""
+    if not sources:
+        return set()
+    root_str = str(Path(root).resolve()) if root is not None else None
+    out: set[str] = set()
+    for source in sources:
+        if not source:
+            continue
+        out.add(str(source).replace("\\", "/"))
+        norm = _norm_source_file(str(source), root_str)
+        if norm:
+            out.add(norm)
+    return out
+
+
+def _edge_confidence_score(attrs: dict) -> float:
+    try:
+        return float(attrs.get("confidence_score", 1.0))
+    except (TypeError, ValueError):
+        return 1.0
+
+
+def _is_generic_label(label: str) -> bool:
+    stripped = label.strip()
+    return stripped in _GENERIC_SYMBOL_LABELS or stripped.removesuffix("()") in _GENERIC_SYMBOL_LABELS
+
+
+def _is_low_confidence_generic_dependency(
+    attrs: dict,
+    source_node: dict,
+    target_node: dict,
+) -> bool:
+    """Suppress speculative dependency edges from generic symbols to code nodes."""
+    if str(attrs.get("confidence", "")).upper() != "INFERRED":
+        return False
+    if _edge_confidence_score(attrs) > 0.5:
+        return False
+    if str(attrs.get("relation", "")) not in _LOW_CONF_GENERIC_RELATIONS:
+        return False
+    source_label = str(source_node.get("label", ""))
+    target_label = str(target_node.get("label", ""))
+    source_generic = _is_generic_label(source_label)
+    target_generic = _is_generic_label(target_label)
+    if not (source_generic or target_generic):
+        return False
+    other = target_node if source_generic else source_node
+    return other.get("file_type") == "code"
+
+
 def edge_data(G: nx.Graph, u: str, v: str) -> dict:
     """Return one edge attribute dict for (u, v), tolerating MultiGraph.
 
@@ -259,6 +333,8 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
             tgt_ext = Path(G.nodes[tgt].get("source_file") or "").suffix.lower()
             if src_ext and tgt_ext and _LANG_FAMILY.get(src_ext) != _LANG_FAMILY.get(tgt_ext):
                 continue
+        if _is_low_confidence_generic_dependency(attrs, G.nodes[src], G.nodes[tgt]):
+            continue
         # Preserve original edge direction - undirected graphs lose it otherwise,
         # causing display functions to show edges backwards.
         attrs["_src"] = src
@@ -379,6 +455,7 @@ def build_merge(
     new_chunks: list[dict],
     graph_path: str | Path = "graphify-out/graph.json",
     prune_sources: list[str] | None = None,
+    replace_sources: list[str] | None = None,
     *,
     directed: bool = False,
     dedup: bool = True,
@@ -387,8 +464,9 @@ def build_merge(
 ) -> nx.Graph:
     """Load existing graph.json, merge new chunks into it, and save back.
 
-    Never replaces - only grows (or prunes deleted-file nodes via prune_sources).
-    Safe to call repeatedly: existing nodes and edges are preserved.
+    By default this only grows the graph. prune_sources removes deleted-file
+    content, while replace_sources first removes old content for changed files
+    before merging their fresh extraction.
     root: if given, absolute source_file paths in new_chunks are made relative (#932).
     """
     graph_path = Path(graph_path)
@@ -406,7 +484,32 @@ def build_merge(
         links_key = "links" if "links" in data else "edges"
         existing_nodes = list(data.get("nodes", []))
         existing_edges = list(data.get(links_key, []))
-        base = [{"nodes": existing_nodes, "edges": existing_edges}]
+        existing_hyperedges = list(data.get("hyperedges", []))
+        remove_sources = _source_match_set(prune_sources, root) | _source_match_set(replace_sources, root)
+        if remove_sources:
+            before = (len(existing_nodes), len(existing_edges), len(existing_hyperedges))
+            existing_nodes = [
+                node for node in existing_nodes
+                if node.get("source_file") not in remove_sources
+            ]
+            existing_edges = [
+                edge for edge in existing_edges
+                if edge.get("source_file") not in remove_sources
+            ]
+            existing_hyperedges = [
+                hyperedge for hyperedge in existing_hyperedges
+                if hyperedge.get("source_file") not in remove_sources
+            ]
+            after = (len(existing_nodes), len(existing_edges), len(existing_hyperedges))
+            removed = tuple(a - b for a, b in zip(before, after))
+            if any(removed):
+                print(
+                    "[graphify] Removed old graph content for "
+                    f"{len(remove_sources)} source key(s): "
+                    f"{removed[0]} node(s), {removed[1]} edge(s), {removed[2]} hyperedge(s).",
+                    file=sys.stderr,
+                )
+        base = [{"nodes": existing_nodes, "edges": existing_edges, "hyperedges": existing_hyperedges}]
     else:
         existing_nodes = []
         base = []
@@ -464,7 +567,7 @@ def build_merge(
 
     # Safety check: refuse to shrink the graph silently (#479)
     # Skip when dedup or prune_sources is active — shrinkage is intentional there.
-    if graph_path.exists() and not dedup and not prune_sources:
+    if graph_path.exists() and not dedup and not prune_sources and not replace_sources:
         existing_n = len(existing_nodes)
         new_n = G.number_of_nodes()
         if new_n < existing_n:

--- a/graphify/diagnostics.py
+++ b/graphify/diagnostics.py
@@ -388,3 +388,196 @@ def format_diagnostic_report(summary: dict[str, Any]) -> str:
         "note: normal graph.json is post-build; raw producer loss must be measured earlier."
     )
     return "\n".join(lines)
+
+
+_QUALITY_GENERIC_SYMBOLS = {
+    "str",
+    "Any",
+    "int",
+    "bool",
+    "float",
+    "Path",
+    "Connection",
+    "Namespace",
+    "main()",
+    "Check",
+    "Report",
+    "HealthReport",
+}
+_QUALITY_RELATIONS = {
+    "calls",
+    "uses",
+    "references",
+    "depends_on",
+    "imports",
+    "implements",
+}
+
+
+def _quality_score(edge: dict[str, Any]) -> float:
+    try:
+        return float(edge.get("confidence_score", 1.0))
+    except (TypeError, ValueError):
+        return 1.0
+
+
+def _quality_label(node: dict[str, Any]) -> str:
+    return str(node.get("label") or node.get("id") or "")
+
+
+def diagnose_quality(
+    data: dict[str, Any],
+    *,
+    low_confidence_threshold: float = 0.5,
+    generic_degree_threshold: int = 10,
+    generic_source_threshold: int = 3,
+    max_examples: int = 10,
+) -> dict[str, Any]:
+    """Read-only quality diagnostics for graph navigation safety."""
+    raw_nodes = data.get("nodes", [])
+    nodes = [
+        node
+        for node in raw_nodes
+        if isinstance(node, dict) and node.get("id") is not None
+    ] if isinstance(raw_nodes, list) else []
+    by_id = {str(node["id"]): node for node in nodes}
+    labels = {node_id: _quality_label(node) for node_id, node in by_id.items()}
+    edges = _edge_list(data)
+
+    dangling_examples: list[dict[str, Any]] = []
+    low_conf_examples: list[dict[str, Any]] = []
+    low_conf_generic_examples: list[dict[str, Any]] = []
+    degree: Counter[str] = Counter()
+    source_files_by_node: dict[str, set[str]] = defaultdict(set)
+    dangling_count = 0
+    low_conf_count = 0
+    low_conf_generic_count = 0
+
+    for edge in edges:
+        if not isinstance(edge, dict):
+            continue
+        source = str(edge.get("source", edge.get("from", "")))
+        target = str(edge.get("target", edge.get("to", "")))
+        if source not in by_id or target not in by_id:
+            dangling_count += 1
+            if len(dangling_examples) < max_examples:
+                dangling_examples.append({"source": source, "target": target})
+            continue
+
+        degree[source] += 1
+        degree[target] += 1
+        source_file = str(edge.get("source_file") or "")
+        if source_file:
+            source_files_by_node[source].add(source_file)
+            source_files_by_node[target].add(source_file)
+
+        is_low = (
+            str(edge.get("confidence", "")).upper() == "INFERRED"
+            and _quality_score(edge) <= low_confidence_threshold
+        )
+        if not is_low:
+            continue
+
+        low_conf_count += 1
+        example = {
+            "source": source,
+            "target": target,
+            "source_label": labels[source],
+            "target_label": labels[target],
+            "relation": edge.get("relation"),
+            "confidence_score": edge.get("confidence_score"),
+            "source_file": edge.get("source_file"),
+        }
+        if len(low_conf_examples) < max_examples:
+            low_conf_examples.append(example)
+
+        source_generic = labels[source] in _QUALITY_GENERIC_SYMBOLS
+        target_generic = labels[target] in _QUALITY_GENERIC_SYMBOLS
+        if (source_generic or target_generic) and str(edge.get("relation", "")) in _QUALITY_RELATIONS:
+            low_conf_generic_count += 1
+            if len(low_conf_generic_examples) < max_examples:
+                low_conf_generic_examples.append(example)
+
+    generic_bridges = []
+    for node_id, label in labels.items():
+        if label not in _QUALITY_GENERIC_SYMBOLS:
+            continue
+        if (
+            degree[node_id] >= generic_degree_threshold
+            and len(source_files_by_node[node_id]) >= generic_source_threshold
+        ):
+            generic_bridges.append({
+                "id": node_id,
+                "label": label,
+                "degree": degree[node_id],
+                "source_file_count": len(source_files_by_node[node_id]),
+            })
+    generic_bridges.sort(key=lambda item: (-item["degree"], item["label"]))
+
+    passed = not dangling_count and not low_conf_count and not low_conf_generic_count and not generic_bridges
+    return {
+        "node_count": len(nodes),
+        "edge_count": len(edges),
+        "dangling_edge_count": dangling_count,
+        "low_confidence_inferred_count": low_conf_count,
+        "low_confidence_generic_edge_count": low_conf_generic_count,
+        "generic_bridge_count": len(generic_bridges),
+        "pass": passed,
+        "examples": {
+            "dangling_edges": dangling_examples,
+            "low_confidence_inferred_edges": low_conf_examples,
+            "low_confidence_generic_edges": low_conf_generic_examples,
+            "generic_bridges": generic_bridges[:max_examples],
+        },
+    }
+
+
+def diagnose_quality_file(
+    path: str | Path,
+    *,
+    low_confidence_threshold: float = 0.5,
+    generic_degree_threshold: int = 10,
+    generic_source_threshold: int = 3,
+    max_examples: int = 10,
+) -> dict[str, Any]:
+    data = _read_json_file(path)
+    summary = diagnose_quality(
+        data,
+        low_confidence_threshold=low_confidence_threshold,
+        generic_degree_threshold=generic_degree_threshold,
+        generic_source_threshold=generic_source_threshold,
+        max_examples=max_examples,
+    )
+    graph_path = Path(path)
+    report_path = graph_path.parent / "GRAPH_REPORT.md"
+    html_path = graph_path.parent / "graph.html"
+    graph_mtime = graph_path.stat().st_mtime
+    summary["input_path"] = str(path)
+    summary["report_stale"] = report_path.exists() and report_path.stat().st_mtime < graph_mtime
+    summary["html_stale"] = html_path.exists() and html_path.stat().st_mtime < graph_mtime
+    summary["pass"] = summary["pass"] and not summary["report_stale"] and not summary["html_stale"]
+    return summary
+
+
+def format_quality_report(summary: dict[str, Any]) -> str:
+    status = "PASS" if summary.get("pass") else "FAIL"
+    lines = [
+        f"[graphify] Quality diagnostic: {status}",
+        f"input: {summary.get('input_path', '<in-memory>')}",
+        f"nodes: {summary['node_count']}",
+        f"edges: {summary['edge_count']}",
+        f"dangling_edges: {summary['dangling_edge_count']}",
+        f"low_confidence_inferred_edges: {summary['low_confidence_inferred_count']}",
+        f"low_confidence_generic_edges: {summary['low_confidence_generic_edge_count']}",
+        f"generic_bridges: {summary['generic_bridge_count']}",
+        f"report_stale: {summary.get('report_stale', False)}",
+        f"html_stale: {summary.get('html_stale', False)}",
+    ]
+    examples = summary.get("examples", {})
+    for key, rows in examples.items():
+        if not rows:
+            continue
+        lines.append(f"{key}:")
+        for row in rows:
+            lines.append(f"  - {json.dumps(row, ensure_ascii=False, sort_keys=True)}")
+    return "\n".join(lines)

--- a/graphify/skills/amp/references/update.md
+++ b/graphify/skills/amp/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/skills/claude/references/update.md
+++ b/graphify/skills/claude/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/skills/claw/references/update.md
+++ b/graphify/skills/claw/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/skills/codex/references/update.md
+++ b/graphify/skills/codex/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/skills/copilot/references/update.md
+++ b/graphify/skills/copilot/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/skills/droid/references/update.md
+++ b/graphify/skills/droid/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/skills/kilo/references/update.md
+++ b/graphify/skills/kilo/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/skills/kiro/references/update.md
+++ b/graphify/skills/kiro/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/skills/opencode/references/update.md
+++ b/graphify/skills/opencode/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/skills/pi/references/update.md
+++ b/graphify/skills/pi/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/skills/trae/references/update.md
+++ b/graphify/skills/trae/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/skills/vscode/references/update.md
+++ b/graphify/skills/vscode/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/skills/windows/references/update.md
+++ b/graphify/skills/windows/references/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -562,11 +562,16 @@ def _rebuild_code(
                 preserved_edges = [
                     e for e in existing.get("links", existing.get("edges", []))
                     if e.get("source") in all_ids and e.get("target") in all_ids
+                    and (not evict_sources or e.get("source_file") not in evict_sources)
+                ]
+                preserved_hyperedges = [
+                    h for h in existing.get("hyperedges", [])
+                    if not evict_sources or h.get("source_file") not in evict_sources
                 ]
                 result = {
                     "nodes": result["nodes"] + preserved_nodes,
                     "edges": result["edges"] + preserved_edges,
-                    "hyperedges": existing.get("hyperedges", []),
+                    "hyperedges": preserved_hyperedges,
                     "input_tokens": 0,
                     "output_tokens": 0,
                 }

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -216,6 +216,136 @@ def test_build_merge_preserves_call_edge_direction(tmp_path):
     )
 
 
+def test_build_merge_replace_sources_removes_old_same_source_content(tmp_path):
+    graph_path = tmp_path / "graph.json"
+    streampark = "scripts_cluster_health_py_streamparkclient"
+    check = "scripts_cluster_health_py_check"
+    factory = "scripts_factory_py_factory"
+    graph_path.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": streampark,
+                        "label": "StreamParkClient",
+                        "file_type": "code",
+                        "source_file": "scripts/cluster_health.py",
+                    },
+                    {
+                        "id": check,
+                        "label": "Check",
+                        "file_type": "code",
+                        "source_file": "scripts/cluster_health.py",
+                    },
+                    {
+                        "id": factory,
+                        "label": "factory()",
+                        "file_type": "code",
+                        "source_file": "scripts/factory.py",
+                    },
+                ],
+                "links": [
+                    {
+                        "source": check,
+                        "target": streampark,
+                        "relation": "references",
+                        "confidence": "EXTRACTED",
+                        "confidence_score": 1.0,
+                        "source_file": "scripts/cluster_health.py",
+                    },
+                    {
+                        "source": factory,
+                        "target": streampark,
+                        "relation": "calls",
+                        "confidence": "EXTRACTED",
+                        "confidence_score": 1.0,
+                        "source_file": "scripts/factory.py",
+                    },
+                ],
+                "hyperedges": [
+                    {
+                        "id": "old_cluster_health_hyperedge",
+                        "nodes": [check, streampark],
+                        "relation": "stale",
+                        "source_file": "scripts/cluster_health.py",
+                    },
+                    {
+                        "id": "factory_hyperedge",
+                        "nodes": [factory, streampark],
+                        "relation": "kept",
+                        "source_file": "scripts/factory.py",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fresh = {
+        "nodes": [
+            {
+                "id": streampark,
+                "label": "StreamParkClient",
+                "file_type": "code",
+                "source_file": "scripts/cluster_health.py",
+            },
+            {
+                "id": check,
+                "label": "Check",
+                "file_type": "code",
+                "source_file": "scripts/cluster_health.py",
+            },
+        ],
+        "edges": [],
+        "hyperedges": [],
+    }
+    graph = build_merge(
+        [fresh],
+        graph_path=graph_path,
+        replace_sources=["scripts/cluster_health.py"],
+    )
+
+    directed_edges = {
+        (data.get("_src", source), data.get("_tgt", target), data.get("source_file"))
+        for source, target, data in graph.edges(data=True)
+    }
+    assert (check, streampark, "scripts/cluster_health.py") not in directed_edges
+    assert (factory, streampark, "scripts/factory.py") in directed_edges
+    hyperedge_ids = {item["id"] for item in graph.graph.get("hyperedges", [])}
+    assert "old_cluster_health_hyperedge" not in hyperedge_ids
+    assert "factory_hyperedge" in hyperedge_ids
+
+
+def test_build_from_json_suppresses_low_confidence_generic_dependency():
+    nodes = [
+        {"id": "check", "label": "Check", "file_type": "code", "source_file": "x.py"},
+        {
+            "id": "streampark",
+            "label": "StreamParkClient",
+            "file_type": "code",
+            "source_file": "x.py",
+        },
+    ]
+    low_conf = {
+        "nodes": nodes,
+        "edges": [
+            {
+                "source": "check",
+                "target": "streampark",
+                "relation": "uses",
+                "confidence": "INFERRED",
+                "confidence_score": 0.5,
+                "source_file": "x.py",
+            }
+        ],
+    }
+    assert build_from_json(low_conf).number_of_edges() == 0
+
+    stronger = dict(low_conf)
+    stronger["edges"] = [dict(low_conf["edges"][0], confidence_score=0.75)]
+    assert build_from_json(stronger).number_of_edges() == 1
+
+
 def test_build_from_json_preserves_first_direction_on_bidirectional_pair(tmp_path):
     """Regression for #1061.
 

--- a/tests/test_multigraph_diagnostics.py
+++ b/tests/test_multigraph_diagnostics.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -10,8 +11,11 @@ import graphify.__main__ as mainmod
 from graphify.diagnostics import (
     diagnose_extraction,
     diagnose_file,
+    diagnose_quality,
+    diagnose_quality_file,
     format_diagnostic_json,
     format_diagnostic_report,
+    format_quality_report,
     scan_producer_suppression_sites,
 )
 
@@ -245,6 +249,63 @@ def test_diagnostic_json_report_is_serializable(tmp_path: Path) -> None:
     json.dumps(payload)
 
 
+def test_diagnose_quality_reports_dirty_graph() -> None:
+    dirty = {
+        "nodes": [
+            {"id": "check", "label": "Check", "file_type": "code"},
+            {"id": "streampark", "label": "StreamParkClient", "file_type": "code"},
+        ],
+        "links": [
+            {
+                "source": "check",
+                "target": "streampark",
+                "relation": "uses",
+                "confidence": "INFERRED",
+                "confidence_score": 0.5,
+                "source_file": "scripts/cluster_health.py",
+            },
+            {
+                "source": "missing",
+                "target": "streampark",
+                "relation": "references",
+                "confidence": "EXTRACTED",
+                "confidence_score": 1.0,
+            },
+        ],
+    }
+
+    summary = diagnose_quality(dirty)
+
+    assert summary["pass"] is False
+    assert summary["dangling_edge_count"] == 1
+    assert summary["low_confidence_inferred_count"] == 1
+    assert summary["low_confidence_generic_edge_count"] == 1
+
+
+def test_diagnose_quality_file_detects_stale_outputs(tmp_path: Path) -> None:
+    graph_path = tmp_path / "graph.json"
+    report_path = tmp_path / "GRAPH_REPORT.md"
+    graph_path.write_text(
+        json.dumps(
+            {
+                "nodes": [{"id": "a", "label": "A", "file_type": "code"}],
+                "links": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    report_path.write_text("# old\n", encoding="utf-8")
+    os.utime(report_path, (1_700_000_000, 1_700_000_000))
+    os.utime(graph_path, (1_700_000_100, 1_700_000_100))
+
+    summary = diagnose_quality_file(graph_path)
+    report = format_quality_report(summary)
+
+    assert summary["report_stale"] is True
+    assert summary["pass"] is False
+    assert "[graphify] Quality diagnostic: FAIL" in report
+
+
 def test_scan_producer_suppression_sites_finds_seen_sets(tmp_path: Path) -> None:
     source = tmp_path / "extract.py"
     source.write_text(
@@ -403,16 +464,82 @@ def test_diagnose_multigraph_cli_json_output(monkeypatch, tmp_path: Path, capsys
     assert payload["summary"]["directed_same_endpoint_collapsed_edges"] == 3
 
 
+def test_diagnose_quality_cli_human_output(monkeypatch, tmp_path: Path, capsys) -> None:
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {"id": "check", "label": "Check", "file_type": "code"},
+                    {"id": "streampark", "label": "StreamParkClient", "file_type": "code"},
+                ],
+                "links": [
+                    {
+                        "source": "check",
+                        "target": "streampark",
+                        "relation": "uses",
+                        "confidence": "INFERRED",
+                        "confidence_score": 0.5,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        mainmod.sys,
+        "argv",
+        ["graphify", "diagnose", "quality", "--graph", str(graph_path)],
+    )
+
+    mainmod.main()
+
+    out = capsys.readouterr().out
+    assert "[graphify] Quality diagnostic: FAIL" in out
+    assert "low_confidence_generic_edges: 1" in out
+
+
+def test_diagnose_quality_cli_json_output(monkeypatch, tmp_path: Path, capsys) -> None:
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text(json.dumps({"nodes": [], "links": []}), encoding="utf-8")
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        mainmod.sys,
+        "argv",
+        ["graphify", "diagnose", "quality", "--graph", str(graph_path), "--json"],
+    )
+
+    mainmod.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["pass"] is True
+    assert payload["node_count"] == 0
+
+
 @pytest.mark.parametrize(
     ("argv_tail", "expected"),
     [
-        ([], "Usage: graphify diagnose multigraph"),
-        (["wrong"], "Usage: graphify diagnose multigraph"),
+        ([], "Usage: graphify diagnose [multigraph|quality]"),
+        (["wrong"], "Usage: graphify diagnose [multigraph|quality]"),
         (["multigraph", "--graph"], "error: --graph requires a path"),
         (["multigraph", "--max-examples"], "error: --max-examples requires an integer"),
         (["multigraph", "--max-examples", "many"], "error: --max-examples requires an integer"),
         (["multigraph", "--max-examples", "-1"], "error: --max-examples must be >= 0"),
         (["multigraph", "--unknown"], "error: unknown diagnose option --unknown"),
+        (["quality", "--graph"], "error: --graph requires a path"),
+        (["quality", "--max-examples"], "error: --max-examples requires an integer"),
+        (["quality", "--max-examples", "many"], "error: --max-examples requires an integer"),
+        (["quality", "--max-examples", "-1"], "error: --max-examples must be >= 0"),
+        (
+            ["quality", "--low-confidence-threshold"],
+            "error: --low-confidence-threshold requires a number",
+        ),
+        (
+            ["quality", "--low-confidence-threshold", "many"],
+            "error: --low-confidence-threshold requires a number",
+        ),
+        (["quality", "--unknown"], "error: unknown diagnose quality option --unknown"),
     ],
 )
 def test_diagnose_multigraph_cli_usage_errors(

--- a/tools/skillgen/expected/graphify__skills__amp__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__amp__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/expected/graphify__skills__claude__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claude__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/expected/graphify__skills__claw__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claw__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/expected/graphify__skills__codex__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__codex__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/expected/graphify__skills__copilot__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__copilot__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/expected/graphify__skills__droid__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__droid__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/expected/graphify__skills__kilo__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kilo__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/expected/graphify__skills__kiro__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kiro__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/expected/graphify__skills__opencode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__opencode__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/expected/graphify__skills__pi__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__pi__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/expected/graphify__skills__trae__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__trae__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/expected/graphify__skills__vscode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__vscode__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/expected/graphify__skills__windows__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__windows__references__update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 

--- a/tools/skillgen/fragments/references/shared/update.md
+++ b/tools/skillgen/fragments/references/shared/update.md
@@ -93,11 +93,11 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# Also prune old nodes for re-extracted (changed) files before inserting fresh AST.
+# Also replace old nodes for re-extracted (changed) files before inserting fresh AST.
 # Without this, build_merge's dedup pass tries to reconcile old and new versions of
 # the same file's nodes and can collapse same-named symbols across files (#1178).
 changed = [f for files in incremental.get('new_files', {}).values() for f in files]
-prune = list(dict.fromkeys(deleted + changed)) or None
+prune = list(dict.fromkeys(deleted)) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).
@@ -105,6 +105,7 @@ G = build_merge(
     [new_extraction],
     graph_path='graphify-out/graph.json',
     prune_sources=prune,
+    replace_sources=changed or None,
 )
 print(f'[graphify update] Merged: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
 


### PR DESCRIPTION
## What changed

- Add `replace_sources` to `build_merge()` so changed files can remove their old graph content before fresh extraction is merged.
- Keep deleted-file cleanup on `prune_sources` and update generated skill references to pass changed files through `replace_sources`.
- Suppress low-confidence inferred dependency edges from generic symbols into code nodes.
- Add `graphify diagnose quality` for read-only graph hygiene checks: dangling edges, low-confidence inferred edges, generic bridge nodes, and stale report/html outputs.
- Filter preserved watch-mode hyperedges by evicted source files.

## Why

Incremental graph refreshes can preserve stale relationships for files that were re-extracted. This is especially noisy when low-confidence generic symbols such as `Check`, `Path`, or `Connection` remain connected to code nodes after the newer extraction no longer emits those edges.

`replace_sources` makes the changed-file path explicit: old content for those source files is removed from the base graph first, then the fresh extraction is merged. Deleted files continue to use `prune_sources`.

## Validation

- `uv run pytest tests/test_build.py tests/test_multigraph_diagnostics.py tests/test_watch.py -q`
- `uv run pytest tests/test_skillgen.py tests/test_build.py tests/test_multigraph_diagnostics.py tests/test_watch.py -q`
- `uv run pytest tests/ -q` (`2039 passed, 28 skipped`)
- `.venv/bin/ruff check graphify/build.py graphify/diagnostics.py graphify/__main__.py graphify/watch.py tests/test_build.py tests/test_multigraph_diagnostics.py`
- `.venv/bin/python -m py_compile graphify/build.py graphify/diagnostics.py graphify/__main__.py graphify/watch.py tests/test_build.py tests/test_multigraph_diagnostics.py`
- `git diff --check`
