### PR TITLE
Merge .gitignore into .graphifyignore instead of replacing it (#1363)

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -757,16 +757,20 @@ def _load_graphifyignore(root: Path) -> list[tuple[Path, str]]:
 
     patterns: list[tuple[Path, str]] = []
     for d in dirs:
-        # Prefer .graphifyignore; fall back to .gitignore so projects that already
-        # maintain a .gitignore get sensible defaults without duplicating it (#945).
-        ignore_file = d / ".graphifyignore"
-        if not ignore_file.exists():
-            ignore_file = d / ".gitignore"
-        if ignore_file.exists():
-            for raw in ignore_file.read_text(encoding="utf-8", errors="ignore").splitlines():
-                line = _parse_gitignore_line(raw)
-                if line:
-                    patterns.append((d, line))
+        # MERGE .gitignore + .graphifyignore — do NOT let one shadow the other.
+        # Read .gitignore first, then .graphifyignore, so .graphifyignore patterns
+        # are appended last and win on conflicts via last-match-wins. This keeps
+        # ".graphifyignore takes priority" while ensuring that adding a
+        # .graphifyignore can only ever exclude MORE — never silently re-include a
+        # path the .gitignore already excluded (which previously let secrets that
+        # were ignored only in .gitignore get indexed into the graph). (#1363)
+        for fname in (".gitignore", ".graphifyignore"):
+            ignore_file = d / fname
+            if ignore_file.exists():
+                for raw in ignore_file.read_text(encoding="utf-8", errors="ignore").splitlines():
+                    line = _parse_gitignore_line(raw)
+                    if line:
+                        patterns.append((d, line))
     return patterns
 
 

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -922,19 +922,47 @@ def test_gitignore_fallback_when_no_graphifyignore(tmp_path):
     assert not any("generated" in f for f in code)
 
 
-def test_graphifyignore_takes_precedence_over_gitignore(tmp_path):
-    """When both exist, .graphifyignore is used and .gitignore is ignored (#945)."""
+def test_graphifyignore_merges_with_gitignore(tmp_path):
+    """When both exist they are MERGED, not mutually exclusive: .gitignore patterns
+    still apply, and .graphifyignore only wins on direct conflicts via last-match-wins.
+
+    Previously .graphifyignore fully shadowed .gitignore in the same directory, so a
+    file ignored only in .gitignore (e.g. a secret) would get indexed into the graph
+    once any .graphifyignore was added. (#1363)
+    """
     (tmp_path / ".git").mkdir()
-    # .gitignore would exclude main.py; .graphifyignore excludes only other.py
-    (tmp_path / ".gitignore").write_text("main.py\n")
-    (tmp_path / ".graphifyignore").write_text("other.py\n")
-    (tmp_path / "main.py").write_text("x = 1")
-    (tmp_path / "other.py").write_text("x = 2")
+    (tmp_path / ".gitignore").write_text("gitonly.py\nkeep.py\n")
+    # .graphifyignore adds its own pattern and re-includes keep.py via negation
+    (tmp_path / ".graphifyignore").write_text("graphonly.py\n!keep.py\n")
+    (tmp_path / "main.py").write_text("x = 0")
+    (tmp_path / "gitonly.py").write_text("x = 1")
+    (tmp_path / "graphonly.py").write_text("x = 2")
+    (tmp_path / "keep.py").write_text("x = 3")
 
     result = detect(tmp_path)
     code = result["files"]["code"]
-    assert any("main.py" in f for f in code)       # gitignore NOT applied
-    assert not any("other.py" in f for f in code)  # graphifyignore IS applied
+    assert any("main.py" in f for f in code)           # ignored nowhere
+    assert not any("gitonly.py" in f for f in code)    # .gitignore still applies (NOT shadowed)
+    assert not any("graphonly.py" in f for f in code)  # .graphifyignore applies
+    assert any("keep.py" in f for f in code)           # .graphifyignore '!' wins on conflict
+
+
+def test_secret_ignored_only_in_gitignore_stays_excluded(tmp_path):
+    """Security regression (#1363): a file excluded only by .gitignore must NOT be
+    indexed just because an unrelated .graphifyignore exists in the same directory."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".gitignore").write_text("prod-dump.md\n")   # secret, excluded only here
+    (tmp_path / ".graphifyignore").write_text("*.png\n")     # unrelated: media only
+    (tmp_path / "prod-dump.md").write_text("# internal data dump")
+    (tmp_path / "keep.md").write_text("# keep")
+    (tmp_path / "pic.png").write_bytes(b"x")
+
+    result = detect(tmp_path)
+    docs = result["files"].get("document", [])
+    imgs = result["files"].get("image", [])
+    assert not any("pic.png" in f for f in imgs)        # .graphifyignore applies
+    assert not any("prod-dump.md" in f for f in docs)   # .gitignore NOT shadowed — secret stays out
+    assert any("keep.md" in f for f in docs)
 
 
 # Regression tests for #947 - .worktrees/ skipped and --exclude flag


### PR DESCRIPTION
Fixes #1363.

## Problem

Within a directory, `_load_graphifyignore` reads **either** `.graphifyignore` **or** `.gitignore`, never both:

```python
ignore_file = d / ".graphifyignore"
if not ignore_file.exists():
    ignore_file = d / ".gitignore"
```

So adding a `.graphifyignore` silently disables that directory's `.gitignore`. A file ignored **only** in `.gitignore` (a `prod-dump.sql`, `customer-data.json`, neutrally-named secret, …) then gets indexed into the graph — and can leak when `graph.json` / `GRAPH_REPORT.md` / `graph.html` are committed. The built-in sensitive-file detection catches `.env`/keys, but not neutrally-named secrets people rely on `.gitignore` to exclude.

The README's "`.graphifyignore` takes priority" reads like merge-with-precedence; the behavior is total replacement.

## Fix

Read **both** files and merge them per directory: `.gitignore` first, then `.graphifyignore` appended last so it still wins on direct conflicts via the existing last-match-wins semantics. Adding a `.graphifyignore` can now only ever exclude **more**, never silently re-include a path `.gitignore` excluded.

- The #945 fallback (honor `.gitignore` when no `.graphifyignore` exists) is unchanged.
- `.graphifyignore` precedence on conflicts is preserved (it's read last → wins), including `!` re-includes.

## Tests

- Rewrote `test_graphifyignore_takes_precedence_over_gitignore` → `test_graphifyignore_merges_with_gitignore`: both files' patterns apply; `.graphifyignore`'s `!negation` wins on conflict.
- Added `test_secret_ignored_only_in_gitignore_stays_excluded`: the #1363 scenario — a file excluded only by `.gitignore` stays out even when an unrelated `.graphifyignore` is present.
- `tests/test_detect.py`: **125 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
