### PR TITLE
fix(ruby): emit inherits edge for class superclass

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2752,6 +2752,37 @@ def _extract_generic(
                                             add_edge(class_nid, target, "references", line,
                                                      context="generic_arg")
 
+            # Ruby: `class Dog < Animal` puts the base class in the `superclass`
+            # field (a `<` token followed by a constant or scope_resolution).
+            # There was no Ruby branch, so every Ruby inherits edge was dropped.
+            if config.ts_module == "tree_sitter_ruby":
+                sup = node.child_by_field_name("superclass")
+                if sup is not None:
+                    base = ""
+                    for sub in sup.children:
+                        if sub.type == "constant":
+                            base = _read_text(sub, source)
+                            break
+                        if sub.type == "scope_resolution":
+                            consts = [c for c in sub.children if c.type == "constant"]
+                            if consts:
+                                base = _read_text(consts[-1], source)
+                            break
+                    if base:
+                        base_nid = _make_id(stem, base)
+                        if base_nid not in seen_ids:
+                            base_nid = _make_id(base)
+                            if base_nid not in seen_ids:
+                                nodes.append({
+                                    "id": base_nid,
+                                    "label": base,
+                                    "file_type": "code",
+                                    "source_file": "",
+                                    "source_location": "",
+                                })
+                                seen_ids.add(base_nid)
+                        add_edge(class_nid, base_nid, "inherits", line)
+
             # C#-specific: inheritance / interface implementation via base_list
             if config.ts_module == "tree_sitter_c_sharp":
                 for child in node.children:

--- a/tests/fixtures/sample.rb
+++ b/tests/fixtures/sample.rb
@@ -22,6 +22,12 @@ class ApiClient
   end
 end
 
+class TimeoutApiClient < ApiClient
+  def fetch(path, method)
+    super
+  end
+end
+
 def parse_response(raw)
   JSON.parse(raw)
 end

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -299,6 +299,22 @@ def test_ruby_finds_function():
     assert any("parse_response" in l for l in _labels(r))
 
 
+def test_ruby_inherits_edge():
+    """`class Sub < Base` must emit an inherits edge.
+
+    Ruby exposes the base class in the `superclass` field, but there was no
+    Ruby branch in the inheritance handler, so the edge was silently dropped.
+    """
+    r = extract_ruby(FIXTURES / "sample.rb")
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    found = any(
+        "TimeoutApiClient" in node_by_id.get(e["source"], "")
+        and node_by_id.get(e["target"], "") == "ApiClient"
+        for e in r["edges"] if e["relation"] == "inherits"
+    )
+    assert found, "TimeoutApiClient should have inherits edge to ApiClient"
+
+
 # ── C# ───────────────────────────────────────────────────────────────────────
 
 def test_csharp_no_error():


### PR DESCRIPTION
## Summary

The Ruby extractor silently drops **every** class inheritance edge. `class Dog < Animal` produces `contains`/method/call edges but no `inherits` edge.

## Root cause

Ruby exposes the base class in the `superclass` field:

```
class <name=constant, superclass=superclass, body=body_statement>
  superclass -> '<' + constant "Animal"
```

The inheritance handler in `_extract_generic` has dedicated branches for java, kotlin, c#, scala, cpp, php, swift, and python — but **none for Ruby**, so the `superclass` field is never read.

## Fix

Add a Ruby branch that reads the `superclass` field and emits an `inherits` edge, handling both forms:
- bare constant: `class Dog < Animal` -> `Animal`
- qualified: `class Cat < M::Base` (`scope_resolution`) -> `Base`

It reuses the same synthesize-base-node-if-absent + `add_edge` pattern as the other language branches.

## Verification

- Added a subclass to the Ruby fixture and a regression test.
- `pytest tests/test_languages.py` -> **268 passed, 13 skipped** (existing Ruby tests unaffected).
- `ruff check --config pyproject.toml` -> clean.

## Before / after

`class Dog < Animal`
- before: only `contains`
- after: `inherits Dog->Animal`