### PR TITLE
fix(llm): adaptive split-and-retry for label_communities on parse failure (#1278)

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -2144,6 +2144,75 @@ def _parse_label_response(text: str, labeled_cids: list[int]) -> dict[int, str]:
     return out
 
 
+def _label_batch_with_retry(
+    batch_cids: list[int],
+    batch_lines: list[str],
+    *,
+    backend: str,
+    model: str | None,
+    depth: int = 0,
+    max_depth: int = 3,
+) -> dict[int, str]:
+    """Label a batch of communities, splitting in half and retrying on parse failure.
+
+    Mirrors `_extract_with_adaptive_retry`'s recovery shape for the labeling path
+    (#1278). When the LLM returns malformed JSON or a non-object payload, the
+    batch is split at the midpoint and each half is retried recursively. Recursion
+    is capped at ``max_depth`` to bound cost.
+
+    Returns ``{cid: name}`` for everything that could be labeled. Communities
+    that still couldn't be parsed at the depth/size base case are absent from
+    the result — callers treat them as placeholder. Any non-parse exception
+    (network, missing config, programming bug) propagates unchanged.
+    """
+    prompt = (
+        "You are naming clusters in a knowledge graph. For each community below, "
+        "return a concise 2-5 word plain-language name describing what it is about "
+        "(e.g. \"Order Management\", \"Payment Flow\", \"Auth Middleware\"). "
+        "Respond ONLY with a JSON object mapping the community id (as a string) to "
+        "its name - no prose, no markdown fences.\n\n" + "\n".join(batch_lines)
+    )
+    max_tokens = _resolve_max_tokens(min(64 + 24 * len(batch_cids), 8192))
+    call_kwargs: dict = {"backend": backend, "max_tokens": max_tokens}
+    if model is not None:
+        call_kwargs["model"] = model
+
+    try:
+        text = _call_llm(prompt, **call_kwargs)
+        return _parse_label_response(text, batch_cids)
+    except (json.JSONDecodeError, ValueError) as exc:
+        # YOUR TURN — implement the split-and-retry logic here.
+        #
+        # Two cases to handle:
+        #
+        # 1. BASE CASE: we can't or shouldn't split further.
+        #    - condition: len(batch_cids) <= 1  OR  depth >= max_depth
+        #    - action: print a warning to sys.stderr identifying which
+        #      community ids couldn't be labeled (use `batch_cids` and `exc`)
+        #    - return {}  — those cids stay as placeholders in the caller
+        #
+        # 2. SPLIT CASE: we can still split.
+        #    - mid = len(batch_cids) // 2
+        #    - recurse on the left half: batch_cids[:mid], batch_lines[:mid]
+        #      with depth=depth + 1, same backend/model/max_depth
+        #    - recurse on the right half: batch_cids[mid:], batch_lines[mid:]
+        #      with depth=depth + 1, same backend/model/max_depth
+        #    - return the merged dict (left | right works on Python 3.9+)
+        if len(batch_cids) <= 1 or depth >= max_depth:
+            print(
+                f"[graphify label] batch of {len(batch_cids)} still unparseable "
+                f"at depth {depth} (cids={batch_cids[:5]}"
+                f"{'...' if len(batch_cids) > 5 else ''}): {exc}",
+                file=sys.stderr,
+            )
+            raise
+        else:
+            mid = len(batch_cids) // 2
+            left = _label_batch_with_retry(batch_cids[:mid], batch_lines[:mid],backend=backend,model=model,depth=depth+1,max_depth=max_depth)
+            right = _label_batch_with_retry(batch_cids[mid:], batch_lines[mid:],backend=backend,model=model,depth=depth+1,max_depth=max_depth)
+            return left | right
+
+
 def label_communities(
     G,
     communities,
@@ -2188,24 +2257,10 @@ def label_communities(
         end = min(start + batch_size, len(labeled_cids))
         batch_lines = lines[start:end]
         batch_cids = labeled_cids[start:end]
-
-        prompt = (
-            "You are naming clusters in a knowledge graph. For each community below, "
-            "return a concise 2-5 word plain-language name describing what it is about "
-            "(e.g. \"Order Management\", \"Payment Flow\", \"Auth Middleware\"). "
-            "Respond ONLY with a JSON object mapping the community id (as a string) to "
-            "its name - no prose, no markdown fences.\n\n" + "\n".join(batch_lines)
-        )
-        # 24 tok/community covers 2-5 word JSON entries including id, quotes,
-        # and punctuation. Cap at 8192 for 16k-context models. Wrapped in
-        # _resolve_max_tokens so GRAPHIFY_MAX_OUTPUT_TOKENS applies here too (#1200).
-        max_tokens = _resolve_max_tokens(min(64 + 24 * len(batch_cids), 8192))
         try:
-            call_kwargs = {"backend": backend, "max_tokens": max_tokens}
-            if model is not None:
-                call_kwargs["model"] = model
-            text = _call_llm(prompt, **call_kwargs)
-            parsed = _parse_label_response(text, batch_cids)
+            parsed = _label_batch_with_retry(
+                batch_cids, batch_lines, backend=backend, model=model,
+            )
             labels.update(parsed)
             written += len(parsed)
         except Exception as exc:

--- a/tests/test_label_retry.py
+++ b/tests/test_label_retry.py
@@ -1,0 +1,46 @@
+"""Tests for graphify.llm._label_batch_with_retry — adaptive split-and-retry
+on JSON parse failure during community labeling (#1278).
+"""
+from __future__ import annotations
+
+import json
+import re
+
+from graphify import llm as llm_mod
+
+
+def test_label_batch_recovers_via_split_on_invalid_json(monkeypatch):
+    """Demonstrates the bug fix.
+
+    The full batch of 4 communities triggers malformed JSON from the LLM.
+    The helper splits in half (2+2) and retries each half. Both sub-batches
+    succeed. Every community ends up labeled — none silently dropped.
+    """
+    batch_cids = [42, 99, 137, 201]
+    batch_lines = [
+        "Community 42: validate_token, get_session",
+        "Community 99: create_order, add_to_cart",
+        "Community 137: build_graph, cluster_nodes",
+        "Community 201: render_route, handle_request",
+    ]
+    call_count = {"n": 0}
+
+    def fake_call_llm(prompt: str, **_kwargs) -> str:
+        """First call (4 communities): returns broken JSON to trigger retry.
+        Subsequent calls (<=2 communities): return a clean JSON object
+        labeling whatever community IDs appear in the prompt.
+        """
+        call_count["n"] += 1
+        cids_in_prompt = [int(m) for m in re.findall(r"Community (\d+):", prompt)]
+        if call_count["n"] == 1:
+            return "{this is not valid json, missing quotes"
+        return json.dumps({str(cid): f"Label {cid}" for cid in cids_in_prompt})
+
+    monkeypatch.setattr(llm_mod, "_call_llm", fake_call_llm)
+
+    result = llm_mod._label_batch_with_retry(
+        batch_cids, batch_lines, backend="gemini", model=None,
+    )
+
+    assert result == {42: "Label 42", 99: "Label 99", 137: "Label 137", 201: "Label 201"}
+    assert call_count["n"] >= 2


### PR DESCRIPTION
## What

Fixes #1278.

`label_communities` previously logged-and-skipped any batch where the LLM returned malformed JSON or a non-object payload. On large graphs (the reporter's case: 121k nodes / 135 batches), a single failed batch silently lost ~100 community names with no recovery and no warning beyond the per-batch stderr line.

This mirrors the recovery shape `_extract_with_adaptive_retry` already uses for the extract path: when a batch fails to parse, split it at the midpoint and retry each half recursively. Most transient LLM JSON glitches go away at the first or second split (smaller prompt → smaller output → less likely to truncate or mangle).

## Fix

- New helper `_label_batch_with_retry()` in `graphify/llm.py`. Catches `(json.JSONDecodeError, ValueError)` from `_parse_label_response`, splits `batch_cids` and `batch_lines` together at `mid = len(batch_cids) // 2`, recurses on each half with `depth + 1`. Recursion capped at `max_depth=3` (same as extract).
- Non-parse exceptions (network errors, missing API keys, programming bugs) propagate unchanged via bare `raise`. The retry net is intentionally narrow.
- `label_communities` is now a thin wrapper: builds slices, calls the helper, tracks `first_error` and `written` exactly as before. The outer graceful-degradation contract is preserved — when retries exhaust at the base case, the original parse error re-raises so `generate_community_labels` still falls back to placeholders rather than silently returning empty.

## Test

New `tests/test_label_retry.py` adds a unit test with a stateful mock that returns malformed JSON on the first call and clean JSON on subsequent (smaller) calls. Confirms:

- All 4 input communities end up labeled despite the initial failure
- `_call_llm` was called more than once (proving the retry actually happened)

All 15 existing tests in `tests/test_labeling.py` continue to pass — including `test_label_communities_malformed_raises` (the old contract is preserved) and `test_generate_community_labels_degrades_on_error` (graceful fallback still works when retries exhaust).

## Design choices worth flagging

- **Exception types caught** — only `(json.JSONDecodeError, ValueError)` (the two things `_parse_label_response` raises). Network errors / config errors are not retried because they're not the recoverable case the issue describes.
- **`max_depth=3`** for consistency with `_extract_with_adaptive_retry`. With `batch_size=100`, this allows up to 8 leaf batches of ~12-13 communities each before giving up. If real-world cases need deeper recursion, that's a follow-up tuning.
- **Re-raise at base case (not silent return)** so the existing `first_error` tracking in `label_communities` still fires. A partial-success edge case (left half succeeds, right half exhausts) loses the left half's labels — but in exchange, the existing graceful-degradation contract is preserved. The alternative (return empty dict at base case) breaks `test_label_communities_malformed_raises` semantics.

## Notes

- Reproducible context: the original issue was on a 121k-node corpus with `batch_size=100` and Gemini backend. I was unable to reproduce the LLM-side malformed-JSON nondeterminism directly; the test uses a stateful mock to simulate the documented failure mode.
- The fix touches only `llm.py` — no API surface changes.
- Ran the full test suite. One pre-existing failure unrelated to this change: `tests/test_cli_export.py::test_export_wiki_accepts_edges_only_graph_json` fails on unmodified v8 with `KeyError: 'links'`. Looks like the same `edges`-vs-`links` key pattern already fixed in `affected.py` (#1280); the wiki export path appears to have been missed. Happy to follow up in a separate PR if useful.