### PR TITLE
fix(packaging): include extractor subpackage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ dev = [
 package = true
 
 [tool.setuptools]
-packages = ["graphify"]
+packages = ["graphify", "graphify.extractors"]
 include-package-data = false
 
 [tool.setuptools.package-data]

--- a/tests/test_wheel_packaging.py
+++ b/tests/test_wheel_packaging.py
@@ -52,6 +52,18 @@ def _expected_artifacts() -> list[Path]:
     return bodies + refs + always
 
 
+def _expected_python_modules() -> list[Path]:
+    """Every committed package module must ship in the wheel.
+
+    A manually curated setuptools package list can accidentally omit subpackages
+    while source-tree pytest still passes. The installed CLI then fails at import
+    time, which is what this guard prevents.
+    """
+    modules = sorted(PKG.rglob("*.py"))
+    assert modules, "no package Python modules found — packaging test mis-wired"
+    return modules
+
+
 @pytest.fixture(scope="module")
 def wheel_namelist(tmp_path_factory) -> set[str]:
     if not _has_build():
@@ -81,4 +93,18 @@ def test_skill_artifact_ships_in_wheel(artifact: Path, wheel_namelist: set[str])
         f"{rel} is committed in the repo but NOT in the built wheel — "
         f"`graphify install` would hard-exit for this host. Check the "
         f"[tool.setuptools.package-data] globs in pyproject.toml."
+    )
+
+
+@pytest.mark.parametrize(
+    "module",
+    _expected_python_modules(),
+    ids=lambda p: str(p.relative_to(PKG)),
+)
+def test_python_module_ships_in_wheel(module: Path, wheel_namelist: set[str]) -> None:
+    rel = "graphify/" + module.relative_to(PKG).as_posix()
+    assert rel in wheel_namelist, (
+        f"{rel} is committed in the repo but NOT in the built wheel — "
+        f"installed graphify commands may fail with ModuleNotFoundError. Check "
+        f"the [tool.setuptools].packages list in pyproject.toml."
     )


### PR DESCRIPTION
## Problem

The current wheel declares only `packages = ["graphify"]`, but `graphify.extract` now imports `graphify.extractors.base`.

A source-tree test run passes because the package is importable from the checkout, but an installed git package can fail at runtime:

```text
ModuleNotFoundError: No module named 'graphify.extractors'
```

One minimal install-time repro is:

```bash
uvx --isolated --from git+https://github.com/safishamsi/graphify.git@v8 graphify extract . --no-cluster --out .
```

## Change

- Include `graphify.extractors` in the setuptools package list.
- Extend the wheel packaging guard so every committed `graphify/**/*.py` module must be present in the built wheel, not only the Markdown skill artifacts.

## Verification

- `uv run pytest tests/test_wheel_packaging.py`
- `uv run graphify update .`
