### PR TITLE
fix: hermes install missing SKILL.md + python3 fallback on Windows

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2506,11 +2506,13 @@ def main() -> None:
             if "--project" in sys.argv[3:]:
                 _project_install(cmd, Path("."))
             else:
+                _copy_skill_file(cmd)
                 _agents_install(Path("."), cmd)
         elif subcmd == "uninstall":
             if "--project" in sys.argv[3:]:
                 _project_uninstall(cmd, Path("."))
             else:
+                _remove_skill_file(cmd)
                 _agents_uninstall(Path("."), platform=cmd)
                 if cmd == "codex":
                     _uninstall_codex_hook(Path("."))

--- a/graphify/skill-claw.md
+++ b/graphify/skill-claw.md
@@ -81,8 +81,12 @@ if [ -z "$PYTHON" ] && [ -n "$GRAPHIFY_BIN" ]; then
         *) "$_SHEBANG" -c "import graphify" 2>/dev/null && PYTHON="$_SHEBANG" ;;
     esac
 fi
-# 3. Fall back to python3
-if [ -z "$PYTHON" ]; then PYTHON="python3"; fi
+# 3. Fall back to python3 (Unix) or python (Windows)
+if [ -z "$PYTHON" ]; then
+    if command -v python3 >/dev/null 2>&1; then PYTHON="python3"
+    elif command -v python >/dev/null 2>&1; then PYTHON="python"
+    fi
+fi
 if ! "$PYTHON" -c "import graphify" 2>/dev/null; then
     if command -v uv >/dev/null 2>&1; then
         uv tool install --upgrade graphifyy -q 2>&1 | tail -3
@@ -596,9 +600,15 @@ if [ ! -f graphify-out/.graphify_python ]; then
     GRAPHIFY_BIN=$(which graphify 2>/dev/null)
     if [ -n "$GRAPHIFY_BIN" ]; then
         PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.-]*) PYTHON="python3" ;; esac
+        case "$PYTHON" in *[!a-zA-Z0-9/_.-]*)
+            if command -v python3 >/dev/null 2>&1; then PYTHON="python3"
+            elif command -v python >/dev/null 2>&1; then PYTHON="python"
+            fi ;;
+        esac
     else
-        PYTHON="python3"
+        if command -v python3 >/dev/null 2>&1; then PYTHON="python3"
+        elif command -v python >/dev/null 2>&1; then PYTHON="python"
+        fi
     fi
     mkdir -p graphify-out
     "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"


### PR DESCRIPTION
## Two fixes for Hermes (and other per-platform shortcut) installations

### Bug 1: `graphify hermes install` skips SKILL.md installation

`graphify hermes install` (and `graphify codex install`, `graphify claw install`, etc.) only calls `_agents_install()` which writes the AGENTS.md section, but never calls `_copy_skill_file()`. This leaves the user with no SKILL.md and no `references/` sidecar — the skill is invisible to the host agent.

The generic `graphify install --platform hermes` works correctly because it goes through `install()` → `_copy_skill_file()`. The per-platform shortcuts bypass this.

**Fix:** Add `_copy_skill_file(cmd)` before `_agents_install()` and `_remove_skill_file(cmd)` before `_agents_uninstall()` in the per-platform CLI handler (`__main__.py` L2508-2514).

This affects all platforms in the group: aider, codex, opencode, claw, droid, trae, trae-cn, hermes.

### Bug 2: `python3` fallback fails on Windows

The skill-claw.md (used by Hermes, claw, aider, and others) falls back to `python3` when uv/pipx/shebang detection fails. On Windows, `python3` does not exist — the executable is `python`.

**Fix:** Replace bare `python3` fallbacks with a two-probe chain:
```bash
if command -v python3 >/dev/null 2>&1; then PYTHON=python3
elif command -v python >/dev/null 2>&1; then PYTHON=python
fi
```

Applied in two locations in skill-claw.md:
- L84: Main detection chain fallback
- L599/L601: Re-detection chain when `.graphify_python` is missing

### Backwards compatibility

Both fixes are fully backwards-compatible:
- Unix users see no change (python3 probe succeeds first)
- The skill install path now works identically to `graphify install --platform`

### Tested on

- Windows 11, Git Bash (MSYS), uv tool install, Python 3.11
- Verified: `graphify hermes install` now installs SKILL.md + references/ + AGENTS.md
- Verified: all 5 python3 references in installed SKILL.md are protected by `command -v` checks