### PR TITLE
docs: add .claudeignore tip for prompt cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,14 @@ uv tool upgrade graphifyy
 graphify install  # overwrites the skill file
 ```
 
+**Claude Code prompt cache invalidated after every `graphify extract`**
+Graphify writes output files (`graph.json`, `graphify-out/`) into the workspace. If those paths aren't ignored, every write invalidates Claude Code's prompt cache, forcing a full re-upload at cache-write rates on the next turn. Add them to `.claudeignore`:
+```text
+# .claudeignore
+graph.json
+graphify-out/
+```
+
 ---
 
 ## Full command reference


### PR DESCRIPTION
## Summary

Closes #1387

Graphify output writes (`graph.json`, `graphify-out/`) invalidate Claude Code's prompt cache when not ignored, forcing costly full re-uploads. Adds a troubleshooting entry with the recommended `.claudeignore` entries.

## Changes

- **`README.md`**: Add troubleshooting entry with `.claudeignore` snippet

## Test plan

- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)