### PR TITLE
docs: fix global add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ graphify export callflow-html --max-sections 8      # cap generated architecture
 graphify export callflow-html --output docs/arch.html
 graphify export callflow-html ./some-repo/graphify-out
 
-graphify global add graphify-out/graph.json myrepo   # register a project graph into ~/.graphify/global.json
+graphify global add graphify-out/graph.json --as myrepo   # register a project graph into ~/.graphify/global-graph.json
 graphify global remove myrepo                         # remove a project from the global graph
 graphify global list                                  # show all registered repos + node/edge counts
 graphify global path                                  # print path to the global graph file


### PR DESCRIPTION
## What

While trying the README example for adding a graph to the global graph, I noticed the documented command does not actually name the repo as shown:

```bash
graphify global add graphify-out/graph.json myrepo
```

The CLI expects the repo name through `--as`, so this updates the example to:

```bash
graphify global add graphify-out/graph.json --as myrepo
```

This also updates the comment on that line to use the actual global graph path, `~/.graphify/global-graph.json`.

## Why

I ran into this because the README made it look like `myrepo` could be passed as a positional argument, but the CLI ignores that extra positional value and falls back to its default repo tag. Using `--as myrepo` matches the CLI help and records the intended name.

## Tests

Not run. This is a README-only change.
