### PR TITLE
transcribe: cap yt-dlp download size (max_filesize) to limit resource/SSRF abuse

### DIFF
--- a/graphify/transcribe.py
+++ b/graphify/transcribe.py
@@ -31,6 +31,17 @@ def _get_whisper():
         ) from exc
 
 
+_DEFAULT_YTDLP_MAX_BYTES = 1024 * 1024 * 1024  # 1 GiB
+
+
+def _ytdlp_max_filesize() -> int:
+    """Max bytes yt-dlp may download. Override with GRAPHIFY_YTDLP_MAX_FILESIZE."""
+    raw = os.environ.get("GRAPHIFY_YTDLP_MAX_FILESIZE", "").strip()
+    if raw.isdigit() and int(raw) > 0:
+        return int(raw)
+    return _DEFAULT_YTDLP_MAX_BYTES
+
+
 def _get_yt_dlp():
     try:
         import yt_dlp
@@ -70,12 +81,20 @@ def download_audio(url: str, output_dir: Path) -> Path:
             print(f"  cached audio: {candidate.name}")
             return candidate
 
+    # NOTE: validate_url() above only vets the INITIAL url. yt-dlp resolves hosts
+    # and follows redirects itself, so an open redirect or DNS rebinding could
+    # still reach an internal host — full SSRF isolation needs a network sandbox
+    # (egress allowlist), which is out of scope here. max_filesize reduces the
+    # blast radius of a malicious/oversized target — best-effort: yt-dlp aborts
+    # when the announced size (Content-Length) exceeds the cap, but cannot
+    # hard-stop a stream of unknown/chunked size.
     ydl_opts = {
         'format': 'bestaudio[ext=m4a]/bestaudio/best',
         'outtmpl': out_template,
         'quiet': True,
         'no_warnings': True,
         'noplaylist': True,
+        'max_filesize': _ytdlp_max_filesize(),
         'postprocessors': [],  # no ffmpeg needed — use native audio
     }
 

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -62,6 +62,59 @@ def test_build_whisper_prompt_nodes_without_labels():
 
 
 # ---------------------------------------------------------------------------
+# download_audio — resource/SSRF hardening
+# ---------------------------------------------------------------------------
+
+class _FakeYDL:
+    """Context-manager stand-in for yt_dlp.YoutubeDL that captures its opts."""
+    captured: dict = {}
+
+    def __init__(self, opts):
+        type(self).captured = opts
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def extract_info(self, url, download):
+        return {"ext": "m4a"}
+
+
+def _patch_ytdlp(monkeypatch):
+    fake_mod = MagicMock()
+    fake_mod.YoutubeDL = _FakeYDL
+    monkeypatch.setattr("graphify.transcribe._get_yt_dlp", lambda: fake_mod)
+    # validate_url is imported inside download_audio from graphify.security
+    monkeypatch.setattr("graphify.security.validate_url", lambda url: None)
+
+
+def test_download_audio_caps_file_size(tmp_path, monkeypatch):
+    """download_audio must pass a positive max_filesize cap to yt-dlp.
+
+    Without a cap, a malicious or oversized media URL can exhaust disk/bandwidth
+    even though validate_url() rejects private-IP/bad-scheme initial URLs.
+    """
+    from graphify.transcribe import download_audio
+    _patch_ytdlp(monkeypatch)
+    download_audio("https://example.com/video", tmp_path)
+    opts = _FakeYDL.captured
+    assert "max_filesize" in opts, "ydl_opts must set max_filesize"
+    assert isinstance(opts["max_filesize"], int) and opts["max_filesize"] > 0
+    assert opts.get("noplaylist") is True
+
+
+def test_download_audio_max_filesize_env_override(tmp_path, monkeypatch):
+    """GRAPHIFY_YTDLP_MAX_FILESIZE overrides the default cap."""
+    from graphify.transcribe import download_audio
+    _patch_ytdlp(monkeypatch)
+    monkeypatch.setenv("GRAPHIFY_YTDLP_MAX_FILESIZE", "12345")
+    download_audio("https://example.com/video", tmp_path)
+    assert _FakeYDL.captured["max_filesize"] == 12345
+
+
+# ---------------------------------------------------------------------------
 # transcribe
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`download_audio()` (URL → audio for transcription) passes a `max_filesize` cap to yt-dlp.
Default 1 GiB, overridable via `GRAPHIFY_YTDLP_MAX_FILESIZE` (bytes).

## Why

`validate_url()` is called before yt-dlp and rejects private-IP / bad-scheme **initial**
URLs. But yt-dlp then resolves hosts and follows redirects on its own, outside graphify's
SSRF handlers — so an open redirect / DNS rebinding, or simply an oversized media target,
can still cause disk/bandwidth exhaustion. Capping the download size bounds that blast radius.

## Honesty / scope

- `max_filesize` is **best-effort**: yt-dlp aborts when the *announced* size (`Content-Length`)
  exceeds the cap, but it cannot hard-stop a stream of unknown/chunked size. The added code
  comment says exactly this.
- This does **not** fully close the redirect / DNS-rebinding SSRF vector — that needs running
  yt-dlp under a network sandbox (egress allowlist), which is out of scope here. The comment
  documents the residual limitation.
- A follow-up integration test (real `yt_dlp.YoutubeDL` + a local server advertising
  `Content-Length > cap`) would prove enforcement end-to-end; happy to add it if you'd like.

## Tests

Two unit tests in `tests/test_transcribe.py` (opts wiring + env override). Full suite green:
`2231 passed, 28 skipped`.
