### PR TITLE
fix: prune orphaned semantic cache entries after extraction

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -4546,6 +4546,7 @@ def main() -> None:
         # Semantic extraction on docs/papers/images. Check cache first.
         from graphify.cache import (
             check_semantic_cache as _check_semantic_cache,
+            cleanup_stale_semantic_entries as _cleanup_stale_semantic,
             save_semantic_cache as _save_semantic_cache,
         )
         sem_result: dict = {
@@ -4636,6 +4637,13 @@ def main() -> None:
                 sem_result["hyperedges"].extend(fresh.get("hyperedges", []))
                 sem_result["input_tokens"] += fresh.get("input_tokens", 0)
                 sem_result["output_tokens"] += fresh.get("output_tokens", 0)
+        if semantic_files:
+            try:
+                pruned = _cleanup_stale_semantic(sem_paths_str, root=out_root)
+                if pruned:
+                    print(f"[graphify extract] pruned {pruned} orphaned semantic cache entries", file=sys.stderr)
+            except Exception:
+                pass
         stages.mark("semantic extract")
 
         pg_result: dict = {"nodes": [], "edges": []}

--- a/graphify/cache.py
+++ b/graphify/cache.py
@@ -474,3 +474,44 @@ def save_semantic_cache(
             save_cached(p, result, root, kind="semantic")
             saved += 1
     return saved
+
+
+def cleanup_stale_semantic_entries(
+    live_paths: list[str],
+    root: Path = Path("."),
+) -> int:
+    """Remove orphaned semantic cache entries not matching any live file.
+
+    When a document changes, ``save_semantic_cache`` writes a new
+    ``{hash}.json`` keyed on the updated content, but the old entry lingers
+    forever.  This mirrors the AST-side ``_cleanup_stale_ast_entries`` concept
+    for the semantic cache: given the current detected document set, delete
+    ``cache/semantic/*.json`` whose stem is not in the live hash set.
+
+    The failure mode is benign — deleting a still-live entry just re-extracts
+    that document on the next run (#1527).
+    """
+    sem_dir = cache_dir(root, "semantic")
+    if not sem_dir.is_dir():
+        return 0
+
+    live_hashes: set[str] = set()
+    for fpath in live_paths:
+        p = Path(fpath)
+        if not p.is_absolute():
+            p = Path(root) / p
+        if p.is_file():
+            try:
+                live_hashes.add(file_hash(p, root))
+            except OSError:
+                pass
+
+    removed = 0
+    for entry in sem_dir.glob("*.json"):
+        if entry.stem not in live_hashes:
+            try:
+                entry.unlink()
+                removed += 1
+            except OSError:
+                pass
+    return removed


### PR DESCRIPTION
## Summary

Closes #1527

The semantic extraction cache (`graphify-out/cache/semantic/`) accumulates orphaned entries when documents change. The AST cache has version-based cleanup, but the semantic cache had no equivalent — orphans grew unbounded.

## Changes

- **`graphify/cache.py`**: Add `cleanup_stale_semantic_entries()` — given the live document paths, compute their hashes and remove any `cache/semantic/*.json` entry not in the live set
- **`graphify/__main__.py`**: Call the cleanup at the end of semantic extraction, print count of pruned entries

## Design

Mirrors the existing `_cleanup_stale_ast_entries` concept:
- Computes live hashes from the detected document set (already known at the call site)
- Removes orphaned `{hash}.json` files whose hash no longer matches any live file
- Failure mode is benign — accidentally deleting a live entry just re-extracts on next run
- Best-effort: OSError during unlink is silently ignored (retried next run)

## Test plan

- [ ] Extract a corpus with documents → note `cache/semantic/` file count
- [ ] Edit one document, re-extract → old orphan should be removed, count stays at live doc count
- [ ] Delete a document, re-extract → its cache entry should be pruned
- [ ] Happy path: unchanged documents still served from cache (no re-extraction)

