### PR TITLE
feat: extract Metal (.metal) kernels into the graph

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -335,7 +335,7 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
                 ".ts": "js", ".tsx": "js",
                 ".go": "go", ".rs": "rs",
                 ".java": "jvm", ".kt": "jvm", ".scala": "jvm", ".groovy": "jvm",
-                ".c": "c", ".h": "c", ".cc": "cpp", ".cpp": "cpp", ".hpp": "cpp",
+                ".c": "c", ".h": "c", ".cc": "cpp", ".cpp": "cpp", ".hpp": "cpp", ".metal": "cpp",
                 ".rb": "rb", ".php": "php", ".cs": "cs", ".swift": "swift", ".lua": "lua",
             }
             src_ext = Path(G.nodes[src].get("source_file") or "").suffix.lower()

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -27,7 +27,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = str(out_path("manifest.json"))
 
-CODE_EXTENSIONS = {'.py', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.ejs', '.ets', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.cu', '.cuh', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.psm1', '.psd1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.svh', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json', '.tf', '.tfvars', '.hcl', '.dm', '.dme', '.dmi', '.dmm', '.dmf', '.sln', '.slnx', '.csproj', '.fsproj', '.vbproj', '.razor', '.cshtml', '.cls', '.trigger'}
+CODE_EXTENSIONS = {'.py', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.ejs', '.ets', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.cu', '.cuh', '.metal', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.psm1', '.psd1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.svh', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json', '.tf', '.tfvars', '.hcl', '.dm', '.dme', '.dmi', '.dmm', '.dmf', '.sln', '.slnx', '.csproj', '.fsproj', '.vbproj', '.razor', '.cshtml', '.cls', '.trigger'}
 DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.txt', '.rst', '.html', '.yaml', '.yml'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -12494,6 +12494,7 @@ _DISPATCH: dict[str, Any] = {
     ".hpp": extract_cpp,
     ".cu": extract_cpp,
     ".cuh": extract_cpp,
+    ".metal": extract_cpp,  # Metal Shading Language is C++14 — reuse cpp extractor (CUDA precedent)
     ".rb": extract_ruby,
     ".cs": extract_csharp,
     ".kt": extract_kotlin,

--- a/tests/fixtures/sample.metal
+++ b/tests/fixtures/sample.metal
@@ -1,0 +1,21 @@
+#include <metal_stdlib>
+using namespace metal;
+
+struct Vec3 {
+    float x;
+    float y;
+    float z;
+};
+
+float dot3(const Vec3 a, const Vec3 b) {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+kernel void saxpy(
+    device const float* x [[buffer(0)]],
+    device float* y [[buffer(1)]],
+    constant float& a [[buffer(2)]],
+    uint i [[thread_position_in_grid]]
+) {
+    y[i] = a * x[i] + y[i];
+}

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -257,6 +257,23 @@ def test_cuda_host_call_edges():
     assert ("main()", "host_norm()") in calls
 
 
+# Metal Shading Language is C++14, so .metal routes through the C++
+# (tree-sitter-cpp) extractor, exactly like CUDA. ERROR nodes around Metal
+# qualifiers ([[buffer(0)]], kernel) are expected and harmless.
+
+def test_metal_no_error():
+    r = extract_cpp(FIXTURES / "sample.metal")
+    assert "error" not in r
+
+def test_metal_finds_struct():
+    r = extract_cpp(FIXTURES / "sample.metal")
+    assert any("Vec3" in l for l in _labels(r))
+
+def test_metal_finds_function():
+    r = extract_cpp(FIXTURES / "sample.metal")
+    assert any("dot3" in l for l in _labels(r))
+
+
 # ── Ruby ─────────────────────────────────────────────────────────────────────
 
 def test_ruby_no_error():


### PR DESCRIPTION

## What

Adds Metal Shading Language (`.metal`) support to graphify by routing it through
the **existing C++ extractor** — the exact reuse pattern CUDA's `.cu`/`.cuh`
already follow. MSL is C++14, so `extract_cpp` (tree-sitter-cpp) handles it with
no new grammar. ERROR nodes around Metal-specific qualifiers (`kernel`,
`[[buffer(0)]]`) are expected and harmless, just as they are for CUDA's
`__global__`/`__device__`.

## Why

Before this change graphify classified `.metal` as non-code and skipped it
entirely, so MLX/Metal compute kernels never appeared in the graph. This lets
them join it like any other source.

## Approach

Mirror CUDA. No dedicated Metal grammar — deferred. ~3-line change across the
same three touchpoints CUDA uses.

## Edits (3 touchpoints)

1. `graphify/detect.py` — `'.metal'` added to `CODE_EXTENSIONS` (next to `.cu`/`.cuh`).
2. `graphify/extract.py` — `".metal": extract_cpp` in the extension→extractor dict.
3. `graphify/build.py` — `".metal": "cpp"` in `_LANG_FAMILY`, so Metal↔C++ count
   as one family for cross-language seam / import resolution.

Plus a contract test + `tests/fixtures/sample.metal` (a real MSL snippet: a
`struct` + a `dot3` function + a `saxpy` kernel).

## Evidence (before → after)

**Contract test** (`tests/test_languages.py`, mirrors the cpp/CUDA tests):
`extract_cpp(FIXTURES / "sample.metal")` — `error` absent, `Vec3` struct and
`dot3` function both appear in nodes. Symbols graphify produced nothing for before.

**E2e** — `GRAPHIFY_OUT=<tmp> graphify update <dir-with-.metal>` on a dir
containing one `kernel.metal`:

| | graph.json | metal-source nodes |
|---|---|---|
| **before** (origin/v8) | not created — `No code files found - nothing to rebuild` | **0** (skipped) |
| **after** (this branch) | `Rebuilt: 11 nodes, 10 edges, 4 communities` | **7** |

After-state metal nodes: `kernel.metal`, `Vec3`, `x`, `y`, `z`, `dot3()`, `saxpy()`.

**Test gate** — `uv run pytest` (full suite): **2351 passed, 28 skipped**
(includes 3 new `test_metal_*`). `ruff check` on changed files: clean.

## Notes

- cpp-reuse, not a new extractor — CUDA precedent; `extract_cpp` is the point.
- Dedicated Metal grammar deferred.
- Branched off `v8`; pushed to fork `GoodOlClint`. PR not opened.
