### PR TITLE
fix(opencode): strip backticks from plugin reminder to prevent silent command substitution

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -1378,6 +1378,12 @@ def _uninstall_kilo_plugin(project_dir: Path) -> None:
 _OPENCODE_PLUGIN_JS = """\
 // graphify OpenCode plugin
 // Injects a knowledge graph reminder before bash tool calls when the graph exists.
+//
+// IMPORTANT: keep the reminder string free of backticks and $(...) constructs.
+// The hook prepends `echo "<reminder>" && <cmd>` to the user's bash command;
+// backticks inside the double-quoted echo trigger bash command substitution,
+// which both corrupts tool output and silently executes the very graphify
+// command we are only suggesting. Plain words render fine in opencode's TUI.
 import { existsSync } from "fs";
 import { join } from "path";
 
@@ -1391,7 +1397,7 @@ export const GraphifyPlugin = async ({ directory }) => {
 
       if (input.tool === "bash") {
         output.args.command =
-          'echo "[graphify] knowledge graph at graphify-out/. For focused questions, run \\`graphify query \\"<question>\\"\\` (scoped subgraph, usually much smaller than GRAPH_REPORT.md) instead of grepping raw files. Read GRAPH_REPORT.md only for broad architecture context." && ' +
+          'echo "[graphify] knowledge graph at graphify-out/. For focused questions, run graphify query with your question (scoped subgraph, usually much smaller than GRAPH_REPORT.md) instead of grepping raw files. Read GRAPH_REPORT.md only for broad architecture context." && ' +
           output.args.command;
         reminded = true;
       }

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -599,6 +599,28 @@ def test_opencode_agents_install_writes_plugin(tmp_path):
     assert "tool.execute.before" in plugin.read_text()
 
 
+def test_opencode_plugin_reminder_has_no_backticks(tmp_path):
+    """The bash reminder string must not contain backticks or $(...) (regression test for #1413).
+
+    The plugin prepends `echo "<reminder>" && <cmd>` to the user's bash command.
+    Backticks or $() inside the reminder trigger bash command substitution
+    when the echo runs, which both corrupts tool output and silently executes
+    the very graphify command we are only suggesting.
+    """
+    _agents_install(tmp_path, "opencode")
+    plugin = tmp_path / ".opencode" / "plugins" / "graphify.js"
+    body = plugin.read_text()
+    # Extract the echoed reminder string literal between the double-quotes
+    # of the `output.args.command = 'echo "..." && ' +` line.
+    import re
+
+    m = re.search(r'echo "([^"]*)"', body)
+    assert m, "echo reminder not found in plugin body"
+    reminder = m.group(1)
+    assert "`" not in reminder, f"backtick in reminder would trigger command substitution: {reminder!r}"
+    assert "$(" not in reminder, f"$() in reminder would trigger command substitution: {reminder!r}"
+
+
 def test_opencode_agents_install_registers_plugin_in_config(tmp_path):
     """opencode install registers the plugin in .opencode/opencode.json."""
     _agents_install(tmp_path, "opencode")


### PR DESCRIPTION
Fixes #1413.

## Summary

The opencode plugin template shipped by `graphify install --platform opencode` embedded the reminder string with backticks around `graphify query "<question>"`. Because the plugin prepends `echo "<reminder>" && <cmd>` to the user's bash command, those backticks triggered **bash command substitution** — every grep/rg/find invocation silently ran `graphify query "<question>"` and substituted its output (`No matching nodes found.`) into the middle of the reminder text the agent sees.

This both (a) corrupted every bash search's tool output with graphify noise, and (b) actually spawned a graphify process + loaded `graph.json` + ran a BFS traversal with the literal token `<question>` on **every** search.

## Root cause

`graphify/__main__.py` line 1394 (v0.8.44):

```python
'echo "[graphify] knowledge graph at graphify-out/. For focused questions, run \`graphify query \\"<question>\\"\` (scoped subgraph...) " && '
```

The literal `` ` `` chars inside the JS string become live backticks when the JS runs inside an `echo "..."` shell command — bash evaluates them as command substitution.

## Fix

Strip the backticks from the reminder string. Plain words render fine in opencode's TUI; markdown code spans were never useful in shell echo output anyway.

Also adds a guard comment in the JS template (`// IMPORTANT: keep the reminder string free of backticks and $(...) constructs`) so a future editor doesn't reintroduce the bug by accident.

## Verification

- New regression test `test_opencode_plugin_reminder_has_no_backticks` parses the generated plugin's `echo "..."` string and asserts it contains no `` ` `` and no `$(`. The test fails on the pre-fix code (it finds the backticks) and passes after the fix.
- All 10 existing opencode install tests still pass; no regressions across the broader install/roundtrip/upgrade/reference suites (156 tests pass).

## Symptom before fix

Real session output, where bash substituted `graphify query "<question>"` → `No matching nodes found.`:

```
[graphify] knowledge graph at graphify-out/. For focused questions, run No matching nodes found. (scoped subgraph, usually much smaller than GRAPH_REPORT.md) instead of grepping raw files. Read GRAPH_REPORT.md only for broad architecture context.
```

Notice `run No matching nodes found.` in the middle of the sentence.

## Symptom after fix

```
[graphify] knowledge graph at graphify-out/. For focused questions, run graphify query with your question (scoped subgraph, usually much smaller than GRAPH_REPORT.md) instead of grepping raw files. Read GRAPH_REPORT.md only for broad architecture context.
```

## Bonus

The same anti-pattern (backticks inside bash echo strings) likely exists in other skill templates. Out of scope for this PR but worth a separate audit.
