### PR TITLE
fix: Fix for the slicer (0.8.42, #1369), regression from 0.8.43 (#1386)

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -24,6 +24,13 @@ from graphify.file_slice import (
     unit_path,
 )
 
+SemanticUnit = Path | FileSlice
+
+
+def _coerce_semantic_units(units: list[SemanticUnit | str]) -> list[SemanticUnit]:
+    """Normalize str/Path inputs; pass FileSlice through unchanged (#1369)."""
+    return [u if isinstance(u, FileSlice) else Path(u) for u in units]
+
 # `_read_files` truncates each file at this many characters before joining into
 # the user message. Token estimates use the same cap so packing matches reality.
 _FILE_CHAR_CAP = 20_000
@@ -1290,7 +1297,7 @@ def _call_bedrock(model: str, user_message: str, max_tokens: int = 8192, *, deep
 
 
 def extract_files_direct(
-    files: list[Path],
+    files: list[SemanticUnit | str],
     backend: str | None = None,
     api_key: str | None = None,
     model: str | None = None,
@@ -1306,9 +1313,10 @@ def extract_files_direct(
 
     Accepts ``str`` paths as well as ``Path``; string entries are coerced up
     front so downstream helpers (``_partition_semantic_files``, ``_read_files``,
-    ``_build_image_refs``) can rely on ``Path`` semantics (#1386).
+    ``_build_image_refs``) can rely on ``Path`` semantics (#1386). ``FileSlice``
+    units from intra-file splitting (#1369) pass through unchanged.
     """
-    files = [Path(f) for f in files]
+    files = _coerce_semantic_units(files)
     if backend is None:
         backend = detect_backend()
         if backend is None:
@@ -1514,7 +1522,7 @@ def _looks_like_context_exceeded(exc: BaseException) -> bool:
 
 
 def _extract_with_adaptive_retry(
-    chunk: list[Path],
+    chunk: list[SemanticUnit],
     backend: str,
     api_key: str | None,
     model: str | None,
@@ -1737,7 +1745,7 @@ def extract_corpus_parallel(
     Accepts ``str`` paths as well as ``Path``; string entries are coerced up
     front so packing/slicing helpers can rely on ``Path`` semantics (#1386).
     """
-    files = [Path(f) for f in files]
+    files = _coerce_semantic_units(files)
     # Split oversized splittable documents into slices that cover the whole file
     # before packing, so content past _FILE_CHAR_CAP is extracted instead of
     # silently dropped (#1369). Files at/under the cap pass through unchanged.
@@ -1754,7 +1762,7 @@ def extract_corpus_parallel(
     }
     total = len(chunks)
 
-    def _run_one(idx: int, chunk: list[Path]) -> tuple[int, dict | None, Exception | None]:
+    def _run_one(idx: int, chunk: list[SemanticUnit]) -> tuple[int, dict | None, Exception | None]:
         t0 = time.time()
         try:
             result = _extract_with_adaptive_retry(

--- a/tests/test_file_slice.py
+++ b/tests/test_file_slice.py
@@ -163,3 +163,18 @@ def test_bisect_slice_splits_at_newline(tmp_path):
 def test_bisect_slice_returns_none_for_tiny(tmp_path):
     f = _write(tmp_path / "a.md", "ab")
     assert bisect_slice(FileSlice(f, 0, 1, 0, 1)) is None
+
+
+def test_extract_files_direct_accepts_file_slice(tmp_path):
+    from unittest.mock import patch
+
+    f = _write(tmp_path / "doc.md", "# Title\n\nSome prose.\n")
+    sl = FileSlice(f, 0, len(f.read_text(encoding="utf-8")), 0, 1)
+    result = {"nodes": [], "edges": [], "hyperedges": [], "input_tokens": 1, "output_tokens": 1}
+    with patch("graphify.llm._call_openai_compat", return_value=result) as call:
+        out = llm.extract_files_direct(
+            [sl], backend="kimi", api_key="test-key", root=tmp_path,
+        )
+    assert out is result
+    user_msg = call.call_args.args[3]
+    assert "Some prose." in user_msg


### PR DESCRIPTION
## Summary

Fixes a wiring bug introduced when **#1369** (intra-file slicing, shipped in 0.8.42) meets **#1386** (str→`Path` coercion in semantic extract entry points, 0.8.43): packed extraction chunks can contain `FileSlice` objects, but `extract_files_direct` still coerced every item with `[Path(f) for f in files]`, which crashes at runtime.

## What was wrong

After #1369, `extract_corpus_parallel` does:

1. `expand_oversized_files()` — split large text docs into `FileSlice` units covering the whole file
2. `_pack_chunks_by_tokens()` — pack those units (mix of whole `Path` files and `FileSlice` slices) into parallel extraction chunks
3. `_extract_with_adaptive_retry(chunk)` → `extract_files_direct(chunk)`

#1386 correctly added str→`Path` coercion at the extract entry points, but both `extract_files_direct` and `extract_corpus_parallel` used:

```python
files = [Path(f) for f in files]
```

`Path()` cannot wrap a `FileSlice`, so any chunk that contained a slice failed immediately:

```text
argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'FileSlice'
```

This only surfaces when slicing actually produces `FileSlice` chunks — e.g. a large markdown corpus with a lowered `--token-budget` (so packing yields multiple slice-bearing chunks). With the default token budget and a small corpus, whole files may still pack as plain `Path` objects and the bug stays hidden.

## Fix

- Introduce `SemanticUnit = Path | FileSlice` and `_coerce_semantic_units()` — coerce `str`/`Path` inputs to `Path`, pass `FileSlice` through unchanged
- Use `_coerce_semantic_units()` in `extract_files_direct`, `extract_corpus_parallel`, and update type hints on `_extract_with_adaptive_retry` / `_run_one`
- Add regression test `test_extract_files_direct_accepts_file_slice`

## Test plan

- [x] `pytest tests/test_file_slice.py tests/test_chunking.py` — 37 passed
- [x] Full suite with project venv — 2092 passed (5 failures unrelated: local Gemma env vars affecting backend-detection tests, wheel build dev-deps)


Made with [Cursor](https://cursor.com)