### PR TITLE
fix: harden graph JSON loading against corruption

### DIFF
--- a/graphify/affected.py
+++ b/graphify/affected.py
@@ -209,7 +209,13 @@ def load_graph(path: Path) -> nx.Graph:
     import json
     from networkx.readwrite import json_graph
 
-    raw = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise RuntimeError(
+            f"Cannot read graph file {path}: {exc}. "
+            "Re-run 'graphify extract' to regenerate it."
+        ) from exc
     # Force directed so stored caller→callee direction survives the round-trip;
     # mirrors serve.py and __main__.py (#1174).
     raw = {**raw, "directed": True}

--- a/graphify/build.py
+++ b/graphify/build.py
@@ -649,7 +649,13 @@ def build_merge(
         # NetworkX round-trip loses direction permanently (#760).
         from graphify.security import check_graph_file_size_cap
         check_graph_file_size_cap(graph_path)
-        data = json.loads(graph_path.read_text(encoding="utf-8"))
+        try:
+            data = json.loads(graph_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            raise RuntimeError(
+                f"Cannot read {graph_path} for incremental merge: {exc}. "
+                "Delete the file and run a full rebuild."
+            ) from exc
         links_key = "links" if "links" in data else "edges"
         existing_nodes = list(data.get("nodes", []))
         existing_edges = list(data.get(links_key, []))

--- a/graphify/diagnostics.py
+++ b/graphify/diagnostics.py
@@ -274,7 +274,13 @@ def _read_json_file(path: str | Path) -> dict[str, Any]:
 
     json_path = Path(path)
     check_graph_file_size_cap(json_path)
-    data = json.loads(json_path.read_text(encoding="utf-8"))
+    try:
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise RuntimeError(
+            f"Cannot parse {json_path}: {exc}. "
+            "The file may be corrupted — re-run 'graphify extract'."
+        ) from exc
     if not isinstance(data, dict):
         raise ValueError("diagnostic input must be a JSON object")
     return data


### PR DESCRIPTION
## Summary

Closes #1536

Three core graph-loading paths call `json.loads()` without catching `JSONDecodeError` or `OSError`. Corrupted `graph.json` files (from incomplete writes, power loss, or manual edits) crash with unhelpful tracebacks.

This PR wraps each site with `try/except` that raises a clear `RuntimeError` with recovery guidance.

## Changes

- **`graphify/build.py:652`** — `build_merge()`: guards the `--update` incremental merge path
- **`graphify/affected.py:212`** — `load_graph()`: guards `graphify prs` graph loading
- **`graphify/diagnostics.py:277`** — `_read_json_file()`: guards `graphify diagnose`

## Test plan

- [ ] Corrupt a `graph.json` manually (e.g., truncate mid-file), run `graphify extract --update` — should get actionable error instead of traceback
- [ ] Run `graphify prs` with corrupt graph — should get clear error
- [ ] Run `graphify diagnose` with corrupt graph — should get clear error
- [ ] Happy path unchanged: normal `graph.json` files load as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)