### PR TITLE
feat(extract): capture dispatch-table indirect_call edges (#1566 slice 1)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4180,6 +4180,60 @@ def _extract_generic(
             return None
         return _read_text(scope, source)
 
+    _PY_COLLECTION_TYPES = ("dictionary", "list", "set", "tuple")
+
+    def _collection_value_idents(coll):
+        # Function-value items of a collection literal: dict -> each pair's `value`;
+        # list/set/tuple -> each element. Identifiers only.
+        if coll.type == "dictionary":
+            for ch in coll.children:
+                if ch.type == "pair":
+                    v = ch.child_by_field_name("value")
+                    if v is not None and v.type == "identifier":
+                        yield v
+        else:
+            for ch in coll.children:
+                if ch.type == "identifier":
+                    yield ch
+
+    def _emit_collection_dispatch(coll, owner_nid: str, enclosing_locals) -> None:
+        # Dispatch tables: a function referenced as a value inside a collection literal
+        # (ROUTES = {"x": handler}, HOOKS = [on_start]). Same guards as the call-argument
+        # case -- skip a param/local shadow, resolve only to a callable def -- under the
+        # distinct INFERRED `indirect_call` relation so strict `calls` stays precise.
+        for ident in _collection_value_idents(coll):
+            name = _read_text(ident, source)
+            if name in enclosing_locals or name in ("self", "cls"):
+                continue
+            ref_nid = label_to_nid.get(name)
+            if ref_nid is None:
+                # Defined in another file -> defer to the cross-file resolver (same
+                # single-definition + callable-target guard as the argument case).
+                raw_calls.append({
+                    "caller_nid": owner_nid,
+                    "callee": name,
+                    "is_member_call": False,
+                    "indirect": True,
+                    "source_file": str_path,
+                    "source_location": f"L{ident.start_point[0] + 1}",
+                })
+                continue
+            if ref_nid == owner_nid or ref_nid not in callable_def_nids:
+                continue
+            if (owner_nid, ref_nid) in seen_call_pairs or (owner_nid, ref_nid) in seen_indirect_pairs:
+                continue
+            seen_indirect_pairs.add((owner_nid, ref_nid))
+            edges.append({
+                "source": owner_nid,
+                "target": ref_nid,
+                "relation": "indirect_call",
+                "context": "collection",
+                "confidence": "INFERRED",
+                "source_file": str_path,
+                "source_location": f"L{ident.start_point[0] + 1}",
+                "weight": 1.0,
+            })
+
     def walk_calls(node, caller_nid: str) -> None:
         if node.type in config.function_boundary_types:
             return
@@ -4618,6 +4672,11 @@ def _extract_generic(
                             "weight": 1.0,
                         })
 
+        # Dispatch tables INSIDE a function body (owner = enclosing function; its
+        # params/locals are the shadow set).
+        if config.ts_module == "tree_sitter_python" and node.type in _PY_COLLECTION_TYPES:
+            _emit_collection_dispatch(node, caller_nid, local_bound_names.get(caller_nid, frozenset()))
+
         for child in node.children:
             walk_calls(child, caller_nid)
 
@@ -4641,6 +4700,22 @@ def _extract_generic(
     # seen_call_pairs, so a closure inside an initializer is not double-walked.
     for owner_nid, init_node in initializer_nodes:
         walk_calls(init_node, owner_nid)
+
+    # Module-level dispatch tables: a function referenced inside a collection literal at
+    # module scope (ROUTES = {"x": handler}) -- the common registry idiom. Walk the
+    # top-level statements only (stop at any def; function/class bodies are owned by
+    # walk_calls / their own nid) and attribute the reference to the file node. No
+    # param/local shadow at module scope, and a module-level rebind is dataflow (out of
+    # scope), so the callable-target guard alone keeps it sound.
+    if config.ts_module == "tree_sitter_python":
+        def _walk_module_dispatch(n) -> None:
+            if n.type in ("function_definition", "class_definition", "decorated_definition"):
+                return
+            if n.type in _PY_COLLECTION_TYPES:
+                _emit_collection_dispatch(n, file_nid, frozenset())
+            for ch in n.children:
+                _walk_module_dispatch(ch)
+        _walk_module_dispatch(root)
 
     # ── Event listener pass ───────────────────────────────────────────────────
     seen_listen_pairs: set[tuple[str, str]] = set()

--- a/tests/test_indirect_dispatch_collections.py
+++ b/tests/test_indirect_dispatch_collections.py
@@ -1,0 +1,136 @@
+"""Indirect dispatch via collection literals (dispatch tables) — #1566 slice 1.
+
+A function referenced as a VALUE inside a dict/list/tuple/set literal
+(`ROUTES = {"x": handler}`, `HOOKS = [on_start]`) is a real dependency. It is emitted
+under the distinct INFERRED `indirect_call` relation, reusing the call-argument guards:
+resolve only to a callable def, and skip a param/local shadow. Positives (module + function
+level, all four literal kinds) plus the shadow / non-callable negatives.
+"""
+import networkx as nx
+
+from graphify.affected import affected_nodes
+from graphify.extract import extract_python
+
+
+def _extract(tmp_path, src):
+    (tmp_path / "m.py").write_text(src)
+    r = extract_python(tmp_path / "m.py")
+    nid = {n["label"].rstrip("()"): n["id"] for n in r["nodes"]}
+    return r, nid
+
+
+def _indirect(r):
+    return {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "indirect_call"}
+
+
+MODULE_TABLE = '''\
+def create_user(): ...
+def delete_user(): ...
+def on_start(): ...
+def on_stop(): ...
+
+ROUTES = {"create": create_user, "delete": delete_user}   # module-level dict registry
+HOOKS = [on_start, on_stop]                                # module-level list
+'''
+
+
+def test_module_level_dict_and_list_emit_indirect_call(tmp_path):
+    r, nid = _extract(tmp_path, MODULE_TABLE)
+    ind = _indirect(r)
+    f = nid["m.py"]
+    assert (f, nid["create_user"]) in ind
+    assert (f, nid["delete_user"]) in ind
+    assert (f, nid["on_start"]) in ind
+    assert (f, nid["on_stop"]) in ind
+    for e in r["edges"]:
+        if e["relation"] == "indirect_call":
+            assert e["context"] == "collection" and e["confidence"] == "INFERRED"
+    # never leaks into the precise `calls` relation
+    calls = {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "calls"}
+    assert (f, nid["create_user"]) not in calls
+
+
+def test_collection_dispatch_feeds_affected(tmp_path):
+    r, nid = _extract(tmp_path, MODULE_TABLE)
+    g = nx.DiGraph()
+    for n in r["nodes"]:
+        g.add_node(n["id"], **n)
+    for e in r["edges"]:
+        g.add_edge(e["source"], e["target"], **e)
+    affected = {h.node_id for h in affected_nodes(g, nid["create_user"])}
+    assert nid["m.py"] in affected   # the module that registers it is in the blast radius
+
+
+FUNCTION_TABLE = '''\
+def create_user(): ...
+
+def setup():
+    routes = {"create": create_user}    # function-level dispatch table
+    return routes
+'''
+
+
+def test_function_level_collection_emits_indirect_call(tmp_path):
+    r, nid = _extract(tmp_path, FUNCTION_TABLE)
+    assert (nid["setup"], nid["create_user"]) in _indirect(r)
+
+
+TUPLE_SET = '''\
+def a(): ...
+def b(): ...
+
+PAIR = (a, b)        # tuple
+UNIQUE = {a, b}      # set
+'''
+
+
+def test_tuple_and_set_literals_emit_indirect_call(tmp_path):
+    r, nid = _extract(tmp_path, TUPLE_SET)
+    ind = _indirect(r)
+    f = nid["m.py"]
+    assert (f, nid["a"]) in ind and (f, nid["b"]) in ind
+
+
+# ── negatives: the guards must hold for collections too ──────────────────────
+
+PARAM_SHADOW = '''\
+def handler(): ...
+
+def setup(handler):
+    routes = {"x": handler}      # `handler` is a PARAMETER, not the module fn
+    return routes
+'''
+
+
+def test_param_shadow_in_collection_emits_nothing(tmp_path):
+    r, nid = _extract(tmp_path, PARAM_SHADOW)
+    assert all(t != nid["handler"] for _s, t in _indirect(r))
+
+
+LOCAL_SHADOW = '''\
+def config(): ...
+
+def use():
+    config = {"k": 1}        # local DATA binding shadows config()
+    table = {"c": config}    # `config` here is the local dict, not the fn
+    return table
+'''
+
+
+def test_local_shadow_in_collection_emits_nothing(tmp_path):
+    r, nid = _extract(tmp_path, LOCAL_SHADOW)
+    assert (nid["use"], nid["config"]) not in _indirect(r)
+
+
+NON_CALLABLE = '''\
+def handler(): ...
+
+TIMEOUT = 30
+CONFIG = {"timeout": TIMEOUT, "label": "ready"}   # data values, not callables
+'''
+
+
+def test_non_callable_collection_values_emit_nothing(tmp_path):
+    r, _nid = _extract(tmp_path, NON_CALLABLE)
+    # TIMEOUT is not a callable def; the string is not an identifier -> no indirect edges
+    assert _indirect(r) == set()


### PR DESCRIPTION
Closes slice 1 of #1566 (dispatch tables).

## What

`indirect_call` (#1565) covered a function passed as a **call argument**. This extends it to the registry idiom: a function referenced as a **value inside a collection literal**.

```python
ROUTES = {"create": create_user, "delete": delete_user}   # module-level dict
HOOKS  = [on_start, on_stop]                               # list / tuple / set
```

`graphify affected create_user` previously dropped the module/function that registers it; now it's in the blast radius.

## How

- Emit `indirect_call` (`context="collection"`, `INFERRED`) for callable-resolving identifiers that are **dict pair values** or **list/set/tuple elements**, at:
  - **module scope** — owner = the file node (the common top-level registry);
  - **inside a function body** — owner = the enclosing function.
- **Reuses the argument-case guards** (`cf747ab`): resolve only to a `callable_def_nids` target, and skip a name in the enclosing function's `local_bound_names` (param/local shadow). Cross-file values defer to the same single-definition resolver as the argument case.
- Strict `calls` is untouched; only `indirect_call` (already in `DEFAULT_AFFECTED_RELATIONS`) is affected.

## Scope / limits (intentional)

- **Python only**, matching the existing `indirect_call`.
- Covers all four literal kinds (dict/list/set/tuple) at module + function scope. **Class-body** attributes are deferred (they need a class owner, not the file) — a small follow-up.
- No dataflow: resolves names, not values (a module-level rebind isn't tracked — out of scope per the issue's non-goals).

## Tests

`tests/test_indirect_dispatch_collections.py` — positives (module dict+list, function-level, tuple+set, `affected`) **and** the negatives the issue asks for: param-shadow, local-shadow, and non-callable values each emit nothing. Full suite green; ruff clean.
