### PR TITLE
Add hybrid retrieval eval CLI

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2157,9 +2157,15 @@ def main() -> None:
         print("    --model=<name>          model to use for community naming")
         print("  query \"<question>\"       BFS traversal of graph.json for a question")
         print("    --dfs                   use depth-first instead of breadth-first")
+        print("    --mode hybrid           use sidecar retrieval seeds, then graph traversal")
+        print("    --debug-retrieval       write graphify-out/retrieval-debug/last-query.json")
         print("    --context C             explicit edge-context filter (repeatable)")
         print("    --budget N              cap output at N tokens (default 2000)")
         print("    --graph <path>          path to graph.json (default graphify-out/graph.json)")
+        print("  index [--graph path] [--out-dir dir]")
+        print("                            build optional graphify-out/vector-index sidecar")
+        print("  eval queries.jsonl [--graph path] [--mode hybrid|bfs|dfs] [--out-dir dir] [--json]")
+        print("                            measure recall@k, MRR, and graph path coverage")
         print("  affected \"X\"             reverse traversal to find nodes impacted by X")
         print("    --relation R            edge relation to traverse in reverse (repeatable)")
         print("    --depth N               reverse traversal depth (default 2)")
@@ -2669,9 +2675,113 @@ def main() -> None:
         else:
             print("Usage: graphify hook [install|uninstall|status]", file=sys.stderr)
             sys.exit(1)
+    elif cmd == "index":
+        from graphify.retrieval import build_vector_index
+        from graphify.serve import _load_graph
+
+        graph_path = _default_graph_path()
+        out_dir: Path | None = None
+        args = sys.argv[2:]
+        i = 0
+        while i < len(args):
+            if args[i] == "--graph" and i + 1 < len(args):
+                graph_path = args[i + 1]
+                i += 2
+            elif args[i].startswith("--graph="):
+                graph_path = args[i].split("=", 1)[1]
+                i += 1
+            elif args[i] == "--out-dir" and i + 1 < len(args):
+                out_dir = Path(args[i + 1])
+                i += 2
+            elif args[i].startswith("--out-dir="):
+                out_dir = Path(args[i].split("=", 1)[1])
+                i += 1
+            else:
+                i += 1
+        gp = Path(graph_path).resolve()
+        G = _load_graph(str(gp))
+        index_dir = build_vector_index(G, gp, out_dir)
+        print(f"Indexed {G.number_of_nodes()} nodes, {G.number_of_edges()} relations -> {index_dir}")
+    elif cmd == "eval":
+        if len(sys.argv) < 3:
+            print("Usage: graphify eval queries.jsonl [--mode hybrid|bfs|dfs] [--k N] [--depth N] [--graph path] [--out-dir dir] [--json]", file=sys.stderr)
+            sys.exit(1)
+        from graphify.eval import EvalError, evaluate_queries, format_report, load_queries
+        from graphify.serve import _load_graph
+
+        queries_path = Path(sys.argv[2])
+        graph_path = _default_graph_path()
+        out_dir: Path | None = None
+        mode = "hybrid"
+        k = 5
+        depth = 2
+        json_output = False
+        args = sys.argv[3:]
+        i = 0
+        while i < len(args):
+            if args[i] == "--mode" and i + 1 < len(args):
+                mode = args[i + 1]
+                i += 2
+            elif args[i].startswith("--mode="):
+                mode = args[i].split("=", 1)[1]
+                i += 1
+            elif args[i] == "--k" and i + 1 < len(args):
+                try:
+                    k = int(args[i + 1])
+                except ValueError:
+                    print("error: --k must be an integer", file=sys.stderr)
+                    sys.exit(1)
+                i += 2
+            elif args[i].startswith("--k="):
+                try:
+                    k = int(args[i].split("=", 1)[1])
+                except ValueError:
+                    print("error: --k must be an integer", file=sys.stderr)
+                    sys.exit(1)
+                i += 1
+            elif args[i] == "--depth" and i + 1 < len(args):
+                try:
+                    depth = int(args[i + 1])
+                except ValueError:
+                    print("error: --depth must be an integer", file=sys.stderr)
+                    sys.exit(1)
+                i += 2
+            elif args[i].startswith("--depth="):
+                try:
+                    depth = int(args[i].split("=", 1)[1])
+                except ValueError:
+                    print("error: --depth must be an integer", file=sys.stderr)
+                    sys.exit(1)
+                i += 1
+            elif args[i] == "--graph" and i + 1 < len(args):
+                graph_path = args[i + 1]
+                i += 2
+            elif args[i].startswith("--graph="):
+                graph_path = args[i].split("=", 1)[1]
+                i += 1
+            elif args[i] == "--out-dir" and i + 1 < len(args):
+                out_dir = Path(args[i + 1])
+                i += 2
+            elif args[i].startswith("--out-dir="):
+                out_dir = Path(args[i].split("=", 1)[1])
+                i += 1
+            elif args[i] == "--json":
+                json_output = True
+                i += 1
+            else:
+                i += 1
+        gp = Path(graph_path).resolve()
+        try:
+            queries = load_queries(queries_path)
+            G = _load_graph(str(gp))
+            result = evaluate_queries(G, gp, queries, mode=mode, k=k, depth=depth, out_dir=out_dir)
+        except EvalError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(result, indent=2, sort_keys=True) if json_output else format_report(result))
     elif cmd == "query":
         if len(sys.argv) < 3:
-            print("Usage: graphify query \"<question>\" [--dfs] [--context C] [--budget N] [--graph path]", file=sys.stderr)
+            print("Usage: graphify query \"<question>\" [--dfs|--mode hybrid] [--context C] [--budget N] [--graph path] [--debug-retrieval]", file=sys.stderr)
             sys.exit(1)
         from graphify.serve import _query_graph_text
         from graphify.security import sanitize_label
@@ -2680,6 +2790,8 @@ def main() -> None:
 
         question = sys.argv[2]
         use_dfs = "--dfs" in sys.argv
+        query_mode = "dfs" if use_dfs else "bfs"
+        debug_retrieval = "--debug-retrieval" in sys.argv
         budget = 2000
         graph_path = _default_graph_path()
         context_filters: list[str] = []
@@ -2706,11 +2818,25 @@ def main() -> None:
             elif args[i].startswith("--context="):
                 context_filters.append(args[i].split("=", 1)[1])
                 i += 1
+            elif args[i] == "--mode" and i + 1 < len(args):
+                query_mode = args[i + 1]
+                i += 2
+            elif args[i].startswith("--mode="):
+                query_mode = args[i].split("=", 1)[1]
+                i += 1
+            elif args[i] in ("--debug-retrieval", "--dfs"):
+                i += 1
             elif args[i] == "--graph" and i + 1 < len(args):
                 graph_path = args[i + 1]
                 i += 2
             else:
                 i += 1
+        if query_mode not in {"bfs", "dfs", "hybrid"}:
+            print("error: --mode must be one of: bfs, dfs, hybrid", file=sys.stderr)
+            sys.exit(1)
+        if use_dfs and query_mode == "hybrid":
+            print("error: --dfs and --mode hybrid are mutually exclusive", file=sys.stderr)
+            sys.exit(1)
         gp = Path(graph_path).resolve()
         if not gp.exists():
             print(f"error: graph file not found: {gp}", file=sys.stderr)
@@ -2735,21 +2861,38 @@ def main() -> None:
             sys.exit(1)
         import time as _time
         _t0 = _time.perf_counter()
-        _mode = "dfs" if use_dfs else "bfs"
+        hybrid_seeds = None
+        hybrid_debug_path = None
+        if query_mode == "hybrid":
+            from graphify.retrieval import load_index, merge_seed_candidates, search_index, write_retrieval_debug
+            from graphify.serve import _query_terms, _score_nodes
+
+            index = load_index(gp)
+            if index is None:
+                print("warning: vector-index missing or stale; run `graphify index` to enable hybrid retrieval. Falling back to BFS.", file=sys.stderr)
+                query_mode = "bfs"
+            else:
+                lexical = _score_nodes(G, _query_terms(question))
+                semantic_hits = search_index(index, question, k=20)
+                hybrid_seeds = merge_seed_candidates(lexical, semantic_hits)
+                if debug_retrieval:
+                    hybrid_debug_path = write_retrieval_debug(gp, question, "hybrid", lexical, semantic_hits, hybrid_seeds)
         _result = _query_graph_text(
             G,
             question,
-            mode=_mode,
+            mode=query_mode,
             depth=2,
             token_budget=budget,
             context_filters=context_filters,
+            hybrid_seeds=hybrid_seeds,
+            hybrid_debug=str(hybrid_debug_path) if hybrid_debug_path else None,
         )
         querylog.log_query(
             kind="query",
             question=question,
             corpus=str(gp),
             result=_result,
-            mode=_mode,
+            mode=query_mode,
             depth=2,
             token_budget=budget,
             duration_ms=(_time.perf_counter() - _t0) * 1000,

--- a/graphify/eval.py
+++ b/graphify/eval.py
@@ -1,0 +1,190 @@
+"""Retrieval quality evaluation for graphify hybrid queries."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+
+from graphify.retrieval import load_index, merge_seed_candidates, search_index
+from graphify.serve import _bfs, _dfs, _pick_seeds, _query_terms, _score_nodes
+
+
+class EvalError(ValueError):
+    """Raised when an eval file is malformed or cannot be evaluated."""
+
+
+def load_queries(path: Path) -> list[dict[str, Any]]:
+    """Load JSONL eval queries.
+
+    Each line must include `question` plus at least one expectation field:
+    `expected_nodes`, `expected_labels`, or `expected_files`.
+    """
+    queries: list[dict[str, Any]] = []
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise EvalError(f"{path}:{line_no}: invalid JSON: {exc}") from exc
+        if not isinstance(item, dict):
+            raise EvalError(f"{path}:{line_no}: expected a JSON object")
+        question = item.get("question")
+        if not isinstance(question, str) or not question.strip():
+            raise EvalError(f"{path}:{line_no}: `question` must be a non-empty string")
+        if not any(item.get(key) for key in ("expected_nodes", "expected_labels", "expected_files")):
+            raise EvalError(
+                f"{path}:{line_no}: add at least one of expected_nodes, expected_labels, expected_files"
+            )
+        queries.append(item)
+    if not queries:
+        raise EvalError(f"{path}: no eval queries found")
+    return queries
+
+
+def _as_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list) and all(isinstance(v, str) for v in value):
+        return value
+    raise EvalError("expectation fields must be strings or string arrays")
+
+
+def _label_matches(data: dict[str, Any], expected: str) -> bool:
+    label = str(data.get("label") or "").lower()
+    return expected.lower() in label
+
+
+def _file_matches(data: dict[str, Any], expected: str) -> bool:
+    source = str(data.get("source_file") or "").lower()
+    return expected.lower() in source
+
+
+def _expected_node_set(G: nx.Graph, query: dict[str, Any]) -> set[str]:
+    expected = set(_as_strings(query.get("expected_nodes")))
+    labels = _as_strings(query.get("expected_labels"))
+    files = _as_strings(query.get("expected_files"))
+    for node_id, data in G.nodes(data=True):
+        if any(_label_matches(data, label) for label in labels):
+            expected.add(str(node_id))
+        if any(_file_matches(data, source) for source in files):
+            expected.add(str(node_id))
+    return {node for node in expected if node in G}
+
+
+def _forbidden_node_set(G: nx.Graph, query: dict[str, Any]) -> set[str]:
+    forbidden = set(_as_strings(query.get("forbidden_nodes")))
+    labels = _as_strings(query.get("forbidden_labels"))
+    files = _as_strings(query.get("forbidden_files"))
+    for node_id, data in G.nodes(data=True):
+        if any(_label_matches(data, label) for label in labels):
+            forbidden.add(str(node_id))
+        if any(_file_matches(data, source) for source in files):
+            forbidden.add(str(node_id))
+    return {node for node in forbidden if node in G}
+
+
+def _rank_candidates(
+    G: nx.Graph,
+    question: str,
+    mode: str,
+    *,
+    k: int,
+    index: dict[str, Any] | None,
+) -> tuple[list[str], bool]:
+    lexical = _score_nodes(G, _query_terms(question))
+    if mode == "hybrid" and index is not None:
+        hits = search_index(index, question, k=max(k, 20))
+        return merge_seed_candidates(lexical, hits, k=k), True
+    return _pick_seeds(lexical, max_k=k), mode != "hybrid"
+
+
+def evaluate_queries(
+    G: nx.Graph,
+    graph_path: Path,
+    queries: list[dict[str, Any]],
+    *,
+    mode: str = "hybrid",
+    k: int = 5,
+    depth: int = 2,
+    out_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Evaluate retrieval seed quality and graph traversal coverage."""
+    if mode not in {"bfs", "dfs", "hybrid"}:
+        raise EvalError("mode must be one of: bfs, dfs, hybrid")
+    if k <= 0:
+        raise EvalError("k must be positive")
+    index = load_index(graph_path, out_dir) if mode == "hybrid" else None
+    if mode == "hybrid" and index is None:
+        raise EvalError("hybrid eval requires a fresh vector-index; run `graphify index` first")
+    rows: list[dict[str, Any]] = []
+    for query in queries:
+        query_mode = str(query.get("mode") or mode)
+        if query_mode not in {"bfs", "dfs", "hybrid"}:
+            raise EvalError("query mode must be one of: bfs, dfs, hybrid")
+        expected = _expected_node_set(G, query)
+        if not expected:
+            raise EvalError(f"query {query['question']!r} matched no expected nodes in graph")
+        forbidden = _forbidden_node_set(G, query)
+        candidates, used_requested_mode = _rank_candidates(
+            G, query["question"], query_mode, k=k, index=index
+        )
+        traversal_mode = "bfs" if query_mode == "hybrid" else query_mode
+        nodes, _edges = _dfs(G, candidates, depth) if traversal_mode == "dfs" else _bfs(G, candidates, depth)
+        first_rank = next((idx + 1 for idx, node_id in enumerate(candidates) if node_id in expected), None)
+        hit_count = len(set(candidates) & expected)
+        reached = set(nodes) & expected
+        forbidden_hits = sorted((set(candidates) | set(nodes)) & forbidden)
+        rows.append(
+            {
+                "question": query["question"],
+                "mode": query_mode,
+                "used_requested_mode": used_requested_mode,
+                "expected_count": len(expected),
+                "candidate_nodes": candidates,
+                "hit": first_rank is not None,
+                "first_rank": first_rank,
+                "reciprocal_rank": 0.0 if first_rank is None else 1.0 / first_rank,
+                "recall_at_k": hit_count / len(expected),
+                "path_coverage": len(reached) / len(expected),
+                "forbidden_hits": forbidden_hits,
+            }
+        )
+    total = len(rows)
+    return {
+        "mode": mode,
+        "k": k,
+        "depth": depth,
+        "query_count": total,
+        "used_requested_mode": all(row["used_requested_mode"] for row in rows),
+        "hit_rate_at_k": sum(1 for row in rows if row["hit"]) / total,
+        "mean_recall_at_k": sum(row["recall_at_k"] for row in rows) / total,
+        "mrr": sum(row["reciprocal_rank"] for row in rows) / total,
+        "mean_path_coverage": sum(row["path_coverage"] for row in rows) / total,
+        "forbidden_hit_count": sum(len(row["forbidden_hits"]) for row in rows),
+        "queries": rows,
+    }
+
+
+def format_report(result: dict[str, Any]) -> str:
+    lines = [
+        f"Eval: {result['query_count']} queries | mode={result['mode']} | k={result['k']} | depth={result['depth']}",
+        f"hit_rate@{result['k']}: {result['hit_rate_at_k']:.3f}",
+        f"mean_recall@{result['k']}: {result['mean_recall_at_k']:.3f}",
+        f"MRR: {result['mrr']:.3f}",
+        f"path_coverage: {result['mean_path_coverage']:.3f}",
+        f"forbidden_hits: {result['forbidden_hit_count']}",
+    ]
+    if not result.get("used_requested_mode", True):
+        lines.append("warning: requested mode was unavailable for at least one query")
+    for row in result["queries"]:
+        rank = row["first_rank"] if row["first_rank"] is not None else "miss"
+        lines.append(
+            f"- {row['question']} | rank={rank} | recall={row['recall_at_k']:.3f} | "
+            f"path={row['path_coverage']:.3f} | forbidden={len(row['forbidden_hits'])}"
+        )
+    return "\n".join(lines)

--- a/graphify/retrieval.py
+++ b/graphify/retrieval.py
@@ -1,0 +1,255 @@
+"""Optional graph-first retrieval sidecar for hybrid queries.
+
+The canonical graph remains the source of truth. This module only writes query-time
+indexes and debug artifacts; retrieval scores never become edge confidence.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import networkx as nx
+
+TOKEN_RE = re.compile(r"\w+")
+SCHEMA_VERSION = "1"
+DEFAULT_EMBEDDING_MODEL = "tfidf-local"
+
+
+def graph_hash(graph_path: Path) -> str:
+    return hashlib.sha256(graph_path.read_bytes()).hexdigest()
+
+
+def _tokens(text: str) -> list[str]:
+    terms: list[str] = []
+    for raw in TOKEN_RE.findall(text or ""):
+        parts = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", raw).split()
+        for part in parts + [raw]:
+            token = part.lower()
+            if len(token) > 1:
+                terms.append(token)
+    return terms
+
+
+def _node_text(node_id: str, data: dict) -> str:
+    parts = [
+        str(data.get("label") or node_id),
+        str(data.get("kind") or ""),
+        str(data.get("file_type") or ""),
+        str(data.get("source_file") or ""),
+        str(data.get("community_name") or data.get("community") or ""),
+        str(data.get("summary") or ""),
+    ]
+    return " ".join(p for p in parts if p)
+
+
+def _edge_iter(G: nx.Graph) -> Iterable[tuple[str, str, dict]]:
+    if isinstance(G, (nx.MultiGraph, nx.MultiDiGraph)):
+        for u, v, _key, data in G.edges(keys=True, data=True):
+            yield str(u), str(v), dict(data)
+    else:
+        for u, v, data in G.edges(data=True):
+            yield str(u), str(v), dict(data)
+
+
+def _edge_text(G: nx.Graph, source: str, target: str, data: dict) -> str:
+    source_label = G.nodes[source].get("label", source) if source in G.nodes else source
+    target_label = G.nodes[target].get("label", target) if target in G.nodes else target
+    parts = [
+        str(source_label),
+        str(data.get("relation") or ""),
+        str(target_label),
+        str(data.get("context") or ""),
+        str(data.get("source_file") or ""),
+    ]
+    return " ".join(p for p in parts if p)
+
+
+def _idf(documents: list[Counter[str]]) -> dict[str, float]:
+    df: Counter[str] = Counter()
+    for doc in documents:
+        df.update(doc.keys())
+    total = len(documents) or 1
+    return {term: math.log(1 + total / (1 + count)) for term, count in df.items()}
+
+
+def _score(query_terms: Counter[str], doc_terms: Counter[str], idf: dict[str, float]) -> float:
+    if not query_terms or not doc_terms:
+        return 0.0
+    dot = 0.0
+    q_norm = 0.0
+    d_norm = 0.0
+    for term, q_tf in query_terms.items():
+        q_weight = q_tf * idf.get(term, 1.0)
+        q_norm += q_weight * q_weight
+        d_tf = doc_terms.get(term, 0)
+        if d_tf:
+            d_weight = d_tf * idf.get(term, 1.0)
+            dot += q_weight * d_weight
+    for term, d_tf in doc_terms.items():
+        d_weight = d_tf * idf.get(term, 1.0)
+        d_norm += d_weight * d_weight
+    if not dot or not q_norm or not d_norm:
+        return 0.0
+    return dot / math.sqrt(q_norm * d_norm)
+
+
+def _out_dir_for_graph(graph_path: Path) -> Path:
+    return graph_path.parent if graph_path.name == "graph.json" else graph_path.parent / "graphify-out"
+
+
+def build_vector_index(G: nx.Graph, graph_path: Path, out_dir: Path | None = None, *, embedding_model: str = DEFAULT_EMBEDDING_MODEL) -> Path:
+    """Build a lightweight local sidecar index for nodes and relations.
+
+    The MVP uses TF-IDF term vectors so it has no new runtime dependency. The
+    manifest is shaped so a future dense embedding backend can replace the index
+    without changing the query contract.
+    """
+    out = out_dir or _out_dir_for_graph(graph_path)
+    index_dir = out / "vector-index"
+    index_dir.mkdir(parents=True, exist_ok=True)
+
+    node_rows: list[dict] = []
+    node_docs: list[Counter[str]] = []
+    for node_id, data in G.nodes(data=True):
+        text = _node_text(str(node_id), dict(data))
+        terms = Counter(_tokens(text))
+        node_docs.append(terms)
+        node_rows.append({"id": str(node_id), "text": text, "terms": dict(terms)})
+
+    relation_rows: list[dict] = []
+    relation_docs: list[Counter[str]] = []
+    for source, target, data in _edge_iter(G):
+        text = _edge_text(G, source, target, data)
+        terms = Counter(_tokens(text))
+        relation_docs.append(terms)
+        relation_rows.append({
+            "source": source,
+            "target": target,
+            "relation": str(data.get("relation") or ""),
+            "text": text,
+            "terms": dict(terms),
+        })
+
+    node_idf = _idf(node_docs)
+    relation_idf = _idf(relation_docs)
+    (index_dir / "nodes.jsonl").write_text("\n".join(json.dumps(r, sort_keys=True) for r in node_rows) + ("\n" if node_rows else ""), encoding="utf-8")
+    (index_dir / "relations.jsonl").write_text("\n".join(json.dumps(r, sort_keys=True) for r in relation_rows) + ("\n" if relation_rows else ""), encoding="utf-8")
+    (index_dir / "idf.json").write_text(json.dumps({"nodes": node_idf, "relations": relation_idf}, indent=2, sort_keys=True), encoding="utf-8")
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "graph_hash": graph_hash(graph_path),
+        "embedding_model": embedding_model,
+        "embedding_dim": None,
+        "backend": "tfidf-local",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "node_count": G.number_of_nodes(),
+        "relation_count": G.number_of_edges(),
+    }
+    (index_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return index_dir
+
+
+def _load_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+def load_index(graph_path: Path, out_dir: Path | None = None) -> dict | None:
+    out = out_dir or _out_dir_for_graph(graph_path)
+    index_dir = out / "vector-index"
+    manifest_path = index_dir / "manifest.json"
+    idf_path = index_dir / "idf.json"
+    nodes_path = index_dir / "nodes.jsonl"
+    relations_path = index_dir / "relations.jsonl"
+    if not all(path.exists() for path in (manifest_path, idf_path, nodes_path, relations_path)):
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if manifest.get("schema_version") != SCHEMA_VERSION:
+            return None
+        if manifest.get("graph_hash") != graph_hash(graph_path):
+            return None
+        idf = json.loads(idf_path.read_text(encoding="utf-8"))
+        nodes = _load_jsonl(nodes_path)
+        relations = _load_jsonl(relations_path)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return {
+        "dir": index_dir,
+        "manifest": manifest,
+        "nodes": nodes,
+        "relations": relations,
+        "idf": idf,
+    }
+
+
+def search_index(index: dict, question: str, *, k: int = 10) -> dict[str, list[dict]]:
+    q = Counter(_tokens(question))
+    node_hits = []
+    for row in index.get("nodes", []):
+        score = _score(q, Counter(row.get("terms", {})), index.get("idf", {}).get("nodes", {}))
+        if score > 0:
+            node_hits.append({"node_id": row["id"], "retrieval_score": score})
+    node_hits.sort(key=lambda r: r["retrieval_score"], reverse=True)
+
+    relation_hits = []
+    for row in index.get("relations", []):
+        score = _score(q, Counter(row.get("terms", {})), index.get("idf", {}).get("relations", {}))
+        if score > 0:
+            relation_hits.append({
+                "source": row["source"],
+                "target": row["target"],
+                "relation": row.get("relation", ""),
+                "retrieval_score": score,
+            })
+    relation_hits.sort(key=lambda r: r["retrieval_score"], reverse=True)
+    return {"nodes": node_hits[:k], "relations": relation_hits[:k]}
+
+
+def merge_seed_candidates(lexical: list[tuple[float, str]], semantic_hits: dict[str, list[dict]], *, k: int = 5) -> list[str]:
+    scores: dict[str, float] = {}
+    for rank, (score, node_id) in enumerate(lexical[:k], start=1):
+        lexical_score = min(float(score), 1000.0) / 1000.0
+        # Keep lexical evidence in the mix, but do not let every weak text match
+        # outrank sidecar-only semantic/relation hits.
+        scores[node_id] = max(scores.get(node_id, 0.0), 0.6 * lexical_score + 0.05 / rank)
+    for rank, hit in enumerate(semantic_hits.get("nodes", [])[:k], start=1):
+        node_id = hit["node_id"]
+        score = float(hit["retrieval_score"])
+        scores[node_id] = max(scores.get(node_id, 0.0), score + 0.1 / rank)
+    for rank, hit in enumerate(semantic_hits.get("relations", [])[:k], start=1):
+        rel_score = 0.95 * float(hit["retrieval_score"]) + 0.05 / rank
+        for node_id in (hit.get("source"), hit.get("target")):
+            if node_id:
+                scores[node_id] = max(scores.get(node_id, 0.0), rel_score)
+    return [node_id for node_id, _ in sorted(scores.items(), key=lambda item: item[1], reverse=True)[:k]]
+
+
+def write_retrieval_debug(graph_path: Path, question: str, mode: str, lexical: list[tuple[float, str]], semantic_hits: dict[str, list[dict]], seeds: list[str]) -> Path:
+    out_dir = _out_dir_for_graph(graph_path)
+    debug_dir = out_dir / "retrieval-debug"
+    debug_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "query": question,
+        "mode": mode,
+        "graph_hash": graph_hash(graph_path),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "lexical_candidates": [{"node_id": node_id, "score": score} for score, node_id in lexical[:20]],
+        "semantic_candidates": semantic_hits,
+        "selected_seeds": seeds,
+    }
+    path = debug_dir / "last-query.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -429,19 +429,24 @@ def _query_graph_text(
     depth: int = 3,
     token_budget: int = 2000,
     context_filters: list[str] | None = None,
+    hybrid_seeds: list[str] | None = None,
+    hybrid_debug: str | None = None,
 ) -> str:
     terms = _query_terms(question)
     scored = _score_nodes(G, terms)
-    start_nodes = _pick_seeds(scored)
+    start_nodes = hybrid_seeds or _pick_seeds(scored)
     if not start_nodes:
         return "No matching nodes found."
     resolved_filters, filter_source = _resolve_context_filters(question, context_filters)
     traversal_graph = _filter_graph_by_context(G, resolved_filters)
-    nodes, edges = _dfs(traversal_graph, start_nodes, depth) if mode == "dfs" else _bfs(traversal_graph, start_nodes, depth)
+    traversal_mode = "bfs" if mode == "hybrid" else mode
+    nodes, edges = _dfs(traversal_graph, start_nodes, depth) if traversal_mode == "dfs" else _bfs(traversal_graph, start_nodes, depth)
     header_parts = [
         f"Traversal: {mode.upper()} depth={depth}",
         f"Start: {[G.nodes[n].get('label', n) for n in start_nodes]}",
     ]
+    if hybrid_debug:
+        header_parts.append(f"Retrieval debug: {hybrid_debug}")
     if resolved_filters:
         header_parts.append(f"Context: {', '.join(resolved_filters)} ({filter_source})")
     header_parts.append(f"{len(nodes)} nodes found")

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,136 @@
+"""Tests for optional graph-first retrieval sidecar."""
+from __future__ import annotations
+
+import json
+
+import networkx as nx
+from networkx.readwrite import json_graph
+
+import graphify.__main__ as mainmod
+
+
+def _write_semantic_gap_graph(tmp_path):
+    G = nx.Graph()
+    G.add_node("n_auth", label="LoginSession", source_file="auth.py", source_location="L1", community=0)
+    G.add_node("n_billing", label="InvoiceAccount", source_file="billing.py", source_location="L2", community=1)
+    G.add_node("n_noise", label="Unrelated", source_file="misc.py", source_location="L3", community=2)
+    G.add_edge("n_auth", "n_billing", relation="shares_data_with", confidence="INFERRED", context="semantic")
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text(json.dumps(json_graph.node_link_data(G, edges="links")), encoding="utf-8")
+    return graph_path
+
+
+def test_index_cli_writes_sidecar_manifest(monkeypatch, tmp_path, capsys):
+    graph_path = _write_semantic_gap_graph(tmp_path)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv", ["graphify", "index", "--graph", str(graph_path), "--out-dir", str(tmp_path)])
+
+    mainmod.main()
+
+    out = capsys.readouterr().out
+    manifest = json.loads((tmp_path / "vector-index" / "manifest.json").read_text(encoding="utf-8"))
+    assert "Indexed 3 nodes, 1 relations" in out
+    assert manifest["backend"] == "tfidf-local"
+    assert manifest["node_count"] == 3
+    assert (tmp_path / "vector-index" / "nodes.jsonl").exists()
+    assert (tmp_path / "vector-index" / "relations.jsonl").exists()
+
+
+def test_query_hybrid_uses_sidecar_and_writes_debug(monkeypatch, tmp_path, capsys):
+    graph_path = _write_semantic_gap_graph(tmp_path)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv", ["graphify", "index", "--graph", str(graph_path), "--out-dir", str(tmp_path)])
+    mainmod.main()
+    capsys.readouterr()
+
+    monkeypatch.setattr(
+        mainmod.sys,
+        "argv",
+        ["graphify", "query", "invoice", "--mode", "hybrid", "--debug-retrieval", "--graph", str(graph_path)],
+    )
+    mainmod.main()
+
+    out = capsys.readouterr().out
+    debug_path = tmp_path / "retrieval-debug" / "last-query.json"
+    debug = json.loads(debug_path.read_text(encoding="utf-8"))
+    assert "Traversal: HYBRID" in out
+    assert "Retrieval debug:" in out
+    assert "InvoiceAccount" in out
+    assert debug["mode"] == "hybrid"
+    assert debug["semantic_candidates"]["nodes"]
+    assert "selected_seeds" in debug
+
+
+def test_hybrid_relation_hit_can_outrank_weak_lexical_noise(tmp_path):
+    from graphify.retrieval import build_vector_index, load_index, merge_seed_candidates, search_index
+
+    graph_path = _write_semantic_gap_graph(tmp_path)
+    G = nx.Graph()
+    G.add_node("n_target", label="PaymentLedger", source_file="billing.py")
+    G.add_node("n_source", label="Checkout", source_file="checkout.py")
+    for idx in range(8):
+        G.add_node(f"n_noise_{idx}", label=f"noise auth placeholder {idx}", source_file="noise.py")
+    G.add_edge("n_source", "n_target", relation="handles", context="invoice reconciliation")
+    graph_path.write_text(json.dumps(json_graph.node_link_data(G, edges="links")), encoding="utf-8")
+    build_vector_index(G, graph_path, tmp_path)
+    index = load_index(graph_path, tmp_path)
+    assert index is not None
+
+    lexical = [(0.01, f"n_noise_{idx}") for idx in range(5)]
+    hits = search_index(index, "invoice", k=5)
+    seeds = merge_seed_candidates(lexical, hits, k=5)
+
+    assert "n_target" in seeds[:2]
+
+
+def test_load_index_rejects_partial_or_corrupt_sidecar(tmp_path):
+    from graphify.retrieval import build_vector_index, load_index
+
+    graph_path = _write_semantic_gap_graph(tmp_path)
+    G = json_graph.node_link_graph(json.loads(graph_path.read_text(encoding="utf-8")), edges="links")
+    build_vector_index(G, graph_path, tmp_path)
+    (tmp_path / "vector-index" / "relations.jsonl").unlink()
+    assert load_index(graph_path, tmp_path) is None
+
+    build_vector_index(G, graph_path, tmp_path)
+    (tmp_path / "vector-index" / "manifest.json").write_text("{not json", encoding="utf-8")
+    assert load_index(graph_path, tmp_path) is None
+
+
+def test_eval_cli_reports_retrieval_quality(monkeypatch, tmp_path, capsys):
+    graph_path = _write_semantic_gap_graph(tmp_path)
+    queries_path = tmp_path / "queries.jsonl"
+    queries_path.write_text(
+        json.dumps({"question": "invoice", "expected_labels": ["InvoiceAccount"], "forbidden_labels": ["Unrelated"]}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv", ["graphify", "index", "--graph", str(graph_path), "--out-dir", str(tmp_path)])
+    mainmod.main()
+    capsys.readouterr()
+
+    monkeypatch.setattr(mainmod.sys, "argv", ["graphify", "eval", str(queries_path), "--graph", str(graph_path)])
+    mainmod.main()
+
+    out = capsys.readouterr().out
+    assert "Eval: 1 queries | mode=hybrid | k=5 | depth=2" in out
+    assert "hit_rate@5: 1.000" in out
+    assert "MRR: 1.000" in out
+    assert "forbidden_hits: 0" in out
+
+
+def test_eval_cli_json_requires_fresh_index(monkeypatch, tmp_path, capsys):
+    graph_path = _write_semantic_gap_graph(tmp_path)
+    queries_path = tmp_path / "queries.jsonl"
+    queries_path.write_text(json.dumps({"question": "invoice", "expected_nodes": ["n_billing"]}) + "\n", encoding="utf-8")
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+
+    monkeypatch.setattr(mainmod.sys, "argv", ["graphify", "eval", str(queries_path), "--graph", str(graph_path), "--json"])
+    try:
+        mainmod.main()
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("expected missing hybrid index to fail eval")
+
+    assert "hybrid eval requires a fresh vector-index" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- add an optional `graphify index` TF-IDF sidecar for graph-first hybrid retrieval
- add `graphify query --mode hybrid --debug-retrieval` without writing retrieval scores into `graph.json`
- add `graphify eval queries.jsonl` for recall@k, MRR, path coverage, and forbidden-hit checks
- fail closed when hybrid eval lacks a fresh sidecar and reject partial/corrupt indexes as stale

## Design notes
- `graph.json` remains the canonical source of truth for nodes, typed edges, provenance, and confidence.
- Retrieval artifacts live under `vector-index/` and `retrieval-debug/` only.
- The MVP uses local TF-IDF so the feature is reversible and adds no heavy runtime dependency.

## Verification
- `uv run ruff check graphify/retrieval.py graphify/eval.py graphify/__main__.py graphify/serve.py tests/test_retrieval.py`
- `uv run pyright graphify/eval.py graphify/retrieval.py tests/test_retrieval.py`
- `uv run pytest tests/test_retrieval.py tests/test_query_cli.py -q`
- `uv run python -m graphify.__main__ index --graph worked/httpx/graph.json`
- `uv run python -m graphify.__main__ eval "$tmp/queries.jsonl" --graph worked/httpx/graph.json`
- `uv run python -m graphify.__main__ query auth --mode hybrid --debug-retrieval --graph worked/httpx/graph.json`
- `uv run pytest -q` → `2124 passed, 28 skipped`

## Docs Impact
Docs not needed: this is an experimental CLI surface covered by built-in help text and tests; longer user-facing retrieval docs should land after dense embedding/rerank provider selection.
