### PR TITLE
fix(reflect): refresh lessons when sidecars change

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2980,15 +2980,25 @@ def main() -> None:
                 graph_arg = str(default_graph)
 
         _gp = Path(graph_arg) if graph_arg else None
-        if opts.if_stale and _lessons_fresh(Path(opts.out), Path(opts.memory_dir), _gp):
+        _analysis_path = None
+        _labels_path = None
+        if _gp is not None:
+            _analysis_path = Path(opts.analysis) if opts.analysis else (
+                _gp.parent / ".graphify_analysis.json")
+            _labels_path = Path(opts.labels) if opts.labels else (
+                _gp.parent / ".graphify_labels.json")
+
+        if opts.if_stale and _lessons_fresh(
+            Path(opts.out), Path(opts.memory_dir), _gp, _analysis_path, _labels_path
+        ):
             print(f"Lessons already up to date -> {opts.out} (skipped; omit --if-stale to force)")
         else:
             out_path, agg = _reflect(
                 memory_dir=Path(opts.memory_dir),
                 out_path=Path(opts.out),
                 graph_path=_gp,
-                analysis_path=Path(opts.analysis) if opts.analysis else None,
-                labels_path=Path(opts.labels) if opts.labels else None,
+                analysis_path=_analysis_path,
+                labels_path=_labels_path,
                 half_life_days=opts.half_life_days,
                 min_corroboration=opts.min_corroboration,
             )

--- a/graphify/reflect.py
+++ b/graphify/reflect.py
@@ -501,9 +501,11 @@ def render_lessons_md(agg: dict[str, Any]) -> str:
 
 
 def lessons_fresh(out_path: Path, memory_dir: Path,
-                  graph_path: Path | None = None) -> bool:
+                  graph_path: Path | None = None,
+                  analysis_path: Path | None = None,
+                  labels_path: Path | None = None) -> bool:
     """True if ``out_path`` exists and is at least as new as every input that
-    feeds it (the memory docs, and the graph when one is used).
+    feeds it (the memory docs, and the graph/sidecars when one is used).
 
     Lets ``graphify reflect --if-stale`` skip a redundant run — e.g. when the git
     post-commit hook just regenerated ``LESSONS.md`` and an agent then runs reflect
@@ -524,8 +526,10 @@ def lessons_fresh(out_path: Path, memory_dir: Path,
                 newest = max(newest, f.stat().st_mtime)
             except OSError:
                 pass
-    if graph_path is not None:
-        gp = Path(graph_path)
+    for input_path in (graph_path, analysis_path, labels_path):
+        if input_path is None:
+            continue
+        gp = Path(input_path)
         try:
             newest = max(newest, gp.stat().st_mtime)
         except OSError:

--- a/tests/test_reflect.py
+++ b/tests/test_reflect.py
@@ -607,6 +607,22 @@ def test_lessons_fresh_false_when_graph_newer(tmp_path):
     assert lessons_fresh(out, mem, graph) is False
 
 
+@pytest.mark.parametrize("sidecar_name", [".graphify_analysis.json", ".graphify_labels.json"])
+def test_lessons_fresh_false_when_graph_sidecar_newer(tmp_path, sidecar_name):
+    import os
+    mem = tmp_path / "memory"; mem.mkdir()
+    (mem / "q.md").write_text("x", encoding="utf-8")
+    out = tmp_path / "LESSONS.md"; out.write_text("y", encoding="utf-8")
+    graph = tmp_path / "graph.json"; graph.write_text("{}", encoding="utf-8")
+    analysis = tmp_path / ".graphify_analysis.json"; analysis.write_text("{}", encoding="utf-8")
+    labels = tmp_path / ".graphify_labels.json"; labels.write_text("{}", encoding="utf-8")
+    for p in [mem / "q.md", graph, analysis, labels]:
+        os.utime(p, (1000, 1000))
+    os.utime(out, (1500, 1500))
+    os.utime(tmp_path / sidecar_name, (2000, 2000))
+    assert lessons_fresh(out, mem, graph, analysis, labels) is False
+
+
 def test_cli_reflect_if_stale_skips_when_fresh(tmp_path):
     """`reflect --if-stale` skips the rebuild when LESSONS.md is already current,
     and still runs when a new outcome arrives."""
@@ -631,6 +647,33 @@ def test_cli_reflect_if_stale_skips_when_fresh(tmp_path):
     ran = _run(["reflect", "--if-stale"], tmp_path)
     assert ran.returncode == 0
     assert "up to date" not in (ran.stdout + ran.stderr).lower()
+
+
+def test_cli_reflect_if_stale_reruns_when_labels_newer(tmp_path):
+    """A label refresh changes LESSONS.md topic headings, so --if-stale must rebuild."""
+    out = _make_graph(tmp_path)
+    graph_data = json.loads((out / "graph.json").read_text())
+    node = graph_data["nodes"][0]
+    real = node["label"]
+    community = str(node["community"])
+    _run(["save-result", "--question", "q", "--answer", "a",
+          "--nodes", real, "--outcome", "useful"], tmp_path)
+    first = _run(["reflect"], tmp_path)
+    assert first.returncode == 0, first.stderr
+
+    lessons = out / "reflections" / "LESSONS.md"
+    labels_path = out / ".graphify_labels.json"
+    labels = json.loads(labels_path.read_text(encoding="utf-8"))
+    labels[community] = "Renamed Topic"
+    labels_path.write_text(json.dumps(labels), encoding="utf-8")
+
+    import os
+    os.utime(lessons, (1500, 1500))
+    os.utime(labels_path, (2000, 2000))
+    ran = _run(["reflect", "--if-stale"], tmp_path)
+    assert ran.returncode == 0, ran.stderr
+    assert "up to date" not in (ran.stdout + ran.stderr).lower()
+    assert "### Renamed Topic" in lessons.read_text(encoding="utf-8")
 
 
 def test_dead_ends_and_corrections_dedupe_by_question():


### PR DESCRIPTION
Follow-up to #1441 and the recent `graphify reflect --if-stale` work.

`graphify reflect` uses `.graphify_analysis.json` and `.graphify_labels.json` when rendering `LESSONS.md`, but `reflect --if-stale` only checked memory docs and `graph.json`.

That could leave lessons stale after community analysis or labels changed. This updates the freshness check to include those sidecar files too, including custom `--analysis` / `--labels` paths.

Tests:

- `uv run --frozen pytest tests/test_reflect.py -q`
- `uv run --frozen pytest tests/ -q --tb=short`
