### PR TITLE
feat: cross-file reference stitch for incremental updates (3/3)

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -4258,6 +4258,7 @@ def main() -> None:
         # AST extraction on code files. Empty code list (docs-only corpus) is
         # the issue #698 case — skip cleanly instead of crashing inside extract().
         ast_result: dict = {"nodes": [], "edges": [], "input_tokens": 0, "output_tokens": 0}
+        _stitch_new_ids: set[str] = set()
         if code_files:
             from graphify.extract import extract as _ast_extract
             # Anchor the cache at the output root, not the scanned project:
@@ -4272,6 +4273,9 @@ def main() -> None:
             except Exception as exc:
                 print(f"[graphify extract] AST extraction failed: {exc}", file=sys.stderr)
                 ast_result = {"nodes": [], "edges": [], "input_tokens": 0, "output_tokens": 0}
+            for _n in ast_result.get("nodes", []):
+                if _n.get("id"):
+                    _stitch_new_ids.add(str(_n["id"]))
 
         # Semantic extraction on docs/papers/images. Check cache first.
         from graphify.cache import (
@@ -4393,6 +4397,9 @@ def main() -> None:
                 sem_result["hyperedges"].extend(fresh.get("hyperedges", []))
                 sem_result["input_tokens"] += fresh.get("input_tokens", 0)
                 sem_result["output_tokens"] += fresh.get("output_tokens", 0)
+                for _n in fresh.get("nodes", []):
+                    if _n.get("id"):
+                        _stitch_new_ids.add(str(_n["id"]))
 
         pg_result: dict = {"nodes": [], "edges": []}
         if cli_postgres_dsn is not None:
@@ -4450,6 +4457,7 @@ def main() -> None:
         }
 
         _incremental_prune: list[str] | None = None
+        _changed_for_stitch: list[str] = []
         if incremental_mode:
             from graphify.build import path_covered_by_extraction as _path_covered
 
@@ -4458,6 +4466,7 @@ def main() -> None:
                 str(p) for p in semantic_files
                 if _path_covered(str(p), sem_result, target)
             ]
+            _changed_for_stitch = list(dict.fromkeys(_changed_code + [str(p) for p in semantic_files]))
             _incremental_prune = (
                 list(dict.fromkeys(deleted_files + _changed_code + _changed_sem)) or None
             )
@@ -4502,15 +4511,54 @@ def main() -> None:
                         _node_sf.get(_e.get("source")) or _node_sf.get(_e.get("target")) or ""
                     )
             _backup(graphify_out)
-            graph_json_path.write_text(
-                json.dumps(merged, indent=2), encoding="utf-8"
-            )
+            if incremental_mode:
+                G = _build_merge(
+                    [merged],
+                    graph_path=existing_graph_path,
+                    prune_sources=_incremental_prune,
+                    dedup=True,
+                    dedup_llm_backend=backend if dedup_llm else None,
+                    root=target,
+                )
+                if _changed_for_stitch:
+                    from graphify.stitch import stitch_incremental_links as _stitch_links
+                    _stitch_links(
+                        G,
+                        _changed_for_stitch,
+                        root=target,
+                        new_node_ids=_stitch_new_ids,
+                    )
+                out_graph = {
+                    "nodes": [{"id": n, **d} for n, d in G.nodes(data=True)],
+                    "edges": [
+                        {
+                            **{k: val for k, val in d.items() if k not in ("_src", "_tgt", "source", "target")},
+                            "source": d.get("_src", u),
+                            "target": d.get("_tgt", v),
+                        }
+                        for u, v, d in G.edges(data=True)
+                    ],
+                    "hyperedges": list(G.graph.get("hyperedges", [])),
+                    "input_tokens": merged["input_tokens"],
+                    "output_tokens": merged["output_tokens"],
+                }
+                graph_json_path.write_text(
+                    json.dumps(out_graph, indent=2), encoding="utf-8"
+                )
+                node_count = len(out_graph["nodes"])
+                edge_count = len(out_graph["edges"])
+            else:
+                graph_json_path.write_text(
+                    json.dumps(merged, indent=2), encoding="utf-8"
+                )
+                node_count = len(merged["nodes"])
+                edge_count = len(merged["edges"])
             cost = _estimate_cost(
                 backend, merged["input_tokens"], merged["output_tokens"]
             )
             print(
                 f"[graphify extract] wrote {graph_json_path} — "
-                f"{len(merged['nodes'])} nodes, {len(merged['edges'])} edges "
+                f"{node_count} nodes, {edge_count} edges "
                 f"(no clustering)"
             )
             if merged["input_tokens"] or merged["output_tokens"]:
@@ -4557,6 +4605,14 @@ def main() -> None:
                 dedup_llm_backend=dedup_backend,
                 root=target,
             )
+            if _changed_for_stitch:
+                from graphify.stitch import stitch_incremental_links as _stitch_links
+                _stitch_links(
+                    G,
+                    _changed_for_stitch,
+                    root=target,
+                    new_node_ids=_stitch_new_ids,
+                )
         else:
             G = _build([merged], dedup=True, dedup_llm_backend=dedup_backend, root=target)
         if G.number_of_nodes() == 0:

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -4284,6 +4284,7 @@ def main() -> None:
         }
         sem_cache_hits = 0
         sem_cache_misses = 0
+        fresh: dict = {"nodes": [], "edges": [], "hyperedges": []}
         if semantic_files:
             sem_paths_str = [str(p) for p in semantic_files]
             cached_nodes, cached_edges, cached_hyperedges, uncached_paths = (
@@ -4352,6 +4353,32 @@ def main() -> None:
                         file=sys.stderr,
                     )
                     sys.exit(1)
+                # Incremental: never prune/replace changed files unless re-extraction
+                # actually produced nodes/edges. Invalid JSON and connection failures
+                # that yield empty chunks must abort before merge (#incremental-safe).
+                if incremental_mode and uncached_paths:
+                    from graphify.build import paths_missing_from_extraction as _paths_missing
+
+                    _missing = _paths_missing(fresh, uncached_paths, target)
+                    if fresh.get("failed_chunks", 0) > 0 or _missing:
+                        if fresh.get("failed_chunks", 0) > 0:
+                            print(
+                                f"[graphify extract] error: {fresh['failed_chunks']} semantic "
+                                f"chunk(s) failed during incremental re-extraction.",
+                                file=sys.stderr,
+                            )
+                        for _path in _missing:
+                            print(
+                                f"[graphify extract] error: re-extraction produced no "
+                                f"nodes/edges for {_path}",
+                                file=sys.stderr,
+                            )
+                        print(
+                            "[graphify extract] incremental update aborted — existing "
+                            "graph.json and manifest unchanged.",
+                            file=sys.stderr,
+                        )
+                        sys.exit(1)
                 try:
                     _save_semantic_cache(
                         fresh.get("nodes", []),
@@ -4421,6 +4448,19 @@ def main() -> None:
             ftype: [f for f in flist if ftype not in _sem_types or f in _sem_extracted]
             for ftype, flist in files_by_type.items()
         }
+
+        _incremental_prune: list[str] | None = None
+        if incremental_mode:
+            from graphify.build import path_covered_by_extraction as _path_covered
+
+            _changed_code = [str(p) for p in code_files]
+            _changed_sem = [
+                str(p) for p in semantic_files
+                if _path_covered(str(p), sem_result, target)
+            ]
+            _incremental_prune = (
+                list(dict.fromkeys(deleted_files + _changed_code + _changed_sem)) or None
+            )
 
         if no_cluster:
             # --no-cluster: dump the raw merged extraction as graph.json.
@@ -4512,7 +4552,7 @@ def main() -> None:
             G = _build_merge(
                 [merged],
                 graph_path=existing_graph_path,
-                prune_sources=deleted_files or None,
+                prune_sources=_incremental_prune,
                 dedup=True,
                 dedup_llm_backend=dedup_backend,
                 root=target,

--- a/graphify/build.py
+++ b/graphify/build.py
@@ -574,6 +574,55 @@ def build_merge(
     return G
 
 
+def source_path_aliases(p: str, root: str | Path | None = None) -> set[str]:
+    """All normalized forms of a scan/manifest path for matching source_file."""
+    aliases: set[str] = set()
+    if not p:
+        return aliases
+    root_resolved = Path(root).resolve() if root else None
+    root_str = str(root_resolved) if root_resolved else None
+    aliases.add(p.replace("\\", "/"))
+    norm = _norm_source_file(p, root_str)
+    if norm:
+        aliases.add(norm)
+    if root_resolved is not None:
+        path = Path(p)
+        try:
+            abs_p = path if path.is_absolute() else root_resolved / path
+            aliases.add(abs_p.resolve().relative_to(root_resolved).as_posix())
+        except ValueError:
+            pass
+    return aliases
+
+
+def source_files_in_extraction(extraction: dict, root: str | Path | None = None) -> set[str]:
+    """Collect all source_file aliases present in an extraction dict."""
+    found: set[str] = set()
+    for key in ("nodes", "edges", "hyperedges"):
+        for item in extraction.get(key, []):
+            sf = item.get("source_file")
+            if sf:
+                found |= source_path_aliases(str(sf), root)
+    return found
+
+
+def path_covered_by_extraction(p: str, extraction: dict, root: str | Path | None = None) -> bool:
+    """True when extraction contains at least one node/edge/hyperedge for path p."""
+    return bool(source_path_aliases(p, root) & source_files_in_extraction(extraction, root))
+
+
+def paths_missing_from_extraction(
+    extraction: dict,
+    paths: list[str],
+    root: str | Path | None = None,
+) -> list[str]:
+    """Return paths whose re-extraction produced no nodes/edges/hyperedges."""
+    if not paths:
+        return []
+    extracted = source_files_in_extraction(extraction, root)
+    return [p for p in paths if not (source_path_aliases(p, root) & extracted)]
+
+
 def prefix_graph_for_global(G: nx.Graph, repo_tag: str) -> nx.Graph:
     """Return a copy of G with all node IDs prefixed with repo_tag::.
 

--- a/graphify/stitch.py
+++ b/graphify/stitch.py
@@ -1,0 +1,288 @@
+"""Post-merge incremental stitch — wire changed-file subgraphs to the existing graph.
+
+After incremental ``build_merge``, re-extracted files often contain mentions of
+symbols and paths elsewhere in the corpus, but the LLM chunk lacked that context.
+This module adds conservative ``references`` edges by scanning changed files on
+disk and resolving mentions against the full merged graph.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import networkx as nx
+
+from graphify.build import source_path_aliases
+from graphify.symbol_resolution import existing_edge_pairs, normalise_callable_label
+
+_BACKTICK = re.compile(r"`([^`]+)`")
+_MD_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+_PATH_EXT = re.compile(
+    r"\.(?:md|py|ts|tsx|js|jsx|java|go|rs|txt|rst|pdf)(?:$|[#?])",
+    re.IGNORECASE,
+)
+_MIN_SYMBOL_LEN = 3
+
+
+def _stitch_label_index(G: nx.Graph) -> dict[str, list[str]]:
+    """Map normalised label -> node ids (code, document, and concept nodes)."""
+    index: dict[str, list[str]] = {}
+    for nid, data in G.nodes(data=True):
+        if data.get("file_type") == "rationale":
+            continue
+        label = str(data.get("label", "")).strip().strip("()")
+        if not label or len(label) < _MIN_SYMBOL_LEN:
+            continue
+        if label.endswith((".py", ".md", ".ts", ".tsx", ".js", ".jsx")):
+            continue
+        key = normalise_callable_label(label)
+        if key:
+            index.setdefault(key, []).append(nid)
+    return index
+
+
+def _nodes_for_source_file(G: nx.Graph, path: str, root: Path) -> list[str]:
+    aliases = source_path_aliases(path, root)
+    if not aliases:
+        return []
+    found: list[str] = []
+    for nid, data in G.nodes(data=True):
+        sf = data.get("source_file")
+        if sf and source_path_aliases(str(sf), root) & aliases:
+            found.append(nid)
+    return found
+
+
+def _source_file_matches_path(source_file: str | None, rel: Path, root: Path) -> bool:
+    if not source_file:
+        return False
+    changed = source_path_aliases(rel.as_posix(), root)
+    return bool(source_path_aliases(str(source_file), root) & changed)
+
+
+def _is_foreign_attribution(source_file: str | None, rel: Path, root: Path) -> bool:
+    """True when source_file points at a different existing file than *rel*."""
+    if not source_file:
+        return False
+    if _source_file_matches_path(source_file, rel, root):
+        return False
+    disk = Path(source_file)
+    if not disk.is_absolute():
+        disk = root / disk
+    return disk.is_file()
+
+
+def _fallback_local_nodes(
+    G: nx.Graph,
+    new_ids: set[str],
+    rel: Path,
+    root: Path,
+) -> list[str]:
+    """Fresh extraction nodes for stitch anchors when source_file was wrong.
+
+    Keeps nodes attributed to missing/hallucinated paths; drops nodes the LLM
+    placed under a different on-disk file (e.g. calendar.md while stitching array.md).
+    """
+    kept: list[str] = []
+    for nid in sorted(new_ids):
+        if nid not in G:
+            continue
+        sf = G.nodes[nid].get("source_file")
+        if _is_foreign_attribution(str(sf) if sf else None, rel, root):
+            continue
+        kept.append(nid)
+    return kept
+
+
+def _pick_path_target_anchor(node_ids: list[str], G: nx.Graph, rel_path: Path) -> str | None:
+    """Pick a file-level target for a path mention; never an arbitrary code symbol."""
+    if not node_ids:
+        return None
+    stem = rel_path.stem.lower().replace("_", " ")
+    doc_nodes = [n for n in node_ids if n.endswith("_document")]
+    if doc_nodes:
+        return sorted(doc_nodes)[0]
+    for nid in sorted(node_ids):
+        data = G.nodes[nid]
+        if data.get("file_type") not in ("document", "concept", "paper"):
+            continue
+        label = str(data.get("label", "")).lower().replace("_", " ")
+        if stem in label or label in stem:
+            return nid
+    return None
+
+
+def _pick_file_anchor(node_ids: list[str], G: nx.Graph, rel_path: Path) -> str | None:
+    if not node_ids:
+        return None
+    stem = rel_path.stem.lower().replace("_", " ")
+    doc_nodes = [n for n in node_ids if n.endswith("_document")]
+    if doc_nodes:
+        return sorted(doc_nodes)[0]
+    for nid in node_ids:
+        data = G.nodes[nid]
+        ft = data.get("file_type")
+        label = str(data.get("label", "")).lower().replace("_", " ")
+        if ft in ("document", "concept", "paper") and stem in label:
+            return nid
+    return sorted(node_ids)[0]
+
+
+def _looks_like_path(token: str) -> bool:
+    token = token.strip()
+    if "/" in token or "\\" in token:
+        return True
+    return bool(_PATH_EXT.search(token))
+
+
+def _resolve_path_target(token: str, root: Path, G: nx.Graph) -> list[str]:
+    token = token.strip().split("#")[0].split("?")[0]
+    if not token:
+        return []
+    candidates = [token]
+    if not Path(token).is_absolute():
+        candidates.append(str(root / token))
+    for cp in candidates:
+        nids = _nodes_for_source_file(G, cp, root)
+        if not nids:
+            continue
+        try:
+            rel = (
+                Path(cp).resolve().relative_to(root.resolve())
+                if Path(cp).is_absolute()
+                else Path(token)
+            )
+        except ValueError:
+            rel = Path(token)
+        anchor = _pick_path_target_anchor(nids, G, rel)
+        return [anchor] if anchor else []
+    return []
+
+
+def _resolve_symbol_targets(
+    token: str,
+    label_index: dict[str, list[str]],
+    local_ids: set[str],
+    G: nx.Graph,
+) -> list[str]:
+    key = normalise_callable_label(token)
+    if not key or len(key) < _MIN_SYMBOL_LEN:
+        return []
+    cands = label_index.get(key, [])
+    if not cands:
+        return []
+    external = [c for c in cands if c not in local_ids]
+    if len(external) == 1:
+        return external
+    if len(external) > 1:
+        by_source: dict[str, list[str]] = {}
+        for nid in external:
+            sf = str(G.nodes[nid].get("source_file", ""))
+            by_source.setdefault(sf, []).append(nid)
+        if len(by_source) == 1:
+            return [sorted(by_source[next(iter(by_source))])[0]]
+        return []
+    return []
+
+
+def _edge_triples_from_graph(G: nx.Graph) -> set[tuple[str, str, str]]:
+    edges = [
+        {
+            "source": d.get("_src", u),
+            "target": d.get("_tgt", v),
+            "relation": d.get("relation", ""),
+        }
+        for u, v, d in G.edges(data=True)
+    ]
+    return existing_edge_pairs(edges)
+
+
+def stitch_incremental_links(
+    G: nx.Graph,
+    changed_paths: list[str],
+    *,
+    root: str | Path,
+    new_node_ids: set[str] | frozenset[str] | None = None,
+) -> int:
+    """Add ``references`` edges from changed files to the rest of the graph.
+
+    Scans each changed file for backtick identifiers and markdown path links,
+    resolves them against *G*, and attaches edges from the changed file's anchor
+    node. Returns the number of edges added.
+
+    When the LLM attributes re-extracted nodes to the wrong ``source_file``,
+    pass *new_node_ids* (node ids from the fresh extraction) so anchors can
+    still be chosen for stitch edges.
+    """
+    if not changed_paths:
+        return 0
+    root_path = Path(root).resolve()
+    new_ids = set(new_node_ids or ())
+    label_index = _stitch_label_index(G)
+    known = _edge_triples_from_graph(G)
+    added = 0
+
+    for path_str in changed_paths:
+        disk_path = Path(path_str)
+        if not disk_path.is_absolute():
+            disk_path = root_path / disk_path
+        if not disk_path.is_file():
+            continue
+        try:
+            rel = disk_path.resolve().relative_to(root_path)
+        except ValueError:
+            rel = Path(path_str)
+        try:
+            text = disk_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        local_nids = _nodes_for_source_file(G, str(rel), root_path)
+        if not local_nids and new_ids:
+            local_nids = _fallback_local_nodes(G, new_ids, rel, root_path)
+        anchor = _pick_file_anchor(local_nids, G, rel)
+        if not anchor:
+            continue
+
+        local_ids = set(local_nids)
+        seen_tokens: set[str] = set()
+
+        for token in _BACKTICK.findall(text) + _MD_LINK.findall(text):
+            token = token.strip()
+            if not token or token in seen_tokens:
+                continue
+            seen_tokens.add(token)
+
+            if _looks_like_path(token):
+                targets = _resolve_path_target(token, root_path, G)
+            else:
+                targets = _resolve_symbol_targets(token, label_index, local_ids, G)
+
+            for tgt in targets:
+                if tgt == anchor:
+                    continue
+                triple = (anchor, tgt, "references")
+                if triple in known:
+                    continue
+                known.add(triple)
+                G.add_edge(
+                    anchor,
+                    tgt,
+                    relation="references",
+                    confidence="EXTRACTED",
+                    confidence_score=1.0,
+                    source_file=rel.as_posix(),
+                    weight=1.0,
+                    _src=anchor,
+                    _tgt=tgt,
+                )
+                added += 1
+
+    if added:
+        print(
+            f"[graphify] Stitched {added} cross-file reference edge(s) "
+            f"for {len(changed_paths)} changed file(s).",
+            file=sys.stderr,
+        )
+    return added

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2,7 +2,17 @@ import json
 from pathlib import Path
 import networkx as nx
 from networkx.readwrite import json_graph
-from graphify.build import build_from_json, build, build_merge, edge_data, edge_datas, dedupe_edges, dedupe_nodes
+from graphify.build import (
+    build_from_json,
+    build,
+    build_merge,
+    dedupe_edges,
+    dedupe_nodes,
+    edge_data,
+    edge_datas,
+    path_covered_by_extraction,
+    paths_missing_from_extraction,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures"
 

--- a/tests/test_stitch.py
+++ b/tests/test_stitch.py
@@ -1,0 +1,178 @@
+"""Tests for incremental post-merge stitch pass."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import networkx as nx
+
+from graphify.build import build_from_json, build_merge
+from graphify.stitch import stitch_incremental_links
+
+
+def _calendar_graph() -> dict:
+    cal_sf = "BoT-calendars-shared/src/CALENDAR_CALCULATIONS.md"
+    return {
+        "nodes": [
+            {
+                "id": "calendar_calculations_calculateworkingtimefromteamscalendar",
+                "label": "calculateWorkingTimeFromTeamsCalendar",
+                "file_type": "code",
+                "source_file": cal_sf,
+            },
+            {
+                "id": "calendar_calculations_createassignmentcalendarsnapshot",
+                "label": "createAssignmentCalendarSnapshot",
+                "file_type": "code",
+                "source_file": cal_sf,
+            },
+        ],
+        "edges": [],
+        "input_tokens": 0,
+        "output_tokens": 0,
+    }
+
+
+def _array_graph() -> dict:
+    array_sf = "ARRAY_FIELDS_TYPED_APPROACH.md"
+    return {
+        "nodes": [
+            {
+                "id": "array_fields_typed_approach_sprint",
+                "label": "Sprint",
+                "file_type": "code",
+                "source_file": array_sf,
+            },
+            {
+                "id": "array_fields_typed_approach_document",
+                "label": "Typed Array Fields Implementation",
+                "file_type": "document",
+                "source_file": array_sf,
+            },
+        ],
+        "edges": [],
+        "input_tokens": 0,
+        "output_tokens": 0,
+    }
+
+
+def test_stitch_links_symbol_mentions_from_changed_markdown(tmp_path: Path) -> None:
+    root = tmp_path / "corpus"
+    root.mkdir()
+    array_md = root / "ARRAY_FIELDS_TYPED_APPROACH.md"
+    cal_dir = root / "BoT-calendars-shared" / "src"
+    cal_dir.mkdir(parents=True)
+    cal_md = cal_dir / "CALENDAR_CALCULATIONS.md"
+    cal_md.write_text("# Calendar\n", encoding="utf-8")
+    array_md.write_text(
+        "# Typed Array Fields Implementation\n\n"
+        "See `BoT-calendars-shared/src/CALENDAR_CALCULATIONS.md` and "
+        "`calculateWorkingTimeFromTeamsCalendar`.\n",
+        encoding="utf-8",
+    )
+
+    graph_path = tmp_path / "graph.json"
+    G0 = build_from_json(_calendar_graph(), root=root)
+    graph_path.write_text(
+        json.dumps(nx.node_link_data(G0, edges="edges")),
+        encoding="utf-8",
+    )
+
+    G = build_merge(
+        [_array_graph()],
+        graph_path=graph_path,
+        prune_sources=None,
+        dedup=False,
+        root=root,
+    )
+
+    added = stitch_incremental_links(
+        G,
+        [str(array_md.relative_to(root))],
+        root=root,
+    )
+    assert added >= 1
+
+    refs = [
+        (d.get("_src", u), d.get("_tgt", v))
+        for u, v, d in G.edges(data=True)
+        if d.get("relation") == "references"
+    ]
+    anchor = "array_fields_typed_approach_document"
+    cal_fn = "calendar_calculations_calculateworkingtimefromteamscalendar"
+    assert (anchor, cal_fn) in refs
+
+
+def test_stitch_uses_new_node_ids_when_source_file_hallucinated(tmp_path: Path) -> None:
+    """LLM may attribute nodes to wrong paths; stitch still wires via new_node_ids."""
+    root = tmp_path / "corpus"
+    root.mkdir()
+    array_md = root / "ARRAY_FIELDS_TYPED_APPROACH.md"
+    cal_dir = root / "BoT-calendars-shared" / "src"
+    cal_dir.mkdir(parents=True)
+    (cal_dir / "CALENDAR_CALCULATIONS.md").write_text("# Calendar\n", encoding="utf-8")
+    array_md.write_text(
+        "# Doc\n\nUse `calculateWorkingTimeFromTeamsCalendar`.\n",
+        encoding="utf-8",
+    )
+
+    graph_path = tmp_path / "graph.json"
+    G0 = build_from_json(_calendar_graph(), root=root)
+    graph_path.write_text(
+        json.dumps(nx.node_link_data(G0, edges="edges")),
+        encoding="utf-8",
+    )
+
+    # Only nodes whose source_file is missing/wrong for *array_md* — do not
+    # attribute nodes to another on-disk file (build_merge #1344 drops all nodes
+    # for every source_file present in the re-extract batch).
+    hallucinated = {
+        "nodes": [
+            {
+                "id": "array_field_renderer_SprintArrayRenderer",
+                "label": "SprintArrayRenderer",
+                "file_type": "code",
+                "source_file": "nextjsapp/app/utils/components/tasks/ArrayFieldRenderer.tsx",
+            },
+        ],
+        "edges": [],
+        "input_tokens": 0,
+        "output_tokens": 0,
+    }
+    G = build_merge([hallucinated], graph_path=graph_path, prune_sources=None, dedup=False, root=root)
+    added = stitch_incremental_links(
+        G,
+        [str(array_md.relative_to(root))],
+        root=root,
+        new_node_ids={"array_field_renderer_SprintArrayRenderer"},
+    )
+    assert added == 1
+    refs = [
+        (d.get("_src", u), d.get("_tgt", v))
+        for u, v, d in G.edges(data=True)
+        if d.get("relation") == "references"
+    ]
+    assert ("array_field_renderer_SprintArrayRenderer", "calendar_calculations_calculateworkingtimefromteamscalendar") in refs
+
+
+def test_stitch_skips_ambiguous_symbol(tmp_path: Path) -> None:
+    root = tmp_path / "corpus"
+    root.mkdir()
+    doc_a = root / "a.md"
+    doc_b = root / "b.md"
+    doc_a.write_text("Uses `handle`.\n", encoding="utf-8")
+    doc_b.write_text("# B\n", encoding="utf-8")
+
+    extraction = {
+        "nodes": [
+            {"id": "svc_a_handle", "label": "handle", "file_type": "code", "source_file": "svc/a.py"},
+            {"id": "svc_b_handle", "label": "handle", "file_type": "code", "source_file": "svc/b.py"},
+            {"id": "b_document", "label": "B", "file_type": "document", "source_file": "b.md"},
+        ],
+        "edges": [],
+        "input_tokens": 0,
+        "output_tokens": 0,
+    }
+    G = build_from_json(extraction, root=root)
+    added = stitch_incremental_links(G, ["b.md"], root=root)
+    assert added == 0


### PR DESCRIPTION
## Context

Split from former [#1326](https://github.com/safishamsi/graphify/pull/1326) (closed) per review feedback — **part 3 of 3**.

### Stacked on part 2

**Merge [#1370](https://github.com/safishamsi/graphify/pull/1370) (incremental safety) before this PR.**

This branch is based on `feat/incremental-safety` (`c5fa2ff`). Because that branch lives on the fork, the GitHub base is `v8` here — the PR diff therefore includes both part 2 and part 3. For a **stitch-only review**, compare on the fork:

https://github.com/Const011/graphify/compare/feat/incremental-safety...feat/cross-file-stitch

- Part 1: #1369 (intra-file slicing) — independent

## Motivation

Incremental `extract` sends **only changed files** to the LLM. Re-extracting one changed doc produced entities and edges **inside that chunk only**. Mentions of symbols elsewhere (e.g. `` `calculateWorkingTimeFromTeamsCalendar` `` referencing a calendar doc already in the graph) did not create edges to existing nodes. BFS / `query` / `path` could not reach the updated region from the rest of the corpus — breaking the “add files one at a time” workflow.

## Problem: incremental updates were not discoverable (isolated subgraph)

**Root cause:** By design, incremental semantic extraction lacks stable node IDs for the rest of the graph; the model often hallucinates `source_file` paths instead of wiring references.

## Fix

New module `graphify/stitch.py` — deterministic **post-merge stitch pass** (incremental only):

- After `build_merge`, scan each changed file **on disk** for backtick identifiers and path-like markdown links.
- Resolve symbols against the **full merged graph** (unique label match; skip ambiguous names — same conservatism as AST cross-file resolution).
- Add `references` edges from an anchor node in the changed file to external targets.
- When the LLM mis-attributes `source_file` on fresh nodes, use `new_node_ids` from the extraction and exclude nodes correctly placed under a **different on-disk file**.

**Why stitch (and not alternatives alone)?**

| Alternative | Why we did not rely on it alone |
|-------------|----------------------------------|
| Full corpus re-extract | Correct but expensive; defeats incremental purpose |
| Pack neighbor files into LLM context | Higher token cost; still no guaranteed stable IDs |
| LLM-only “wire edges” pass | Extra cost + variance; mentions are already in source text |
| Bidirectional / rewrite unchanged files | Out of scope; outbound stitch + undirected search is enough |

Stitch is **deterministic, cheap, and testable** — it reuses `source_path_aliases` from `build.py` (#1370) and label indexing patterns from `symbol_resolution.py`.

## `__main__.py` note (`--no-cluster`)

This PR wires stitch into both the **clustered** and **`--no-cluster` incremental** paths. The latter routes incremental updates through `build_merge` before writing raw JSON so stitch can run on a `NetworkX` graph. **This changes the documented no-cluster contract** (parallel edges may collapse via merge dedup). Flagging explicitly per review on #1326 — happy to gate behind a flag if preferred.

## Files added in part 3

| File | Change |
|------|--------|
| `graphify/stitch.py` | New — post-merge cross-file `references` edges |
| `graphify/__main__.py` | `_stitch_new_ids`, `_changed_for_stitch`, `stitch_incremental_links` hooks (requires #1370 `__main__` / `build.py` base) |
| `tests/test_stitch.py` | New (self-contained `tmp_path` fixtures) |

## Test plan

- [x] `pytest tests/test_stitch.py tests/test_build.py tests/test_extract.py`
- [ ] Upstream CI on Linux
- [ ] Incremental smoke: re-extract changed doc → stitch adds cross-file `references`, verified with `graphify path`


Made with [Cursor](https://cursor.com)