### PR TITLE
fix(extract): emit Java enum and annotation type nodes

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2065,7 +2065,11 @@ _JAVA_CONFIG = LanguageConfig(
     ts_module="tree_sitter_java",
     # record_declaration shares class_declaration's name/body/interfaces fields,
     # so it becomes a first-class type node instead of an isolated file (#1373).
-    class_types=frozenset({"class_declaration", "interface_declaration", "record_declaration"}),
+    # Enums and annotation declarations use the same name/body contract.
+    class_types=frozenset({
+        "class_declaration", "interface_declaration", "record_declaration",
+        "enum_declaration", "annotation_type_declaration",
+    }),
     function_types=frozenset({"method_declaration", "constructor_declaration"}),
     import_types=frozenset({"import_declaration"}),
     # object_creation_expression (`new Foo(...)`) is handled by a dedicated Java

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -399,6 +399,36 @@ def test_java_type_annotations_have_attribute_context(tmp_path):
     assert ("CheckoutService", "Entity") in refs
 
 
+def test_java_enum_and_annotation_declarations_are_type_nodes(tmp_path):
+    source = tmp_path / "TypeDeclarations.java"
+    source.write_text(
+        "enum PaymentStatus { PENDING, PAID }\n"
+        "@interface Audited {}\n"
+        "class Order { PaymentStatus status; }\n"
+        "@Audited class CheckoutService {}\n"
+    )
+
+    result = extract_java(source)
+
+    assert ("TypeDeclarations.java", "PaymentStatus") in _edge_labels(
+        result, "contains"
+    )
+    assert ("TypeDeclarations.java", "Audited") in _edge_labels(result, "contains")
+    assert ("Order", "PaymentStatus") in _edge_labels(
+        result, "references", "field"
+    )
+    assert ("CheckoutService", "Audited") in _edge_labels(
+        result, "references", "attribute"
+    )
+    definitions = {
+        node["label"]: node
+        for node in result["nodes"]
+        if node.get("label") in {"PaymentStatus", "Audited"}
+    }
+    assert definitions["PaymentStatus"].get("source_file") == str(source)
+    assert definitions["Audited"].get("source_file") == str(source)
+
+
 def test_csharp_field_type_references_have_field_context():
     r = extract_csharp(FIXTURES / "sample.cs")
     refs = _references(r)


### PR DESCRIPTION
## Summary

- model Java enum and annotation type declarations as source-backed type nodes
- preserve existing field and attribute references while adding file `contains` edges

Fixes #1512

## Result

Label-normalized relevant edges from the final patch:

```json
[
  {
    "source": "TypeDeclarations.java",
    "target": "PaymentStatus",
    "relation": "contains",
    "confidence": "EXTRACTED"
  },
  {
    "source": "TypeDeclarations.java",
    "target": "Audited",
    "relation": "contains",
    "confidence": "EXTRACTED"
  },
  {
    "source": "Order",
    "target": "PaymentStatus",
    "relation": "references",
    "confidence": "EXTRACTED",
    "context": "field"
  },
  {
    "source": "CheckoutService",
    "target": "Audited",
    "relation": "references",
    "confidence": "EXTRACTED",
    "context": "attribute"
  }
]
```

## Testing

- `uv run --frozen pytest tests/test_languages.py -q -k java_enum_and_annotation` (1 passed)
- `uv run --frozen pytest tests/ -q --tb=short` (2442 passed, 28 skipped)
- `uv run --frozen ruff check graphify/extract.py tests/test_languages.py` (passed)
