### PR TITLE
feat(extract): capture indirect dispatch as indirect_call edges

### DIFF
--- a/graphify/affected.py
+++ b/graphify/affected.py
@@ -11,6 +11,7 @@ import networkx as nx
 
 DEFAULT_AFFECTED_RELATIONS = (
     "calls",
+    "indirect_call",
     "references",
     "imports",
     "imports_from",

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4314,6 +4314,44 @@ def _extract_generic(
                         rc_entry["lang"] = "cpp"
                     raw_calls.append(rc_entry)
 
+            # Indirect dispatch: a function passed BY NAME as a call argument
+            # (executor.submit(fn), Thread(target=fn), map(fn, xs)) is a real dependency
+            # the callee-only scan above can't see. Emit it as a distinct `indirect_call`
+            # relation so strict `calls` queries stay precise while affected/blast-radius
+            # picks up the edge. Python only for now; dispatch via dict literals, getattr
+            # or decorators lives in other AST nodes and is left to a follow-up.
+            if config.ts_module == "tree_sitter_python":
+                args_node = node.child_by_field_name("arguments")
+                if args_node is not None:
+                    for arg in args_node.children:
+                        if arg.type == "identifier":
+                            ident = arg
+                        elif arg.type == "keyword_argument":
+                            ident = arg.child_by_field_name("value")
+                        else:
+                            continue
+                        if ident is None or ident.type != "identifier":
+                            continue
+                        ref_nid = label_to_nid.get(_read_text(ident, source))
+                        if not ref_nid or ref_nid == caller_nid:
+                            continue
+                        if (caller_nid, ref_nid) in seen_call_pairs:
+                            continue  # already a direct call to this target
+                        marker = (caller_nid, ref_nid, "indirect_call")
+                        if marker in seen_call_pairs:
+                            continue
+                        seen_call_pairs.add(marker)
+                        edges.append({
+                            "source": caller_nid,
+                            "target": ref_nid,
+                            "relation": "indirect_call",
+                            "context": "argument",
+                            "confidence": "INFERRED",
+                            "source_file": str_path,
+                            "source_location": f"L{ident.start_point[0] + 1}",
+                            "weight": 1.0,
+                        })
+
             # Helper function calls: config('foo.bar') → uses_config edge to "foo"
             if (callee_name and callee_name in config.helper_fn_names):
                 args_node = node.child_by_field_name("arguments")

--- a/tests/test_indirect_dispatch.py
+++ b/tests/test_indirect_dispatch.py
@@ -1,0 +1,69 @@
+"""Indirect dispatch edges.
+
+A function passed BY NAME as a call argument (`executor.submit(fn)`, `Thread(target=fn)`) is a
+real dependency, but the callee-only call scan never recorded it — so `affected` (blast radius)
+dropped those callers. These tests pin that such calls now emit a distinct `indirect_call` edge
+(leaving the precise `calls` relation untouched) and that `affected` picks them up.
+"""
+import networkx as nx
+
+from graphify.affected import affected_nodes
+from graphify.extract import extract_python
+
+SRC = '''\
+import threading
+
+
+def handler(x):
+    return x * 2
+
+
+def direct():
+    return handler(1)                          # direct call -> `calls`
+
+
+def via_submit(pool):
+    pool.submit(handler, 1)                    # indirect: positional arg
+
+
+def via_thread():
+    threading.Thread(target=handler).start()   # indirect: keyword arg
+'''
+
+
+def _build(tmp_path):
+    (tmp_path / "dispatch.py").write_text(SRC)
+    r = extract_python(tmp_path / "dispatch.py")
+    nid = {n["label"].rstrip("()"): n["id"] for n in r["nodes"]}   # labels are "handler()"
+    return r, nid
+
+
+def test_emits_indirect_call_edges_and_keeps_calls_precise(tmp_path):
+    r, nid = _build(tmp_path)
+    calls = {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "calls"}
+    indirect = {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "indirect_call"}
+    handler = nid["handler"]
+
+    # the direct caller stays a `calls` edge — precise relation not regressed
+    assert (nid["direct"], handler) in calls
+    # the two indirect callers are captured, and under the DISTINCT relation
+    assert (nid["via_submit"], handler) in indirect
+    assert (nid["via_thread"], handler) in indirect
+    assert (nid["via_submit"], handler) not in calls
+
+    for e in (e for e in r["edges"] if e["relation"] == "indirect_call"):
+        assert e["context"] == "argument" and e["confidence"] == "INFERRED"
+
+
+def test_affected_includes_indirect_callers(tmp_path):
+    r, nid = _build(tmp_path)
+    g = nx.DiGraph()
+    for n in r["nodes"]:
+        g.add_node(n["id"], **n)
+    for e in r["edges"]:
+        g.add_edge(e["source"], e["target"], **e)
+
+    affected = {h.node_id for h in affected_nodes(g, nid["handler"])}
+    # blast radius of `handler` now includes the dispatchers it used to drop
+    assert nid["via_submit"] in affected
+    assert nid["via_thread"] in affected


### PR DESCRIPTION
## Problem

`affected` (blast radius) is sound for direct calls but blind to **indirect dispatch**. A function passed *by name* as a call argument — `executor.submit(fn)`, `Thread(target=fn)`, `map(fn, xs)` — is a real dependency, but the callee-only scan in `walk_calls` never records it, so those callers are dropped from `affected`.

Minimal repro (0.9.3):

```python
def handler(x): return x * 2
def direct():         return handler(1)         # caught
def via_submit(pool): pool.submit(handler, 1)   # MISSED
```

`graphify affected handler` lists `direct()` but omits `via_submit()`. An under-counting blast radius reads complete while dropping exactly the callers where regressions hide.

## Change

- In `walk_calls` (Python), scan a call's `arguments` for resolvable function-name identifiers (positional + `keyword_argument` values) and emit a **distinct `indirect_call` relation**. Keeping it separate leaves strict `calls` queries precise while `affected`/blast-radius picks up the edge.
- Add `indirect_call` to `DEFAULT_AFFECTED_RELATIONS`.
- Dedup-safe (won't duplicate an existing direct `calls` edge); `confidence="INFERRED"`, `context="argument"`.

After: `affected handler` -> `direct`, `via_submit`, `via_thread`.

## Scope / limits (intentional)

- **Python only** for now; the same pattern extends to the other tree-sitter grammars.
- Covers the call-argument case (executors, threads, callbacks, `map`/`filter`). Dispatch via **dict literals** (`{k: fn}`), **`getattr`-by-string**, and **decorators** lives in other AST nodes and is left for a follow-up.
- Same-file resolution via the in-file `label_to_nid`; cross-file indirect refs can later reuse the existing `raw_calls` path.

## Tests

`tests/test_indirect_dispatch.py` — the indirect callers get `indirect_call` edges, the direct caller stays a `calls` edge (no relation regression), and `affected(handler)` now includes the dispatchers. Full suite green; `ruff` clean.
