### PR TITLE
feat: add --missing-only flag to label command to skip already named communities

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2150,6 +2150,7 @@ def main() -> None:
         print("    --no-viz                skip graph.html generation (useful for >5000 node graphs / CI)")
         print("    --graph <path>          path to graph.json (default <path>/graphify-out/graph.json)")
         print("    --no-label              keep 'Community N' placeholders (skip LLM community naming)")
+        print("    --missing-only          only re-label communities that have 'Community N' placeholders")
         print("    --backend=<name>        backend to use for community naming (default: auto-detect)")
         print("    --model=<name>          model to use for community naming")
         print("  label <path>            (re)name communities with the configured LLM backend, regenerate report")
@@ -3146,6 +3147,7 @@ def main() -> None:
         # the optional positional path can appear in any order (#724).
         no_viz = "--no-viz" in sys.argv
         no_label = "--no-label" in sys.argv
+        missing_only = "--missing-only" in sys.argv
         _backend_arg = next((a for a in sys.argv if a.startswith("--backend=")), None)
         label_backend = _backend_arg.split("=", 1)[1] if _backend_arg else None
         _model_arg = next((a for a in sys.argv if a.startswith("--model=")), None)
@@ -3178,7 +3180,7 @@ def main() -> None:
                 co_exclude_hubs = float(args[i_arg + 1]); i_arg += 2
             elif a.startswith("--exclude-hubs="):
                 co_exclude_hubs = float(a.split("=", 1)[1]); i_arg += 1
-            elif a == "--no-viz" or a.startswith("--min-community-size="):
+            elif a == "--no-viz" or a == "--missing-only" or a.startswith("--min-community-size="):
                 i_arg += 1
             elif a.startswith("--"):
                 i_arg += 1
@@ -3250,6 +3252,14 @@ def main() -> None:
         out = watch_path / "graphify-out"
         out.mkdir(parents=True, exist_ok=True)
         labels_path = out / ".graphify_labels.json"
+        
+        existing_labels = {}
+        if labels_path.exists():
+            try:
+                existing_labels = {int(k): v for k, v in json.loads(labels_path.read_text(encoding="utf-8")).items()}
+            except Exception:
+                pass
+
         if labels_path.exists() and not force_relabel:
             try:
                 labels = {int(k): v for k, v in json.loads(labels_path.read_text(encoding="utf-8")).items()}
@@ -3263,12 +3273,30 @@ def main() -> None:
             # auto-name communities with the configured backend rather than leave
             # "Community N" (#1097). Degrades to placeholders if no backend/on error.
             from graphify.llm import generate_community_labels
-            print("Labeling communities...")
+            
+            target_communities = communities
+            if missing_only and existing_labels:
+                target_communities = {
+                    cid: members for cid, members in communities.items()
+                    if cid not in existing_labels or str(existing_labels[cid]).startswith("Community ")
+                }
+                print(f"Labeling {len(target_communities)} missing communities...")
+            else:
+                print("Labeling communities...")
+                
             # The final labels (LLM or placeholder fallback) are persisted to
             # .graphify_labels.json by the unconditional write below.
-            labels, _ = generate_community_labels(
-                G, communities, backend=label_backend, model=label_model, gods=gods
+            new_labels, _ = generate_community_labels(
+                G, target_communities, backend=label_backend, model=label_model, gods=gods
             )
+            
+            if missing_only and existing_labels:
+                labels = {**existing_labels, **new_labels}
+                for cid in communities:
+                    if cid not in labels:
+                        labels[cid] = f"Community {cid}"
+            else:
+                labels = new_labels
         questions = suggest_questions(G, communities, labels)
         tokens = {"input": 0, "output": 0}
         from graphify.export import _git_head as _gh

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2150,7 +2150,7 @@ def main() -> None:
         print("    --no-viz                skip graph.html generation (useful for >5000 node graphs / CI)")
         print("    --graph <path>          path to graph.json (default <path>/graphify-out/graph.json)")
         print("    --no-label              keep 'Community N' placeholders (skip LLM community naming)")
-        print("    --missing-only          only re-label communities that have 'Community N' placeholders")
+        print("    --missing-only          only re-label communities that have 'Community N' placeholders (works with 'label' command)")
         print("    --backend=<name>        backend to use for community naming (default: auto-detect)")
         print("    --model=<name>          model to use for community naming")
         print("  label <path>            (re)name communities with the configured LLM backend, regenerate report")
@@ -3252,7 +3252,7 @@ def main() -> None:
         out = watch_path / "graphify-out"
         out.mkdir(parents=True, exist_ok=True)
         labels_path = out / ".graphify_labels.json"
-        
+
         existing_labels = {}
         if labels_path.exists():
             try:
@@ -3273,7 +3273,7 @@ def main() -> None:
             # auto-name communities with the configured backend rather than leave
             # "Community N" (#1097). Degrades to placeholders if no backend/on error.
             from graphify.llm import generate_community_labels
-            
+
             target_communities = communities
             if missing_only and existing_labels:
                 target_communities = {
@@ -3283,13 +3283,13 @@ def main() -> None:
                 print(f"Labeling {len(target_communities)} missing communities...")
             else:
                 print("Labeling communities...")
-                
+
             # The final labels (LLM or placeholder fallback) are persisted to
             # .graphify_labels.json by the unconditional write below.
             new_labels, _ = generate_community_labels(
                 G, target_communities, backend=label_backend, model=label_model, gods=gods
             )
-            
+
             if missing_only and existing_labels:
                 labels = {**existing_labels, **new_labels}
                 for cid in communities:

--- a/graphify/export.py
+++ b/graphify/export.py
@@ -153,7 +153,7 @@ COMMUNITY_COLORS = [
     "#EDC948", "#B07AA1", "#FF9DA7", "#9C755F", "#BAB0AC",
 ]
 
-MAX_NODES_FOR_VIZ = 5_000
+MAX_NODES_FOR_VIZ = 15_000
 
 
 def _viz_node_limit() -> int:

--- a/graphify/export.py
+++ b/graphify/export.py
@@ -153,7 +153,7 @@ COMMUNITY_COLORS = [
     "#EDC948", "#B07AA1", "#FF9DA7", "#9C755F", "#BAB0AC",
 ]
 
-MAX_NODES_FOR_VIZ = 15_000
+MAX_NODES_FOR_VIZ = 5_000
 
 
 def _viz_node_limit() -> int:

--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -278,3 +278,53 @@ def test_label_communities_max_communities_caps_total(monkeypatch):
     label_communities(G, communities, backend="gemini", max_communities=40, batch_size=100)
     # Only 40 communities should have been sent to the backend.
     assert len(captured_cids) == 40
+
+
+def test_label_cli_missing_only_preserves_existing(tmp_path, monkeypatch):
+    import graphify.__main__ as cli
+
+    out = tmp_path / "graphify-out"
+    out.mkdir()
+    graph = {
+        "directed": False,
+        "nodes": [
+            {"id": "n1", "label": "Node1", "community": 0},
+            {"id": "n2", "label": "Node2", "community": 1},
+        ],
+        "links": [],
+    }
+    (out / "graph.json").write_text(json.dumps(graph), encoding="utf-8")
+    
+    # Community 0 is named, Community 1 is missing/placeholder
+    labels_file = out / ".graphify_labels.json"
+    labels_file.write_text(json.dumps({"0": "Existing Name", "1": "Community 1"}), encoding="utf-8")
+
+    captured_targets = {}
+
+    def fake_generate(G, target_communities, *, backend=None, model=None, gods=None, quiet=False):
+        captured_targets.update(target_communities)
+        return {1: "New Name"}, "llm"
+
+    monkeypatch.setattr("graphify.llm.generate_community_labels", fake_generate)
+    monkeypatch.setattr("graphify.export.to_html", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "graphify",
+            "label",
+            str(tmp_path),
+            "--missing-only",
+            "--no-viz",
+        ],
+    )
+
+    cli.main()
+
+    # The generate function should only be asked to name community 1
+    assert 1 in captured_targets
+    assert 0 not in captured_targets
+
+    # The final labels file should merge the old "Existing Name" with the new "New Name"
+    final_labels = json.loads(labels_file.read_text(encoding="utf-8"))
+    assert final_labels == {"0": "Existing Name", "1": "New Name"}


### PR DESCRIPTION
I am working on a massive codebase that has over 7,500 nodes. When running `graphify label .`, the LLM backend often struggles to label all 1,000+ communities perfectly in one go due to API rate limits or parsing errors, successfully labeling some while leaving others as `Community N`. The core issue is that running `graphify label .` again completely wipes out the perfectly valid community names generated in the previous run, forcing the LLM to start from scratch. Sometimes, this leads to communities that were correctly named in the first run reverting back to `Community N` in the second run, creating an endless loop of wasted tokens.

To solve this, I introduced the `--missing-only` flag. When passed, `graphify label .` will first load `.graphify_labels.json`, preserve all successfully named communities, and only query the LLM backend for communities that are missing or still have the `Community N` placeholder.

This ensures a robust, incremental labeling process for very large codebases and saves a massive amount of LLM tokens and API costs. Tested locally on my 7,500+ node graph with perfect success.