### PR TITLE
fix(hooks): limit Windows hook rebuild workers

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -1,6 +1,7 @@
 # git hook integration - install/uninstall graphify post-commit and post-checkout hooks
 from __future__ import annotations
 import configparser
+import os
 import re
 import sys
 from pathlib import Path
@@ -224,6 +225,13 @@ _HOOK_SCRIPT = """\
 # churn run-to-run. Pinning it makes graphify-out reproducible.
 export PYTHONHASHSEED=0
 
+# Git for Windows/MSYS hooks can inherit fragile pipe handles from GUI clients
+# and agent shells. Keep hook-triggered rebuilds sequential by default there;
+# explicit GRAPHIFY_MAX_WORKERS still wins for users who want parallelism.
+if [ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]; then
+    export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"
+fi
+
 # Skip during rebase/merge/cherry-pick to avoid blocking --continue with unstaged changes
 GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 [ -d "$GIT_DIR/rebase-merge" ] && exit 0
@@ -268,6 +276,13 @@ _CHECKOUT_SCRIPT = """\
 # order is randomized per-process by PYTHONHASHSEED, so community assignments
 # churn run-to-run. Pinning it makes graphify-out reproducible.
 export PYTHONHASHSEED=0
+
+# Git for Windows/MSYS hooks can inherit fragile pipe handles from GUI clients
+# and agent shells. Keep hook-triggered rebuilds sequential by default there;
+# explicit GRAPHIFY_MAX_WORKERS still wins for users who want parallelism.
+if [ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]; then
+    export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"
+fi
 
 PREV_HEAD=$1
 NEW_HEAD=$2
@@ -319,6 +334,8 @@ def _reject_windows_path(value: str, source: str) -> None:
     junk directory (backslashes and all), while install reports success and the
     real ``.git/hooks`` gets nothing. Fail loudly instead so the user can fix it.
     """
+    if os.name == "nt":
+        return
     if _WINDOWS_DRIVE_RE.match(value) or "\\" in value:
         raise RuntimeError(
             f"git hooks path from {source} looks like a Windows path: {value!r}. "

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -254,6 +254,15 @@ def test_hooks_use_cross_platform_detach(name, script):
     assert "0x00000200" in script, f"{name} missing CREATE_NEW_PROCESS_GROUP flag"
 
 
+@pytest.mark.parametrize("name,script", _HOOK_SCRIPTS)
+def test_hooks_limit_windows_workers_by_default(name, script):
+    """Git for Windows/MSYS hooks can expose fragile pipe handles to spawned
+    ProcessPoolExecutor children. Hook-triggered rebuilds should default to one
+    worker there, while still allowing explicit user overrides."""
+    assert '[ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]' in script
+    assert 'export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"' in script
+
+
 def _launcher_payload(script: str) -> str:
     """Extract the `python -c "<payload>"` the hook hands to GRAPHIFY_PYTHON.
 
@@ -351,9 +360,10 @@ def _set_hookspath(repo: Path, value: str) -> None:
     r"D:\hooks",
     r"some\back\slashed\path",
 ])
-def test_windows_hookspath_rejected_no_junk_dir(tmp_path, winpath):
+def test_windows_hookspath_rejected_no_junk_dir_on_posix(tmp_path, monkeypatch, winpath):
     """A Windows-style core.hooksPath must raise (loud failure), not silently
-    create a backslash-named junk directory and report success (#1385)."""
+    create a backslash-named junk directory and report success on POSIX/WSL (#1385)."""
+    monkeypatch.setattr("graphify.hooks.os.name", "posix")
     repo = _make_git_repo(tmp_path)
     _set_hookspath(repo, winpath)
     with pytest.raises(RuntimeError, match="Windows path"):


### PR DESCRIPTION
## Summary

This fixes a Windows/Git Bash/MSYS-specific failure mode in Graphify git hooks.

When the generated post-commit hook launches the detached background rebuild on Windows, the rebuild can reach AST extraction and spawn ProcessPoolExecutor children. In some Git-for-Windows/MSYS or GUI-client environments, the Python child process inherits fragile pipe handles and the rebuild reports a Windows startup failure similar to:

`	ext
error 2147942632 (0x800700e8) starting <python> -c from multiprocessing.spawn import spawn_main; spawn_main(...) --multiprocessing-fork
`

The commit itself can still succeed, but the hook-triggered graph rebuild becomes noisy or unreliable.

## Fix

- In generated post-commit and post-checkout hooks, detect Windows/MSYS via WINDIR or MSYSTEM.
- Default hook-triggered rebuilds to GRAPHIFY_MAX_WORKERS=1 in those environments.
- Preserve explicit user configuration: if GRAPHIFY_MAX_WORKERS is already set, the hook does not override it.
- Leave Linux/macOS behavior unchanged because those variables are absent.
- Keep the existing Windows-path rejection for POSIX/WSL core.hooksPath, but do not reject native Windows paths when running on Windows itself.

## Why this shape

The hook remains installed and keeps the graph updated after commits/checkouts. The change only avoids multiprocessing from the Git hook environment on Windows by default, which is the fragile part. Users who prefer parallel hook rebuilds can still opt back in by setting GRAPHIFY_MAX_WORKERS explicitly.

## Tests

`	ext
python -m pytest tests/test_hooks.py -q
# 42 passed

python -m pytest tests/test_extract.py -q -k BrokenProcessPool or windows_spawn or parallel
# 2 passed, 98 deselected

git diff --check
# clean
`

I also ran a smoke test in a temporary git repo: installed the Graphify hooks from this branch, verified the generated post-commit hook contains the Windows/MSYS worker default, made a real commit, and confirmed the detached rebuild completed successfully.
