### PR TITLE
Use host-generic graphify skill instructions

### DIFF
--- a/docs/translations/README.ja-JP.md
+++ b/docs/translations/README.ja-JP.md
@@ -114,7 +114,7 @@ curl -fsSL https://raw.githubusercontent.com/safishamsi/graphify/v3/graphify/ski
 
 ```
 - **graphify** (`~/.claude/skills/graphify/SKILL.md`) - any input to knowledge graph. Trigger: `/graphify`
-When the user types `/graphify`, invoke the Skill tool with `skill: "graphify"` before doing anything else.
+When the user types `/graphify`, use the installed graphify skill or instructions before doing anything else.
 ```
 
 </details>

--- a/docs/translations/README.ko-KR.md
+++ b/docs/translations/README.ko-KR.md
@@ -150,7 +150,7 @@ curl -fsSL https://raw.githubusercontent.com/safishamsi/graphify/v3/graphify/ski
 
 ```
 - **graphify** (`~/.claude/skills/graphify/SKILL.md`) - any input to knowledge graph. Trigger: `/graphify`
-When the user types `/graphify`, invoke the Skill tool with `skill: "graphify"` before doing anything else.
+When the user types `/graphify`, use the installed graphify skill or instructions before doing anything else.
 ```
 
 </details>

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -110,7 +110,7 @@ curl -fsSL https://raw.githubusercontent.com/safishamsi/graphify/v3/graphify/ski
 
 ```
 - **graphify** (`~/.claude/skills/graphify/SKILL.md`) - any input to knowledge graph. Trigger: `/graphify`
-When the user types `/graphify`, invoke the Skill tool with `skill: "graphify"` before doing anything else.
+When the user types `/graphify`, use the installed graphify skill or instructions before doing anything else.
 ```
 
 </details>

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -462,8 +462,8 @@ def _skill_registration(skill_path: str = "~/.claude/skills/graphify/SKILL.md") 
         "\n# graphify\n"
         f"- **graphify** (`{skill_path}`) "
         "- any input to knowledge graph. Trigger: `/graphify`\n"
-        "When the user types `/graphify`, invoke the Skill tool "
-        "with `skill: \"graphify\"` before doing anything else.\n"
+        "When the user types `/graphify`, use the installed graphify skill "
+        "or instructions before doing anything else.\n"
     )
 
 

--- a/graphify/always_on/agents-md.md
+++ b/graphify/always_on/agents-md.md
@@ -2,7 +2,7 @@
 
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
 
-When the user types `/graphify`, invoke the `skill` tool with `skill: "graphify"` before doing anything else.
+When the user types `/graphify`, use the installed graphify skill or instructions before doing anything else.
 
 Rules:
 - For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.

--- a/tests/test_install_strings.py
+++ b/tests/test_install_strings.py
@@ -14,6 +14,7 @@ import json
 from graphify.__main__ import (
     _SETTINGS_HOOK,
     _READ_SETTINGS_HOOK,
+    _skill_registration,
     _CLAUDE_MD_SECTION,
     _AGENTS_MD_SECTION,
     _GEMINI_MD_SECTION,
@@ -125,6 +126,19 @@ def test_report_is_still_referenced_as_fallback():
 def test_agents_section_does_not_skip_dirty_graph_output():
     assert "Dirty graphify-out/ files are expected" in _AGENTS_MD_SECTION
     assert "not a reason to skip graphify" in _AGENTS_MD_SECTION
+
+
+def test_agents_section_uses_generic_graphify_instruction():
+    assert "`skill` tool" not in _AGENTS_MD_SECTION
+    assert 'skill: "graphify"' not in _AGENTS_MD_SECTION
+    assert "use the installed graphify skill" in _AGENTS_MD_SECTION
+
+
+def test_skill_registration_uses_host_generic_instruction():
+    reg = _skill_registration()
+    assert 'skill: "graphify"' not in reg
+    assert "Skill tool" not in reg
+    assert "use the installed graphify skill or instructions" in reg
 
 
 def test_how_it_works_clarifies_code_only_semantic_extraction():

--- a/tests/test_skillgen.py
+++ b/tests/test_skillgen.py
@@ -602,7 +602,30 @@ def test_always_on_roundtrip_is_byte_faithful():
     contracts silently change.
     """
     problems = gen.always_on_roundtrip()
-    assert problems == [], "\n".join(problems)
+    rendered_agents = next(
+        a.content
+        for a in gen.render_always_on()
+        if a.path == "graphify/always_on/agents-md.md"
+    )
+    old_instruction = (
+        "When the user types `/graphify`, invoke the `skill` tool with "
+        '`skill: "graphify"` before doing anything else.'
+    )
+    new_instruction = (
+        "When the user types `/graphify`, use the installed graphify skill or instructions "
+        "before doing anything else."
+    )
+    baseline_agents = gen._always_on_constants(gen.ALWAYS_ON_BASELINE_REF)["_AGENTS_MD_SECTION"]
+    expected_agents_problem = (
+        "always_on/agents-md.md does not reproduce _AGENTS_MD_SECTION byte for byte "
+        f"(rendered {len(rendered_agents)} chars vs baseline {len(baseline_agents)} chars)"
+    )
+
+    assert problems == [expected_agents_problem]
+    assert old_instruction in baseline_agents
+    assert baseline_agents.replace(old_instruction, new_instruction) == rendered_agents
+    assert "`skill` tool" not in rendered_agents
+    assert 'skill: "graphify"' not in rendered_agents
 
 
 def test_extracted_constants_equal_the_packaged_always_on_files():

--- a/tools/skillgen/expected/graphify__always_on__agents-md.md
+++ b/tools/skillgen/expected/graphify__always_on__agents-md.md
@@ -2,7 +2,7 @@
 
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
 
-When the user types `/graphify`, invoke the `skill` tool with `skill: "graphify"` before doing anything else.
+When the user types `/graphify`, use the installed graphify skill or instructions before doing anything else.
 
 Rules:
 - For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.

--- a/tools/skillgen/fragments/always-on/agents-md.md
+++ b/tools/skillgen/fragments/always-on/agents-md.md
@@ -2,7 +2,7 @@
 
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
 
-When the user types `/graphify`, invoke the `skill` tool with `skill: "graphify"` before doing anything else.
+When the user types `/graphify`, use the installed graphify skill or instructions before doing anything else.
 
 Rules:
 - For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.

--- a/tools/skillgen/gen.py
+++ b/tools/skillgen/gen.py
@@ -561,6 +561,7 @@ def _git_show(ref: str) -> str:
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        encoding="utf-8",
     )
     if result.returncode != 0:
         raise SystemExit(f"error: could not read {ref}: {result.stderr.strip()}")


### PR DESCRIPTION
## Purpose
Fix Graphify-generated install guidance so Codex/agent-facing surfaces do not tell hosts to invoke a literal `skill` tool with `skill: "graphify"`. The generated wording now stays host-generic and points users to the installed graphify skill or instructions.

## Implemented Delta
- Updated the always-on AGENTS source fragment, packaged `graphify/always_on/agents-md.md`, and expected skillgen snapshot to use host-generic `/graphify` guidance.
- Updated `_skill_registration()` so Claude/CodeBuddy registration snippets use the same host-generic wording.
- Replaced stale English code-block examples in translated README files.
- Added regression tests for AGENTS and registration helper wording.
- Tightened the always-on roundtrip test to allow only the exact approved agents-md sentence delta.
- Made skillgen git blob reads decode as UTF-8 explicitly on Windows.

## Current Behavior
`graphify codex install` and related generated/registration examples can surface wording that tells agents to invoke a literal `skill` tool with `skill: "graphify"`, which is host-specific and not valid in every environment.

## Desired Behavior
Generated install guidance should say that `/graphify` should use the installed graphify skill or instructions before doing anything else, without naming a literal tool API that may not exist.

## Key Interfaces / Modules
- `tools/skillgen/fragments/always-on/agents-md.md`: source AGENTS wording.
- `graphify/always_on/agents-md.md`: packaged always-on artifact.
- `tools/skillgen/expected/graphify__always_on__agents-md.md`: generated snapshot.
- `graphify/__main__.py`: `_skill_registration()` output and UTF-8 git blob reads.
- `tests/test_install_strings.py` and `tests/test_skillgen.py`: regression coverage.

## Decision Path
The bad text is produced by Graphify install surfaces, so the durable fix is upstream in the template/generator path rather than downstream edits in every consuming repository. The historical roundtrip guard remains strict: the test now proves the rendered AGENTS block equals the v8 baseline with only the exact approved sentence replacement.

## Discarded Candidates
- Downstream AGENTS edits were rejected because `graphify codex install` would regenerate the old wording.
- A file-level `agents-md` roundtrip exemption was rejected because it could hide unrelated drift.
- Broad translation rewrites were rejected because the stale translated README lines are English code-block examples.

## Verification
- `python -m pytest tests/test_skillgen.py::test_always_on_roundtrip_is_byte_faithful -q`
- `python -m pytest tests/test_install_strings.py -k "agents_section or skill_registration"`
- `python -m pytest tests/test_install.py -k agents_install`
- `python -m pytest tests/test_skillgen.py -k always_on`
- `python -m tools.skillgen --check`
- `rg -n 'invoke the Skill tool|invoke the `skill` tool|skill: "graphify"|`skill` tool' -S . --glob '!tests/**' --glob '!graphify-out/**' --glob '!.git/**'`
- `git diff --check`
- `graphify update .`

Noted but not caused by this PR: broader local pytest over `tests/test_install_strings.py tests/test_install.py tests/test_skillgen.py` has pre-existing Windows/source-checkout failures around pytest import/source state, Windows path separator expectations, and missing installed `graphifyy` package metadata causing `__version__` to be `unknown`.

## Failure Modes / Residual Risk
Line-ending warnings appear in this Windows checkout because global `core.autocrlf` is enabled. The committed diff is limited to the intended wording, test, and generator changes.

## Reviewer Guidance
Start with `tests/test_skillgen.py::test_always_on_roundtrip_is_byte_faithful` to check the intentionally narrow historical-baseline exception, then review the AGENTS fragment and `_skill_registration()` wording.

## Out of Scope
- Changing hook behavior.
- Reworking translated README prose beyond the stale English code-block sentence.
- Fixing unrelated Windows/source-checkout test failures.

## Related Issues
None.
