### PR TITLE
feat(extract): link XAML ViewModels and bindings

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -11060,6 +11060,84 @@ _XAML_NON_EVENT_ATTRS = frozenset({
 # markup, a path, or a sentence. Used to skip values like "{Binding ...}" or
 # free-form content before looking them up as code-behind methods.
 _XAML_IDENT_RE = re.compile(r"[A-Za-z_]\w*")
+_XAML_DESIGN_INSTANCE_TYPE_RE = re.compile(
+    r"\bType\s*=\s*(?:\{x:Type\s+)?(?P<type>[\w.:+]+)"
+)
+
+
+def _xaml_markup_extension(value: str) -> tuple[str, str] | None:
+    value = value.strip()
+    if not (value.startswith("{") and value.endswith("}")):
+        return None
+    inner = value[1:-1].strip()
+    if not inner or inner.startswith("}"):
+        return None
+    name, _, args = inner.partition(" ")
+    return name, args.strip()
+
+
+def _xaml_split_markup_args(args: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    for idx, ch in enumerate(args):
+        if ch == "{":
+            depth += 1
+        elif ch == "}" and depth:
+            depth -= 1
+        elif ch == "," and depth == 0:
+            parts.append(args[start:idx].strip())
+            start = idx + 1
+    tail = args[start:].strip()
+    if tail:
+        parts.append(tail)
+    return parts
+
+
+def _xaml_static_resource_key(value: str) -> str | None:
+    markup = _xaml_markup_extension(value)
+    if not markup:
+        return None
+    name, args = markup
+    if name != "StaticResource":
+        return None
+    for part in _xaml_split_markup_args(args):
+        if "=" not in part:
+            return part.strip() or None
+        key, resource = part.split("=", 1)
+        if key.strip() == "ResourceKey":
+            return resource.strip() or None
+    return None
+
+
+def _xaml_binding_refs(value: str) -> tuple[str | None, str | None]:
+    markup = _xaml_markup_extension(value)
+    if not markup:
+        return None, None
+    name, args = markup
+    if name != "Binding":
+        return None, None
+
+    path_ref = None
+    converter_ref = None
+    for part in _xaml_split_markup_args(args):
+        if not part:
+            continue
+        if "=" not in part:
+            if path_ref is None:
+                path_ref = part.strip()
+            continue
+        key, raw_value = part.split("=", 1)
+        key = key.strip()
+        raw_value = raw_value.strip()
+        if key == "Path":
+            path_ref = raw_value
+        elif key == "Converter":
+            converter_ref = _xaml_static_resource_key(raw_value)
+
+    if path_ref and ("{" in path_ref or "}" in path_ref):
+        path_ref = None
+    return path_ref or None, converter_ref or None
 
 
 def _xaml_codebehind_path(path: Path) -> Path | None:
@@ -11132,6 +11210,205 @@ def _xaml_codebehind_symbols(
         if label.startswith(".") and label.endswith("()") and _has_event_handler_signature(node):
             methods[label.strip("()").lstrip(".")] = node
     return class_node, methods, class_method_edges
+
+
+def _xaml_type_simple_name(type_ref: str) -> str | None:
+    type_ref = type_ref.strip().strip("{}")
+    if not type_ref:
+        return None
+    type_ref = type_ref.split(",", 1)[0].strip()
+    if type_ref.startswith("x:Type "):
+        type_ref = type_ref[len("x:Type "):].strip()
+    if ":" in type_ref:
+        type_ref = type_ref.rsplit(":", 1)[-1]
+    if "." in type_ref:
+        type_ref = type_ref.rsplit(".", 1)[-1]
+    if "+" in type_ref:
+        type_ref = type_ref.rsplit("+", 1)[-1]
+    return type_ref if _XAML_IDENT_RE.fullmatch(type_ref) else None
+
+
+def _xaml_explicit_viewmodel_names(tree) -> tuple[bool, list[str]]:
+    has_data_context = False
+    names: list[str] = []
+    for elem in tree.iter():
+        elem_type = _xml_local_name(elem.tag)
+        if elem_type.endswith(".DataContext") or elem_type == "DataContext":
+            has_data_context = True
+            for child in list(elem):
+                vm_name = _xaml_type_simple_name(_xml_local_name(child.tag))
+                if vm_name and vm_name not in names:
+                    names.append(vm_name)
+        for key, value in elem.attrib.items():
+            if _xml_local_name(key) != "DataContext" or not value:
+                continue
+            has_data_context = True
+            match = _XAML_DESIGN_INSTANCE_TYPE_RE.search(value)
+            if match:
+                vm_name = _xaml_type_simple_name(match.group("type"))
+                if vm_name and vm_name not in names:
+                    names.append(vm_name)
+    return has_data_context, names
+
+
+def _xaml_prism_autowire_viewmodel(tree) -> bool:
+    for elem in tree.iter():
+        for key, value in elem.attrib.items():
+            if (
+                _xml_local_name(key).endswith("ViewModelLocator.AutoWireViewModel")
+                and value.strip().lower() == "true"
+            ):
+                return True
+    return False
+
+
+def _xaml_inferred_viewmodel_names(view_name: str | None) -> list[str]:
+    if not view_name:
+        return []
+    names: list[str] = []
+
+    def add(name: str) -> None:
+        if name.endswith("ViewModel") and name not in names:
+            names.append(name)
+
+    if view_name == "MainWindow":
+        add("MainWindowViewModel")
+        add("MainViewModel")
+    for suffix in ("UserControl", "View", "Page", "Control"):
+        if view_name.endswith(suffix) and len(view_name) > len(suffix):
+            add(view_name[:-len(suffix)] + "ViewModel")
+            break
+    return names
+
+
+def _xaml_project_root(path: Path) -> Path:
+    project_markers = (".csproj", ".fsproj", ".vbproj", ".sln", ".slnx")
+    root = path.parent
+    for directory in (path.parent, *path.parent.parents):
+        try:
+            if any(child.suffix in project_markers for child in directory.iterdir()):
+                root = directory
+                break
+        except OSError:
+            continue
+    if _XAML_ACTIVE_EXTRACT_ROOT is None:
+        return root
+    boundary = _XAML_ACTIVE_EXTRACT_ROOT.resolve()
+    try:
+        root.resolve().relative_to(boundary)
+        return root
+    except ValueError:
+        return boundary
+
+
+def _xaml_csharp_class_nodes(path: Path) -> dict[str, list[dict]]:
+    from graphify.detect import _is_ignored, _is_noise_dir, _load_graphifyignore
+    root = _xaml_project_root(path)
+    cache_key = str(root.resolve()) if _XAML_ACTIVE_EXTRACT_ROOT is not None else None
+    if cache_key and cache_key in _XAML_CSHARP_CLASS_CACHE:
+        return _XAML_CSHARP_CLASS_CACHE[cache_key]
+    classes: dict[str, list[dict]] = {}
+    patterns = _load_graphifyignore(root)
+    ignore_cache: dict[Path, bool] = {}
+    try:
+        cs_files = sorted(root.rglob("*.cs"))
+    except OSError:
+        return classes
+    for cs_path in cs_files:
+        if any(_is_noise_dir(part) for part in cs_path.parts):
+            continue
+        if patterns and _is_ignored(cs_path, root, patterns, _cache=ignore_cache):
+            continue
+        result = extract_csharp(cs_path)
+        if result.get("error"):
+            continue
+        for node in result.get("nodes", []):
+            label = str(node.get("label", ""))
+            if not label.endswith("ViewModel") or not _XAML_IDENT_RE.fullmatch(label):
+                continue
+            if node.get("source_file"):
+                classes.setdefault(label, []).append(node)
+    if cache_key:
+        _XAML_CSHARP_CLASS_CACHE[cache_key] = classes
+    return classes
+
+
+def _xaml_pascal_name(name: str) -> str | None:
+    name = name.strip().lstrip("_")
+    if name.startswith("m_"):
+        name = name[2:]
+    return name[:1].upper() + name[1:] if _XAML_IDENT_RE.fullmatch(name) else None
+
+
+_XAML_TOOLKIT_FIELD_RE = re.compile(r"\b(?P<name>_?m?_?[A-Za-z_]\w*)\s*(?:=.*)?;")
+_XAML_TOOLKIT_METHOD_RE = re.compile(r"\b(?P<name>[A-Za-z_]\w*)\s*\(")
+_XAML_ACTIVE_EXTRACT_ROOT: Path | None = None
+_XAML_CSHARP_CLASS_CACHE: dict[str, dict[str, list[dict]]] = {}
+
+
+def _xaml_communitytoolkit_members(vm_node: dict) -> tuple[dict[str, dict], list[dict]]:
+    source_file = vm_node.get("source_file")
+    vm_id = vm_node.get("id")
+    if not source_file or not vm_id:
+        return {}, []
+    try:
+        lines = Path(source_file).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {}, []
+
+    members: dict[str, dict] = {}
+    edges: list[dict] = []
+
+    def add_member(label: str, line_no: int, context: str) -> None:
+        nid = _make_id(vm_id, label)
+        members[label] = {
+            "id": nid,
+            "label": label,
+            "file_type": "code",
+            "source_file": source_file,
+            "source_location": f"L{line_no}",
+        }
+        edges.append({
+            "source": vm_id,
+            "target": nid,
+            "relation": "defines",
+            "confidence": "INFERRED",
+            "source_file": source_file,
+            "source_location": f"L{line_no}",
+            "weight": 1.0,
+            "context": context,
+        })
+
+    pending: tuple[str, int] | None = None
+    for line_no, line in enumerate(lines, 1):
+        remainder = line.split("]", 1)[1].strip() if "]" in line else ""
+        if "[" in line and "ObservableProperty" in line:
+            pending = ("property", line_no)
+            if not remainder:
+                continue
+            line = remainder
+        if "[" in line and "RelayCommand" in line:
+            pending = ("command", line_no)
+            if not remainder:
+                continue
+            line = remainder
+        if not pending or not line.strip() or line.lstrip().startswith("["):
+            continue
+
+        kind, attr_line = pending
+        pending = None
+        if kind == "property":
+            match = _XAML_TOOLKIT_FIELD_RE.search(line)
+            label = _xaml_pascal_name(match.group("name")) if match else None
+            if label:
+                add_member(label, attr_line, "communitytoolkit_observable_property")
+        else:
+            match = _XAML_TOOLKIT_METHOD_RE.search(line)
+            if match:
+                method = match.group("name").removesuffix("Async")
+                add_member(f"{method}Command", attr_line, "communitytoolkit_relay_command")
+
+    return members, edges
 
 
 def extract_xaml(path: Path) -> dict:
@@ -11207,6 +11484,7 @@ def extract_xaml(path: Path) -> dict:
         *,
         context: str | None = None,
         source_file: str = str_path,
+        confidence: str = "EXTRACTED",
     ) -> None:
         key = (src_nid, tgt_nid, relation, context)
         if key in seen_edges:
@@ -11214,7 +11492,7 @@ def extract_xaml(path: Path) -> dict:
         seen_edges.add(key)
         edge = {
             "source": src_nid, "target": tgt_nid, "relation": relation,
-            "confidence": "EXTRACTED", "source_file": source_file,
+            "confidence": confidence, "source_file": source_file,
             "source_location": f"L{line}", "weight": 1.0,
         }
         if context:
@@ -11249,7 +11527,38 @@ def extract_xaml(path: Path) -> dict:
             add_node(class_nid, class_label, line_for(class_name))
         add_edge(root_nid, class_nid, "references", line_for(class_name), context="x_class")
 
-    binding_re = re.compile(r"\{Binding\s+([^,}\s]+)")
+    has_data_context, vm_names = _xaml_explicit_viewmodel_names(tree)
+    prism_autowire = _xaml_prism_autowire_viewmodel(tree)
+    vm_confidence = "EXTRACTED"
+    if not has_data_context:
+        view_name = class_name.rsplit(".", 1)[-1] if class_name else None
+        view_name = view_name or (path.stem if prism_autowire else None)
+        vm_names = _xaml_inferred_viewmodel_names(view_name)
+        vm_confidence = "INFERRED"
+    generated_members: dict[str, dict] = {}
+    generated_member_edges: list[dict] = []
+    if vm_names:
+        csharp_classes = _xaml_csharp_class_nodes(path)
+        vm_candidates = []
+        for vm_name in vm_names:
+            vm_candidates.extend(csharp_classes.get(vm_name, []))
+        by_id = {node.get("id"): node for node in vm_candidates if node.get("id")}
+        if len(by_id) == 1:
+            vm_node = next(iter(by_id.values()))
+            add_existing_node(vm_node)
+            add_edge(
+                root_nid,
+                vm_node["id"],
+                "references",
+                line_for(vm_node["label"]),
+                context="view_model",
+                confidence=vm_confidence,
+            )
+            generated_members, generated_member_edges = _xaml_communitytoolkit_members(vm_node)
+            for member in generated_members.values():
+                add_existing_node(member)
+            for member_edge in generated_member_edges:
+                add_existing_edge(member_edge)
 
     for elem in tree.iter():
         elem_type = _xml_local_name(elem.tag)
@@ -11286,13 +11595,43 @@ def extract_xaml(path: Path) -> dict:
                             add_existing_node(class_node)
                             add_existing_edge(method_edge)
                             break
-            for match in binding_re.finditer(value):
-                binding = match.group(1).strip()
-                if not binding:
-                    continue
-                bind_nid = _make_id("binding", binding)
-                add_node(bind_nid, binding, line_for(value), file_type="concept")
-                add_edge(owner_nid, bind_nid, "references", line_for(value), context="binding")
+            binding_path, binding_converter = _xaml_binding_refs(value)
+            if binding_path:
+                bind_nid = _make_id("binding", binding_path)
+                add_node(bind_nid, binding_path, line_for(value), file_type="concept")
+                binding_context = (
+                    "binding_command"
+                    if attr_local == "Command" or attr_local.endswith(".Command")
+                    else "binding_path"
+                )
+                add_edge(owner_nid, bind_nid, "references", line_for(value), context=binding_context)
+                generated_member = generated_members.get(binding_path)
+                if generated_member:
+                    add_existing_node(generated_member)
+                    add_edge(
+                        owner_nid,
+                        generated_member["id"],
+                        "references",
+                        line_for(value),
+                        context=binding_context,
+                        confidence="INFERRED",
+                    )
+            if binding_converter:
+                converter_nid = _make_id("binding_converter", binding_converter)
+                add_node(converter_nid, binding_converter, line_for(value), file_type="concept")
+                add_edge(owner_nid, converter_nid, "references", line_for(value), context="binding_converter")
+            if elem_type == "Binding" and attr_local == "Path":
+                direct_path = value.strip()
+                if direct_path and "{" not in direct_path and "}" not in direct_path:
+                    bind_nid = _make_id("binding", direct_path)
+                    add_node(bind_nid, direct_path, line_for(value), file_type="concept")
+                    add_edge(owner_nid, bind_nid, "references", line_for(value), context="binding_path")
+            if elem_type == "Binding" and attr_local == "Converter":
+                direct_converter = _xaml_static_resource_key(value)
+                if direct_converter:
+                    converter_nid = _make_id("binding_converter", direct_converter)
+                    add_node(converter_nid, direct_converter, line_for(value), file_type="concept")
+                    add_edge(owner_nid, converter_nid, "references", line_for(value), context="binding_converter")
 
     return {"nodes": nodes, "edges": edges}
 
@@ -12304,6 +12643,16 @@ def _get_extractor(path: Path) -> Any | None:
     return _DISPATCH.get(path.suffix)
 
 
+def _safe_extract_with_xaml_root(extractor, path: Path, root: Path) -> dict:
+    global _XAML_ACTIVE_EXTRACT_ROOT
+    previous_root = _XAML_ACTIVE_EXTRACT_ROOT
+    _XAML_ACTIVE_EXTRACT_ROOT = root.resolve()
+    try:
+        return _safe_extract(extractor, path)
+    finally:
+        _XAML_ACTIVE_EXTRACT_ROOT = previous_root
+
+
 def _extract_single_file(args: tuple) -> tuple[int, dict]:
     """Worker function for parallel extraction. Runs in a subprocess.
 
@@ -12332,7 +12681,7 @@ def _extract_single_file(args: tuple) -> tuple[int, dict]:
     if extractor is None:
         return idx, {"nodes": [], "edges": []}
 
-    result = _safe_extract(extractor, path)
+    result = _safe_extract_with_xaml_root(extractor, path, cache_root)
     if not bypass_cache and "error" not in result:
         save_cached(path, result, cache_root)
     return idx, result
@@ -12456,7 +12805,7 @@ def _extract_sequential(
             per_file[idx] = {"nodes": [], "edges": []}
             continue
         bypass_cache = path.suffix in _JS_CACHE_BYPASS_SUFFIXES
-        result = _safe_extract(extractor, path)
+        result = _safe_extract_with_xaml_root(extractor, path, effective_root)
         if not bypass_cache and "error" not in result:
             save_cached(path, result, effective_root)
         per_file[idx] = result
@@ -12496,6 +12845,7 @@ def extract(
     _raise_recursion_limit()
     # Workspace package manifests/globs can change during watch or repeated extraction.
     _WORKSPACE_PACKAGE_CACHE.clear()
+    _XAML_CSHARP_CLASS_CACHE.clear()
 
     # Infer a common root for cache keys (use first diverging segment, not sum of all matches)
     try:

--- a/tests/fixtures/bindings.xaml
+++ b/tests/fixtures/bindings.xaml
@@ -1,0 +1,12 @@
+<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Window.Resources>
+        <Binding x:Key="TaxBinding" Path="Invoice.Tax" Converter="{StaticResource TaxConverter}" />
+    </Window.Resources>
+    <StackPanel x:Name="RootPanel">
+        <TextBlock x:Name="UserText" Text="{Binding User.Name}" />
+        <TextBlock x:Name="TotalText" Text="{Binding Path=Order.Total, Converter={StaticResource MoneyConverter}}" />
+        <Button x:Name="SaveButton" Command="{Binding SaveCommand}" />
+        <TextBlock x:Name="ModeText" Text="{Binding Mode=TwoWay}" />
+    </StackPanel>
+</Window>

--- a/tests/fixtures/xaml_viewmodel/App.csproj
+++ b/tests/fixtures/xaml_viewmodel/App.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/tests/fixtures/xaml_viewmodel/ViewModels/DesignViewModel.cs
+++ b/tests/fixtures/xaml_viewmodel/ViewModels/DesignViewModel.cs
@@ -1,0 +1,6 @@
+namespace Demo.ViewModels
+{
+    public class DesignViewModel
+    {
+    }
+}

--- a/tests/fixtures/xaml_viewmodel/ViewModels/MainViewModel.cs
+++ b/tests/fixtures/xaml_viewmodel/ViewModels/MainViewModel.cs
@@ -1,0 +1,6 @@
+namespace Demo.ViewModels
+{
+    public class MainViewModel
+    {
+    }
+}

--- a/tests/fixtures/xaml_viewmodel/ViewModels/PrismOrderViewModel.cs
+++ b/tests/fixtures/xaml_viewmodel/ViewModels/PrismOrderViewModel.cs
@@ -1,0 +1,5 @@
+namespace Demo.ViewModels;
+
+public class PrismOrderViewModel
+{
+}

--- a/tests/fixtures/xaml_viewmodel/ViewModels/SettingsViewModel.cs
+++ b/tests/fixtures/xaml_viewmodel/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,6 @@
+namespace Demo.ViewModels
+{
+    public class SettingsViewModel
+    {
+    }
+}

--- a/tests/fixtures/xaml_viewmodel/ViewModels/ToolkitViewModel.cs
+++ b/tests/fixtures/xaml_viewmodel/ViewModels/ToolkitViewModel.cs
@@ -1,0 +1,30 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Demo.ViewModels;
+
+public partial class ToolkitViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string userName = "";
+
+    [ObservableProperty] private string email = "";
+
+    // ObservableProperty
+    private string ignoredName = "";
+
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        await Task.CompletedTask;
+    }
+
+    [RelayCommand] private void Refresh()
+    {
+    }
+
+    // RelayCommand
+    private void Ignored()
+    {
+    }
+}

--- a/tests/fixtures/xaml_viewmodel/Views/DesignView.xaml
+++ b/tests/fixtures/xaml_viewmodel/Views/DesignView.xaml
@@ -1,0 +1,8 @@
+<UserControl x:Class="Demo.DesignView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:Demo.ViewModels"
+             d:DataContext="{d:DesignInstance Type=vm:DesignViewModel}">
+    <Grid />
+</UserControl>

--- a/tests/fixtures/xaml_viewmodel/Views/ExplicitMainWindow.xaml
+++ b/tests/fixtures/xaml_viewmodel/Views/ExplicitMainWindow.xaml
@@ -1,0 +1,9 @@
+<Window x:Class="Demo.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:Demo.ViewModels">
+    <Window.DataContext>
+        <vm:MainViewModel />
+    </Window.DataContext>
+    <Grid />
+</Window>

--- a/tests/fixtures/xaml_viewmodel/Views/PrismOrderView.xaml
+++ b/tests/fixtures/xaml_viewmodel/Views/PrismOrderView.xaml
@@ -1,0 +1,5 @@
+<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:prism="http://prismlibrary.com/"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <Grid />
+</UserControl>

--- a/tests/fixtures/xaml_viewmodel/Views/SettingsView.xaml
+++ b/tests/fixtures/xaml_viewmodel/Views/SettingsView.xaml
@@ -1,0 +1,5 @@
+<UserControl x:Class="Demo.SettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid />
+</UserControl>

--- a/tests/fixtures/xaml_viewmodel/Views/ToolkitView.xaml
+++ b/tests/fixtures/xaml_viewmodel/Views/ToolkitView.xaml
@@ -1,0 +1,19 @@
+<UserControl x:Class="Demo.ToolkitView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+             xmlns:vm="clr-namespace:Demo.ViewModels">
+    <UserControl.DataContext>
+        <vm:ToolkitViewModel />
+    </UserControl.DataContext>
+    <Grid>
+        <TextBlock Text="{Binding UserName}" />
+        <TextBlock Text="{Binding Email}" />
+        <i:Interaction.Triggers>
+            <i:EventTrigger EventName="Loaded">
+                <i:InvokeCommandAction Command="{Binding SaveCommand}" />
+                <i:InvokeCommandAction Command="{Binding RefreshCommand}" />
+            </i:EventTrigger>
+        </i:Interaction.Triggers>
+    </Grid>
+</UserControl>

--- a/tests/test_dotnet.py
+++ b/tests/test_dotnet.py
@@ -1,8 +1,9 @@
 """Tests for .NET project file extraction (.sln, .csproj, .xaml, .razor)."""
 from pathlib import Path
+import shutil
 import tempfile
 import pytest
-from graphify.extract import extract_sln, extract_slnx, extract_csproj, extract_xaml, extract_razor
+from graphify.extract import extract, extract_sln, extract_slnx, extract_csproj, extract_xaml, extract_razor
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -13,6 +14,13 @@ def _labels(r):
 
 def _relations(r):
     return {e["relation"] for e in r["edges"]}
+
+
+def _view_model_edges(r):
+    return [
+        e for e in r["edges"]
+        if e["relation"] == "references" and e.get("context") == "view_model"
+    ]
 
 
 # ── .sln ─────────────────────────────────────────────────────────────────────
@@ -129,7 +137,197 @@ def test_xaml_named_controls_and_bindings():
     r = extract_xaml(FIXTURES / "sample.xaml")
     labels = set(_labels(r))
     assert {"RootPanel", "UserNameBox", "SaveButton", "UserName"} <= labels
-    assert any(e["relation"] == "references" and e.get("context") == "binding" for e in r["edges"])
+    assert any(e["relation"] == "references" and e.get("context") == "binding_path" for e in r["edges"])
+
+
+def test_xaml_extracts_binding_paths_commands_and_converters():
+    r = extract_xaml(FIXTURES / "bindings.xaml")
+    labels_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    refs = {
+        (labels_by_id[e["target"]], e.get("context"))
+        for e in r["edges"]
+        if e["relation"] == "references"
+    }
+
+    assert ("User.Name", "binding_path") in refs
+    assert ("Order.Total", "binding_path") in refs
+    assert ("Invoice.Tax", "binding_path") in refs
+    assert ("SaveCommand", "binding_command") in refs
+    assert ("MoneyConverter", "binding_converter") in refs
+    assert ("TaxConverter", "binding_converter") in refs
+    assert ("TwoWay", "binding_path") not in refs
+
+
+def test_xaml_element_datacontext_links_real_viewmodel_class():
+    r = extract_xaml(FIXTURES / "xaml_viewmodel" / "Views" / "ExplicitMainWindow.xaml")
+    nodes = {n["id"]: n for n in r["nodes"]}
+    edges = _view_model_edges(r)
+
+    assert len(edges) == 1
+    assert edges[0]["confidence"] == "EXTRACTED"
+    assert nodes[edges[0]["target"]]["label"] == "MainViewModel"
+    assert nodes[edges[0]["target"]]["source_file"].endswith("MainViewModel.cs")
+
+
+def test_xaml_design_instance_datacontext_links_real_viewmodel_class():
+    r = extract_xaml(FIXTURES / "xaml_viewmodel" / "Views" / "DesignView.xaml")
+    nodes = {n["id"]: n for n in r["nodes"]}
+    edges = _view_model_edges(r)
+
+    assert len(edges) == 1
+    assert edges[0]["confidence"] == "EXTRACTED"
+    assert nodes[edges[0]["target"]]["label"] == "DesignViewModel"
+
+
+def test_xaml_infers_viewmodel_by_name_only_without_datacontext():
+    r = extract_xaml(FIXTURES / "xaml_viewmodel" / "Views" / "SettingsView.xaml")
+    nodes = {n["id"]: n for n in r["nodes"]}
+    edges = _view_model_edges(r)
+
+    assert len(edges) == 1
+    assert edges[0]["confidence"] == "INFERRED"
+    assert nodes[edges[0]["target"]]["label"] == "SettingsViewModel"
+
+
+def test_xaml_prism_autowire_infers_viewmodel_from_filename():
+    r = extract_xaml(FIXTURES / "xaml_viewmodel" / "Views" / "PrismOrderView.xaml")
+    nodes = {n["id"]: n for n in r["nodes"]}
+    edges = _view_model_edges(r)
+
+    assert len(edges) == 1
+    assert edges[0]["confidence"] == "INFERRED"
+    assert nodes[edges[0]["target"]]["label"] == "PrismOrderViewModel"
+
+
+def test_xaml_prism_autowire_false_does_not_infer_from_filename(tmp_path):
+    project = tmp_path / "xaml_viewmodel"
+    shutil.copytree(FIXTURES / "xaml_viewmodel", project)
+    xaml = project / "Views" / "PrismOrderView.xaml"
+    xaml.write_text(
+        xaml.read_text(encoding="utf-8").replace(
+            'AutoWireViewModel="True"', 'AutoWireViewModel="False"'
+        ),
+        encoding="utf-8",
+    )
+
+    r = extract_xaml(xaml)
+
+    assert _view_model_edges(r) == []
+
+
+def test_xaml_links_communitytoolkit_generated_members_and_event_to_command():
+    r = extract_xaml(FIXTURES / "xaml_viewmodel" / "Views" / "ToolkitView.xaml")
+    nodes = {n["id"]: n for n in r["nodes"]}
+    refs = [
+        (nodes[e["target"]], e.get("context"), e["confidence"])
+        for e in r["edges"]
+        if e["relation"] == "references"
+    ]
+    generated_defs = {
+        (nodes[e["target"]]["label"], e.get("context"))
+        for e in r["edges"]
+        if e["relation"] == "defines"
+    }
+
+    assert ("UserName", "communitytoolkit_observable_property") in generated_defs
+    assert ("Email", "communitytoolkit_observable_property") in generated_defs
+    assert ("SaveCommand", "communitytoolkit_relay_command") in generated_defs
+    assert ("RefreshCommand", "communitytoolkit_relay_command") in generated_defs
+    assert ("IgnoredName", "communitytoolkit_observable_property") not in generated_defs
+    assert ("IgnoredCommand", "communitytoolkit_relay_command") not in generated_defs
+    assert any(
+        node["label"] == "UserName"
+        and node["source_file"].endswith("ToolkitViewModel.cs")
+        and context == "binding_path"
+        and confidence == "INFERRED"
+        for node, context, confidence in refs
+    )
+    assert any(
+        node["label"] == "SaveCommand"
+        and node["source_file"].endswith("ToolkitViewModel.cs")
+        and context == "binding_command"
+        and confidence == "INFERRED"
+        for node, context, confidence in refs
+    )
+    assert any(
+        node["label"] == "Email"
+        and node["source_file"].endswith("ToolkitViewModel.cs")
+        and context == "binding_path"
+        and confidence == "INFERRED"
+        for node, context, confidence in refs
+    )
+    assert any(
+        node["label"] == "RefreshCommand"
+        and node["source_file"].endswith("ToolkitViewModel.cs")
+        and context == "binding_command"
+        and confidence == "INFERRED"
+        for node, context, confidence in refs
+    )
+
+
+def test_extract_preserves_xaml_viewmodel_edge_after_id_remap(tmp_path):
+    project = tmp_path / "xaml_viewmodel"
+    shutil.copytree(FIXTURES / "xaml_viewmodel", project)
+    files = sorted(project.rglob("*.xaml")) + sorted(project.rglob("*.cs"))
+
+    r = extract(files, cache_root=project, parallel=False)
+    nodes = {n["id"]: n for n in r["nodes"]}
+    edges = _view_model_edges(r)
+
+    assert any(nodes[e["target"]]["label"] == "MainViewModel" for e in edges)
+    assert any(nodes[e["target"]]["label"] == "DesignViewModel" for e in edges)
+    assert any(
+        nodes[e["target"]]["label"] == "SettingsViewModel" and e["confidence"] == "INFERRED"
+        for e in edges
+    )
+
+
+def test_extract_xaml_viewmodel_resolution_stays_inside_cache_root(tmp_path):
+    project = tmp_path / "xaml_viewmodel"
+    shutil.copytree(FIXTURES / "xaml_viewmodel", project)
+
+    r = extract(
+        [project / "Views" / "ExplicitMainWindow.xaml"],
+        cache_root=project / "Views",
+        parallel=False,
+    )
+
+    assert _view_model_edges(r) == []
+
+
+def test_xaml_viewmodel_resolution_respects_graphifyignore(tmp_path):
+    project = tmp_path / "xaml_viewmodel"
+    shutil.copytree(FIXTURES / "xaml_viewmodel", project)
+    (project / ".graphifyignore").write_text("ViewModels/MainViewModel.cs\n", encoding="utf-8")
+
+    r = extract_xaml(project / "Views" / "ExplicitMainWindow.xaml")
+
+    assert _view_model_edges(r) == []
+
+
+def test_xaml_ambiguous_viewmodel_names_emit_no_edge(tmp_path):
+    (tmp_path / "Views").mkdir()
+    (tmp_path / "ViewModels").mkdir()
+    (tmp_path / "App.csproj").write_text("<Project Sdk=\"Microsoft.NET.Sdk\" />", encoding="utf-8")
+    xaml = (
+        '<Window x:Class="Demo.MainWindow"\n'
+        '        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"\n'
+        '        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">\n'
+        "</Window>\n"
+    )
+    (tmp_path / "Views" / "MainWindow.xaml").write_text(xaml, encoding="utf-8")
+    (tmp_path / "ViewModels" / "MainWindowViewModel.cs").write_text(
+        "namespace Demo { public class MainWindowViewModel { } }\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "ViewModels" / "MainViewModel.cs").write_text(
+        "namespace Demo { public class MainViewModel { } }\n",
+        encoding="utf-8",
+    )
+
+    r = extract_xaml(tmp_path / "Views" / "MainWindow.xaml")
+
+    assert _view_model_edges(r) == []
 
 
 def test_xaml_events_resolve_to_codebehind_methods():


### PR DESCRIPTION
## What

Adds deeper WPF/XAML graph extraction on top of the initial XAML support.

This branch resolves XAML views to ViewModels from:

- explicit `<Window.DataContext><vm:MainViewModel /></Window.DataContext>` / equivalent `DataContext` elements
- design-time `d:DataContext="{d:DesignInstance Type=...}"`
- naming conventions like `SettingsView` -> `SettingsViewModel`
- Prism `ViewModelLocator.AutoWireViewModel="True"`

It also extracts richer binding references:

- binding paths: `{Binding User.Name}`, `{Binding Path=Order.Total}`
- commands: `Command="{Binding SaveCommand}"`
- converters: `Converter={StaticResource MoneyConverter}`
- direct `<Binding Path="..." Converter="..." />`

This adds support for common WPF MVVM patterns/frameworks:

- plain WPF/MVVM `DataContext` patterns
- design-time ViewModel hints
- naming-convention ViewModel lookup
- Prism AutoWire ViewModel conventions
- CommunityToolkit.Mvvm generated members:
  - `[ObservableProperty] private string userName;` -> inferred `UserName`
  - `[ObservableProperty]` on the line above a field -> inferred generated property
  - `[RelayCommand] private void Save()` -> inferred `SaveCommand`
  - `[RelayCommand] private async Task SaveAsync()` -> inferred `SaveCommand`
- EventToCommand-style command binding via `InvokeCommandAction Command="{Binding SaveCommand}"`

Inference is conservative:

- only links a ViewModel when exactly one matching C# class is found
- skips ambiguous ViewModel candidates
- marks convention/generated links as `INFERRED`
- does not infer commands from plain methods without `[RelayCommand]`
- respects `.gitignore` / `.graphifyignore`
- keeps ViewModel `.cs` scans inside the active extraction root

## Why

WPF apps often split UI behavior across `.xaml`, `.xaml.cs`, ViewModels, binding paths, commands, converters, and MVVM framework conventions. Without these links, graphify can see the files but misses the relationships that explain how UI flows into application code.

This makes WPF/XAML more useful in the graph:

- views connect to their real ViewModels
- buttons/commands connect to command members
- Toolkit-generated properties and commands are represented
- Prism AutoWire conventions are understood
- bindings and converters become searchable graph references

## Scope

This is WPF/XAML-oriented support.

WinUI, MAUI, Avalonia, and other XAML-based stacks may get some collateral benefit where their syntax overlaps with WPF/XAML, but they are not the focus of this PR or the previous WPF PR. I am not a WinUI/MAUI expert, so I would not want to claim direct support unless someone specifically asks for it and provides real examples.

If there are issues, bugs, or additions needed for further WPF support, please tag me: @MikeKatsoulakis.

## Tests

Added focused fixtures and tests for:

- explicit ViewModel `DataContext`
- design-time ViewModel `DataContext`
- naming inference
- Prism AutoWire true/false behavior
- ambiguous ViewModel candidates
- CommunityToolkit generated members, including same-line and next-line attributes
- EventToCommand command bindings
- binding paths, converters, and commands
- extraction ID remapping
- `.graphifyignore` behavior
- cache-root scan boundary behavior
- false-positive cases for Toolkit comments and non-event XAML attributes

Validated with:

```bash
uv run --frozen pytest tests/test_dotnet.py -q
uv run --frozen pytest tests/test_languages.py -k "sln or csproj or xaml or razor" -q
uv run --frozen ruff check graphify\extract.py tests\test_dotnet.py
git diff --check
```

Local full-suite note: `uv run --frozen pytest tests/ -q` still fails on this Windows checkout with existing platform/path/skillgen baseline failures; the targeted .NET/XAML checks above pass.

## Security Review

A security pass found that ViewModel lookup could scan `.cs` files outside the requested extraction boundary and repeat scans per XAML file. This branch fixes that by bounding lookup to the active extraction root, respecting ignore files, and caching the class scan during extraction.

No XML entity expansion, regex DoS, or graph-label injection issue was found.
