### PR TITLE
feat: fall back to claude-cli backend when no API key is configured

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -3354,7 +3354,10 @@ def main() -> None:
                 or os.environ.get("DEEPSEEK_API_KEY")
                 or os.environ.get("GRAPHIFY_NO_TIPS")
             ):
-                print("Tip: set GEMINI_API_KEY or GOOGLE_API_KEY to use Gemini for semantic extraction.")
+                print(
+                    "Tip: set GEMINI_API_KEY or GOOGLE_API_KEY to use Gemini for semantic extraction, "
+                    "or install Claude Code (`claude` on $PATH) for zero-config extraction (claude-cli)."
+                )
         else:
             print(
                 "Nothing to update or rebuild failed — check output above.",
@@ -4210,8 +4213,9 @@ def main() -> None:
                     "error: no LLM API key found (" + "; ".join(reasons) + "). "
                     "Set GEMINI_API_KEY or GOOGLE_API_KEY (gemini), MOONSHOT_API_KEY "
                     "(kimi), ANTHROPIC_API_KEY (claude), OPENAI_API_KEY (openai), "
-                    "DEEPSEEK_API_KEY (deepseek), or pass --backend. A code-only "
-                    "corpus needs no key.",
+                    "DEEPSEEK_API_KEY (deepseek), or pass --backend. "
+                    "Alternatively, install Claude Code and ensure `claude` is on $PATH "
+                    "(claude-cli) — no API key required. A code-only corpus needs no key.",
                     file=sys.stderr,
                 )
                 sys.exit(1)

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -2061,13 +2061,13 @@ def _validate_ollama_base_url(url: str, *, warn: bool = True) -> None:
 def detect_backend() -> str | None:
     """Return the name of whichever backend has an API key set, or None.
 
-    Priority: gemini → kimi → claude → openai → deepseek → azure → bedrock → ollama (last, opt-in).
+    Priority: gemini → kimi → claude → openai → deepseek → azure → bedrock → ollama → claude-cli (last resort, no key needed).
 
-    Ollama is intentionally checked LAST so a paid API key (Anthropic/OpenAI/etc.)
-    is never silently shadowed by an incidental OLLAMA_BASE_URL in the environment
-    — see security finding F-002/F-029. Setting OLLAMA_BASE_URL alongside a paid
-    key now keeps you on the paid backend; remove the paid key (or pass
-    --backend ollama explicitly) to route to the local model.
+    Ollama is intentionally checked after paid API keys so a real key is never
+    silently shadowed by an incidental OLLAMA_BASE_URL — see security finding
+    F-002/F-029. claude-cli is checked last: it requires no API key, only the
+    ``claude`` CLI on $PATH (Claude Code). This lets users who have Claude Code
+    installed get full semantic extraction without configuring any env vars.
     """
     for backend in ("gemini", "kimi", "claude", "openai", "deepseek"):
         if _get_backend_api_key(backend):
@@ -2084,6 +2084,17 @@ def detect_backend() -> str | None:
         if name not in ("gemini", "kimi", "claude", "openai", "deepseek", "azure", "bedrock", "ollama", "claude-cli"):
             if _get_backend_api_key(name):
                 return name
+    # Last resort: no API key configured anywhere, but the Claude Code CLI is
+    # available locally. Route through it so users get working semantic
+    # extraction without needing to set any environment variable.
+    import shutil
+    _claude_bin = (
+        (shutil.which("claude.cmd") or shutil.which("claude"))
+        if sys.platform == "win32"
+        else shutil.which("claude")
+    )
+    if _claude_bin:
+        return "claude-cli"
     return None
 
 

--- a/tests/test_llm_backends.py
+++ b/tests/test_llm_backends.py
@@ -845,3 +845,30 @@ def test_openai_compat_env_var_temperature_applied(tmp_path, monkeypatch):
     llm.extract_files_direct([tmp_path / "f.py"], backend="openai", root=tmp_path)
 
     assert captured.get("temperature") == 0.3
+
+
+def test_detect_backend_falls_back_to_claude_cli_when_no_keys(monkeypatch):
+    _clear_backend_env(monkeypatch)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    with patch("shutil.which", return_value="/usr/local/bin/claude"):
+        assert llm.detect_backend() == "claude-cli"
+
+
+def test_detect_backend_prefers_api_key_over_claude_cli(monkeypatch):
+    _clear_backend_env(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    with patch("shutil.which", return_value="/usr/local/bin/claude"):
+        assert llm.detect_backend() == "claude"
+
+
+def test_detect_backend_returns_none_when_no_keys_and_no_claude_cli(monkeypatch):
+    _clear_backend_env(monkeypatch)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    with patch("shutil.which", return_value=None):
+        assert llm.detect_backend() is None


### PR DESCRIPTION
## Summary

The `claude-cli` backend is fully implemented and works great. This PR wires it into `detect_backend()` as a last-resort fallback for **headless / terminal runs** — when `graphify extract .` or `graphify .` is called directly from a shell with no API key configured.

**Context:** When `/graphify` is invoked as a Claude Code skill, semantic extraction already works without any API key — the skill spawns a Claude Code subagent that uses the active session. No change needed there. The gap is the CLI path: a user who runs `graphify extract .` from a terminal, has no API key set, but has Claude Code installed currently sees:

```
error: no LLM API key found (N doc/paper/image file(s) need semantic extraction). Set GEMINI_API_KEY ...
```

With this PR, graphify checks `shutil.which("claude")` as a final fallback and auto-selects `claude-cli`, so the extraction works without any environment setup.

## Changes

- **`graphify/llm.py` — `detect_backend()`**: add `shutil.which("claude")` check after the custom-providers loop, immediately before `return None`. Windows-aware (`claude.cmd` first). Updates docstring to reflect new priority chain.
- **`graphify/__main__.py`**: update the "no LLM API key found" error message and the post-`graphify update` tip to mention `claude-cli` as a zero-config option.
- **`tests/test_llm_backends.py`**: three new tests — (1) falls back to `claude-cli` when no keys and CLI present, (2) API key wins over CLI, (3) returns `None` when neither key nor CLI is available.

## Behaviour

| Situation | Before | After |
|-----------|--------|-------|
| No API keys, `claude` on PATH (terminal run) | Error | Auto-selects `claude-cli` |
| `/graphify` as Claude Code skill | Works (subagent) | Unchanged |
| API key set + `claude` on PATH | Uses API key | Uses API key (unchanged) |
| No API keys, no `claude` | Error | Error (unchanged) |
| `--backend claude-cli` explicit | Works | Works (unchanged) |

`claude-cli` remains last in the chain — a real API key always wins.