### PR TITLE
fix(extract): emit Java field type references

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2964,6 +2964,22 @@ def _extract_generic(
                          "references", line, context="field")
             return
 
+        if (config.ts_module == "tree_sitter_java"
+                and t == "field_declaration"
+                and parent_class_nid):
+            type_node = node.child_by_field_name("type")
+            if type_node is not None:
+                line = node.start_point[0] + 1
+                refs: list[tuple[str, str]] = []
+                _java_collect_type_refs(type_node, source, False, refs)
+                for ref_name, role in refs:
+                    ctx = "generic_arg" if role == "generic_arg" else "field"
+                    target_nid = ensure_named_node(ref_name, line)
+                    if target_nid != parent_class_nid:
+                        add_edge(parent_class_nid, target_nid, "references",
+                                 line, context=ctx)
+            return
+
         if (config.ts_module == "tree_sitter_php"
                 and t == "property_declaration"
                 and parent_class_nid):

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -344,6 +344,25 @@ def test_java_parameter_return_generic_and_attribute_contexts():
     assert ("build", "Override") in _edge_labels(result, "references", "attribute")
 
 
+def test_java_field_type_references_have_field_context(tmp_path):
+    source = tmp_path / "Fields.java"
+    source.write_text(
+        "class PaymentGateway {}\n"
+        "class Handler {}\n"
+        "class CheckoutService {\n"
+        "    PaymentGateway gateway;\n"
+        "    List<Handler> handlers;\n"
+        "}\n"
+    )
+    result = extract_java(source)
+    assert ("CheckoutService", "PaymentGateway") in _edge_labels(
+        result, "references", "field"
+    )
+    assert ("CheckoutService", "Handler") in _edge_labels(
+        result, "references", "generic_arg"
+    )
+
+
 def test_csharp_field_type_references_have_field_context():
     r = extract_csharp(FIXTURES / "sample.cs")
     refs = _references(r)


### PR DESCRIPTION
## Summary

- emit `references` edges for Java field types
- preserve `field` and `generic_arg` contexts

## Why

Java field types were missing from the extraction cache and final graph, hiding composition and injected dependencies in Java projects.

Fixes #1484

## Result

The extraction cache now includes:

```json
{"source": "fieldreference_checkoutservice", "target": "fieldreference_paymentgateway", "relation": "references", "confidence": "EXTRACTED", "context": "field"}
```

## Testing

- `uv run --frozen pytest tests/test_languages.py tests/test_java_type_resolution.py -q -k java` (16 passed, 261 deselected)
- `uv run --frozen pytest tests/ -q --tb=short` (2413 passed, 28 skipped)
- `uv run --frozen ruff check graphify/extract.py tests/test_languages.py` (passed)
