### PR TITLE
feat(haskell): add tree-sitter-haskell language support

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -27,7 +27,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = str(out_path("manifest.json"))
 
-CODE_EXTENSIONS = {'.py', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.ejs', '.ets', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.cu', '.cuh', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.psm1', '.psd1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.svh', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json', '.tf', '.tfvars', '.hcl', '.dm', '.dme', '.dmi', '.dmm', '.dmf', '.sln', '.slnx', '.csproj', '.fsproj', '.vbproj', '.razor', '.cshtml', '.cls', '.trigger'}
+CODE_EXTENSIONS = {'.py', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.ejs', '.ets', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.cu', '.cuh', '.rb', '.swift', '.kt', '.kts', '.hs', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.psm1', '.psd1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.svh', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json', '.tf', '.tfvars', '.hcl', '.dm', '.dme', '.dmi', '.dmm', '.dmf', '.sln', '.slnx', '.csproj', '.fsproj', '.vbproj', '.razor', '.cshtml', '.cls', '.trigger'}
 DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.txt', '.rst', '.html', '.yaml', '.yml'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1636,6 +1636,35 @@ def _import_kotlin(node, source: bytes, file_nid: str, stem: str, edges: list, s
             break
 
 
+def _import_haskell(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str) -> None:
+    # Haskell `import` nodes carry the module path in a `module` field
+    # (`import Data.Map as Map` -> module=`Data.Map`). Mirror the Kotlin handler:
+    # anchor an `imports` edge to the file and key the target on the last dotted
+    # segment (Data.Map.Strict -> Strict) for parity with the other languages.
+    mod_node = node.child_by_field_name("module")
+    if mod_node is None:
+        for child in node.children:
+            if child.type in ("module", "qualified"):
+                mod_node = child
+                break
+    if mod_node is None:
+        return
+    raw = _read_text(mod_node, source)
+    module_name = raw.split(".")[-1].strip()
+    if module_name:
+        tgt_nid = _make_id(module_name)
+        edges.append({
+            "source": file_nid,
+            "target": tgt_nid,
+            "relation": "imports",
+            "context": "import",
+            "confidence": "EXTRACTED",
+            "source_file": str_path,
+            "source_location": f"L{node.start_point[0] + 1}",
+            "weight": 1.0,
+        })
+
+
 def _import_scala(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str) -> None:
     for child in node.children:
         if child.type in ("stable_id", "identifier"):
@@ -2187,6 +2216,34 @@ _KOTLIN_CONFIG = LanguageConfig(
     body_fallback_child_types=("function_body", "class_body"),
     function_boundary_types=frozenset({"function_declaration"}),
     import_handler=_import_kotlin,
+)
+
+_HASKELL_CONFIG = LanguageConfig(
+    ts_module="tree_sitter_haskell",
+    # data/newtype/type-synonym/class/instance all expose a `name` field and act
+    # as containers. NOTE: `type_synomym` is the grammar's real (misspelled) node
+    # type — do not "fix" it.
+    class_types=frozenset({"data_type", "newtype", "type_synomym", "class", "instance"}),
+    # `function` and `bind` are value definitions. `signature` (the type sig) is
+    # deliberately excluded — and crucially, a function *type* `a -> b` is ALSO a
+    # `function` node nested under `signature`. We rely on `name_field="name"`
+    # (present only on real definitions) with NO name fallback, so type-level
+    # `function` nodes resolve to no name and are skipped.
+    function_types=frozenset({"function", "bind"}),
+    import_types=frozenset({"import"}),
+    # Haskell application nests (`f x y` -> apply(apply(f, x), y)) and uses no
+    # member-accessor syntax. We also treat bare `variable`/`qualified` leaves as
+    # calls so higher-order uses (`map area xs`) attribute `area` to the caller.
+    # The dedicated walk_calls branch (keyed on tree_sitter_haskell) resolves all
+    # three node types; only in-file names produce edges, the rest are cross-file.
+    call_types=frozenset({"apply", "variable", "qualified"}),
+    call_function_field="function",
+    name_field="name",
+    name_fallback_child_types=(),
+    body_field="",
+    body_fallback_child_types=("match",),
+    function_boundary_types=frozenset({"function", "bind"}),
+    import_handler=_import_haskell,
 )
 
 _SCALA_CONFIG = LanguageConfig(
@@ -3552,6 +3609,25 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                                 if child.type == "identifier":
                                     callee_name = _read_text(child, source)
                                     break
+            elif config.ts_module == "tree_sitter_haskell":
+                # Application nests (`f x y` -> apply(apply(f, x), y)); the direct
+                # callee is the leftmost leaf reached by descending the `function`
+                # field. Bare `variable`/`qualified` leaves are also in call_types
+                # so higher-order uses (the `area` in `map area xs`) attribute to
+                # the caller. Strip the module qualifier (Map.insert -> insert).
+                if node.type == "apply":
+                    cur = node
+                    while cur is not None and cur.type == "apply":
+                        cur = cur.child_by_field_name("function")
+                    if cur is not None:
+                        if cur.type in ("variable", "name"):
+                            callee_name = _read_text(cur, source)
+                        elif cur.type in ("qualified", "constructor"):
+                            callee_name = _read_text(cur, source).rsplit(".", 1)[-1]
+                elif node.type == "variable":
+                    callee_name = _read_text(node, source)
+                elif node.type == "qualified":
+                    callee_name = _read_text(node, source).rsplit(".", 1)[-1]
             elif config.ts_module == "tree_sitter_c_sharp" and node.type == "invocation_expression":
                 # C#: try name field, then first named child
                 name_node = node.child_by_field_name("name")
@@ -4588,6 +4664,11 @@ def extract_apex(path: Path) -> dict:
 def extract_kotlin(path: Path) -> dict:
     """Extract classes, objects, functions, and imports from a .kt/.kts file."""
     return _extract_generic(path, _KOTLIN_CONFIG)
+
+
+def extract_haskell(path: Path) -> dict:
+    """Extract data types, classes, functions, and imports from a .hs file."""
+    return _extract_generic(path, _HASKELL_CONFIG)
 
 
 def extract_scala(path: Path) -> dict:
@@ -12389,6 +12470,7 @@ _DISPATCH: dict[str, Any] = {
     ".cs": extract_csharp,
     ".kt": extract_kotlin,
     ".kts": extract_kotlin,
+    ".hs": extract_haskell,
     ".scala": extract_scala,
     ".php": extract_php,
     ".swift": extract_swift,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "tree-sitter-ruby>=0.23,<0.25",
     "tree-sitter-c-sharp>=0.23,<0.25",
     "tree-sitter-kotlin>=1.0,<2.0",
+    "tree-sitter-haskell>=0.23,<0.24",
     "tree-sitter-scala>=0.23,<0.27",
     "tree-sitter-php>=0.23,<0.25",
     "tree-sitter-swift>=0.7,<0.9",

--- a/tests/fixtures/sample.hs
+++ b/tests/fixtures/sample.hs
@@ -1,0 +1,24 @@
+module Sample where
+
+import Data.List (sort)
+import qualified Data.Map as Map
+import Control.Monad (forM_)
+
+data Shape = Circle Double | Square Double
+
+class Describable a where
+  describe :: a -> String
+
+instance Describable Shape where
+  describe (Circle r) = "circle"
+  describe (Square s) = "square"
+
+area :: Shape -> Double
+area (Circle r) = 3.14 * r * r
+area (Square s) = s * s
+
+totalArea :: [Shape] -> Double
+totalArea shapes = sum (map area shapes)
+
+main :: IO ()
+main = forM_ [Circle 1.0] (\s -> putStrLn (describe s))

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from graphify.extract import (
     extract_java, extract_c, extract_cpp, extract_ruby,
-    extract_csharp, extract_kotlin, extract_scala, extract_php,
+    extract_csharp, extract_kotlin, extract_haskell, extract_scala, extract_php,
     extract_swift, extract_go, extract_julia, extract_js, extract_fortran,
     extract_groovy, extract_sln, extract_csproj, extract_razor,
     extract_dm, extract_dmi, extract_dmm, extract_dmf,
@@ -420,6 +420,63 @@ def test_kotlin_parameter_return_generic_and_field_contexts():
     assert ("run", "Result") in _edge_labels(r, "references", "return_type")
     assert ("run", "DataProcessor") in _edge_labels(r, "references", "generic_arg")
     assert ("DataProcessor", "Result") in _edge_labels(r, "references", "field")
+
+
+# ── Haskell ───────────────────────────────────────────────────────────────────
+
+_needs_haskell = pytest.mark.skipif(
+    _ilu.find_spec("tree_sitter_haskell") is None,
+    reason="tree-sitter-haskell not installed",
+)
+
+
+@_needs_haskell
+def test_haskell_no_error():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    assert "error" not in r
+
+
+@_needs_haskell
+def test_haskell_finds_data_type():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    assert any("Shape" in l for l in _labels(r))
+
+
+@_needs_haskell
+def test_haskell_finds_class():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    assert any("Describable" in l for l in _labels(r))
+
+
+@_needs_haskell
+def test_haskell_finds_functions():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    labels = _labels(r)
+    assert any("area" in l for l in labels)
+    assert any("totalArea" in l for l in labels)
+    assert any("main" in l for l in labels)
+
+
+@_needs_haskell
+def test_haskell_excludes_type_level_signatures():
+    """A function *type* (`Shape -> Double`) is a `function` node nested under
+    `signature`; it must not be mistaken for a value definition (no `Double()`)."""
+    r = extract_haskell(FIXTURES / "sample.hs")
+    assert not any(_normalize_symbol_label(l) == "Double" for l in _labels(r))
+
+
+@_needs_haskell
+def test_haskell_emits_imports():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    assert "imports" in _relations(r)
+
+
+@_needs_haskell
+def test_haskell_emits_in_file_call():
+    """totalArea applies `area` as a higher-order argument (`map area shapes`);
+    the apply/variable call-walker branch must attribute area to totalArea."""
+    r = extract_haskell(FIXTURES / "sample.hs")
+    assert ("totalArea()", "area()") in _calls(r)
 
 
 # ── Scala ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds Haskell (`.hs`) as a first-class extracted language, following the existing `LanguageConfig`/`_extract_generic` pattern (modeled on Kotlin).

## What's included
- **`tree-sitter-haskell>=0.23,<0.24`** as a core dependency (abi3 wheels exist for all platforms).
- **`_HASKELL_CONFIG`** — maps `data_type`/`newtype`/`type_synomym`/`class`/`instance` → containers, `function`/`bind` → functions, `import` → imports, `apply`/`variable`/`qualified` → calls.
- **`_import_haskell`** — reads the `import` node's `module` field (Haskell-specific; Kotlin uses `path`).
- **A Haskell branch in `walk_calls`** — Haskell application nests (`f x y` → `apply(apply(f, x), y)`), so it descends the leftmost `function` field for the direct callee, and also treats bare `variable`/`qualified` leaves as calls so higher-order uses (the `area` in `map area xs`) attribute to the caller.
- `extract_haskell`, `.hs` in `_DISPATCH`, `.hs` in `detect.CODE_EXTENSIONS`.
- Fixture `tests/fixtures/sample.hs` + 7 tests (skipif when the grammar is absent).

## Two grammar gotchas handled
1. In tree-sitter-haskell a function *type* (`Shape -> Double`) is **also** a `function` node (nested under `signature`). A naïve config emits a spurious `Double()` "function". Fixed by `name_fallback_child_types=()` so type-level nodes (which lack a `name` field) are skipped. Regression test included.
2. `type_synomym` is the grammar's real (misspelled) node-type string — kept verbatim, not "corrected".

## Verification
- 7 Haskell tests pass; full `test_languages.py` = 257 passed, 13 skipped (optional `tree-sitter-dm`), no regressions.
- Exercised on a large real Haskell codebase (~470 `.hs` files): clean parse, with data types, classes, functions, imports, and cross-function call edges (e.g. `updateS7TagMonitor → resolveUpdateDataType`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)