### PR TITLE
feat: increase default HTML visualization limit to 15,000 nodes

### DIFF
--- a/graphify/export.py
+++ b/graphify/export.py
@@ -153,7 +153,7 @@ COMMUNITY_COLORS = [
     "#EDC948", "#B07AA1", "#FF9DA7", "#9C755F", "#BAB0AC",
 ]
 
-MAX_NODES_FOR_VIZ = 5_000
+MAX_NODES_FOR_VIZ = 15_000
 
 
 def _viz_node_limit() -> int:


### PR DESCRIPTION
### Description
This PR increases the `MAX_NODES_FOR_VIZ` limit from 5,000 to 15,000. 

### Justification
The previous limit of 5,000 nodes was established as a very conservative safety measure to prevent browser crashes. However, modern developer machines and browser engines are more than capable of rendering and interacting with network graphs well over 15,000-20,000 nodes using `vis-network` without running out of memory. 

As projects grow in complexity, hitting the 5k limit becomes increasingly common (requiring developers to manually override it via `GRAPHIFY_VIZ_NODE_LIMIT`). Bumping the default to 15,000 provides a much better out-of-the-box experience for medium-to-large codebases without sacrificing stability for the vast majority of users today.