### PR TITLE
fix(extract): skip Java type parameter references

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -644,16 +644,54 @@ def _csharp_attribute_names(method_node, source: bytes) -> list[str]:
     return names
 
 
-def _java_collect_type_refs(node, source: bytes, generic: bool, out: list[tuple[str, str]]) -> None:
+_JAVA_TYPE_PARAMETER_SCOPE_DECLARATIONS = frozenset({
+    "class_declaration",
+    "interface_declaration",
+    "record_declaration",
+    "method_declaration",
+    "constructor_declaration",
+})
+
+
+def _java_type_parameters_in_scope(node, source: bytes) -> frozenset[str]:
+    """Return Java type-parameter names visible from ``node``."""
+    names: set[str] = set()
+    scope = node
+    while scope is not None:
+        if scope.type in _JAVA_TYPE_PARAMETER_SCOPE_DECLARATIONS:
+            params = scope.child_by_field_name("type_parameters")
+            if params is not None:
+                for param in params.children:
+                    if param.type != "type_parameter":
+                        continue
+                    name_node = next(
+                        (child for child in param.children if child.type == "type_identifier"),
+                        None,
+                    )
+                    if name_node is not None:
+                        names.add(_read_text(name_node, source))
+        scope = scope.parent
+    return frozenset(names)
+
+
+def _java_collect_type_refs(
+    node,
+    source: bytes,
+    generic: bool,
+    out: list[tuple[str, str]],
+    skip: frozenset[str] | None = None,
+) -> None:
     """Walk a Java type expression; append (name, role) tuples."""
     if node is None:
         return
+    if skip is None:
+        skip = _java_type_parameters_in_scope(node, source)
     t = node.type
     if t in ("integral_type", "floating_point_type", "boolean_type", "void_type"):
         return
     if t == "type_identifier":
         name = _read_text(node, source)
-        if name:
+        if name and name not in skip:
             out.append((name, "generic_arg" if generic else "type"))
         return
     if t == "scoped_type_identifier":
@@ -665,24 +703,24 @@ def _java_collect_type_refs(node, source: bytes, generic: bool, out: list[tuple[
         for c in node.children:
             if c.type in ("type_identifier", "scoped_type_identifier"):
                 text = _read_text(c, source).rsplit(".", 1)[-1]
-                if text:
+                if text and (c.type == "scoped_type_identifier" or text not in skip):
                     out.append((text, "generic_arg" if generic else "type"))
                 break
         for c in node.children:
             if c.type == "type_arguments":
                 for arg in c.children:
                     if arg.is_named:
-                        _java_collect_type_refs(arg, source, True, out)
+                        _java_collect_type_refs(arg, source, True, out, skip)
         return
     if t == "array_type":
         for c in node.children:
             if c.is_named:
-                _java_collect_type_refs(c, source, generic, out)
+                _java_collect_type_refs(c, source, generic, out, skip)
         return
     if node.is_named:
         for c in node.children:
             if c.is_named:
-                _java_collect_type_refs(c, source, generic, out)
+                _java_collect_type_refs(c, source, generic, out, skip)
 
 
 def _java_annotation_names(declaration_node, source: bytes) -> list[str]:

--- a/tests/test_java_type_resolution.py
+++ b/tests/test_java_type_resolution.py
@@ -137,6 +137,19 @@ def test_java_record_implements_interface(tmp_path: Path):
     assert implements, "record implementing an interface should emit an implements edge"
 
 
+def test_java_type_parameters_do_not_resolve_to_real_class(tmp_path: Path):
+    real_type = _write(tmp_path / "T.java", "public class T {}\n")
+    generic = _write(
+        tmp_path / "Generic.java",
+        "public class Generic<T> { java.util.List<T> values; }\n",
+    )
+
+    result = extract([real_type, generic], cache_root=tmp_path)
+
+    references = _label_edges(result, {"references"})
+    assert ("Generic", "references", "T") not in references
+
+
 def test_java_cross_file_constructor_call_resolves(tmp_path: Path):
     # #1373: `new Foo(...)` in a method body must produce a cross-file edge to the
     # Foo definition. Foo is NOT used as a return type here, so the edge can only

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -379,6 +379,34 @@ def test_java_generic_parents_include_type_argument_references(tmp_path):
     assert ("DerivedHandler", "Event") in refs
 
 
+def test_java_type_parameters_do_not_emit_references(tmp_path):
+    source = tmp_path / "TypeParameters.java"
+    source.write_text(
+        "class Payload {}\n"
+        "class Base<X> {}\n"
+        "class Box<T> extends Base<T> {\n"
+        "    T value;\n"
+        "    List<T> values;\n"
+        "    <U> U convert(T input, List<U> mapped, List<Payload> retained) {\n"
+        "        return null;\n"
+        "    }\n"
+        "    <V> Box(V value) {}\n"
+        "}\n"
+    )
+
+    result = extract_java(source)
+
+    references = _references(result)
+    assert not [edge for _, target, edge in references if target in {"T", "U", "V"}]
+    assert not [
+        node
+        for node in result["nodes"]
+        if node.get("label") in {"T", "U", "V"} and not node.get("source_file")
+    ]
+    assert ("Box", "Base") in _edge_labels(result, "inherits")
+    assert ("convert", "Payload") in _edge_labels(result, "references", "generic_arg")
+
+
 def test_java_parameter_return_generic_and_attribute_contexts():
     result = extract_java(FIXTURES / "sample.java")
     assert ("build", "HttpClient") in _edge_labels(result, "references", "parameter_type")


### PR DESCRIPTION
## Summary

- track Java type parameters declared by enclosing types, methods, and constructors
- skip unqualified references to those parameters while preserving real type references
- cover per-file output and cross-file collisions with real classes of the same name

Fixes #1517

## Result

Label-normalized verification summary from the final extraction:

```json
{
  "type_parameter_nodes": [],
  "type_parameter_reference_edges": [],
  "retained_edges": [
    {
      "source": "Box",
      "target": "Base",
      "relation": "inherits",
      "confidence": "EXTRACTED"
    },
    {
      "source": "convert",
      "target": "Payload",
      "relation": "references",
      "context": "generic_arg",
      "confidence": "EXTRACTED"
    }
  ]
}
```

## Testing

- `uv run --frozen pytest tests/test_languages.py tests/test_java_type_resolution.py -q -k java_type_parameters` (2 passed)
- `uv run --frozen pytest tests/ -q --tb=short` (2496 passed, 3 skipped)
- `uv run --frozen ruff check graphify/extract.py tests/test_languages.py tests/test_java_type_resolution.py` (passed)