### PR TITLE
feat: make per-file extraction char cap configurable via GRAPHIFY_FILE_CHAR_CAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ These are only needed for **headless / CI extraction** (`graphify extract`). Whe
 | `AWS_*` / `~/.aws/credentials` | AWS Bedrock — standard credential chain | `--backend bedrock` (no API key, uses IAM) |
 | `GRAPHIFY_MAX_WORKERS` | AST parallelism thread count | optional — also `--max-workers` flag |
 | `GRAPHIFY_MAX_OUTPUT_TOKENS` | Raise output cap for dense corpora | optional — e.g. `32768` for large files |
+| `GRAPHIFY_FILE_CHAR_CAP` | Per-file character cap before truncation in semantic extraction (default `20000`). Raise it for corpora of large individual files (e.g. concatenated chat logs) so the tail of each file isn't silently dropped | optional — e.g. `200000` |
 | `GRAPHIFY_API_TIMEOUT` | Per-call timeout in seconds for HTTP, claude-cli, and Anthropic SDK backends (default: 600) | optional — also `--api-timeout` flag |
 | `GRAPHIFY_FORCE` | Force graph rebuild even with fewer nodes | optional — also `--force` flag |
 | `GRAPHIFY_GOOGLE_WORKSPACE` | Auto-enable Google Workspace export | optional — set to `1` |

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -18,7 +18,10 @@ from pathlib import Path
 
 # `_read_files` truncates each file at this many characters before joining into
 # the user message. Token estimates use the same cap so packing matches reality.
-_FILE_CHAR_CAP = 20_000
+# The 20k default keeps cost/context bounded, but silently drops the tail of any
+# file longer than it — corpora of large individual files (e.g. concatenated chat
+# logs) lose most of their content. Override with GRAPHIFY_FILE_CHAR_CAP to raise it.
+_FILE_CHAR_CAP = int(os.environ.get("GRAPHIFY_FILE_CHAR_CAP", "20000"))
 # `_read_files` wraps each file in an `<untrusted_source path=... sha256=...>`
 # delimiter block (see issue #1210); this is roughly the per-file overhead in
 # characters that wrapper adds (open tag + 64-char sha + close tag + newlines).


### PR DESCRIPTION
## Problem

`_read_files` truncates each file at `_FILE_CHAR_CAP = 20_000` chars before joining into the extraction prompt (`llm.py`), and `_estimate_file_tokens` caps at the same value so packing matches. For corpora made of a few **large** files (e.g. concatenated chat/dialogue logs of 100-600 KB each):

1. Each file loses 80-97% of its content — only the first 20k chars are extracted.
2. Token-packing under-counts, so `_pack_chunks_by_tokens` puts everything into a single chunk (`chunk 1/1`), which then extracts almost no edges.

Symptom: `graphify extract <large-corpus> --backend claude-cli` produces a sparse graph (many nodes, ~0 edges) regardless of `--token-budget`, because every file is silently clipped to its first 20k chars.

## Fix

Make the cap configurable via `GRAPHIFY_FILE_CHAR_CAP` (default unchanged at `20000`). Large-file corpora opt in with e.g. `GRAPHIFY_FILE_CHAR_CAP=200000`; default cost/context behavior is unchanged. README env-var table updated.

## Test

- default -> `_FILE_CHAR_CAP == 20000`
- `GRAPHIFY_FILE_CHAR_CAP=200000` -> `_FILE_CHAR_CAP == 200000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)