### PR TITLE
fix(hooks): match real file extension in Read|Glob hook (.astro miss, .json false-fire)

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -405,6 +405,10 @@ _READ_SETTINGS_HOOK = {
     # python3 (already a graphify dependency), the shell is POSIX, and every branch
     # fails open, so a legitimate read always goes through. Reading the graph's own
     # report under graphify-out/ is suppressed so it never starts a feedback loop.
+    # The extension test compares each value's real trailing extension (segment
+    # after the last '/' then after the last '.') against exts -- not a substring
+    # scan, which both missed framework files like .astro and false-matched .json
+    # against .js (the substring '.js' is inside '.json').
     "matcher": "Read|Glob",
     "hooks": [
         {
@@ -414,9 +418,11 @@ _READ_SETTINGS_HOOK = {
                 "import json,sys;"
                 "d=json.load(sys.stdin);"
                 "t=d.get('tool_input',d);"
-                "s=(str(t.get('file_path') or '')+' '+str(t.get('pattern') or '')+' '+str(t.get('path') or '')).lower().replace(chr(92),'/');"
-                "exts=('.py','.js','.ts','.tsx','.jsx','.go','.rs','.java','.rb','.c','.h','.cpp','.hpp','.cc','.cs','.kt','.swift','.php','.scala','.lua','.sh','.md','.rst','.txt','.mdx');"
-                "sys.stdout.write('1' if 'graphify-out/' not in s and any(e in s for e in exts) else '')\" 2>/dev/null || true); "
+                "exts=('.py','.js','.ts','.tsx','.jsx','.astro','.vue','.svelte','.go','.rs','.java','.rb','.c','.h','.cpp','.hpp','.cc','.cs','.kt','.swift','.php','.scala','.lua','.sh','.md','.rst','.txt','.mdx');"
+                "vals=[str(t.get('file_path') or ''),str(t.get('pattern') or ''),str(t.get('path') or '')];"
+                "j=' '.join(vals).lower().replace(chr(92),'/');"
+                "tails=[('.'+x.rsplit('.',1)[-1]) for v in vals if v for x in [v.lower().replace(chr(92),'/').rsplit('/',1)[-1]] if '.' in x];"
+                "sys.stdout.write('1' if 'graphify-out/' not in j and any(tl in exts for tl in tails) else '')\" 2>/dev/null || true); "
                 "if [ \"$HIT\" = 1 ] && [ -f graphify-out/graph.json ]; then "
                 r"""echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"MANDATORY: graphify-out/graph.json exists. You MUST run graphify before reading source files. Use: `graphify query \"<question>\"` (scoped subgraph), `graphify explain \"<concept>\"`, or `graphify path \"<A>\" \"<B>\"`. Only read raw files after graphify has oriented you, or to modify/debug specific lines. This rule applies to subagents too — include it in every subagent prompt involving code exploration."}}'; """
                 "fi || true"

--- a/tests/test_read_hook.py
+++ b/tests/test_read_hook.py
@@ -62,6 +62,25 @@ def test_glob_pattern_nudges(tmp_path):
     assert "graphify query" in out
 
 
+def test_nudges_on_framework_source(tmp_path):
+    """.astro/.vue/.svelte are real source types and must nudge (regression)."""
+    for path in ("src/components/Hero.astro", "src/App.vue", "src/Card.svelte"):
+        out = _run({"file_path": path}, tmp_path, graph=True).stdout
+        assert "graphify query" in out, f"{path} should nudge"
+
+
+def test_astro_glob_nudges(tmp_path):
+    out = _run({"pattern": "**/*.astro"}, tmp_path, graph=True).stdout
+    assert "graphify query" in out
+
+
+def test_silent_on_json_config(tmp_path):
+    """Config files must stay silent: '.json' must not match the '.js' extension."""
+    for path in ("package.json", "tsconfig.json", "data.geojson"):
+        out = _run({"file_path": path}, tmp_path, graph=True).stdout
+        assert out.strip() == "", f"{path} should not nudge"
+
+
 def test_fails_open_on_malformed_stdin(tmp_path):
     (tmp_path / "graphify-out").mkdir()
     (tmp_path / "graphify-out" / "graph.json").write_text("{}", encoding="utf-8")


### PR DESCRIPTION
Fixes #1463.

## Problem

The `Read|Glob` `PreToolUse` hook (`_READ_SETTINGS_HOOK` in `graphify/__main__.py`, used by both the Claude and CodeBuddy installers) decided whether to nudge by **substring-scanning** the joined `file_path` + `pattern` + `path` for known extensions:

```python
s = (file_path + ' ' + pattern + ' ' + path).lower().replace('\\','/')
hit = 'graphify-out/' not in s and any(e in s for e in exts)
```

Two opposite failures fall out of that:

- **False negative — `.astro` / `.vue` / `.svelte` never nudge.** They weren't in `exts`, so on Astro/Vue/Svelte projects (where they're the primary source type) reading or globbing a component never surfaced the graph. Only the Bash/grep hook covered those repos.
- **False positive — `.json` matches `.js`.** `'.js'` is a substring of `'.json'`, so reading `package.json`, `tsconfig.json`, etc. spuriously fired the "run graphify first" nudge. Any path containing a listed ext as a substring over-fires.

## Fix

Compare each value's **real trailing extension** (segment after the last `/`, then after the last `.`) against `exts`, and add the framework extensions:

```python
vals  = [file_path, pattern, path]
j     = ' '.join(vals).lower().replace('\\','/')
tails = [('.'+x.rsplit('.',1)[-1])
         for v in vals if v
         for x in [v.lower().replace('\\','/').rsplit('/',1)[-1]] if '.' in x]
hit   = 'graphify-out/' not in j and any(t in exts for t in tails)
```

`package.json` → tail `.json` (not in `exts`, silent); `**/*.astro` → tail `.astro` (matched, fires). The `graphify-out/` suppression and the fail-open behaviour are unchanged.

## Tests

Added regression tests in `tests/test_read_hook.py`:
- `test_nudges_on_framework_source` — `.astro` / `.vue` / `.svelte` reads nudge
- `test_astro_glob_nudges` — `**/*.astro` glob nudges
- `test_silent_on_json_config` — `package.json` / `tsconfig.json` / `data.geojson` stay silent

All existing cases still pass:

```
pytest tests/test_read_hook.py tests/test_install_strings.py tests/test_codebuddy.py
42 passed
```
