### PR TITLE
fix: NFC-normalize labels in resolve_seed for accented/CJK lookups (#1338)

### DIFF
--- a/graphify/affected.py
+++ b/graphify/affected.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
+import unicodedata
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
 import networkx as nx
+
+
+def _normalize(text: str) -> str:
+    """Return *text* in a canonical form so NFD and NFC compare equal.
+
+    macOS stores filenames in NFD; Python string literals and most input
+    methods produce NFC. Comparing the two without normalization silently
+    fails for accented Latin, Japanese with dakuten, and Korean Hangul.
+    """
+    return unicodedata.normalize("NFC", text)
 
 
 DEFAULT_AFFECTED_RELATIONS = (
@@ -52,11 +63,11 @@ def _bare_name(label: str) -> str:
 def resolve_seed(graph: nx.Graph, query: str) -> str | None:
     if query in graph:
         return query
-    query_lower = query.lower()
+    query_lower = _normalize(query).lower()
     exact_label_matches = [
         str(node_id)
         for node_id, data in graph.nodes(data=True)
-        if str(data.get("label", "")).lower() == query_lower
+        if _normalize(str(data.get("label", ""))).lower() == query_lower
     ]
     if len(exact_label_matches) == 1:
         return exact_label_matches[0]
@@ -67,21 +78,21 @@ def resolve_seed(graph: nx.Graph, query: str) -> str | None:
     bare_name_matches = [
         str(node_id)
         for node_id, data in graph.nodes(data=True)
-        if _bare_name(str(data.get("label", ""))) == query_bare
+        if _bare_name(_normalize(str(data.get("label", "")))) == query_bare
     ]
     if len(bare_name_matches) == 1:
         return bare_name_matches[0]
     exact_source_matches = [
         str(node_id)
         for node_id, data in graph.nodes(data=True)
-        if str(data.get("source_file", "")).lower() == query_lower
+        if _normalize(str(data.get("source_file", ""))).lower() == query_lower
     ]
     if len(exact_source_matches) == 1:
         return exact_source_matches[0]
     contains_matches = [
         str(node_id)
         for node_id, data in graph.nodes(data=True)
-        if query_lower in str(data.get("label", "")).lower()
+        if query_lower in _normalize(str(data.get("label", ""))).lower()
     ]
     if len(contains_matches) == 1:
         return contains_matches[0]

--- a/tests/test_affected.py
+++ b/tests/test_affected.py
@@ -1,0 +1,27 @@
+"""Unit tests for graphify.affected.resolve_seed.
+
+Covers Unicode normalization (NFC) so accented and CJK labels resolve
+regardless of whether the query comes in NFC (Python source, most input
+methods) or NFD (macOS filenames, some IMEs).
+"""
+from __future__ import annotations
+
+import unicodedata
+
+import networkx as nx
+
+from graphify.affected import resolve_seed
+
+
+def _graph_with(label: str) -> nx.Graph:
+    """Build a one-node graph whose label is stored exactly as given."""
+    g = nx.DiGraph()
+    g.add_node("n1", label=label, source_file="pkg/foo.py", source_location="L1")
+    return g
+
+
+def test_resolve_seed_matches_nfd_query_against_nfc_label() -> None:
+    label_nfc = "Auditoría"
+    query_nfd = unicodedata.normalize("NFD", label_nfc)
+    graph = _graph_with(label_nfc)
+    assert resolve_seed(graph, query_nfd) == "n1"


### PR DESCRIPTION
## What

Fixes #1338.

`resolve_seed` in `graphify/affected.py` compared queries and labels using `.lower()` only, without Unicode normalization. As a result, a query in NFD form never matched an NFC-stored label (or vice versa) — even though the two are visually identical.

This affects:
- **macOS users** — APFS returns filenames in NFD, so any source/label flowing through the filesystem can be NFD while labels extracted from source code are NFC.
- **Accented Latin** — `Auditoría` (NFC) vs `Auditori` + combining acute (NFD).
- **Japanese with dakuten / handakuten** — `が` is one codepoint in NFC, `か` + combining `゛` in NFD.
- **Korean Hangul** — every syllable decomposes; `한` (NFC) vs three jamo (NFD).
- **Chinese** is largely unaffected (single-codepoint Han characters) except for CJK compatibility cases.

## Fix

A small `_normalize()` helper applies `unicodedata.normalize("NFC", ...)`. It's invoked on both the query and every label/source_file value before comparison in all 4 comparison sites inside `resolve_seed`. Both sides normalized → no assumption about which form the graph happened to store.

Why NFC (and not NFKC): NFC handles the practical macOS + CJK cases without folding full-width/half-width Latin or CJK compatibility forms — keeping the lookup faithful to the user's intent.

## Test

New `tests/test_affected.py` adds a unit test using a Spanish label (`Auditoría`) where the query is the NFD form of the NFC-stored label. Confirmed:
- Without the fix: `assert None == 'n1'` (the bug)
- With the fix: passes

All 7 existing `tests/test_affected_cli.py` tests continue to pass — no regression to bare-name matching, callable decoration, or tie-handling.

## Notes

- Real-user case: I hit this on macOS with bilingual (中文 / 日本語) node labels — `graphify explain` and `graphify path` would silently return "no match" for labels that visibly existed in the graph.
- The same NFD-vs-NFC pattern likely affects `serve._find_node` (the second symptom mentioned in the issue, around punctuation tokenization). Happy to follow up in a separate PR if useful — keeping this one minimal.