### PR TITLE
fix(extract): disambiguate imported symbol stubs

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2461,6 +2461,7 @@ def _extract_generic(
                 "file_type": "code",
                 "source_file": "",
                 "source_location": "",
+                "origin_file": str_path,
             })
         return nid
 
@@ -7517,6 +7518,13 @@ def _source_key(source_file: str, root: Path) -> str:
         return str(source_path)
 
 
+def _node_disambiguation_source_key(node: dict, root: Path) -> str:
+    source_file = str(node.get("source_file", ""))
+    if source_file:
+        return _source_key(source_file, root)
+    return _source_key(str(node.get("origin_file", "")), root)
+
+
 def _disambiguate_colliding_node_ids(
     nodes: list[dict],
     edges: list[dict],
@@ -7542,12 +7550,12 @@ def _disambiguate_colliding_node_ids(
     remap: dict[tuple[str, str], str] = {}
     ambiguous_ids: set[str] = set()
     for old_id, group in by_id.items():
-        source_keys = {_source_key(str(node.get("source_file", "")), root) for node in group}
+        source_keys = {_node_disambiguation_source_key(node, root) for node in group}
         if len(group) < 2 or len(source_keys) < 2:
             continue
         ambiguous_ids.add(old_id)
         for node in group:
-            source_key = _source_key(str(node.get("source_file", "")), root)
+            source_key = _node_disambiguation_source_key(node, root)
             if not source_key:
                 continue
             new_id = _make_id(source_key, old_id)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -123,6 +123,25 @@ def test_cross_file_type_annotation_refs_resolve_to_single_node(tmp_path):
     assert "_py" not in thing_nodes[0]["id"], thing_nodes[0]["id"]
 
 
+def test_imported_type_stubs_do_not_collide_across_source_files(tmp_path):
+    """#1462: imported stdlib/type stubs with the same label are distinct uses
+    when there is no single project definition to rewire onto. They need the
+    referencing file as a disambiguator while still keeping ``source_file`` empty
+    so real project definitions can be rewired by #1402."""
+    first = tmp_path / "pkg/a.py"
+    second = tmp_path / "pkg/b.py"
+    first.parent.mkdir(parents=True)
+    first.write_text("from pathlib import Path\ndef use_a(p: Path):\n    return p\n", encoding="utf-8")
+    second.write_text("from pathlib import Path\ndef use_b(p: Path):\n    return p\n", encoding="utf-8")
+
+    result = extract([first, second], cache_root=tmp_path)
+    path_nodes = [node for node in result["nodes"] if node["label"] == "Path"]
+
+    assert len(path_nodes) == 2
+    assert len({node["id"] for node in path_nodes}) == 2
+    assert all(not node.get("source_file") for node in path_nodes)
+
+
 def test_extract_updates_raw_call_callers_after_duplicate_id_disambiguation(tmp_path):
     first = tmp_path / "apps/api/Program.cs"
     second = tmp_path / "tools/api/Program.cs"


### PR DESCRIPTION
## Summary
- preserve the referencing file for generic imported symbol stubs via an internal origin_file field
- use that origin when duplicate node IDs need source-based disambiguation
- add regression coverage for repeated imported Path type stubs across files

Fixes #1462

## Testing
- python -m pytest tests/test_extract.py -k "imported_type_stubs or cross_file_type_annotation_refs or duplicate_symbol_ids"