### PR TITLE
fix: resolve F821 undefined name 'nx' in prs.py

### DIFF
--- a/graphify/prs.py
+++ b/graphify/prs.py
@@ -25,6 +25,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import networkx as nx
 
 
 # ── ANSI colours ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
`ruff check .` was failing because `prs.py` type-hints `"nx.Graph"` but never actually imports `nx`. The string annotation hides this at runtime, but ruff still needs the name resolvable for static analysis.

Fixed by adding a `TYPE_CHECKING`-only import of `networkx as nx` at the top of the file. No real import added, no runtime cost, no behavior change — just satisfies the linter.

Verified 
`ruff check .`, `pyright`, and `pytest` all pass clean after the change.
This was the only thing keeping CI from going green.

- `ruff check .` — clean
- `pyright` — no new issues
- `pytest` — unaffected

Small fix, but it's currently the only thing standing between a green and red CI baseline.