### PR TITLE
feat(label-communities): add producer for .graphify_labels.json

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2996,6 +2996,101 @@ def main() -> None:
             nodes_returned=len(connections),
         )
 
+    elif cmd == "label-communities":
+        # Produce human-readable community labels. serve._load_community_labels,
+        # report.py and analyze.py already READ a `.graphify_labels.json` next to
+        # the graph ({community_id: label}) and fall back to "Community <id>" when
+        # it is absent — but nothing WROTE it. This is that missing producer:
+        # deterministic, no-LLM, no new deps. For each Louvain community it picks
+        # the dominant source area + the strongest representative phrase and
+        # writes "<area> · <phrase>".
+        import re as _re
+        from collections import Counter as _Counter, defaultdict as _defaultdict
+
+        graph_path = _default_graph_path()
+        args = sys.argv[2:]
+        for i, a in enumerate(args):
+            if a == "--graph" and i + 1 < len(args):
+                graph_path = args[i + 1]
+        gp = Path(graph_path).resolve()
+        if not gp.exists():
+            print(f"error: graph file not found: {gp}", file=sys.stderr)
+            sys.exit(1)
+        _enforce_graph_size_cap_or_exit(gp)
+        g = json.loads(gp.read_text(encoding="utf-8"))
+        nodes = g.get("nodes", [])
+        links = g.get("links") or g.get("edges") or []
+
+        deg: dict = _defaultdict(int)
+        for e in links:
+            deg[e.get("source")] += 1
+            deg[e.get("target")] += 1
+
+        by_comm: dict = _defaultdict(list)
+        for n in nodes:
+            cid = n.get("community")
+            if cid is not None:
+                by_comm[str(cid)].append(n)
+        if not by_comm:
+            print(
+                "error: no node has a 'community' attribute — run `graphify "
+                "extract` / `graphify cluster` first.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        _generic = {
+            "config", "configuration", "context", "operator", "namespace",
+            "capacity", "steps", "step", "outputs", "output", "deploy", "source",
+            "true", "false", "str", "int", "bool", "none", "null", "layout",
+            "index", "readme", "readme.md", "overview", "introduction", "usage",
+        }
+
+        def _area(source_file: str) -> str:
+            sf = (source_file or "").strip("/")
+            if not sf:
+                return "misc"
+            parts = sf.split("/")
+            # First directory segment, or the bare filename if at the root.
+            return parts[0] if len(parts) > 1 else parts[0]
+
+        def _short(label: str, n: int = 56) -> str:
+            label = _re.sub(r"\s+", " ", str(label)).strip().strip('"')
+            label = _re.sub(r"\s*#+\s*$", "", label)
+            return label[:n] + ("…" if len(label) > n else "")
+
+        labels: dict = {}
+        rows: list = []
+        for cid, members in by_comm.items():
+            area = _Counter(_area(m.get("source_file") or "") for m in members).most_common(1)[0][0]
+
+            def pick(pred, members=members):
+                cands = sorted(
+                    (m for m in members if pred(m)),
+                    key=lambda m: -deg.get(m.get("id"), 0),
+                )
+                for m in cands:
+                    lab = _short(m.get("label") or "")
+                    if lab and lab.lower() not in _generic and not lab.endswith("()"):
+                        return lab
+                return None
+
+            phrase = (
+                pick(lambda m: m.get("file_type") == "concept")
+                or pick(lambda m: m.get("file_type") in ("document", "rationale"))
+                or pick(lambda m: True)
+                or "(mixed)"
+            )
+            labels[cid] = f"{area} · {phrase}"
+            rows.append((cid, len(members), labels[cid]))
+
+        out_path = gp.parent / ".graphify_labels.json"
+        out_path.write_text(json.dumps(labels, ensure_ascii=False, indent=0), encoding="utf-8")
+        rows.sort(key=lambda r: -r[1])
+        print(f"Labeled {len(labels)} communities -> {out_path}")
+        for cid, size, label in rows[:10]:
+            print(f"  community {cid:<5} ({size:>4} nodes)  {label}")
+
     elif cmd == "diagnose":
         subcmd = sys.argv[2] if len(sys.argv) > 2 else ""
         if subcmd != "multigraph":

--- a/tests/test_label_communities_cli.py
+++ b/tests/test_label_communities_cli.py
@@ -1,0 +1,88 @@
+"""Tests for the `graphify label-communities` producer.
+
+serve._load_community_labels / report.py / analyze.py all READ a
+`.graphify_labels.json` next to the graph and fall back to "Community <id>"
+when it is absent. This subcommand is the producer for that file.
+"""
+from __future__ import annotations
+
+import json
+
+import graphify.__main__ as mainmod
+
+
+def _write_graph(tmp_path):
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            # community 0 — billing area, strongest concept = "Payment gateway"
+            {"id": "pg", "label": "Payment gateway", "file_type": "concept",
+             "source_file": "billing/gateway.py", "community": 0},
+            {"id": "charge", "label": "charge()", "file_type": "code",
+             "source_file": "billing/charge.py", "community": 0},
+            {"id": "refund", "label": "refund()", "file_type": "code",
+             "source_file": "billing/refund.py", "community": 0},
+            # community 1 — auth area, strongest concept = "Token validator"
+            {"id": "tv", "label": "Token validator", "file_type": "concept",
+             "source_file": "auth/validator.py", "community": 1},
+            {"id": "login", "label": "login()", "file_type": "code",
+             "source_file": "auth/login.py", "community": 1},
+        ],
+        "links": [
+            {"source": "charge", "target": "pg", "relation": "calls", "confidence": "EXTRACTED"},
+            {"source": "refund", "target": "pg", "relation": "calls", "confidence": "EXTRACTED"},
+            {"source": "login", "target": "tv", "relation": "calls", "confidence": "EXTRACTED"},
+        ],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    return p
+
+
+def _run(monkeypatch, capsys, graph_path):
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        mainmod.sys, "argv",
+        ["graphify", "label-communities", "--graph", str(graph_path)],
+    )
+    mainmod.main()
+    return capsys.readouterr().out
+
+
+def test_label_communities_writes_labels_file(monkeypatch, tmp_path, capsys):
+    graph_path = _write_graph(tmp_path)
+    out = _run(monkeypatch, capsys, graph_path)
+
+    labels_path = tmp_path / ".graphify_labels.json"
+    assert labels_path.exists()
+    labels = json.loads(labels_path.read_text())
+
+    # area · strongest-concept-phrase, highest-degree concept wins.
+    assert labels["0"] == "billing · Payment gateway"
+    assert labels["1"] == "auth · Token validator"
+    assert "Labeled 2 communities" in out
+
+    # Keys must parse back as ints — the exact contract _load_community_labels uses.
+    assert {int(k) for k in labels} == {0, 1}
+
+
+def test_label_communities_errors_without_community_attr(monkeypatch, tmp_path, capsys):
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [{"id": "a", "label": "A", "source_file": "x.py"}],
+        "links": [],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        mainmod.sys, "argv",
+        ["graphify", "label-communities", "--graph", str(p)],
+    )
+    import pytest
+
+    with pytest.raises(SystemExit) as exc:
+        mainmod.main()
+    assert exc.value.code == 1
+    assert "no node has a 'community' attribute" in capsys.readouterr().err


### PR DESCRIPTION
## Problem

`serve._load_community_labels`, `report.py` and `analyze.py` already **read** a `.graphify_labels.json` next to the graph (`{community_id: label}`) and fall back to `"Community <id>"` when it's absent:

```python
# serve.py
def _load_community_labels() -> dict[int, str]:
    labels_path = Path(graph_path).parent / ".graphify_labels.json"
    if labels_path.exists():
        return {int(k): v for k, v in json.loads(labels_path.read_text()).items()}
    return {cid: f"Community {cid}" for cid in communities}
```

But nothing in the toolchain ever **writes** that file — so the read side is effectively dead and every community renders as the opaque integer `Community 42` in `explain`, the MCP resources, the report and suggested questions.

## Fix

Add the missing producer: a `graphify label-communities [--graph path]` subcommand. Deterministic, no LLM, no new dependencies.

For each Louvain community it picks:
- the dominant **source area** (first path segment of `source_file`), and
- the strongest **representative phrase** — highest-degree `concept` node, else `document`/`rationale`, else any non-generic, non-`foo()` label

and writes `<area> · <phrase>` to `.graphify_labels.json` (the exact file/format the read side expects). Errors clearly if no node has a `community` attribute yet (run `extract`/`cluster` first).

```
$ graphify label-communities --graph graph.json
Labeled 1425 communities -> .../.graphify_labels.json
  community 0     ( 530 nodes)  billing · Payment gateway
  community 4     ( 206 nodes)  agent · LangGraph orchestration for infrastructure tasks
  ...
```

## Tests

`tests/test_label_communities_cli.py`:
- writes `.graphify_labels.json` with `<area> · <concept>` labels, int-parseable keys (the `_load_community_labels` contract);
- errors when the graph has no `community` attribute.

`pytest tests/test_label_communities_cli.py` → 2 passed.
