### PR TITLE
feat: add XAML extraction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ To remove graphify from all platforms at once: `graphify uninstall` (add `--purg
 
 | Type | Extensions |
 |------|-----------|
-| Code (36 tree-sitter grammars) | `.py .ts .js .jsx .tsx .mjs .go .rs .java .c .cpp .h .hpp .cu .cuh .rb .cs .kt .scala .php .swift .lua .luau .zig .ps1 .psm1 .ex .exs .m .mm .jl .vue .svelte .astro .groovy .gradle .dart .v .sv .svh .sql .f .f90 .f95 .f03 .f08 .pas .pp .dpr .dpk .lpr .inc .dfm .lfm .lpk .sh .bash .json .dm .dme .dmi .dmm .dmf .sln .slnx .csproj .fsproj .vbproj .razor .cshtml` (`.dm`/`.dme` requires `uv tool install graphifyy[dm]`; CUDA `.cu`/`.cuh` reuse the C++ grammar) |
+| Code (36 tree-sitter grammars) | `.py .ts .js .jsx .tsx .mjs .go .rs .java .c .cpp .h .hpp .cu .cuh .rb .cs .kt .scala .php .swift .lua .luau .zig .ps1 .psm1 .ex .exs .m .mm .jl .vue .svelte .astro .groovy .gradle .dart .v .sv .svh .sql .f .f90 .f95 .f03 .f08 .pas .pp .dpr .dpk .lpr .inc .dfm .lfm .lpk .sh .bash .json .dm .dme .dmi .dmm .dmf .sln .slnx .csproj .fsproj .vbproj .xaml .razor .cshtml` (`.dm`/`.dme` requires `uv tool install graphifyy[dm]`; CUDA `.cu`/`.cuh` reuse the C++ grammar) |
 | Salesforce Apex | `.cls .trigger` (regex-based; classes, interfaces, enums, methods, triggers, SOQL/DML edges) |
 | Terraform / HCL | `.tf .tfvars .hcl` (requires `uv tool install graphifyy[terraform]`) |
 | MCP configs | `.mcp.json` `mcp.json` `mcp_servers.json` `claude_desktop_config.json` — extracts server nodes, package refs, env var requirements |

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -27,7 +27,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = str(out_path("manifest.json"))
 
-CODE_EXTENSIONS = {'.py', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.ejs', '.ets', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.cu', '.cuh', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.psm1', '.psd1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.svh', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json', '.tf', '.tfvars', '.hcl', '.dm', '.dme', '.dmi', '.dmm', '.dmf', '.sln', '.slnx', '.csproj', '.fsproj', '.vbproj', '.razor', '.cshtml', '.cls', '.trigger'}
+CODE_EXTENSIONS = {'.py', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.ejs', '.ets', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.cu', '.cuh', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.psm1', '.psd1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.svh', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json', '.tf', '.tfvars', '.hcl', '.dm', '.dme', '.dmi', '.dmm', '.dmf', '.sln', '.slnx', '.csproj', '.fsproj', '.vbproj', '.xaml', '.razor', '.cshtml', '.cls', '.trigger'}
 DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.txt', '.rst', '.html', '.yaml', '.yml'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -11036,6 +11036,213 @@ def extract_csproj(path: Path) -> dict:
     return {"nodes": nodes, "edges": edges}
 
 
+def _xml_local_name(name: str) -> str:
+    return name.rsplit("}", 1)[-1] if name.startswith("{") else name
+
+
+def _xaml_codebehind_path(path: Path) -> Path | None:
+    expected = path.with_suffix(path.suffix + ".cs")
+    if expected.exists():
+        return expected
+    try:
+        for sibling in path.parent.iterdir():
+            if sibling.name.casefold() == expected.name.casefold():
+                return sibling
+    except OSError:
+        return None
+    return None
+
+
+def _xaml_codebehind_symbols(
+    path: Path,
+    class_name: str | None,
+) -> tuple[dict | None, dict[str, dict], list[dict]]:
+    codebehind = _xaml_codebehind_path(path)
+    if not codebehind:
+        return None, {}, []
+    result = extract_csharp(codebehind)
+    if result.get("error"):
+        return None, {}, []
+
+    class_simple = class_name.rsplit(".", 1)[-1] if class_name else None
+    class_node = None
+    if class_simple:
+        for node in result.get("nodes", []):
+            if node.get("label") == class_simple:
+                class_node = node
+                break
+
+    class_method_edges: list[dict] = []
+    if class_node:
+        class_id = class_node.get("id")
+        for edge in result.get("edges", []):
+            if edge.get("source") == class_id and edge.get("relation") == "method":
+                class_method_edges.append(edge)
+    method_ids = {edge.get("target") for edge in class_method_edges} if class_node else None
+    methods: dict[str, dict] = {}
+    for node in result.get("nodes", []):
+        if method_ids is not None and node.get("id") not in method_ids:
+            continue
+        label = str(node.get("label", ""))
+        if label.startswith(".") and label.endswith("()"):
+            methods[label.strip("()").lstrip(".")] = node
+    return class_node, methods, class_method_edges
+
+
+def extract_xaml(path: Path) -> dict:
+    """Extract WPF/XAML structure, bindings, x:Class, and event handler references."""
+    import xml.etree.ElementTree as ET
+
+    try:
+        src = path.read_bytes()
+    except OSError:
+        return {"nodes": [], "edges": [], "error": f"cannot read {path}"}
+
+    if len(src) > _PROJECT_XML_MAX_BYTES:
+        return {"nodes": [], "edges": [], "error": "xaml file too large"}
+    if not _project_xml_is_safe(src):
+        return {"nodes": [], "edges": [],
+                "error": "refusing XML with DOCTYPE/ENTITY declaration"}
+
+    try:
+        tree = ET.fromstring(src)
+    except ET.ParseError as e:
+        return {"nodes": [], "edges": [], "error": f"XML parse error: {e}"}
+
+    text = src.decode("utf-8", errors="replace")
+    lines = text.splitlines()
+    str_path = str(path)
+    stem = _file_stem(path)
+    file_nid = _make_id(str(path))
+    root_type = _xml_local_name(tree.tag)
+    root_nid = _make_id(stem, root_type)
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen_ids: set[str] = set()
+    seen_edges: set[tuple[str, str, str, str | None]] = set()
+
+    def line_for(value: str | None) -> int:
+        if value:
+            for idx, line in enumerate(lines, 1):
+                if value in line:
+                    return idx
+        return 1
+
+    def add_node(
+        nid: str,
+        label: str,
+        line: int | None,
+        *,
+        file_type: str = "code",
+        source_file: str = str_path,
+    ) -> None:
+        if nid in seen_ids:
+            return
+        seen_ids.add(nid)
+        nodes.append({
+            "id": nid, "label": label, "file_type": file_type,
+            "source_file": source_file,
+            "source_location": f"L{line}" if line else None,
+        })
+
+    def add_existing_node(node: dict | None) -> None:
+        if not node:
+            return
+        nid = node.get("id")
+        if not nid or nid in seen_ids:
+            return
+        seen_ids.add(nid)
+        nodes.append(dict(node))
+
+    def add_edge(
+        src_nid: str,
+        tgt_nid: str,
+        relation: str,
+        line: int,
+        *,
+        context: str | None = None,
+        source_file: str = str_path,
+    ) -> None:
+        key = (src_nid, tgt_nid, relation, context)
+        if key in seen_edges:
+            return
+        seen_edges.add(key)
+        edge = {
+            "source": src_nid, "target": tgt_nid, "relation": relation,
+            "confidence": "EXTRACTED", "source_file": source_file,
+            "source_location": f"L{line}", "weight": 1.0,
+        }
+        if context:
+            edge["context"] = context
+        edges.append(edge)
+
+    def add_existing_edge(edge: dict) -> None:
+        key = (edge.get("source"), edge.get("target"), edge.get("relation"), edge.get("context"))
+        if key in seen_edges:
+            return
+        seen_edges.add(key)
+        edges.append(dict(edge))
+
+    add_node(file_nid, path.name, 1)
+    add_node(root_nid, root_type, 1)
+    add_edge(file_nid, root_nid, "contains", 1)
+
+    class_name = None
+    for key, value in tree.attrib.items():
+        if _xml_local_name(key) == "Class" and value:
+            class_name = value.strip()
+            break
+
+    class_node, codebehind_methods, class_method_edges = _xaml_codebehind_symbols(path, class_name)
+    if class_name:
+        if class_node:
+            class_nid = class_node["id"]
+            add_existing_node(class_node)
+        else:
+            class_label = class_name.rsplit(".", 1)[-1]
+            class_nid = _make_id(stem, class_label)
+            add_node(class_nid, class_label, line_for(class_name))
+        add_edge(root_nid, class_nid, "references", line_for(class_name), context="x_class")
+
+    binding_re = re.compile(r"\{Binding\s+([^,}\s]+)")
+
+    for elem in tree.iter():
+        elem_type = _xml_local_name(elem.tag)
+        elem_name = None
+        for key, value in elem.attrib.items():
+            if _xml_local_name(key) == "Name" and value:
+                elem_name = value.strip()
+                break
+        owner_nid = root_nid
+        if elem_name:
+            owner_nid = _make_id(stem, elem_name)
+            add_node(owner_nid, elem_name, line_for(elem_name))
+            add_edge(root_nid, owner_nid, "contains", line_for(elem_name))
+            type_nid = _make_id("xaml", elem_type)
+            add_node(type_nid, elem_type, line_for(elem_name), file_type="concept")
+            add_edge(owner_nid, type_nid, "references", line_for(elem_name), context="type")
+
+        for value in elem.attrib.values():
+            method = codebehind_methods.get(value or "")
+            if method:
+                add_existing_node(method)
+                add_edge(owner_nid, method["id"], "references", line_for(value), context="event")
+                for method_edge in class_method_edges:
+                    if method_edge.get("target") == method["id"]:
+                        add_existing_node(class_node)
+                        add_existing_edge(method_edge)
+                        break
+            for match in binding_re.finditer(value or ""):
+                binding = match.group(1).strip()
+                if not binding:
+                    continue
+                bind_nid = _make_id("binding", binding)
+                add_node(bind_nid, binding, line_for(value), file_type="concept")
+                add_edge(owner_nid, bind_nid, "references", line_for(value), context="binding")
+
+    return {"nodes": nodes, "edges": edges}
+
+
 
 
 # Config/manifest JSON filenames the structural extractor understands. Anything
@@ -12018,6 +12225,7 @@ _DISPATCH: dict[str, Any] = {
     ".csproj": extract_csproj,
     ".fsproj": extract_csproj,
     ".vbproj": extract_csproj,
+    ".xaml": extract_xaml,
     ".razor": extract_razor,
     ".cshtml": extract_razor,
     ".cls": extract_apex,

--- a/tests/fixtures/sample.xaml
+++ b/tests/fixtures/sample.xaml
@@ -1,0 +1,10 @@
+<Window x:Class="GraphifyDemo.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Dashboard"
+        Loaded="Window_Loaded">
+    <StackPanel x:Name="RootPanel">
+        <TextBox Name="UserNameBox" Text="{Binding UserName}" TextChanged="UserNameChanged" />
+        <Button x:Name="SaveButton" Content="Save" Click="Save_Click" />
+    </StackPanel>
+</Window>

--- a/tests/fixtures/sample.xaml.cs
+++ b/tests/fixtures/sample.xaml.cs
@@ -1,0 +1,19 @@
+using System.Windows;
+
+namespace GraphifyDemo
+{
+    public partial class MainWindow : Window
+    {
+        private void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+        }
+
+        private void UserNameChanged(object sender, RoutedEventArgs e)
+        {
+        }
+
+        private void Save_Click(object sender, RoutedEventArgs e)
+        {
+        }
+    }
+}

--- a/tests/test_dotnet.py
+++ b/tests/test_dotnet.py
@@ -1,8 +1,8 @@
-"""Tests for .NET project file extraction (.sln, .csproj, .razor)."""
+"""Tests for .NET project file extraction (.sln, .csproj, .xaml, .razor)."""
 from pathlib import Path
 import tempfile
 import pytest
-from graphify.extract import extract_sln, extract_slnx, extract_csproj, extract_razor
+from graphify.extract import extract_sln, extract_slnx, extract_csproj, extract_xaml, extract_razor
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -107,6 +107,48 @@ def test_csproj_invalid_xml():
     assert "error" in r
 
 
+# ── .xaml ────────────────────────────────────────────────────────────────────
+
+def test_xaml_class_resolves_to_codebehind_partial_class():
+    r = extract_xaml(FIXTURES / "sample.xaml")
+    assert "error" not in r
+    class_nodes = [
+        n for n in r["nodes"]
+        if n["label"] == "MainWindow" and str(n.get("source_file", "")).endswith("sample.xaml.cs")
+    ]
+    assert class_nodes
+    assert any(
+        e["relation"] == "references"
+        and e.get("context") == "x_class"
+        and e["target"] == class_nodes[0]["id"]
+        for e in r["edges"]
+    )
+
+
+def test_xaml_named_controls_and_bindings():
+    r = extract_xaml(FIXTURES / "sample.xaml")
+    labels = set(_labels(r))
+    assert {"RootPanel", "UserNameBox", "SaveButton", "UserName"} <= labels
+    assert any(e["relation"] == "references" and e.get("context") == "binding" for e in r["edges"])
+
+
+def test_xaml_events_resolve_to_codebehind_methods():
+    r = extract_xaml(FIXTURES / "sample.xaml")
+    method_nodes = {
+        n["label"].strip("()").lstrip("."): n["id"]
+        for n in r["nodes"]
+        if str(n.get("source_file", "")).endswith("sample.xaml.cs")
+    }
+    assert {"Window_Loaded", "UserNameChanged", "Save_Click"} <= set(method_nodes)
+    event_targets = {
+        e["target"] for e in r["edges"]
+        if e["relation"] == "references" and e.get("context") == "event"
+    }
+    assert method_nodes["Window_Loaded"] in event_targets
+    assert method_nodes["UserNameChanged"] in event_targets
+    assert method_nodes["Save_Click"] in event_targets
+
+
 # ── .razor ───────────────────────────────────────────────────────────────────
 
 def test_razor_using_and_inject():
@@ -150,11 +192,11 @@ def test_razor_missing_file():
 
 def test_dispatch_table():
     from graphify.extract import _get_extractor
-    for ext in (".sln", ".slnx", ".csproj", ".fsproj", ".vbproj", ".razor", ".cshtml"):
+    for ext in (".sln", ".slnx", ".csproj", ".fsproj", ".vbproj", ".xaml", ".razor", ".cshtml"):
         assert _get_extractor(Path(f"foo{ext}")) is not None, f"{ext} not in dispatch"
 
 
 def test_code_extensions():
     from graphify.detect import CODE_EXTENSIONS
-    for ext in (".sln", ".slnx", ".csproj", ".fsproj", ".vbproj", ".razor", ".cshtml"):
+    for ext in (".sln", ".slnx", ".csproj", ".fsproj", ".vbproj", ".xaml", ".razor", ".cshtml"):
         assert ext in CODE_EXTENSIONS, f"{ext} missing"

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,4 +1,4 @@
-"""Tests for language extractors: Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Go, Julia, Fortran, JS/TS, .NET project files."""
+"""Tests for language extractors: Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Go, Julia, Fortran, JS/TS, .NET project files, XAML."""
 from __future__ import annotations
 from pathlib import Path
 import pytest
@@ -6,7 +6,7 @@ from graphify.extract import (
     extract_java, extract_c, extract_cpp, extract_ruby,
     extract_csharp, extract_kotlin, extract_scala, extract_php,
     extract_swift, extract_go, extract_julia, extract_js, extract_fortran,
-    extract_groovy, extract_sln, extract_csproj, extract_razor,
+    extract_groovy, extract_sln, extract_csproj, extract_xaml, extract_razor,
     extract_dm, extract_dmi, extract_dmm, extract_dmf,
     extract_powershell, extract_apex, extract_verilog,
     extract_powershell_manifest,
@@ -1755,7 +1755,7 @@ def test_dmf_no_dangling_edges():
         assert e["target"] in node_ids
 
 
-# -- .NET project files (.sln, .csproj, .razor) -------------------------------
+# -- .NET project files (.sln, .csproj, .xaml, .razor) ------------------------
 
 def test_sln_no_error():
     r = extract_sln(FIXTURES / "sample.sln")
@@ -1797,6 +1797,12 @@ def test_csproj_finds_target_framework():
 def test_csproj_finds_sdk():
     r = extract_csproj(FIXTURES / "sample.csproj")
     assert any("Microsoft.NET.Sdk.Web" in l for l in _labels(r))
+
+def test_xaml_finds_class_and_event_references():
+    r = extract_xaml(FIXTURES / "sample.xaml")
+    assert "error" not in r
+    assert "MainWindow" in _labels(r)
+    assert any(e["relation"] == "references" and e.get("context") == "event" for e in r["edges"])
 
 def test_razor_no_error():
     r = extract_razor(FIXTURES / "sample.razor")


### PR DESCRIPTION
Refs #1456.

## What

Adds basic WPF/XAML structural extraction without a new parser dependency.

This PR makes `.xaml` files first-class code inputs and extracts:

- the XAML file/root element
- named controls from `x:Name` / `Name`
- simple `{Binding ...}` references
- `x:Class` references
- event-handler references that resolve to methods on the matching `.xaml.cs` partial class

## Why

WPF projects keep important frontend structure in XAML, but graphify currently skips `.xaml` files. That means UI controls, bindings, view classes, and event handlers are invisible in the graph even though the matching C# code-behind is already extractable.

Resolving `x:Class` and event handlers gives the graph a useful bridge from the view markup to the C# partial class and methods without turning this into a full WPF analyzer.

## XAML coverage in this PR

Added now:

- `.xaml` file discovery and dispatch
- root element extraction (`Window`, `UserControl`, etc.)
- control nodes for elements with `x:Name` or `Name`
- control type references (`Button`, `TextBox`, `StackPanel`, etc.)
- simple `{Binding PropertyName}` references
- `x:Class="Namespace.Type"` links to the matching `.xaml.cs` partial class when present
- event-handler links from XAML attributes to methods on that partial class

Deferred deeper analysis:

- `StaticResource` / `DynamicResource` and resource dictionary resolution
- merged dictionaries, styles, templates, and control templates
- complex binding paths, converters, commands, and `DataContext` / ViewModel inference
- routed event bubbling semantics
- cross-file resolution between XAML views and separate ViewModel classes

## Changes

- `graphify/detect.py`: add `.xaml` to `CODE_EXTENSIONS`
- `graphify/extract.py`: add `extract_xaml()` and dispatch registration
- `tests/fixtures/sample.xaml` / `sample.xaml.cs`: add a small WPF fixture pair
- `tests/test_dotnet.py`: cover XAML class resolution, named controls, bindings, and event-handler links
- `tests/test_languages.py`: add the contribution-path XAML smoke test
- `README.md`: document `.xaml` in the supported file extensions table

## Testing

- `uv run pytest tests/test_dotnet.py tests/test_languages.py::test_xaml_finds_class_and_event_references -q`
- `uv run ruff check graphify tests --select E9,F63,F7,F82`

Full `uv run pytest tests/ -q` was attempted locally on Windows, but existing unrelated Windows/path and install/skillgen failures prevent a clean full-suite result on this machine.