### PR TITLE
fix(extract): resolve JS namespace re-export bindings

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -8042,6 +8042,14 @@ class _StarExportFact:
 
 
 @dataclass(frozen=True)
+class _NamespaceExportFact:
+    file_path: Path
+    exported_name: str
+    target_path: Path
+    line: int
+
+
+@dataclass(frozen=True)
 class _SymbolUseFact:
     file_path: Path
     source_id: str
@@ -8058,6 +8066,7 @@ class _SymbolResolutionFacts:
     aliases: list[_SymbolAliasFact] = field(default_factory=list)
     exports: list[_SymbolExportFact] = field(default_factory=list)
     star_exports: list[_StarExportFact] = field(default_factory=list)
+    namespace_exports: list[_NamespaceExportFact] = field(default_factory=list)
     uses: list[_SymbolUseFact] = field(default_factory=list)
     # File-to-file submodule imports from `from pkg import submod` (#1146).
     # Each entry is (importing_file, submodule_file, line).
@@ -8078,6 +8087,7 @@ def _apply_symbol_resolution_facts(
         or facts.aliases
         or facts.exports
         or facts.star_exports
+        or facts.namespace_exports
         or facts.uses
         or facts.module_imports
     ):
@@ -8180,6 +8190,36 @@ def _apply_symbol_resolution_facts(
                 "export",
                 star_fact.line,
                 star_fact.file_path,
+            )
+
+    for namespace_fact in facts.namespace_exports:
+        source_path = namespace_fact.file_path.resolve()
+        target_path = namespace_fact.target_path.resolve()
+        namespace_id = ensure_symbol_node(
+            namespace_fact.file_path,
+            namespace_fact.exported_name,
+            namespace_fact.line,
+        )
+        named_exports_by_file.setdefault(source_path, {})[
+            namespace_fact.exported_name
+        ] = (source_path, namespace_fact.exported_name)
+        source_id = source_file_id.get(source_path)
+        if source_id is not None:
+            add_edge(
+                source_id,
+                namespace_id,
+                "contains",
+                "namespace_export",
+                namespace_fact.line,
+                namespace_fact.file_path,
+            )
+            add_edge(
+                source_id,
+                _make_id(str(path_by_resolved.get(target_path, target_path))),
+                "re_exports",
+                "export",
+                namespace_fact.line,
+                namespace_fact.file_path,
             )
 
     for export_fact in facts.exports:
@@ -8361,6 +8401,16 @@ def _js_export_clause(node):
 
 def _js_export_statement_is_star(node) -> bool:
     return any(child.type == "*" for child in node.children)
+
+
+def _js_namespace_export_name(node, source: bytes) -> str | None:
+    for child in node.children:
+        if child.type != "namespace_export":
+            continue
+        for sub in child.children:
+            if sub.type == "identifier":
+                return _read_text(sub, source) or None
+    return None
 
 
 def _js_lexical_aliases(node, source: bytes) -> list[tuple[str, str]]:
@@ -8727,7 +8777,17 @@ def _collect_js_symbol_resolution_facts(paths: list[Path], facts: _SymbolResolut
                 if target_path is None:
                     continue
                 target_path = target_path.resolve()
-                if _js_export_statement_is_star(node):
+                namespace_name = _js_namespace_export_name(node, source)
+                if namespace_name is not None:
+                    facts.namespace_exports.append(
+                        _NamespaceExportFact(
+                            path,
+                            namespace_name,
+                            target_path,
+                            node.start_point[0] + 1,
+                        )
+                    )
+                elif _js_export_statement_is_star(node):
                     facts.star_exports.append(
                         _StarExportFact(path, target_path, node.start_point[0] + 1)
                     )

--- a/tests/test_js_import_resolution.py
+++ b/tests/test_js_import_resolution.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from graphify.extract import _file_node_id, _file_stem, _make_id, extract
 
 
@@ -135,6 +137,90 @@ def test_ts_export_star_from_index_resolves_imported_symbol_to_origin(tmp_path: 
     result = _extract_for([target, barrel, consumer], tmp_path)
 
     assert _has_edge(result, "src/lib/index.ts", "src/lib/foo.ts", "re_exports")
+    assert _has_symbol_edge(result, "src/routes/page.ts", "src/lib/foo.ts", "Foo")
+
+
+@pytest.mark.parametrize("suffix", ["ts", "js"])
+def test_js_namespace_reexport_import_targets_real_binding(
+    tmp_path: Path,
+    monkeypatch,
+    suffix: str,
+):
+    monkeypatch.chdir(tmp_path)
+    target = _write(Path(f"src/lib/foo.{suffix}"), "export class Foo { id = '' }\n")
+    barrel = _write(Path(f"src/lib/index.{suffix}"), "export * as ns from './foo'\n")
+    consumer = _write(
+        Path(f"src/routes/page.{suffix}"),
+        "import { ns } from '../lib/index'\nexport const use = () => ns.Foo\n",
+    )
+
+    result = _extract_for([target, barrel, consumer], Path("."))
+
+    namespace_id = _make_id(_file_stem(Path(f"src/lib/index.{suffix}")), "ns")
+    node_ids = {node["id"] for node in result["nodes"]}
+    assert namespace_id in node_ids
+    assert _has_symbol_edge(
+        result,
+        f"src/routes/page.{suffix}",
+        f"src/lib/index.{suffix}",
+        "ns",
+    )
+    assert _has_edge(
+        result,
+        f"src/lib/index.{suffix}",
+        f"src/lib/foo.{suffix}",
+        "re_exports",
+    )
+    assert (
+        _file_node_id(Path(f"src/lib/index.{suffix}")),
+        namespace_id,
+        "contains",
+    ) in {
+        (edge["source"], edge["target"], edge["relation"])
+        for edge in result["edges"]
+    }
+    assert not [
+        edge
+        for edge in result["edges"]
+        if edge["source"] not in node_ids or edge["target"] not in node_ids
+    ]
+
+
+def test_ts_reexport_cycle_resolves_symbol_from_non_cycle_branch(tmp_path: Path):
+    target = _write(tmp_path / "src/lib/foo.ts", "export class Foo { id = '' }\n")
+    first = _write(
+        tmp_path / "src/lib/first.ts",
+        "export * from './second'\nexport * from './foo'\n",
+    )
+    second = _write(tmp_path / "src/lib/second.ts", "export * from './first'\n")
+    consumer = _write(
+        tmp_path / "src/routes/page.ts",
+        "import type { Foo } from '../lib/first'\nexport type X = Foo\n",
+    )
+
+    result = _extract_for([target, first, second, consumer], tmp_path)
+
+    assert _has_symbol_edge(result, "src/routes/page.ts", "src/lib/foo.ts", "Foo")
+
+
+def test_ts_reexport_chain_beyond_sixteen_hops_resolves_origin(tmp_path: Path):
+    target = _write(tmp_path / "src/lib/foo.ts", "export class Foo { id = '' }\n")
+    barrels: list[Path] = []
+    previous = "foo"
+    for index in range(20):
+        barrel = _write(
+            tmp_path / f"src/lib/barrel_{index}.ts",
+            f"export * from './{previous}'\n",
+        )
+        barrels.append(barrel)
+        previous = f"barrel_{index}"
+    consumer = _write(
+        tmp_path / "src/routes/page.ts",
+        "import type { Foo } from '../lib/barrel_19'\nexport type X = Foo\n",
+    )
+
+    result = extract([target, *barrels, consumer], cache_root=tmp_path, parallel=False)
+
     assert _has_symbol_edge(result, "src/routes/page.ts", "src/lib/foo.ts", "Foo")
 
 


### PR DESCRIPTION
## Summary

Split from #927. #1544 covers wildcard path aliases; `v8` already handles named and star barrel re-exports. This PR adds the remaining namespace binding and regression coverage for cycles and chains beyond 16 hops.

Fixes #1551

## Result

Relevant fields from a representative `extract()` result:

```json
{
  "nodes": [
    {"id": "src_lib_index_ns", "label": "ns", "source_file": "src/lib/index.ts"}
  ],
  "edges": [
    {"source": "src_routes_page", "target": "src_lib_index_ns", "relation": "imports", "context": "import", "confidence": "EXTRACTED"},
    {"source": "src_lib_index", "target": "src_lib_index_ns", "relation": "contains", "context": "namespace_export", "confidence": "EXTRACTED"},
    {"source": "src_lib_index", "target": "src_lib_foo", "relation": "re_exports", "context": "export", "confidence": "EXTRACTED"}
  ]
}
```

The full result contains nodes for every shown source and target (0 dangling edges).

## Testing

- `uv run --frozen --no-sync pytest tests/test_js_import_resolution.py -q` (44 passed)
- `uv run --frozen pytest tests/ -q --tb=short` (CI: 2560 passed, 3 skipped on Python 3.12)
- `uv run --frozen --no-sync ruff check graphify/extract.py tests/test_js_import_resolution.py` (passed)
