### PR TITLE
fix(export): never emit punctuation-only Obsidian filenames (e.g. @.md)

### DIFF
--- a/graphify/export.py
+++ b/graphify/export.py
@@ -866,7 +866,14 @@ def to_obsidian(
         cleaned = re.sub(r'[\\/*?:"<>|#^[\]]', "", label.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")).strip()
         # Strip trailing .md/.mdx/.markdown so "CLAUDE.md" doesn't become "CLAUDE.md.md"
         cleaned = re.sub(r"\.(md|mdx|qmd|markdown)$", "", cleaned, flags=re.IGNORECASE)
-        return _cap_filename(cleaned) if cleaned else "unnamed"
+        # A stem of only punctuation (e.g. "@", "*", "#") survives the unsafe-char
+        # strip above but is empty once a downstream tool re-slugs on word chars
+        # (e.g. qmd's handelize() reduces "@" -> "" and raises, aborting the whole
+        # `qmd update`). Require at least one word char; else fall back so we never
+        # emit a "@.md"-style filename. (#1409)
+        if not re.search(r"\w", cleaned, flags=re.UNICODE):
+            return "unnamed"
+        return _cap_filename(cleaned)
 
     node_filename: dict[str, str] = {}
     seen_names: dict[str, int] = {}
@@ -1112,7 +1119,14 @@ def to_canvas(
     def safe_name(label: str) -> str:
         cleaned = re.sub(r'[\\/*?:"<>|#^[\]]', "", label.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")).strip()
         cleaned = re.sub(r"\.(md|mdx|qmd|markdown)$", "", cleaned, flags=re.IGNORECASE)
-        return _cap_filename(cleaned) if cleaned else "unnamed"
+        # A stem of only punctuation (e.g. "@", "*", "#") survives the unsafe-char
+        # strip above but is empty once a downstream tool re-slugs on word chars
+        # (e.g. qmd's handelize() reduces "@" -> "" and raises, aborting the whole
+        # `qmd update`). Require at least one word char; else fall back so we never
+        # emit a "@.md"-style filename. (#1409)
+        if not re.search(r"\w", cleaned, flags=re.UNICODE):
+            return "unnamed"
+        return _cap_filename(cleaned)
 
     # Build node_filenames if not provided (same dedup logic as to_obsidian)
     if node_filenames is None:


### PR DESCRIPTION
Fixes #1409.

### Problem
`to_obsidian()`'s `safe_name()` can produce a **punctuation-only filename** (e.g. `@.md`) when a node label is all-punctuation after the unsafe-char strip — e.g. a `@/*` node from a `tsconfig.json` `paths` key leaves a bare `@`, which is truthy and so slips past the `else "unnamed"` fallback.

The file is valid on disk but **empty once a downstream tool re-slugs the stem on word chars**. In particular it crashes `qmd update` (handelize() reduces `@` → `""` and raises), and because qmd indexes collections in a batch, that one generated file aborts reindexing for *every* collection on the machine.

### Fix
Require at least one `\w` char in the stem; otherwise fall back to `"unnamed"`. Applied to **both** `safe_name` occurrences (node export + community export). The existing dedup logic already disambiguates multiple `unnamed` collisions.

Behavior is unchanged for any label containing a word char (`@types/node` → `@typesnode.md` as before); only the pathological all-punctuation case changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)