### PR TITLE
fix(path): resolve endpoints whole-string like explain, not per-token

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2843,7 +2843,7 @@ def main() -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
-        from graphify.serve import _score_nodes
+        from graphify.serve import _score_nodes, _find_node
         from networkx.readwrite import json_graph
         import networkx as _nx
 
@@ -2868,15 +2868,25 @@ def main() -> None:
             G = json_graph.node_link_graph(_raw, edges="links")
         except TypeError:
             G = json_graph.node_link_graph(_raw)
+        # Resolve each endpoint whole-string first (exact > prefix > substring,
+        # the same precedence `explain` uses via _find_node), and fall back to
+        # the per-token lexical scorer only when the whole-string resolver finds
+        # nothing. _score_nodes tokenises the label and scores per token, so a
+        # multi-word / natural-language endpoint never gets an exact hit; several
+        # nodes then tie and [0] resolves to the wrong one, producing a spurious
+        # "No path found" for a pair that is actually a hop or two apart.
+        src_find = _find_node(G, source_label)
+        tgt_find = _find_node(G, target_label)
         src_scored = _score_nodes(G, [t.lower() for t in source_label.split()])
         tgt_scored = _score_nodes(G, [t.lower() for t in target_label.split()])
-        if not src_scored:
+        if not src_find and not src_scored:
             print(f"No node matching '{source_label}' found.", file=sys.stderr)
             sys.exit(1)
-        if not tgt_scored:
+        if not tgt_find and not tgt_scored:
             print(f"No node matching '{target_label}' found.", file=sys.stderr)
             sys.exit(1)
-        src_nid, tgt_nid = src_scored[0][1], tgt_scored[0][1]
+        src_nid = src_find[0] if src_find else src_scored[0][1]
+        tgt_nid = tgt_find[0] if tgt_find else tgt_scored[0][1]
         # Ambiguity guard: when both queries resolve to the same node, the
         # shortest path is trivially zero hops, which is almost never what the
         # caller wanted (see bug #828).
@@ -2887,8 +2897,13 @@ def main() -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
-        for _name, _scored in (("source", src_scored), ("target", tgt_scored)):
-            if len(_scored) >= 2:
+        # Only the lexical-scorer fallback can be ambiguous; a whole-string
+        # _find_node hit is deterministic (tiered), so skip the warning there.
+        for _name, _find, _scored in (
+            ("source", src_find, src_scored),
+            ("target", tgt_find, tgt_scored),
+        ):
+            if not _find and len(_scored) >= 2:
                 _top, _runner = _scored[0][0], _scored[1][0]
                 if _top > 0 and (_top - _runner) / _top < 0.10:
                     print(

--- a/tests/test_path_cli.py
+++ b/tests/test_path_cli.py
@@ -46,3 +46,64 @@ def test_reverse_arrow(monkeypatch, tmp_path, capsys):
     assert "Shortest path (1 hops):" in out
     assert "validateSanitySession() <--calls [EXTRACTED]-- createPatchHandler()" in out
     assert "validateSanitySession() --calls [EXTRACTED]--> createPatchHandler()" not in out
+
+
+def _write_multiword_graph(tmp_path):
+    """src --contains--> a multi-word concept node, plus a single-token decoy that
+    the per-token lexical scorer ranks first but that is isolated from src."""
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": "src", "label": "alpha", "source_file": "a.py", "community": 0},
+            {"id": "tgt", "label": "beta gamma delta", "source_file": "b.py", "community": 0},
+            # EXACT-matches the "delta" token (1000 * idf) so it outscores the real
+            # multi-token node (prefix 100 + substring 1 + ...); isolated from src.
+            {"id": "decoy", "label": "delta", "source_file": "c.py", "community": 0},
+        ],
+        "links": [
+            {"source": "src", "target": "tgt",
+             "relation": "contains", "confidence": "EXTRACTED"},
+        ],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    return p
+
+
+def test_path_resolves_multiword_endpoint_whole_string(monkeypatch, tmp_path, capsys):
+    """A multi-word / natural-language endpoint must resolve whole-string (the
+    same exact > prefix > substring precedence `explain` uses via _find_node),
+    not via the per-token lexical scorer. Otherwise a single-token EXACT decoy
+    outscores the real node and `path` reports a spurious "No path found" for a
+    pair that is one hop apart."""
+    p = _write_multiword_graph(tmp_path)
+    out = _run(monkeypatch, p, "alpha", "beta gamma delta", capsys)
+    assert "No path found" not in out
+    assert "Shortest path (1 hops):" in out
+    assert "alpha --contains [EXTRACTED]--> beta gamma delta" in out
+
+
+def test_path_falls_back_to_lexical_scorer_when_no_whole_string_match(
+    monkeypatch, tmp_path, capsys
+):
+    """When no node matches the endpoint whole-string, `path` still resolves it
+    via the lexical scorer — partial/fuzzy endpoints keep working."""
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": "src", "label": "alpha", "source_file": "a.py", "community": 0},
+            {"id": "tgt", "label": "payment processor service",
+             "source_file": "b.py", "community": 0},
+        ],
+        "links": [
+            {"source": "src", "target": "tgt",
+             "relation": "contains", "confidence": "EXTRACTED"},
+        ],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    # "payment" only prefix-matches the real label — no whole-string hit.
+    out = _run(monkeypatch, p, "alpha", "payment", capsys)
+    assert "No path found" not in out
+    assert "Shortest path (1 hops):" in out
+    assert "payment processor service" in out


### PR DESCRIPTION
## Problem

`graphify path "<source>" "<target>"` resolves both endpoints with `_score_nodes(...)[0]` (`graphify/__main__.py`). `_score_nodes` tokenises the label and scores per token (EXACT 1000 / PREFIX 100 / SUBSTRING 1, × idf).

A multi-word / natural-language endpoint therefore never gets a whole-string exact hit. A single-token node that EXACT-matches one of the query tokens (1000 × idf) outscores the real multi-token node (prefix 100 + substring 1 + …), so `path` resolves to the wrong node and prints a spurious **"No path found"** for a pair that is actually a hop or two apart.

`explain` does not have this problem — it already resolves whole-string via `_find_node` (exact > prefix > substring).

### Repro

Graph: `src("alpha") --contains--> tgt("beta gamma delta")`, plus an isolated decoy node labelled `"delta"`.

```
$ graphify path "alpha" "beta gamma delta"
No path found between 'alpha' and 'beta gamma delta'.   # decoy "delta" wins the scorer, has no path
```

## Fix

Resolve each endpoint with `_find_node` first (the same exact > prefix > substring whole-string precedence `explain` uses), falling back to the per-token lexical scorer only when the whole-string resolver finds nothing — so partial/fuzzy endpoints keep working.

- Same-node ambiguity guard preserved.
- The "match was ambiguous" warning now fires only on the lexical-scorer fallback (a tiered `_find_node` hit is deterministic, so no false warning).

```
$ graphify path "alpha" "beta gamma delta"
Shortest path (1 hops):
  alpha --contains [EXTRACTED]--> beta gamma delta
```

## Tests

`tests/test_path_cli.py`:
- `test_path_resolves_multiword_endpoint_whole_string` — the repro above (fails before this change).
- `test_path_falls_back_to_lexical_scorer_when_no_whole_string_match` — partial endpoint still resolves via the scorer.

Existing arrow-direction tests (#849) still pass. `pytest tests/test_path_cli.py` → 4 passed.
