### PR TITLE
fix: catch OSError when Cargo.toml is missing during --cargo introspection

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -4395,7 +4395,7 @@ def main() -> None:
             print("[graphify extract] introspecting Cargo workspace...")
             try:
                 cargo_result = introspect_cargo(target)
-            except (ConnectionError, ImportError) as exc:
+            except (ConnectionError, ImportError, OSError) as exc:
                 print(f"error: {exc}", file=sys.stderr)
                 sys.exit(1)
             print(f"[graphify extract] Cargo: {len(cargo_result['nodes'])} nodes, "


### PR DESCRIPTION
Small, isolated fix: catches a missing-file error that currently crashes `--cargo` with a raw traceback instead of a clean message. One-line change, no new behavior, no risk to existing functionality.

**Before:** `--cargo` on a missing `Cargo.toml` crashes with a raw 10-line Python traceback — confusing for anyone who just typo'd a path.

**After:** Same situation now exits with one clean line: `error: [Errno 2] No such file or directory: '...\Cargo.toml'` — and exit code 1, so scripts/CI calling this still detect failure correctly.

## Problem
`graphify extract <path> --cargo` against a folder with no `Cargo.toml` throws a raw, unhandled `FileNotFoundError` straight at the user:
FileNotFoundError: [Errno 2] No such file or directory: 'C:\path\Cargo.toml'
A typo'd path or running `--cargo` one directory too high gets you a 10-line traceback instead of a sentence telling you what went wrong.

## Root cause
`introspect_cargo()` opens `Cargo.toml` directly, so a missing file raises `FileNotFoundError` — a subclass of `OSError`. The call site in `__main__.py` only catches `ConnectionError` and `ImportError`, so this one slips through uncaught.

## Testing
- Missing `Cargo.toml` → `error: [Errno 2] No such file or directory: '...\Cargo.toml'`, exit code 1, no traceback
- Valid `Cargo.toml` → introspection still runs and extracts crate nodes exactly as before
- `pytest`, `ruff check`, `pyright` all green on the changed file