### PR TITLE
fix(reflect): resolve learning-sidecar source_file against the project root

### DIFF
--- a/graphify/reflect.py
+++ b/graphify/reflect.py
@@ -664,6 +664,39 @@ def _resolve_canonical_id(cited: str, id_set: dict[str, str],
     return None
 
 
+def _source_root(graph_path: Path) -> Path:
+    """Directory that node ``source_file`` paths are resolved against.
+
+    ``source_file`` is stored **relative to the project root** (the "no absolute
+    paths in output" contract, #555/#932) — NOT relative to ``graph.json``'s own
+    directory. graph.json lives in the output dir (``graphify-out/``), one level
+    below the project root, so joining a relative ``source_file`` onto
+    ``graph_path.parent`` looks one directory too deep: the file is never found,
+    the stored fingerprint stays empty, and every node is flagged stale even on a
+    freshly built graph.
+
+    Resolved in order:
+      1. the absolute path recorded in ``<output-dir>/.graphify_root`` (the same
+         marker the git hooks trust; also correct when ``GRAPHIFY_OUT`` is an
+         absolute/elsewhere override),
+      2. the parent of the output dir when graph.json sits inside it,
+      3. graph.json's own directory (flat layouts; an absolute ``source_file``
+         resolves regardless of root).
+    """
+    graph_path = Path(graph_path)
+    out_dir = graph_path.parent
+    try:
+        recorded = (out_dir / ".graphify_root").read_text(encoding="utf-8").strip()
+        if recorded:
+            return Path(recorded)
+    except (OSError, ValueError):
+        pass  # unreadable or non-UTF-8 marker -> fall through (best-effort)
+    from graphify.paths import GRAPHIFY_OUT_NAME
+    if out_dir.name == GRAPHIFY_OUT_NAME:
+        return out_dir.parent
+    return out_dir
+
+
 def _code_fingerprint(node: dict[str, Any] | None, root: Path) -> str:
     """File-level content hash of the node's ``source_file``, or '' if unavailable.
 
@@ -718,7 +751,7 @@ def build_learning_overlay(agg: dict[str, Any], graph_path: Path,
         now = now.replace(tzinfo=timezone.utc)
 
     graph_path = Path(graph_path)
-    root = graph_path.parent
+    root = _source_root(graph_path)
     id_set, label_to_ids, node_by_id = _build_id_label_maps(graph_path)
     prov_map = agg.get("_node_provenance", {})
 
@@ -804,7 +837,7 @@ def load_learning_overlay(graph_path: Path) -> dict[str, dict[str, Any]]:
     nodes = data.get("nodes")
     if not isinstance(nodes, dict):
         return {}
-    root = Path(graph_path).parent
+    root = _source_root(Path(graph_path))
     out: dict[str, dict[str, Any]] = {}
     for nid, entry in nodes.items():
         if not isinstance(entry, dict):

--- a/tests/test_reflect.py
+++ b/tests/test_reflect.py
@@ -837,6 +837,67 @@ def test_loader_marks_entry_stale_when_source_file_changes(tmp_path):
     assert after["auth_login"]["stale"] is True
 
 
+def test_fingerprint_resolves_relative_source_file_under_project_root(tmp_path):
+    """Real graphs store ``source_file`` RELATIVE to the project root (the
+    "no absolute paths in output" contract, #555/#932), with graph.json in the
+    output dir one level below it. The fingerprint must resolve that relative
+    path against the project root — not against graph.json's own ``graphify-out/``
+    directory — or the file is never found, the stored fingerprint stays empty,
+    and every node reads as permanently stale on a freshly built graph.
+
+    Regression: the prior stale test passed only because it used an *absolute*
+    ``source_file``, which skips the relative-path join entirely.
+    """
+    out = tmp_path / "graphify-out"
+    # Source file at the PROJECT ROOT; the node cites it by a project-relative path.
+    (tmp_path / "auth.py").write_text("def login(): pass\n", encoding="utf-8")
+    _overlay_graph(out, [
+        {"id": "auth_login", "label": "login()", "source_file": "auth.py", "community": 0},
+    ])
+    mem = out / "memory"
+    _write_raw_doc(mem, "a.md", "2026-05-01", outcome="useful", nodes=["login()"])
+    _write_raw_doc(mem, "b.md", "2026-05-10", outcome="useful", nodes=["login()"])
+    reflect(mem, out / "reflections" / "LESSONS.md",
+            graph_path=out / "graph.json", now=_NOW)
+
+    # The relative path must actually be resolved + fingerprinted, not left empty.
+    sidecar = json.loads((out / LEARNING_SIDECAR_NAME).read_text(encoding="utf-8"))
+    assert sidecar["nodes"]["auth_login"]["code_fingerprint"], \
+        "relative source_file must be fingerprinted (regression: empty => always stale)"
+
+    # An unedited file reads as fresh; a real edit flips it to stale.
+    fresh = load_learning_overlay(out / "graph.json")
+    assert fresh["auth_login"]["stale"] is False
+    (tmp_path / "auth.py").write_text("def login(): return 1  # changed\n", encoding="utf-8")
+    after = load_learning_overlay(out / "graph.json")
+    assert after["auth_login"]["stale"] is True
+
+
+def test_fingerprint_honours_graphify_root_marker(tmp_path):
+    """When ``<output-dir>/.graphify_root`` records the project root (the marker
+    the git hooks write and trust), a relative ``source_file`` resolves against it
+    — covering a custom/absolute ``GRAPHIFY_OUT`` where the output dir is not a
+    child of the project root."""
+    proj = tmp_path / "project"
+    proj.mkdir()
+    (proj / "auth.py").write_text("def login(): pass\n", encoding="utf-8")
+    # Output dir deliberately NOT under the project root.
+    out = tmp_path / "elsewhere-out"
+    _overlay_graph(out, [
+        {"id": "auth_login", "label": "login()", "source_file": "auth.py", "community": 0},
+    ])
+    (out / ".graphify_root").write_text(str(proj), encoding="utf-8")
+    mem = out / "memory"
+    _write_raw_doc(mem, "a.md", "2026-05-01", outcome="useful", nodes=["login()"])
+    _write_raw_doc(mem, "b.md", "2026-05-10", outcome="useful", nodes=["login()"])
+    reflect(mem, out / "reflections" / "LESSONS.md",
+            graph_path=out / "graph.json", now=_NOW)
+
+    sidecar = json.loads((out / LEARNING_SIDECAR_NAME).read_text(encoding="utf-8"))
+    assert sidecar["nodes"]["auth_login"]["code_fingerprint"]
+    assert load_learning_overlay(out / "graph.json")["auth_login"]["stale"] is False
+
+
 def test_provenance_capped_to_five_most_recent(tmp_path):
     """A node cited by >5 useful results keeps exactly the 5 most-recent in
     provenance (recent-first)."""


### PR DESCRIPTION

The `.graphify_learning.json` work-memory overlay (#1441, `5779767`) is great — but its
**staleness / "re-verify" hint is broken in the standard layout**: it fires on *every*
annotated node, even on a freshly built graph with zero edits.

### Symptom

On a clean AST build (no source edits since the build), every node shows the re-verify tag:

```
Node: .RegisterBlueprint()
  Lesson: preferred source (start here) — 3 useful, score=2.99997647 [code changed since — re-verify]
```

It surfaces the same way on all four read surfaces — `explain` (`__main__.py`),
`graph.html` (`export.py`), `GRAPH_REPORT.md` (`report.py`), and `serve.py`. A hint that
fires on everything, always, carries no signal.

### Root cause

`source_file` is stored **relative to the project root** ("no absolute paths in output",
#555/#932). But `graph.json` lives in the output dir (`graphify-out/`), one level *below*
the project root, and both `_code_fingerprint` (write) and `_is_stale` (read) resolved the
relative `source_file` against `graph_path.parent` (= `graphify-out/`):

```
graphify-out/admin/blueprint.go   # looked up here — never exists
admin/blueprint.go                # actually lives at the project root, one level up
```

So `file_hash` always raised, the stored `code_fingerprint` was always `""`, and the
read-side `_is_stale` saw the file as "vanished" → returned `True` for every node.

### Fix

Add `_source_root(graph_path)` and use it on both sides. It resolves the directory that
`source_file` is relative to, in order:

1. the absolute path recorded in `<output-dir>/.graphify_root` — the same marker the
   git hooks already trust, and the only correct answer when `GRAPHIFY_OUT` is an
   absolute / elsewhere override (#686/#1423);
2. the parent of the output dir when `graph.json` sits inside it;
3. `graph.json`'s own directory (flat layouts; an absolute `source_file` resolves
   regardless of root).

`graph.json` itself is still never touched — this only changes which directory the
fingerprint is computed against.

After the fix, same node, same clean build:

```
Lesson: preferred source (start here) — 3 useful, score=2.99917354
```

…and a real edit to `admin/blueprint.go` correctly flips the node to stale.

### Why the suite was green

`test_loader_marks_entry_stale_when_source_file_changes` set `source_file` to an
**absolute** path (`str(tmp_path / "auth.py")`), which skips the relative-path join — so
it exercised a path real graphs never take. Added two regression tests using a **relative**
`source_file` (the real-world case): one for the standard `graphify-out/` layout, one
driven by the `.graphify_root` marker. Both fail on `v8` (`assert '' ` — empty fingerprint)
and pass with the fix.

### Verification

- `tests/test_reflect.py` — **58 passed** (incl. the 2 new regression tests).
- `test_reflect + test_export + test_report + test_serve + test_explain_cli` — **186 passed**.
- `ruff check graphify/reflect.py` — clean.
- End-to-end on a real AST graph (1065 nodes): fingerprints now populate; the bogus
  re-verify tag is gone; an actual edit re-flags the node.

### Scope

Touches only `graphify/reflect.py` (one helper + two one-line call-site changes) and
`tests/test_reflect.py`. No version bump, no CHANGELOG entry