### PR TITLE
fix(groovy): emit inherits/implements edges for extends/implements

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2801,7 +2801,7 @@ def _extract_generic(
                                                  context="generic_arg")
 
             # Java-specific: extends (superclass) / implements (interfaces) / interface-extends
-            if config.ts_module == "tree_sitter_java":
+            if config.ts_module in ("tree_sitter_java", "tree_sitter_groovy"):
                 def _emit_java_parent(base_name: str, rel: str, at_line: int) -> None:
                     if not base_name:
                         return

--- a/tests/fixtures/sample.groovy
+++ b/tests/fixtures/sample.groovy
@@ -19,3 +19,17 @@ class SampleService {
         processor.reset()
     }
 }
+
+interface Resettable {
+    void reset()
+}
+
+class ExtendedService extends SampleService implements Resettable {
+    ExtendedService(Processor processor) {
+        super(processor)
+    }
+
+    void reset() {
+        // no-op
+    }
+}

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1789,6 +1789,35 @@ def test_groovy_no_dangling_edges():
         assert e["source"] in node_ids
 
 
+def test_groovy_extends_edge():
+    """`class X extends Base` must emit an inherits edge.
+
+    tree-sitter-groovy exposes inheritance via the same `superclass` field as
+    tree-sitter-java, but the inheritance handler was gated to Java only, so
+    Groovy extends/implements were silently dropped.
+    """
+    r = extract_groovy(FIXTURES / "sample.groovy")
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    found = any(
+        "ExtendedService" in node_by_id.get(e["source"], "")
+        and "SampleService" in node_by_id.get(e["target"], "")
+        for e in r["edges"] if e["relation"] == "inherits"
+    )
+    assert found, "ExtendedService should have inherits edge to SampleService"
+
+
+def test_groovy_implements_edge():
+    """`class X implements Iface` must emit an implements edge."""
+    r = extract_groovy(FIXTURES / "sample.groovy")
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    found = any(
+        "ExtendedService" in node_by_id.get(e["source"], "")
+        and "Resettable" in node_by_id.get(e["target"], "")
+        for e in r["edges"] if e["relation"] == "implements"
+    )
+    assert found, "ExtendedService should have implements edge to Resettable"
+
+
 def test_groovy_spock_finds_class():
     r = extract_groovy(FIXTURES / "sample_spock.groovy")
     assert any("SampleSpec" in l for l in _labels(r))


### PR DESCRIPTION
## Summary

The Groovy extractor silently drops **every** `extends` and `implements` relationship. `contains`, methods, imports, and calls all work — but class inheritance produces no edges.

## Root cause

tree-sitter-groovy exposes inheritance through the **same** grammar shape as tree-sitter-java:

```
class_declaration <superclass=superclass, interfaces=super_interfaces>
  superclass        -> extends + type_identifier
  super_interfaces  -> implements + type_list -> type_identifier
```

But the inheritance-emitting block in `_extract_generic` is gated on `config.ts_module == "tree_sitter_java"`. Groovy (`ts_module="tree_sitter_groovy"`) never enters it — it was the only class-based JVM language in the file without an inheritance handler (Java, Kotlin, Scala, C#, Swift, C++, PHP, Python all have one).

## Fix

Widen the gate to include `tree_sitter_groovy`. The existing `_emit_java_parent_type` / `_java_collect_type_refs` path consumes the identical node shapes verbatim — no new handler needed.

```diff
-            if config.ts_module == "tree_sitter_java":
+            if config.ts_module in ("tree_sitter_java", "tree_sitter_groovy"):
```

## Verification

- Added a base class + interface to the Groovy fixture and two regression tests (`extends` -> `inherits`, `implements` -> `implements`).
- `pytest tests/test_languages.py` -> **269 passed, 13 skipped** (was 267 + my 2 new); Java inheritance tests unaffected (the shared path is reused, not changed).
- `ruff check --config pyproject.toml` -> clean.

## Before / after

`class UserService extends Base implements Repo {}`
- before: only `contains` edges
- after: `inherits UserService->Base`, `implements UserService->Repo`