### PR TITLE
fix(extract): emit Java type annotation references

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -684,11 +684,11 @@ def _java_collect_type_refs(node, source: bytes, generic: bool, out: list[tuple[
                 _java_collect_type_refs(c, source, generic, out)
 
 
-def _java_method_annotation_names(method_node, source: bytes) -> list[str]:
-    """Collect annotation names from a Java method's `modifiers` child."""
+def _java_annotation_names(declaration_node, source: bytes) -> list[str]:
+    """Collect annotation names from a Java declaration's `modifiers` child."""
     names: list[str] = []
     modifiers = None
-    for child in method_node.children:
+    for child in declaration_node.children:
         if child.type == "modifiers":
             modifiers = child
             break
@@ -2792,6 +2792,12 @@ def _extract_generic(
                                         if tid.type == "type_identifier":
                                             _emit_java_parent(_read_text(tid, source), "inherits", line)
 
+                for anno_name in _java_annotation_names(node, source):
+                    target_nid = ensure_named_node(anno_name, line)
+                    if target_nid != class_nid:
+                        add_edge(class_nid, target_nid, "references", line,
+                                 context="attribute")
+
             # Scala: extends_clause carries `extends Base with Trait1 with Trait2`.
             # The first base after `extends` is `inherits`; each subsequent
             # type after `with` is `mixes_in`. Also walk class_parameters for
@@ -3190,7 +3196,7 @@ def _extract_generic(
                         target_nid = ensure_named_node(ref_name, line)
                         if target_nid != func_nid:
                             add_edge(func_nid, target_nid, "references", line, context=ctx)
-                for anno_name in _java_method_annotation_names(node, source):
+                for anno_name in _java_annotation_names(node, source):
                     target_nid = ensure_named_node(anno_name, line)
                     if target_nid != func_nid:
                         add_edge(func_nid, target_nid, "references", line, context="attribute")

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -344,6 +344,21 @@ def test_java_parameter_return_generic_and_attribute_contexts():
     assert ("build", "Override") in _edge_labels(result, "references", "attribute")
 
 
+def test_java_type_annotations_have_attribute_context(tmp_path):
+    source = tmp_path / "TypeAnnotations.java"
+    source.write_text(
+        '@Service\n'
+        '@Entity(name = "checkout")\n'
+        'class CheckoutService {}\n'
+    )
+
+    result = extract_java(source)
+
+    refs = _edge_labels(result, "references", "attribute")
+    assert ("CheckoutService", "Service") in refs
+    assert ("CheckoutService", "Entity") in refs
+
+
 def test_csharp_field_type_references_have_field_context():
     r = extract_csharp(FIXTURES / "sample.cs")
     refs = _references(r)


### PR DESCRIPTION
## Summary

- emit `references` edges for annotations on Java classes, interfaces, and records
- reuse the existing `attribute` context used by Java method annotations

## Why

Type-level annotations such as `@Service` and `@Entity` were missing from the extraction cache and final graph, hiding framework roles in Java and Spring projects.

Fixes #1486

## Result

The extraction cache now includes:

```json
[
  {"source": "typeannotations_checkoutservice", "target": "service", "relation": "references", "confidence": "EXTRACTED", "context": "attribute"},
  {"source": "typeannotations_checkoutservice", "target": "entity", "relation": "references", "confidence": "EXTRACTED", "context": "attribute"}
]
```

## Testing

- `uv run --frozen pytest tests/test_languages.py tests/test_java_type_resolution.py -q -k java` (16 passed, 261 deselected)
- `uv run --frozen pytest tests/ -q --tb=short` (2413 passed, 28 skipped)
- `uv run --frozen ruff check graphify/extract.py tests/test_languages.py` (passed)
