### PR TITLE
fix(extract): Go ensure_named_node emits sourceless cross-file stub (#1402 gap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## Unreleased
+
+- Fix: the Go AST extractor no longer creates phantom duplicate nodes for cross-file type references — the Go copy of `ensure_named_node` still used the older sourced-stub fallback; it now emits a sourceless stub like the other extractors, extending the #1402 fix to Go (#1500).
+
 ## 0.8.50 (2026-06-27)
 
 - Feat: `graphify label --missing-only` relabels only communities that are unnamed or still hold a `Community N` placeholder, preserving existing non-placeholder labels from `.graphify_labels.json` (#1481, thanks @jiangyq9; supersedes #1421 by @matiasduartee, who proposed the same flag). Lets a large graph be relabeled incrementally without re-naming (and paying for) communities that already have good names.

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -6472,7 +6472,21 @@ def extract_go(path: Path) -> dict:
             return nid
         nid = _make_id(name)
         if nid not in seen_ids:
-            add_node(nid, name, line)
+            # The name isn't declared in this file, so this is a cross-file reference
+            # (e.g. a type defined in another file of the package). Emit a SOURCELESS
+            # stub — like the inheritance-base path in the other extractors — so the
+            # corpus-level rewire can collapse it onto the real definition. A sourced
+            # stub here makes _disambiguate_colliding_node_ids bake the referencing
+            # file's path (with extension) into the id and blocks the rewire, which is
+            # the phantom-duplicate-node bug (#1402).
+            seen_ids.add(nid)
+            nodes.append({
+                "id": nid,
+                "label": name,
+                "file_type": "code",
+                "source_file": "",
+                "source_location": "",
+            })
         return nid
 
     def emit_go_method_refs(func_node, func_nid: str, line: int) -> None:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -123,6 +123,35 @@ def test_cross_file_type_annotation_refs_resolve_to_single_node(tmp_path):
     assert "_py" not in thing_nodes[0]["id"], thing_nodes[0]["id"]
 
 
+def test_go_cross_file_type_refs_resolve_to_single_node(tmp_path):
+    """#1402 (Go): the sourceless-stub fix landed in six extractors but the Go copy
+    of ``ensure_named_node`` was missed, so a Go type defined once but referenced via
+    parameter/return types in N sibling files produced 1+N phantom duplicate nodes
+    with the referencing file's path (extension and all) baked into the id
+    (e.g. ``pkg_a_go_thing``). Same-package references must resolve to the single
+    canonical type node instead."""
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "thing.go").write_text(
+        "package pkg\n\ntype Thing struct{}\n\nfunc (t Thing) Run() int { return 1 }\n",
+        encoding="utf-8",
+    )
+    (pkg / "a.go").write_text(
+        "package pkg\n\nfunc UseA(obj Thing) Thing { return obj }\n", encoding="utf-8"
+    )
+    (pkg / "b.go").write_text(
+        "package pkg\n\nfunc UseB(obj Thing) Thing { return obj }\n", encoding="utf-8"
+    )
+
+    result = extract([pkg / "thing.go", pkg / "a.go", pkg / "b.go"], cache_root=tmp_path)
+
+    thing_nodes = [n for n in result["nodes"] if n["label"] == "Thing"]
+    assert len(thing_nodes) == 1, [n["id"] for n in thing_nodes]
+    # The phantom signature is the referencing file's path (with .go extension)
+    # baked into the id — must not appear.
+    assert "_go" not in thing_nodes[0]["id"], thing_nodes[0]["id"]
+
+
 def test_extract_updates_raw_call_callers_after_duplicate_id_disambiguation(tmp_path):
     first = tmp_path / "apps/api/Program.cs"
     second = tmp_path / "tools/api/Program.cs"


### PR DESCRIPTION

Closes #1500. Follow-up to #1402 / `0aeda15`.

#1402 fixed the phantom-duplicate-node bug by making `ensure_named_node`'s cross-file
fallback emit a **sourceless** stub instead of a **sourced** one, so
`_rewire_unique_stub_nodes` collapses a type referenced in N files onto its single
definition (instead of 1+N nodes with the referencing file's path baked into the id,
`pkg_a_go_thing`). This extends that fix to the Go copy of `ensure_named_node`, which
still used the older **sourced**-stub fallback and so still produced the phantoms on `v8`.

## Change

`graphify/extract.py` — Go `ensure_named_node` cross-file fallback now appends a
sourceless stub (`source_file=""`, `source_location=""`) like the other extractors,
instead of calling `add_node(...)`. Go's package-scoped first check
(`_make_id(pkg_scope, name)`, which the others don't have) is preserved; only the
fallback branch changed. Adds a one-line `## Unreleased` CHANGELOG entry.

## Result

Minimal repro now yields one `pkg_thing` instead of `['pkg_a_go_thing',
'pkg_b_go_thing', 'pkg_thing']`. On two production Go corpora (AST-only):

| repo | phantom type-ref nodes | edges stranded on phantoms | total nodes |
|---|---|---|---|
| A (62 .go) | 116 → **7** | 503 → **297** | 1629 → 1428 |
| B (103 .go) | 158 → **7** | 230 → **82** | 1105 → 824 |

The residual 7 per repo are the cases the other extractors also leave alone —
mostly references to external types (the `database/sql` `Null*` family: a same-named
local constructor func, no local type), plus the occasional type genuinely defined
under the same name in two packages (conservative non-merge, #1257).

## Tests

- New `test_go_cross_file_type_refs_resolve_to_single_node` (mirrors the Python #1402
  test). Fails pre-fix (3 nodes: `pkg_thing`, `pkg_a_go_thing`, `pkg_b_go_thing`),
  passes post-fix.
- `tests/test_extract.py`, `tests/test_languages.py`, `tests/test_multilang.py`: 416 pass.
