### PR TITLE
fix(imports): resolve workspace subpath exports (#1308)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -356,6 +356,26 @@ def _load_workspace_packages(start_dir: Path) -> dict[str, Path]:
     return packages
 
 
+_EXPORT_CONDITION_PRIORITY = (
+    "source", "import", "module", "default", "require", "svelte", "types",
+)
+
+
+def _resolve_export_target(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        for cond in _EXPORT_CONDITION_PRIORITY:
+            v = value.get(cond)
+            if isinstance(v, str):
+                return v
+            if isinstance(v, dict):
+                nested = _resolve_export_target(v)
+                if nested:
+                    return nested
+    return None
+
+
 def _package_entry_candidates(package_dir: Path, subpath: str) -> list[Path]:
     manifest = package_dir / "package.json"
     manifest_data: dict[str, Any] = {}
@@ -365,20 +385,30 @@ def _package_entry_candidates(package_dir: Path, subpath: str) -> list[Path]:
         pass
 
     if subpath:
+        exports = manifest_data.get("exports")
+        if isinstance(exports, dict):
+            subpath_key = "./" + subpath
+            target = _resolve_export_target(exports.get(subpath_key))
+            if target:
+                return [package_dir / target]
+            for pattern, pattern_value in exports.items():
+                if "*" in pattern and pattern.count("*") == 1:
+                    prefix, suffix = pattern.split("*", 1)
+                    if (subpath_key.startswith(prefix)
+                            and (not suffix or subpath_key.endswith(suffix))):
+                        matched = subpath_key[len(prefix):len(subpath_key) - len(suffix) if suffix else None]
+                        resolved = _resolve_export_target(pattern_value)
+                        if resolved and "*" in resolved:
+                            return [package_dir / resolved.replace("*", matched)]
         return [package_dir / subpath]
 
     exports = manifest_data.get("exports")
     if isinstance(exports, str):
         return [package_dir / exports]
     if isinstance(exports, dict):
-        dot_export = exports.get(".")
-        if isinstance(dot_export, str):
-            return [package_dir / dot_export]
-        if isinstance(dot_export, dict):
-            for key in ("types", "import", "default", "svelte"):
-                value = dot_export.get(key)
-                if isinstance(value, str):
-                    return [package_dir / value]
+        dot_target = _resolve_export_target(exports.get("."))
+        if dot_target:
+            return [package_dir / dot_target]
 
     candidates: list[Path] = []
     for key in ("svelte", "module", "main", "types"):
@@ -1346,7 +1376,7 @@ def _resolve_js_import_target(raw: str, str_path: str) -> "tuple[str, Path | Non
         return None
     resolved_path = _resolve_js_module_path(raw, Path(str_path).parent)
     if resolved_path is not None:
-        return _make_id(str(resolved_path)), resolved_path
+        return _make_id(_file_stem(resolved_path)), resolved_path
     module_name = raw.split("/")[-1]
     if not module_name:
         return None
@@ -4115,7 +4145,7 @@ def extract_svelte(path: Path) -> dict:
                 # imports of bare paths and .svelte.ts rune files land on real
                 # file nodes instead of phantom ids (#716).
                 resolved = _resolve_js_module_path(resolved)
-                node_id = _make_id(str(resolved))
+                node_id = _make_id(_file_stem(resolved))
                 stub_source_file = str(resolved)
             else:
                 # Check tsconfig.json path aliases (e.g. "$lib/" -> "src/lib/", "@/" -> "src/")
@@ -4129,7 +4159,7 @@ def extract_svelte(path: Path) -> dict:
                         break
                 if resolved_alias is not None:
                     resolved_alias = _resolve_js_module_path(resolved_alias)
-                    node_id = _make_id(str(resolved_alias))
+                    node_id = _make_id(_file_stem(resolved_alias))
                     stub_source_file = str(resolved_alias)
                 else:
                     # Bare/scoped import (node_modules) - use last segment;
@@ -4181,7 +4211,7 @@ def extract_svelte(path: Path) -> dict:
                         resolved = resolved.with_suffix(".ts")
                     elif resolved.suffix == ".jsx":
                         resolved = resolved.with_suffix(".tsx")
-                    node_id = _make_id(str(resolved))
+                    node_id = _make_id(_file_stem(resolved))
                     stub_source_file = str(resolved)
                 else:
                     resolved_alias = None
@@ -4191,7 +4221,7 @@ def extract_svelte(path: Path) -> dict:
                             resolved_alias = Path(os.path.normpath(Path(alias_base) / rest))
                             break
                     if resolved_alias is not None:
-                        node_id = _make_id(str(resolved_alias))
+                        node_id = _make_id(_file_stem(resolved_alias))
                         stub_source_file = str(resolved_alias)
                     else:
                         module_name = raw.split("/")[-1]
@@ -4251,7 +4281,7 @@ def extract_astro(path: Path) -> dict:
             if raw.startswith("."):
                 resolved = Path(os.path.normpath(path.parent / raw))
                 resolved = _resolve_js_module_path(resolved)
-                node_id = _make_id(str(resolved))
+                node_id = _make_id(_file_stem(resolved))
                 stub_source_file = str(resolved)
             else:
                 resolved_alias = None
@@ -4262,7 +4292,7 @@ def extract_astro(path: Path) -> dict:
                         break
                 if resolved_alias is not None:
                     resolved_alias = _resolve_js_module_path(resolved_alias)
-                    node_id = _make_id(str(resolved_alias))
+                    node_id = _make_id(_file_stem(resolved_alias))
                     stub_source_file = str(resolved_alias)
                 else:
                     module_name = raw.split("/")[-1]
@@ -4317,7 +4347,7 @@ def extract_astro(path: Path) -> dict:
                         resolved = resolved.with_suffix(".ts")
                     elif resolved.suffix == ".jsx":
                         resolved = resolved.with_suffix(".tsx")
-                    node_id = _make_id(str(resolved))
+                    node_id = _make_id(_file_stem(resolved))
                     stub_source_file = str(resolved)
                 else:
                     resolved_alias = None
@@ -4327,7 +4357,7 @@ def extract_astro(path: Path) -> dict:
                             resolved_alias = Path(os.path.normpath(Path(alias_base) / rest))
                             break
                     if resolved_alias is not None:
-                        node_id = _make_id(str(resolved_alias))
+                        node_id = _make_id(_file_stem(resolved_alias))
                         stub_source_file = str(resolved_alias)
                     else:
                         module_name = raw.split("/")[-1]
@@ -4433,7 +4463,7 @@ def extract_vue(path: Path) -> dict:
             if raw.startswith("."):
                 resolved = Path(os.path.normpath(path.parent / raw))
                 resolved = _resolve_js_module_path(resolved)
-                node_id = _make_id(str(resolved))
+                node_id = _make_id(_file_stem(resolved))
                 stub_source_file = str(resolved)
             else:
                 resolved_alias = None
@@ -4444,7 +4474,7 @@ def extract_vue(path: Path) -> dict:
                         break
                 if resolved_alias is not None:
                     resolved_alias = _resolve_js_module_path(resolved_alias)
-                    node_id = _make_id(str(resolved_alias))
+                    node_id = _make_id(_file_stem(resolved_alias))
                     stub_source_file = str(resolved_alias)
                 else:
                     module_name = raw.split("/")[-1]
@@ -13307,6 +13337,8 @@ def extract(
         if old_id != new_id:
             id_remap[old_id] = new_id
         old_pref = _file_node_id(path)
+        if old_pref != new_id and old_pref not in id_remap:
+            id_remap[old_pref] = new_id
         if old_pref != new_id:
             prefix_remap[path.resolve()] = (old_pref, new_id)
     if id_remap:

--- a/tests/test_import_extension_resolution.py
+++ b/tests/test_import_extension_resolution.py
@@ -11,6 +11,7 @@ so `build_from_json` dropped the edge as external.
 from pathlib import Path
 
 from graphify.extract import (
+    _file_stem,
     _make_id,
     _resolve_js_module_path,
     extract_js,
@@ -185,7 +186,7 @@ def test_bare_path_import_resolves_in_ts_file(tmp_path):
     importer = _write(tmp_path / "page.ts",
                       "import type { GetNestedType } from './type-helpers'\n")
     result = extract_js(importer)
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     assert expected in _import_targets(result), (
         f"Bare-path .ts import must resolve to target node id; "
         f"expected {expected}; got {_import_targets(result)}"
@@ -199,7 +200,7 @@ def test_directory_import_resolves_to_index_ts(tmp_path):
     importer = _write(tmp_path / "page.ts",
                       "import { enqueue } from './queue'\n")
     result = extract_js(importer)
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     assert expected in _import_targets(result), (
         f"Directory import must resolve to ./queue/index.ts; "
         f"expected {expected}; got {_import_targets(result)}"
@@ -216,7 +217,7 @@ def test_dot_svelte_import_resolves_to_dot_svelte_ts(tmp_path):
     importer = _write(tmp_path / "page.ts",
                       "import { isMobile } from './is-mobile.svelte'\n")
     result = extract_js(importer)
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     assert expected in _import_targets(result), (
         f".svelte → .svelte.ts resolution failed; "
         f"expected {expected}; got {_import_targets(result)}"
@@ -233,7 +234,7 @@ def test_explicit_ts_import_still_works(tmp_path):
     importer = _write(tmp_path / "page.ts",
                       "import { x } from './foo.ts'\n")
     result = extract_js(importer)
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     assert expected in _import_targets(result), (
         f"Explicit .ts imports must still resolve; "
         f"expected {expected}; got {_import_targets(result)}"
@@ -247,7 +248,7 @@ def test_explicit_svelte_import_still_works(tmp_path):
     importer = _write(tmp_path / "page.ts",
                       "import Card from './Card.svelte'\n")
     result = extract_js(importer)
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     assert expected in _import_targets(result), (
         f"Existing .svelte imports must resolve to the .svelte node, "
         f"not get redirected; expected {expected}; "
@@ -285,7 +286,7 @@ def test_alias_import_with_bare_path_resolves(tmp_path):
     importer = _write(importer_dir / "page.ts",
                       "import type { X } from '$lib/type-helpers'\n")
     result = extract_js(importer)
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     assert expected in _import_targets(result), (
         f"Alias + bare-path resolution failed; "
         f"expected {expected}; got {_import_targets(result)}"
@@ -304,7 +305,7 @@ def test_type_only_import_with_bare_path_resolves(tmp_path):
     importer = _write(tmp_path / "page.ts",
                       "import type { GetNestedType } from './type-helpers'\n")
     result = extract_js(importer)
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     assert expected in _import_targets(result), (
         f"Type-only import with bare path failed to resolve; "
         f"expected {expected}; got {_import_targets(result)}"
@@ -342,7 +343,7 @@ def test_alias_directory_import_resolves_to_index_ts(tmp_path):
     importer = _write(src / "routes" / "page.ts",
                       "import { enqueue } from '$lib/queue'\n")
     result = extract_js(importer)
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     assert expected in _import_targets(result), (
         f"Alias + directory resolution failed; "
         f"expected {expected}; got {_import_targets(result)}"
@@ -428,7 +429,7 @@ def test_end_to_end_multi_dot_import_resolves(tmp_path):
     importer = _write(tmp_path / "page.ts",
                       "import { apply } from './tag-action.shared'\n")
     result = extract_js(importer)
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     assert expected in _import_targets(result), (
         f"Multi-dot import failed end-to-end; "
         f"expected {expected}; got {_import_targets(result)}"
@@ -448,7 +449,7 @@ def test_resolve_chain_alias_and_extension_compose(tmp_path):
     importer = _write(src / "routes" / "page.ts",
                       "import { isMobile } from '$lib/hooks/is-mobile.svelte'\n")
     result = extract_js(importer)
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     assert expected in _import_targets(result), (
         f"Alias + .svelte→.svelte.ts chain failed to compose; "
         f"expected {expected}; got {_import_targets(result)}"
@@ -473,7 +474,7 @@ export async function validate(name: string) {
 }
 """)
     result = extract_js(importer)
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     targets = {str(e.get("target") or "") for e in result["edges"]
                if e.get("relation") in ("imports", "imports_from")}
     assert expected in targets, (
@@ -498,7 +499,7 @@ export async function load() {
 }
 """)
     result = extract_js(importer)
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     targets = {str(e.get("target") or "") for e in result["edges"]
                if e.get("relation") in ("imports", "imports_from")}
     assert expected in targets, (
@@ -521,7 +522,7 @@ def test_dynamic_import_bare_path_resolves(tmp_path):
     result = extract_svelte(importer)
     dyn_targets = {str(e.get("target") or "") for e in result["edges"]
                    if e.get("relation") == "dynamic_import"}
-    expected = _make_id(str(target))
+    expected = _make_id(_file_stem(target))
     assert expected in dyn_targets, (
         f"dynamic_import of .svelte that's actually .svelte.ts must "
         f"resolve through the new resolver; "

--- a/tests/test_js_import_resolution.py
+++ b/tests/test_js_import_resolution.py
@@ -532,6 +532,119 @@ def test_pnpm_workspace_takes_precedence_over_package_json_workspaces(tmp_path: 
     assert _has_edge(result, "apps/web/src/page.ts", "packages/types/src/index.ts")
 
 
+def test_workspace_subpath_export_string_resolves(tmp_path: Path):
+    _write(
+        tmp_path / "pnpm-workspace.yaml",
+        "packages:\n  - 'apps/*'\n  - 'packages/*'\n",
+    )
+    _write(
+        tmp_path / "packages/pkg-a/package.json",
+        json.dumps({
+            "name": "@example/pkg-a",
+            "exports": {
+                ".": "./src/index.ts",
+                "./browser": "./src/browser.ts",
+            },
+        }),
+    )
+    target = _write(
+        tmp_path / "packages/pkg-a/src/browser.ts",
+        'export const value = "ok"\n',
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/consumer.ts",
+        "import { value } from '@example/pkg-a/browser'\nexport const v = value\n",
+    )
+
+    result = _extract_for([target, importer], tmp_path)
+
+    assert _has_edge(result, "apps/web/src/consumer.ts", "packages/pkg-a/src/browser.ts")
+
+
+def test_workspace_subpath_export_condition_object_resolves(tmp_path: Path):
+    _write(
+        tmp_path / "pnpm-workspace.yaml",
+        "packages:\n  - 'apps/*'\n  - 'packages/*'\n",
+    )
+    _write(
+        tmp_path / "packages/pkg-a/package.json",
+        json.dumps({
+            "name": "@example/pkg-a",
+            "exports": {
+                "./browser": {
+                    "source": "./src/browser.ts",
+                    "import": "./dist/esm/browser.js",
+                    "require": "./dist/cjs/browser.js",
+                    "types": "./dist/types/browser.d.ts",
+                },
+            },
+        }),
+    )
+    target = _write(
+        tmp_path / "packages/pkg-a/src/browser.ts",
+        'export const value = "ok"\n',
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/consumer.ts",
+        "import { value } from '@example/pkg-a/browser'\nexport const v = value\n",
+    )
+
+    result = _extract_for([target, importer], tmp_path)
+
+    assert _has_edge(result, "apps/web/src/consumer.ts", "packages/pkg-a/src/browser.ts")
+
+
+def test_workspace_subpath_export_wildcard_resolves(tmp_path: Path):
+    _write(
+        tmp_path / "pnpm-workspace.yaml",
+        "packages:\n  - 'apps/*'\n  - 'packages/*'\n",
+    )
+    _write(
+        tmp_path / "packages/pkg-a/package.json",
+        json.dumps({
+            "name": "@example/pkg-a",
+            "exports": {
+                "./*": {"source": "./src/*.ts"},
+            },
+        }),
+    )
+    target = _write(
+        tmp_path / "packages/pkg-a/src/utils.ts",
+        "export function add(a: number, b: number) { return a + b }\n",
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/consumer.ts",
+        "import { add } from '@example/pkg-a/utils'\nexport const sum = add(1, 2)\n",
+    )
+
+    result = _extract_for([target, importer], tmp_path)
+
+    assert _has_edge(result, "apps/web/src/consumer.ts", "packages/pkg-a/src/utils.ts")
+
+
+def test_workspace_subpath_export_falls_back_to_filesystem(tmp_path: Path):
+    _write(
+        tmp_path / "pnpm-workspace.yaml",
+        "packages:\n  - 'apps/*'\n  - 'packages/*'\n",
+    )
+    _write(
+        tmp_path / "packages/pkg-a/package.json",
+        json.dumps({"name": "@example/pkg-a"}),
+    )
+    target = _write(
+        tmp_path / "packages/pkg-a/browser.ts",
+        'export const value = "ok"\n',
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/consumer.ts",
+        "import { value } from '@example/pkg-a/browser'\nexport const v = value\n",
+    )
+
+    result = _extract_for([target, importer], tmp_path)
+
+    assert _has_edge(result, "apps/web/src/consumer.ts", "packages/pkg-a/browser.ts")
+
+
 def test_js_import_resolution_ignores_stale_importer_cache_when_target_appears(tmp_path: Path):
     importer = _write(
         tmp_path / "src/lib/page.ts",


### PR DESCRIPTION
## Summary
- Workspace imports with subpath exports (e.g. `import { value } from "@example/pkg-a/browser"`) now resolve through the `package.json` `exports` map instead of falling back to a bare path string
- Supports string values, condition objects (`source > import > module > default > require > svelte > types`), nested conditions, and wildcard patterns (`"./*": "./src/*.ts"`)
- Normalizes import node IDs to use `_file_stem` instead of full paths across JS/Svelte/Astro/Vue extractors

Closes #1308

## Test plan
- [x] 4 new tests: string subpath, condition object, wildcard, filesystem fallback
- [x] All 10 workspace tests pass
- [x] All 38 import extension resolution tests pass
- [x] Full 34-test JS import resolution suite passes — 0 regressions

