### PR TITLE
docs(build): correct deduplicate_by_label docstring (dormant, not auto-called)

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -423,7 +423,15 @@ def deduplicate_by_label(nodes: list[dict], edges: list[dict]) -> tuple[list[dic
     """Merge nodes that share a normalised label, rewriting edge references.
 
     Prefers IDs without chunk suffixes (_c\\d+) and shorter IDs when tied.
-    Drops self-loops created by the merge. Called in build() automatically.
+    Drops self-loops created by the merge.
+
+    Dormant: this is NOT wired into ``build()`` — the active dedup path is
+    ``deduplicate_entities`` (imported and called in ``build``), which supersedes
+    it. The previous "Called in build() automatically" note was never true. It
+    also merges by label alone with no ``file_type`` guard, so it must not be
+    enabled for code nodes: same-label symbols from different files/packages
+    (e.g. two ``Account`` types) would collapse into one — the cross-file
+    conflation ``deduplicate_entities`` deliberately avoids for code (#1205).
     """
     _CHUNK_SUFFIX = re.compile(r"_c\d+$")
     canonical: dict[str, dict] = {}  # norm_label -> surviving node


### PR DESCRIPTION

`deduplicate_by_label` (`graphify/build.py`) is never called — the wired dedup path
is `deduplicate_entities` (imported and called in `build()`). But its docstring says
**"Called in build() automatically,"** which is not true.

## Change

Docstring only, no behavior change. It now states the helper is **dormant** (not
wired into `build()`, superseded by `deduplicate_entities`) and warns that it merges
by **label alone with no `file_type` guard** — so it must not be enabled for code
nodes: same-label symbols from different files/packages (e.g. two `Account` types)
would collapse into one, the cross-file conflation `deduplicate_entities` deliberately
avoids for code (#1205). Worth flagging because the dedup design docs suggest "wiring
up the dormant `deduplicate_by_label`" as a free win — which would reintroduce that bug.

## Alternative: delete it

Since the function is unused and superseded, **deleting it outright is also
reasonable** — happy to do that instead. I went with the minimal,
non-destructive docstring correction; let me know which you'd rather, and whether the
stale "wire up dormant `deduplicate_by_label`" references under `docs/superpowers/`
should be cleaned up too.

## Tests

`tests/test_build.py`, `tests/test_dedup.py`: 93 pass. No CHANGELOG entry
````
