### PR TITLE
[codex] fix js workspace import resolution

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -99,6 +99,7 @@ def _file_node_id(rel_path: Path) -> str:
 
 _TSCONFIG_ALIAS_CACHE: dict[str, dict[str, str]] = {}
 _WORKSPACE_PACKAGE_CACHE: dict[str, dict[str, Path]] = {}
+_WORKSPACE_MANIFEST_NAMES = ("pnpm-workspace.yaml", "package.json")
 _JS_CACHE_BYPASS_SUFFIXES = {".js", ".jsx", ".mjs", ".ts", ".tsx", ".vue", ".svelte"}
 _JS_RESOLVE_EXTS = (".ts", ".tsx", ".svelte", ".js", ".jsx", ".mjs")
 _JS_INDEX_FILES = ("index.ts", "index.tsx", "index.svelte", "index.js", "index.jsx", "index.mjs")
@@ -299,10 +300,18 @@ def _find_workspace_root(start_dir: Path) -> Path | None:
     for candidate in [current, *current.parents]:
         if (candidate / "pnpm-workspace.yaml").exists():
             return candidate
+        package_json = candidate / "package.json"
+        if package_json.is_file():
+            try:
+                data = json.loads(package_json.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            if "workspaces" in data:
+                return candidate
     return None
 
 
-def _workspace_globs(workspace_file: Path) -> list[str]:
+def _pnpm_workspace_globs(workspace_file: Path) -> list[str]:
     globs: list[str] = []
     in_packages = False
     for raw_line in workspace_file.read_text(encoding="utf-8", errors="replace").splitlines():
@@ -322,16 +331,42 @@ def _workspace_globs(workspace_file: Path) -> list[str]:
     return globs
 
 
+def _workspace_globs(root: Path) -> list[str]:
+    pnpm_workspace = root / "pnpm-workspace.yaml"
+    if pnpm_workspace.exists():
+        return _pnpm_workspace_globs(pnpm_workspace)
+
+    package_json = root / "package.json"
+    try:
+        data = json.loads(package_json.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+
+    workspaces = data.get("workspaces")
+    if isinstance(workspaces, list):
+        return [item for item in workspaces if isinstance(item, str) and not item.startswith("!")]
+    if isinstance(workspaces, dict):
+        packages = workspaces.get("packages")
+        if isinstance(packages, list):
+            return [item for item in packages if isinstance(item, str) and not item.startswith("!")]
+    return []
+
+
 def _load_workspace_packages(start_dir: Path) -> dict[str, Path]:
     root = _find_workspace_root(start_dir)
     if root is None:
         return {}
-    key = str(root)
+    manifest_mtimes = tuple(
+        (name, (root / name).stat().st_mtime_ns)
+        for name in _WORKSPACE_MANIFEST_NAMES
+        if (root / name).is_file()
+    )
+    key = str((root, manifest_mtimes))
     if key in _WORKSPACE_PACKAGE_CACHE:
         return _WORKSPACE_PACKAGE_CACHE[key]
 
     packages: dict[str, Path] = {}
-    for pattern in _workspace_globs(root / "pnpm-workspace.yaml"):
+    for pattern in _workspace_globs(root):
         package_dirs: list[Path] = [root] if pattern in (".", "./") else list(root.glob(pattern))
         for package_dir in package_dirs:
             manifest = package_dir / "package.json"

--- a/tests/test_js_import_resolution.py
+++ b/tests/test_js_import_resolution.py
@@ -459,6 +459,79 @@ def test_pnpm_workspace_package_import_resolves_package_entry(tmp_path: Path):
     assert _has_edge(result, "apps/web/src/page.ts", "packages/types/src/index.ts")
 
 
+def test_npm_workspace_package_import_resolves_package_entry(tmp_path: Path):
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"workspaces": ["apps/*", "packages/*"]}),
+    )
+    _write(
+        tmp_path / "packages/types/package.json",
+        json.dumps({"name": "@workspace/types", "exports": "./src/index.ts"}),
+    )
+    target = _write(
+        tmp_path / "packages/types/src/index.ts",
+        "export interface SomeDto { id: string }\n",
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/page.ts",
+        "import type { SomeDto } from '@workspace/types'\nconst dto: SomeDto = { id: '1' }\n",
+    )
+
+    result = _extract_for([target, importer], tmp_path)
+
+    assert _has_edge(result, "apps/web/src/page.ts", "packages/types/src/index.ts")
+
+
+def test_yarn_workspace_package_import_resolves_package_entry(tmp_path: Path):
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"workspaces": {"packages": ["apps/*", "packages/*"]}}),
+    )
+    _write(
+        tmp_path / "packages/types/package.json",
+        json.dumps({"name": "@workspace/types", "exports": "./src/index.ts"}),
+    )
+    target = _write(
+        tmp_path / "packages/types/src/index.ts",
+        "export interface SomeDto { id: string }\n",
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/page.ts",
+        "import type { SomeDto } from '@workspace/types'\nconst dto: SomeDto = { id: '1' }\n",
+    )
+
+    result = _extract_for([target, importer], tmp_path)
+
+    assert _has_edge(result, "apps/web/src/page.ts", "packages/types/src/index.ts")
+
+
+def test_pnpm_workspace_takes_precedence_over_package_json_workspaces(tmp_path: Path):
+    _write(
+        tmp_path / "pnpm-workspace.yaml",
+        "packages:\n  - 'apps/*'\n  - 'packages/*'\n",
+    )
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"workspaces": ["other/*"]}),
+    )
+    _write(
+        tmp_path / "packages/types/package.json",
+        json.dumps({"name": "@workspace/types", "exports": "./src/index.ts"}),
+    )
+    target = _write(
+        tmp_path / "packages/types/src/index.ts",
+        "export interface SomeDto { id: string }\n",
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/page.ts",
+        "import type { SomeDto } from '@workspace/types'\nconst dto: SomeDto = { id: '1' }\n",
+    )
+
+    result = _extract_for([target, importer], tmp_path)
+
+    assert _has_edge(result, "apps/web/src/page.ts", "packages/types/src/index.ts")
+
+
 def test_js_import_resolution_ignores_stale_importer_cache_when_target_appears(tmp_path: Path):
     importer = _write(
         tmp_path / "src/lib/page.ts",


### PR DESCRIPTION
## Summary

Fixes JS/TS workspace package import resolution for npm and Yarn workspaces declared in root `package.json`.

## Root cause

Workspace package discovery only treated `pnpm-workspace.yaml` as a workspace root. npm and Yarn monorepos usually declare workspaces in `package.json`, so sibling package imports like `@workspace/types` were left unresolved as external imports.

## Changes

- Detect workspace roots from `package.json` when it contains `workspaces`.
- Read workspace globs from npm array form and Yarn object form.
- Keep existing pnpm behavior first when both manifests exist.
- Add regression coverage for npm, Yarn, and pnpm precedence.

## Validation

- `python -m pytest tests/test_js_import_resolution.py -q`
- `python -m graphify update .`
