### PR TITLE
fix(extract): drop internal origin_file so it stops leaking into graph.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## Unreleased
+
+- Fix: the internal `origin_file` disambiguation field (#1462) is no longer serialized into graph.json, where it had shipped as an absolute, machine-specific path — it is dropped once the colliding-id pass consumes it, keeping output portable (#555, #932). `_origin` stays (the incremental watcher needs it, #1116).
+
 ## 0.8.51 (2026-06-28)
 
 - Fix: the Obsidian export (`--obsidian` / `to_obsidian`) no longer overwrites a user's own notes or `.obsidian/` config when pointed at an existing vault (#1506). It wrote one note per node straight into the target dir and unconditionally replaced `.obsidian/graph.json`, so `--obsidian-dir ~/my-vault` could clobber a same-named note (`Database.md`) and the user's graph-view settings — silently, no backup. graphify now records the files it owns in a `.graphify_obsidian_manifest.json` and refuses to overwrite any pre-existing file it didn't create (skipping it with one aggregated warning); a re-run still updates graphify's own notes. The default `graphify-out/obsidian` output is unchanged.

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -13466,6 +13466,15 @@ def extract(
         except ValueError:
             pass
 
+    # origin_file is an internal disambiguation hint (#1462): the colliding-id pass
+    # above reads it to keep same-named cross-file stubs distinct, after which nothing
+    # consumes it. Drop it from the returned nodes so it never ships into graph.json as
+    # an absolute, machine-specific path — the same "no absolute paths in output"
+    # contract that relativizes source_file just above (#555, #932). The per-file AST
+    # cache keeps its own copy, which is what the colliding-id pass reads on a cache hit.
+    for n in all_nodes:
+        n.pop("origin_file", None)
+
     # Tag AST provenance so the incremental watch rebuild can distinguish
     # AST-extracted nodes from semantic/LLM nodes. On a full re-extraction
     # the watcher drops any AST-marked node missing from the fresh output

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -171,6 +171,36 @@ def test_imported_type_stubs_do_not_collide_across_source_files(tmp_path):
     assert all(not node.get("source_file") for node in path_nodes)
 
 
+def test_origin_file_is_not_serialized_into_extract_output(tmp_path):
+    """origin_file is an internal disambiguation hint (#1462) consumed only by the
+    colliding-id pass during extraction. It must not survive into the returned nodes
+    (and thus graph.json), where it would ship as an absolute, machine-specific path —
+    the "no absolute paths in output" contract (#555, #932). Disambiguation still keys
+    on it first, so the two same-label cross-file stubs stay distinct."""
+    first = tmp_path / "pkg/a.py"
+    second = tmp_path / "pkg/b.py"
+    first.parent.mkdir(parents=True)
+    first.write_text("from pathlib import Path\ndef use_a(p: Path):\n    return p\n", encoding="utf-8")
+    second.write_text("from pathlib import Path\ndef use_b(p: Path):\n    return p\n", encoding="utf-8")
+
+    result = extract([first, second], cache_root=tmp_path)
+
+    # The internal field is gone from every node...
+    assert all("origin_file" not in node for node in result["nodes"])
+    # ...so no node leaks the absolute sandbox path that origin_file used to carry.
+    leaked = [
+        (node.get("id"), key, value)
+        for node in result["nodes"]
+        for key, value in node.items()
+        if isinstance(value, str) and str(tmp_path) in value
+    ]
+    assert not leaked, f"absolute paths leaked into nodes: {leaked}"
+    # ...yet the colliding-id pass still kept the two cross-file stubs distinct.
+    path_nodes = [node for node in result["nodes"] if node["label"] == "Path"]
+    assert len(path_nodes) == 2
+    assert len({node["id"] for node in path_nodes}) == 2
+
+
 def test_extract_updates_raw_call_callers_after_duplicate_id_disambiguation(tmp_path):
     first = tmp_path / "apps/api/Program.cs"
     second = tmp_path / "tools/api/Program.cs"


### PR DESCRIPTION

Follow-up to #1462. `ensure_named_node`'s cross-file fallback tags each sourceless stub
with an internal `origin_file` field — the referencing file's **absolute** path — so
`_disambiguate_colliding_node_ids` can keep same-named cross-file references distinct.
That field is consumed only by the colliding-id pass during extraction, but it was never
dropped, so it shipped into `graph.json` verbatim as an absolute, machine-specific path,
violating the "no absolute paths in output" contract that already relativizes `source_file`
(#555, #932). No exporter caught it: `to_json` passes node fields through unchanged, and
`to_graphml` (and the Neo4j/FalkorDB pushers) strip only `_`-prefixed keys — `origin_file`
has no underscore.

## Change

Drop `origin_file` from the combined node list after the colliding-id pass consumes it,
right before the `_origin` tagging loop in `extract()` (one strip at the source — covers
every export surface and the cache-hit path; cannot re-enter via `build_from_json`).

## Why `_origin` is left alone

The original observation also named `_origin`. It is **intentionally kept**: the
incremental watcher reads `n.get("_origin") == "ast"` from the persisted `graph.json` to
evict stale AST nodes on a full rebuild (#1116, `watch.py`). Stripping it would reintroduce
that bug. It is the constant `"ast"` — not a path — so it is not an absolute-path leak.

## Result

| field on a cross-file stub | before | after |
|---|---|---|
| `origin_file` (abs path) | present, e.g. `/Users/you/proj/pkg/a.py` | **gone** |
| node id / `source_file` distinctness | distinct | distinct (unchanged) |
| `_origin` | `"ast"` | `"ast"` (unchanged) |

The colliding-id pass runs **before** the strip, so cross-file stubs stay distinct; the
per-file AST cache keeps its own `origin_file` copy for the cache-hit path.

## Tests

- New `test_origin_file_is_not_serialized_into_extract_output`: asserts no node carries
  `origin_file` (or any absolute sandbox path) while the two cross-file `Path` stubs stay
  distinct. Fails pre-fix, passes post-fix.
- Full suite: 2494 passed, 2 skipped.

## Out of scope

- The **per-file AST cache** still stores `origin_file` as an absolute path
  (`cache.save_cached` relativizes `source_file` per #777 but not `origin_file`). The cache
  is a private, content-hashed, version-namespaced artifact that never ships, and the strip
  above keeps it out of `graph.json` regardless — so this is a separate portability/hygiene
  follow-up, not part of this fix.
- For a same-named cross-file stub, the disambiguated node **id** is a slug derived from the
  referencing path; under a fully-resolved scan root that slug is root-relative. This is
  #1462's existing disambiguation behavior, unchanged here.