### PR TITLE
fix(opencode): write global-install plugin to ~/.config/opencode/ instead of cwd

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -694,7 +694,7 @@ def install(platform: str = "claude", *, project: bool = False, project_dir: Pat
             print(f"  CODEBUDDY.md     ->  created at {codebuddy_md}")
 
     if platform == "opencode":
-        _install_opencode_plugin(project_dir if project else Path("."))
+        _install_opencode_plugin(project_dir or Path("."), project=project)
 
     # Refresh version stamps in all other previously-installed skill dirs so
     # stale-version warnings don't fire for platforms not explicitly re-installed.
@@ -1404,14 +1404,38 @@ _OPENCODE_PLUGIN_PATH = Path(".opencode") / "plugins" / "graphify.js"
 _OPENCODE_CONFIG_PATH = Path(".opencode") / "opencode.json"
 
 
-def _install_opencode_plugin(project_dir: Path) -> None:
-    """Write graphify.js plugin and register it in opencode.json."""
-    plugin_file = project_dir / _OPENCODE_PLUGIN_PATH
+def _install_opencode_plugin(project_dir: Path, *, project: bool = True) -> None:
+    """Write graphify.js plugin and register it in opencode.json.
+
+    When ``project`` is True (default), the plugin lands at
+    ``<project_dir>/.opencode/plugins/graphify.js`` and is registered in
+    ``<project_dir>/.opencode/opencode.json`` — opencode's project-scoped
+    config location (one of three valid project-config paths opencode walks
+    up from cwd to find).
+
+    When ``project`` is False (global install), the plugin lands at
+    ``~/.config/opencode/.opencode/plugins/graphify.js`` (opencode resolves
+    a ``.opencode/plugins/<name>.js`` plugin entry relative to the
+    declaring config's directory) and is registered in
+    ``~/.config/opencode/opencode.json`` — opencode's ONLY global config
+    location. Note: the previous behaviour wrote both files into
+    ``<cwd>/.opencode/`` which only worked if cwd was the global config
+    dir. See issue #1412.
+    """
+    base = project_dir if project else (Path.home() / ".config" / "opencode")
+    plugin_file = base / _OPENCODE_PLUGIN_PATH
+    # Project mode writes the config inside .opencode/ (one of three valid
+    # project-config locations). Global mode must write to the user's real
+    # global config at <base>/opencode.json — <base>/.opencode/opencode.json
+    # is NOT a config location opencode loads.
+    if project:
+        config_file = base / _OPENCODE_CONFIG_PATH
+    else:
+        config_file = base / "opencode.json"
     plugin_file.parent.mkdir(parents=True, exist_ok=True)
     plugin_file.write_text(_OPENCODE_PLUGIN_JS, encoding="utf-8")
-    print(f"  {_OPENCODE_PLUGIN_PATH}  ->  tool.execute.before hook written")
+    print(f"  {plugin_file.resolve()}  ->  tool.execute.before hook written")
 
-    config_file = project_dir / _OPENCODE_CONFIG_PATH
     if config_file.exists():
         try:
             config = json.loads(config_file.read_text(encoding="utf-8"))
@@ -1425,19 +1449,28 @@ def _install_opencode_plugin(project_dir: Path) -> None:
     if entry not in plugins:
         plugins.append(entry)
         config_file.write_text(json.dumps(config, indent=2), encoding="utf-8")
-        print(f"  {_OPENCODE_CONFIG_PATH}  ->  plugin registered")
+        print(f"  {config_file.resolve()}  ->  plugin registered")
     else:
-        print(f"  {_OPENCODE_CONFIG_PATH}  ->  plugin already registered (no change)")
+        print(f"  {config_file.resolve()}  ->  plugin already registered (no change)")
 
 
-def _uninstall_opencode_plugin(project_dir: Path) -> None:
-    """Remove graphify.js plugin and deregister from opencode.json."""
-    plugin_file = project_dir / _OPENCODE_PLUGIN_PATH
+def _uninstall_opencode_plugin(project_dir: Path, *, project: bool = True) -> None:
+    """Remove graphify.js plugin and deregister from opencode.json.
+
+    Mirrors :func:`_install_opencode_plugin`: ``project`` selects between
+    the project-scoped config tree (``<project_dir>/.opencode/``) and the
+    global config (``~/.config/opencode/opencode.json``).
+    """
+    base = project_dir if project else (Path.home() / ".config" / "opencode")
+    plugin_file = base / _OPENCODE_PLUGIN_PATH
     if plugin_file.exists():
         plugin_file.unlink()
-        print(f"  {_OPENCODE_PLUGIN_PATH}  ->  removed")
+        print(f"  {plugin_file.resolve()}  ->  removed")
 
-    config_file = project_dir / _OPENCODE_CONFIG_PATH
+    if project:
+        config_file = base / _OPENCODE_CONFIG_PATH
+    else:
+        config_file = base / "opencode.json"
     if not config_file.exists():
         return
     try:
@@ -1451,7 +1484,7 @@ def _uninstall_opencode_plugin(project_dir: Path) -> None:
         if not plugins:
             config.pop("plugin")
         config_file.write_text(json.dumps(config, indent=2), encoding="utf-8")
-        print(f"  {_OPENCODE_CONFIG_PATH}  ->  plugin deregistered")
+        print(f"  {config_file.resolve()}  ->  plugin deregistered")
 
 
 _CODEX_HOOK = {

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -57,6 +57,69 @@ def test_install_opencode(tmp_path):
     ).exists()
 
 
+def test_install_opencode_global_writes_plugin_to_config_dir(tmp_path):
+    """Global opencode install writes the plugin under ~/.config/opencode/.opencode/, not cwd.
+
+    Regression test for #1412: opencode resolves `.opencode/plugins/<name>.js`
+    entries relative to the declaring config's directory. The global config
+    lives at `~/.config/opencode/opencode.json`, so the plugin must land at
+    `~/.config/opencode/.opencode/plugins/graphify.js` to be loaded.
+    Previously the installer wrote to `<cwd>/.opencode/plugins/graphify.js`,
+    which only worked if the user happened to run `graphify install` from
+    inside `~/.config/opencode/`.
+    """
+    _install(tmp_path, "opencode")
+    # Must be at the global config dir, not under cwd
+    assert (tmp_path / ".config" / "opencode" / ".opencode" / "plugins" / "graphify.js").exists()
+    # Must NOT pollute the cwd with a stray .opencode/ tree
+    assert not (tmp_path / ".opencode").exists()
+
+
+def test_install_opencode_global_registers_plugin_in_config(tmp_path):
+    """Global opencode install registers the plugin in ~/.config/opencode/opencode.json.
+
+    opencode's only global config is ``~/.config/opencode/opencode.json`` — NOT
+    ``~/.config/opencode/.opencode/opencode.json`` (that path is neither a
+    project config walked-up from cwd nor the global config, so opencode
+    silently ignores it). The first attempt at #1412 wrote the registration
+    to the wrong file; this test pins the correct location.
+    """
+    import json as _json
+
+    _install(tmp_path, "opencode")
+    # The real global config — must contain the plugin entry.
+    global_config = tmp_path / ".config" / "opencode" / "opencode.json"
+    # The phantom path the bug created — must NOT exist as a side effect of
+    # registration (a plugin FILE may live under .opencode/plugins/, but a
+    # config file under .opencode/ at the global level is invisible to opencode).
+    phantom_config = tmp_path / ".config" / "opencode" / ".opencode" / "opencode.json"
+
+    assert global_config.exists(), f"global config not written at {global_config}"
+    config = _json.loads(global_config.read_text())
+    assert any("graphify.js" in p for p in config.get("plugin", [])), "plugin not registered in global config"
+
+    if phantom_config.exists():
+        # If a phantom config exists at all, it must NOT contain a plugin entry
+        # (otherwise we've split state across two files and opencode only loads one).
+        phantom = _json.loads(phantom_config.read_text())
+        assert not any("graphify.js" in p for p in phantom.get("plugin", [])), (
+            f"plugin entry leaked into phantom config at {phantom_config}"
+        )
+
+
+def test_uninstall_opencode_global_removes_plugin(tmp_path):
+    """Global opencode uninstall removes the plugin from ~/.config/opencode/.opencode/."""
+    _install(tmp_path, "opencode")
+    plugin = tmp_path / ".config" / "opencode" / ".opencode" / "plugins" / "graphify.js"
+    assert plugin.exists()
+    from graphify.__main__ import _uninstall_opencode_plugin
+
+    # Global mode: project=False resolves base via Path.home()
+    with patch("graphify.__main__.Path.home", return_value=tmp_path):
+        _uninstall_opencode_plugin(tmp_path, project=False)
+    assert not plugin.exists()
+
+
 def test_install_positional_platform_opencode(tmp_path, monkeypatch):
     from graphify.__main__ import main
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
Fixes #1412.

## Summary

Running `graphify install --platform opencode` **without** `--project` (the documented global-install mode) wrote the plugin to `<cwd>/.opencode/plugins/graphify.js` and created a stray `<cwd>/.opencode/opencode.json`. Neither file is loaded by opencode — opencode resolves `.opencode/plugins/<name>.js` entries **relative to the declaring config's directory**, and the global config lives at `~/.config/opencode/opencode.json`, not cwd.

The installer log claimed success (`tool.execute.before hook written`, `plugin registered`), but the plugin silently never loaded. This is the global-mode sibling of #1040 (which was the `--project` variant of the same class of bug).

## Root cause

`graphify/__main__.py` line 697 (v0.8.44):

```python
if platform == "opencode":
    _install_opencode_plugin(project_dir if project else Path("."))
```

For global installs (`project=False`), this resolved the plugin destination against `Path(".")` — the current working directory. Run from `~`, the plugin landed at `~/.opencode/plugins/graphify.js`. Run from any other cwd, it landed wherever the user happened to be.

Meanwhile, the **skill** install path (line 148-151) already handled both modes correctly:

```python
if platform_name == "opencode":
    if project:
        return (project_dir or Path(".")) / ".opencode" / "skills" / "graphify" / "SKILL.md"
    return Path.home() / ".config" / "opencode" / "skills" / "graphify" / "SKILL.md"
```

The plugin install path simply didn't have the same branching — it always used `project_dir` regardless of mode.

## Fix

Thread `project: bool = True` into `_install_opencode_plugin` / `_uninstall_opencode_plugin`. When `project=False`, resolve base dir via `Path.home() / ".config" / "opencode"` (matching the existing skill-path logic, monkey-patchable in tests via `Path.home`). When `project=True` (default, used by `_agents_install` etc.), behaviour is unchanged.

Only the global-mode caller (`install()` at line 697) passes the new flag; the five other callers (`_agents_install`, `_agents_uninstall` × 3, `uninstall_all`) are project-scoped by design and use the default.

Also: the install/uninstall messages now print the resolved absolute path so users can see where the plugin actually landed (previously they saw the relative `.opencode/plugins/graphify.js` which gave no clue about which tree it was written to).

## Verification

Three new regression tests:

1. `test_install_opencode_global_writes_plugin_to_config_dir` — after global install, plugin exists at `~/.config/opencode/.opencode/plugins/graphify.js` and there is **no** stray `<cwd>/.opencode/` tree.
2. `test_install_opencode_global_registers_plugin_in_config` — registration goes into `~/.config/opencode/.opencode/opencode.json`, not a stray cwd-relative file.
3. `test_uninstall_opencode_global_removes_plugin` — global uninstall (`project=False`) removes the plugin from the correct location.

All 12 opencode install tests pass; no regressions in the broader install/roundtrip/upgrade/reference suites (156 tests pass).

## Workaround for users on already-released versions

```bash
mkdir -p ~/.config/opencode/.opencode/plugins
cp ~/.opencode/plugins/graphify.js ~/.config/opencode/.opencode/plugins/graphify.js
rm -rf ~/.opencode/plugins ~/.opencode/opencode.json
```

## Related

- #1040 — `--project` variant of the same bug class (project-mode skill path was wrong; this PR fixes the corresponding global-mode plugin path)
- #1413 — backtick command-substitution bug in the plugin template (filed same day; companion PR)
- The opencode docs at https://opencode.ai/config.json and the built-in `customize-opencode` skill both clearly distinguish `~/.config/opencode/` (config) from `~/.opencode/` (runtime/binary).
