### PR TITLE
fix: clean home-scope skill registration on uninstall; back up config files (#1121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 ## Unreleased
 
+- Fix: global `graphify uninstall` now strips the `# graphify` skill registration from `~/.claude/CLAUDE.md` (and `graphify install --platform codebuddy`'s registration from `~/.codebuddy/CODEBUDDY.md`). Previously a global install wrote the registration to the home-scope file but uninstall only looked at `./CLAUDE.md` in the cwd — and matched the wrong heading level — leaving an orphaned reference pointing at a now-deleted skill (#1121).
+- Feat: install and uninstall now back up any user-editable config file (CLAUDE.md, CODEBUDDY.md, GEMINI.md, AGENTS.md, VS Code instructions) before modifying or deleting it. Backups are timestamped under `~/.graphify/backups/<date>/`. Set `GRAPHIFY_NO_BACKUP=1` to disable. graphify-owned files (skill trees, Cursor/Devin rule files) are not backed up — they contain no user content.
 - Fix: `graphify query`, `graphify explain`, and MCP `query_graph`/`get_node` now show the human-readable community name (e.g. "FlashAttention Paper") instead of a blank or numeric ID after running `cluster-only`. `to_json` now accepts `community_labels` and embeds `community_name` on each node; read paths fall back to the numeric `community` field for backward compatibility with old graphs (#1305).
 - Fix: `graphify-mcp` and `python -m graphify.serve` now accept `--graph <path>` as an alias for the positional argument, consistent with every other graphify subcommand. Previously `--graph` raised "unrecognized arguments" (#1304).
 

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -326,19 +326,7 @@ def _project_scope_root(path: Path, project_dir: Path) -> Path:
 
 def _remove_claude_skill_registration(project_dir: Path) -> None:
     """Remove the project-scoped Claude skill registration file/section."""
-    claude_md = project_dir / ".claude" / "CLAUDE.md"
-    if not claude_md.exists():
-        return
-    content = claude_md.read_text(encoding="utf-8")
-    if "# graphify" not in content:
-        return
-    cleaned = re.sub(r"\n*# graphify\n.*?(?=\n# |\Z)", "", content, flags=re.DOTALL).rstrip()
-    if cleaned:
-        claude_md.write_text(cleaned + "\n", encoding="utf-8")
-        print(f"  CLAUDE.md        ->  graphify skill registration removed from {claude_md}")
-    else:
-        claude_md.unlink()
-        print(f"  CLAUDE.md        ->  deleted {claude_md}")
+    _strip_skill_registration(project_dir / ".claude" / "CLAUDE.md")
 
 
 def _print_project_git_add_hint(paths: list[Path]) -> None:
@@ -414,6 +402,66 @@ def _skill_registration(skill_path: str = "~/.claude/skills/graphify/SKILL.md") 
         "When the user types `/graphify`, invoke the Skill tool "
         "with `skill: \"graphify\"` before doing anything else.\n"
     )
+
+
+def _backup_config_file(path: Path) -> "Path | None":
+    """Snapshot a user-editable config file before graphify modifies or deletes it.
+
+    Copies <path> into ~/.graphify/backups/<date>/ under a name derived from its
+    absolute path, so an install or uninstall can be undone by hand. No-op when
+    the file is absent. Honors GRAPHIFY_NO_BACKUP=1. Never raises — a backup
+    failure warns but never blocks the operation (mirrors
+    export.backup_if_protected, issue #834).
+    """
+    if os.environ.get("GRAPHIFY_NO_BACKUP"):
+        return None
+    if not path.exists() or not path.is_file():
+        return None
+    try:
+        from datetime import date
+
+        backups = Path.home() / ".graphify" / "backups" / date.today().isoformat()
+        backups.mkdir(parents=True, exist_ok=True)
+        safe = re.sub(r"[^A-Za-z0-9._-]", "_", str(path.resolve()).lstrip("/\\"))
+        dst = backups / safe
+        shutil.copy2(path, dst)
+        print(f"  backup           ->  {dst}")
+        return dst
+    except Exception as exc:  # never block install/uninstall on a backup failure
+        print(f"  backup           ->  warning: could not back up {path} ({exc})")
+        return None
+
+
+def _write_config(path: Path, content: str) -> None:
+    """Back up an existing user-editable config file, then write new content."""
+    _backup_config_file(path)
+    path.write_text(content, encoding="utf-8")
+
+
+def _unlink_config(path: Path) -> None:
+    """Back up a user-editable config file, then delete it."""
+    _backup_config_file(path)
+    path.unlink()
+
+
+def _strip_skill_registration(md_path: Path) -> bool:
+    """Remove the `# graphify` skill-registration block (the form written by the
+    global `install()` path via _skill_registration) from md_path, backing the
+    file up first. Returns True if a change was made. No-op if the file is absent
+    or holds no graphify block."""
+    if not md_path.exists():
+        return False
+    content = md_path.read_text(encoding="utf-8")
+    if "# graphify" not in content:
+        return False
+    cleaned = re.sub(r"\n*# graphify\n.*?(?=\n# |\Z)", "", content, flags=re.DOTALL).rstrip()
+    if cleaned:
+        _write_config(md_path, cleaned + "\n")
+        print(f"  registration     ->  graphify block removed from {md_path}")
+    else:
+        _unlink_config(md_path)
+        print(f"  registration     ->  deleted {md_path}")
+    return True
 
 
 _PLATFORM_CONFIG: dict[str, dict] = {
@@ -670,7 +718,7 @@ def install(platform: str = "claude", *, project: bool = False, project_dir: Pat
             if "graphify" in content:
                 print(f"  CLAUDE.md        ->  already registered (no change)")
             else:
-                claude_md.write_text(content.rstrip() + registration, encoding="utf-8")
+                _write_config(claude_md, content.rstrip() + registration)
                 print(f"  CLAUDE.md        ->  skill registered in {claude_md}")
         else:
             claude_md.parent.mkdir(parents=True, exist_ok=True)
@@ -686,7 +734,7 @@ def install(platform: str = "claude", *, project: bool = False, project_dir: Pat
             if "graphify" in content:
                 print(f"  CODEBUDDY.md     ->  already registered (no change)")
             else:
-                codebuddy_md.write_text(content.rstrip() + registration, encoding="utf-8")
+                _write_config(codebuddy_md, content.rstrip() + registration)
                 print(f"  CODEBUDDY.md     ->  skill registered in {codebuddy_md}")
         else:
             codebuddy_md.parent.mkdir(parents=True, exist_ok=True)
@@ -770,7 +818,7 @@ def gemini_install(project_dir: Path | None = None, *, project: bool = False) ->
     if target.exists() and new_content == target.read_text(encoding="utf-8"):
         print(f"graphify already configured in {target.resolve()} (no change)")
     else:
-        target.write_text(new_content, encoding="utf-8")
+        _write_config(target, new_content)
         print(f"graphify section written to {target.resolve()}")
 
     # Always re-install the Gemini hook so an older payload (e.g. pre-issue-#580
@@ -837,10 +885,10 @@ def gemini_uninstall(project_dir: Path | None = None, *, project: bool = False) 
         r"\n*## graphify\n.*?(?=\n## |\Z)", "", content, flags=re.DOTALL
     ).rstrip()
     if cleaned:
-        target.write_text(cleaned + "\n", encoding="utf-8")
+        _write_config(target, cleaned + "\n")
         print(f"graphify section removed from {target.resolve()}")
     else:
-        target.unlink()
+        _unlink_config(target)
         print(f"GEMINI.md was empty after removal - deleted {target.resolve()}")
     _uninstall_gemini_hook(project_dir)
 
@@ -889,7 +937,7 @@ def vscode_install(project_dir: Path | None = None) -> None:
         if new_content == content:
             print(f"  {instructions}  ->  already configured (no change)")
         else:
-            instructions.write_text(new_content, encoding="utf-8")
+            _write_config(instructions, new_content)
             print(f"  {instructions}  ->  graphify section {'updated' if _VSCODE_INSTRUCTIONS_MARKER in content else 'added'}")
     else:
         instructions.write_text(_always_on("vscode-instructions"), encoding="utf-8")
@@ -934,10 +982,10 @@ def vscode_uninstall(project_dir: Path | None = None) -> None:
         r"\n*## graphify\n.*?(?=\n## |\Z)", "", content, flags=re.DOTALL
     ).rstrip()
     if cleaned:
-        instructions.write_text(cleaned + "\n", encoding="utf-8")
+        _write_config(instructions, cleaned + "\n")
         print(f"  graphify section removed from {instructions}")
     else:
-        instructions.unlink()
+        _unlink_config(instructions)
         print(f"  {instructions}  ->  deleted (was empty after removal)")
 
 
@@ -1558,7 +1606,7 @@ def _agents_install(project_dir: Path, platform: str) -> None:
     if target.exists() and new_content == target.read_text(encoding="utf-8"):
         print(f"graphify already configured in {target.resolve()} (no change)")
     else:
-        target.write_text(new_content, encoding="utf-8")
+        _write_config(target, new_content)
         print(f"graphify section written to {target.resolve()}")
 
     if platform == "codex":
@@ -1726,10 +1774,10 @@ def _agents_uninstall(project_dir: Path, platform: str = "") -> None:
         flags=re.DOTALL,
     ).rstrip()
     if cleaned:
-        target.write_text(cleaned + "\n", encoding="utf-8")
+        _write_config(target, cleaned + "\n")
         print(f"graphify section removed from {target.resolve()}")
     else:
-        target.unlink()
+        _unlink_config(target)
         print(f"AGENTS.md was empty after removal - deleted {target.resolve()}")
 
     if platform == "opencode":
@@ -1797,7 +1845,7 @@ def claude_install(project_dir: Path | None = None) -> None:
     if target.exists() and new_content == target.read_text(encoding="utf-8"):
         print(f"graphify already configured in {target.resolve()} (no change)")
     else:
-        target.write_text(new_content, encoding="utf-8")
+        _write_config(target, new_content)
         print(f"graphify section written to {target.resolve()}")
 
     # Always re-install the Claude Code PreToolUse hook so an old hook
@@ -1901,6 +1949,13 @@ def claude_uninstall(project_dir: Path | None = None, *, project: bool = False) 
     """
     project_dir = project_dir or Path(".")
     _remove_skill_file("claude", project=project, project_dir=project_dir)
+    # Global `graphify install` registers the skill as a `# graphify` block in
+    # ~/.claude/CLAUDE.md (see install(), the non-project branch). The project
+    # path strips its .claude/CLAUDE.md via _remove_claude_skill_registration in
+    # _project_uninstall; mirror that for the home scope here so a global
+    # uninstall doesn't orphan the registration pointing at a deleted skill (#1121).
+    if not project:
+        _remove_claude_skill_registration(Path.home())
     target = project_dir / "CLAUDE.md"
 
     if not target.exists():
@@ -1920,10 +1975,10 @@ def claude_uninstall(project_dir: Path | None = None, *, project: bool = False) 
         flags=re.DOTALL,
     ).rstrip()
     if cleaned:
-        target.write_text(cleaned + "\n", encoding="utf-8")
+        _write_config(target, cleaned + "\n")
         print(f"graphify section removed from {target.resolve()}")
     else:
-        target.unlink()
+        _unlink_config(target)
         print(f"CLAUDE.md was empty after removal - deleted {target.resolve()}")
 
     _uninstall_claude_hook(project_dir or Path("."))
@@ -1945,7 +2000,7 @@ def codebuddy_install(project_dir: Path | None = None) -> None:
     if target.exists() and new_content == target.read_text(encoding="utf-8"):
         print(f"graphify already configured in {target.resolve()} (no change)")
     else:
-        target.write_text(new_content, encoding="utf-8")
+        _write_config(target, new_content)
         print(f"graphify section written to {target.resolve()}")
 
     # Also write CodeBuddy PreToolUse hook to .codebuddy/settings.json
@@ -2001,6 +2056,12 @@ def codebuddy_uninstall(project_dir: Path | None = None, *, project: bool = Fals
     """Remove the graphify skill tree (SKILL.md + references/) and the CODEBUDDY.md section."""
     project_dir = project_dir or Path(".")
     _remove_skill_file("codebuddy", project=project, project_dir=project_dir)
+    # Global `graphify install --platform codebuddy` registers a `# graphify`
+    # block in ~/.codebuddy/CODEBUDDY.md (see install(), the codebuddy branch).
+    # Strip it on a global uninstall so it is not orphaned pointing at a deleted
+    # skill — same class of fix as claude (#1121).
+    if not project:
+        _strip_skill_registration(Path.home() / ".codebuddy" / "CODEBUDDY.md")
     target = project_dir / "CODEBUDDY.md"
 
     if not target.exists():
@@ -2020,10 +2081,10 @@ def codebuddy_uninstall(project_dir: Path | None = None, *, project: bool = Fals
         flags=re.DOTALL,
     ).rstrip()
     if cleaned:
-        target.write_text(cleaned + "\n", encoding="utf-8")
+        _write_config(target, cleaned + "\n")
         print(f"graphify section removed from {target.resolve()}")
     else:
-        target.unlink()
+        _unlink_config(target)
         print(f"CODEBUDDY.md was empty after removal - deleted {target.resolve()}")
 
     _uninstall_codebuddy_hook(project_dir or Path("."))

--- a/tests/test_claude_md.py
+++ b/tests/test_claude_md.py
@@ -1,7 +1,24 @@
 """Tests for graphify claude install / uninstall commands."""
 from pathlib import Path
 import pytest
-from graphify.__main__ import claude_install, claude_uninstall, _CLAUDE_MD_MARKER, _CLAUDE_MD_SECTION
+from graphify.__main__ import (
+    claude_install,
+    claude_uninstall,
+    install,
+    _skill_registration,
+    _CLAUDE_MD_MARKER,
+    _CLAUDE_MD_SECTION,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Redirect Path.home() to a sandbox so global-scope writes/removals never
+    touch the developer's real ~/.claude/CLAUDE.md."""
+    home = tmp_path / "_home"
+    home.mkdir()
+    monkeypatch.setattr("graphify.__main__.Path.home", lambda: home)
+    return home
 
 
 # ---------------------------------------------------------------------------
@@ -95,6 +112,45 @@ def test_uninstall_no_op_when_no_file(tmp_path, capsys):
     claude_uninstall(tmp_path)
     out = capsys.readouterr().out
     assert "No CLAUDE.md" in out or "nothing to do" in out
+
+
+def test_global_uninstall_removes_home_registration(tmp_path, monkeypatch, _isolated_home):
+    """Global `graphify install` writes a `# graphify` block to ~/.claude/CLAUDE.md;
+    `graphify uninstall` (global scope) must strip it, not orphan it (#1121)."""
+    monkeypatch.chdir(tmp_path)
+    install(platform="claude")  # global scope (project=False)
+
+    home_md = _isolated_home / ".claude" / "CLAUDE.md"
+    assert home_md.exists()
+    assert "# graphify" in home_md.read_text()
+
+    claude_uninstall(tmp_path)  # global scope
+    # The block was the only content, so the file is removed entirely;
+    # either way the registration must be gone.
+    assert not home_md.exists() or "# graphify" not in home_md.read_text()
+
+
+def test_global_uninstall_preserves_other_home_content(tmp_path, monkeypatch, _isolated_home):
+    """Global uninstall keeps non-graphify content in ~/.claude/CLAUDE.md."""
+    home_md = _isolated_home / ".claude" / "CLAUDE.md"
+    home_md.parent.mkdir(parents=True, exist_ok=True)
+    home_md.write_text("# My global rules\n\nKeep me.\n" + _skill_registration())
+
+    claude_uninstall(tmp_path)  # global scope
+    content = home_md.read_text()
+    assert "My global rules" in content
+    assert "Keep me." in content
+    assert "# graphify" not in content
+
+
+def test_project_uninstall_does_not_touch_home(tmp_path, monkeypatch, _isolated_home):
+    """Project-scoped uninstall must not strip the home registration."""
+    home_md = _isolated_home / ".claude" / "CLAUDE.md"
+    home_md.parent.mkdir(parents=True, exist_ok=True)
+    home_md.write_text(_skill_registration())
+
+    claude_uninstall(tmp_path, project=True)  # project scope
+    assert "# graphify" in home_md.read_text()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_codebuddy.py
+++ b/tests/test_codebuddy.py
@@ -270,6 +270,39 @@ def test_uninstall_all_removes_codebuddy_hook(tmp_path, monkeypatch):
         assert not any("graphify" in str(h) for h in hooks)
 
 
+def test_user_uninstall_removes_home_registration(tmp_path, monkeypatch):
+    """Global `graphify install --platform codebuddy` writes a `# graphify` block
+    to ~/.codebuddy/CODEBUDDY.md; the global uninstall must strip it, not orphan
+    it pointing at a deleted skill (#1121)."""
+    from graphify.__main__ import install, codebuddy_uninstall
+    monkeypatch.chdir(tmp_path)
+    home_md = tmp_path / ".codebuddy" / "CODEBUDDY.md"
+    with patch("graphify.__main__.Path.home", return_value=tmp_path):
+        install(platform="codebuddy")  # global scope (project=False)
+        assert home_md.exists()
+        assert "# graphify" in home_md.read_text()
+
+        codebuddy_uninstall(tmp_path)  # global scope
+    # block was the only content → file removed; either way it's gone
+    assert not home_md.exists() or "# graphify" not in home_md.read_text()
+
+
+def test_user_uninstall_preserves_other_home_content(tmp_path, monkeypatch):
+    """Global codebuddy uninstall keeps non-graphify content in the home file."""
+    from graphify.__main__ import install, codebuddy_uninstall
+    monkeypatch.chdir(tmp_path)
+    home_md = tmp_path / ".codebuddy" / "CODEBUDDY.md"
+    home_md.parent.mkdir(parents=True, exist_ok=True)
+    home_md.write_text("# My global notes\n\nKeep me.\n")
+    with patch("graphify.__main__.Path.home", return_value=tmp_path):
+        install(platform="codebuddy")  # appends # graphify block
+        codebuddy_uninstall(tmp_path)
+    content = home_md.read_text()
+    assert "My global notes" in content
+    assert "Keep me." in content
+    assert "# graphify" not in content
+
+
 # ---------------------------------------------------------------------------
 # Platform config sanity
 # ---------------------------------------------------------------------------

--- a/tests/test_install_backup.py
+++ b/tests/test_install_backup.py
@@ -1,0 +1,74 @@
+"""Tests for the install/uninstall backup safety net (_backup_config_file)."""
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Sandbox Path.home() so backups land under the temp dir, never the real
+    ~/.graphify/backups."""
+    home = tmp_path / "_home"
+    home.mkdir()
+    monkeypatch.setattr("graphify.__main__.Path.home", lambda: home)
+    monkeypatch.delenv("GRAPHIFY_NO_BACKUP", raising=False)
+    return home
+
+
+def _backups_root(home):
+    return home / ".graphify" / "backups"
+
+
+def test_backup_noop_when_file_absent(tmp_path, _isolated_home):
+    from graphify.__main__ import _backup_config_file
+    assert _backup_config_file(tmp_path / "does-not-exist.md") is None
+    assert not _backups_root(_isolated_home).exists()
+
+
+def test_backup_copies_existing_file(tmp_path, _isolated_home):
+    from graphify.__main__ import _backup_config_file
+    f = tmp_path / "CLAUDE.md"
+    f.write_text("original user content\n")
+    dst = _backup_config_file(f)
+    assert dst is not None and dst.exists()
+    assert dst.read_text() == "original user content\n"
+    assert _backups_root(_isolated_home) in dst.parents
+
+
+def test_backup_disabled_by_env(tmp_path, monkeypatch, _isolated_home):
+    from graphify.__main__ import _backup_config_file
+    monkeypatch.setenv("GRAPHIFY_NO_BACKUP", "1")
+    f = tmp_path / "CLAUDE.md"
+    f.write_text("content\n")
+    assert _backup_config_file(f) is None
+    assert not _backups_root(_isolated_home).exists()
+
+
+def test_install_backs_up_existing_claude_md(tmp_path, monkeypatch, _isolated_home):
+    """A global install that appends to an existing ~/.claude/CLAUDE.md snapshots
+    the pre-install file first."""
+    from graphify.__main__ import install
+    monkeypatch.chdir(tmp_path)
+    home_md = _isolated_home / ".claude" / "CLAUDE.md"
+    home_md.parent.mkdir(parents=True, exist_ok=True)
+    home_md.write_text("# pre-existing rules\n")
+
+    install(platform="claude")  # appends the # graphify block → triggers backup
+
+    backups = list(_backups_root(_isolated_home).rglob("*CLAUDE.md"))
+    assert backups, "expected a CLAUDE.md backup under ~/.graphify/backups/"
+    assert any("pre-existing rules" in b.read_text() for b in backups)
+
+
+def test_uninstall_backs_up_before_stripping(tmp_path, monkeypatch, _isolated_home):
+    """Uninstall snapshots CLAUDE.md before it strips the graphify section."""
+    from graphify.__main__ import claude_install, claude_uninstall
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "CLAUDE.md"
+    target.write_text("# my project\n\nkeep this.\n")
+    claude_install(tmp_path)  # appends ## graphify section
+    claude_uninstall(tmp_path)  # strips it → backup of the pre-strip file
+
+    backups = list(_backups_root(_isolated_home).rglob("*CLAUDE.md"))
+    assert backups, "expected a CLAUDE.md backup before uninstall stripped it"


### PR DESCRIPTION
## Problem
Global `graphify install` writes the `# graphify` skill registration to a **home-scoped** file (`~/.claude/CLAUDE.md`, and `~/.codebuddy/CODEBUDDY.md` for codebuddy), but `graphify uninstall` only stripped `./CLAUDE.md` in the cwd — and matched the wrong heading level (`##` vs the `#` install wrote). Result: the registration is **orphaned**, left pointing at a now-deleted skill. Project-scope (`--project`) was already symmetric; this was global-scope only.

## Fix
- `claude_uninstall` / `codebuddy_uninstall` now strip the home-scope `# graphify` block on global (non-project) uninstall, via a shared `_strip_skill_registration` helper.
- **Backup safety net:** install/uninstall now snapshot any user-editable config file (`CLAUDE.md`, `CODEBUDDY.md`, `GEMINI.md`, `AGENTS.md`, VS Code instructions) to `~/.graphify/backups/<date>/` before modifying or deleting it. `GRAPHIFY_NO_BACKUP=1` disables it; mirrors the existing `export.backup_if_protected` convention. graphify-owned files (skill trees, Cursor/Devin rule files) are intentionally not backed up — they hold no user content.

## Audit
Checked every platform's install-target vs uninstall-target. Only **claude** and **codebuddy** had the home-scope asymmetry (both fixed); gemini, the AGENTS.md family, and vscode were already symmetric.

## Tests
- Home-scope uninstall regressions for claude and codebuddy (with sandboxed `Path.home()`).
- New `tests/test_install_backup.py` suite covering the backup helper and `GRAPHIFY_NO_BACKUP`.
- Full suite: 2039 passed, 28 skipped.