### PR TITLE
fix(fortran): emit calls edges for function invocations

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -7503,6 +7503,19 @@ def extract_fortran(path: Path) -> dict:
                 target_nid = _make_id(stem, callee)
                 add_edge(scope_nid, target_nid, "calls", node.start_point[0] + 1,
                          confidence="EXTRACTED", context="call")
+        # x = compute(args) — function invocations are `call_expression`, which
+        # shares Fortran's `name(...)` syntax with array indexing. Only emit a
+        # call edge when the callee resolves to a procedure defined in this file
+        # (an array variable produces no matching node), so array accesses can't
+        # fabricate spurious `calls` edges.
+        elif t == "call_expression":
+            name_node = next((c for c in node.children if c.type == "identifier"), None)
+            if name_node:
+                callee = _read_text(name_node, source).lower()
+                target_nid = _make_id(stem, callee)
+                if target_nid in seen_ids and target_nid != scope_nid:
+                    add_edge(scope_nid, target_nid, "calls", node.start_point[0] + 1,
+                             confidence="EXTRACTED", context="call")
         for child in node.children:
             walk_calls(child, scope_nid)
 

--- a/tests/fixtures/sample.f90
+++ b/tests/fixtures/sample.f90
@@ -43,6 +43,19 @@ contains
     print *, "Area =", area
   end subroutine print_area
 
+  function double_val(x) result(y)
+    real, intent(in) :: x
+    real :: y
+    y = x * 2.0
+  end function double_val
+
+  subroutine report(radius)
+    real, intent(in) :: radius
+    real :: scaled
+    scaled = double_val(radius)
+    print *, scaled
+  end subroutine report
+
 end module geometry
 
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1514,6 +1514,24 @@ def test_fortran_finds_calls():
     assert len(call_edges) >= 1
 
 
+def test_fortran_finds_function_call():
+    """`y = f(x)` function invocations must emit a calls edge.
+
+    Function calls are `call_expression` (not `subroutine_call`); that node was
+    never handled, so every function-to-function call was dropped. The callee is
+    resolved against defined procedures so array indexing (`arr(i)`) can't
+    fabricate a spurious edge.
+    """
+    r = extract_fortran(FIXTURES / "sample.f90")
+    labels = {n["id"]: n["label"] for n in r["nodes"]}
+    found = any(
+        "report" in labels.get(e["source"], "")
+        and "double_val" in labels.get(e["target"], "")
+        for e in r["edges"] if e["relation"] == "calls"
+    )
+    assert found, "report() should have a calls edge to double_val()"
+
+
 def test_fortran_case_insensitive_names():
     r = extract_fortran(FIXTURES / "sample.f90")
     labels = [n["label"] for n in r["nodes"]]


### PR DESCRIPTION
## Summary

Fortran function calls (`y = f(x)`) emit **no** `calls` edge. Only `call sub(...)` (subroutine) calls were captured.

## Root cause

`walk_calls` handled `subroutine_call` but not `call_expression`, which is how tree-sitter-fortran represents a function invocation:

```
assignment_statement
  identifier "x"
  call_expression        <-- unhandled
    identifier "compute"
```

So every function-to-function call was dropped.

## Fix

Handle `call_expression`. Fortran uses the **same** `name(...)` syntax for array indexing (`arr(i)`), so — unlike `subroutine_call` — the callee is resolved against procedures **defined in the file** (`target_nid in seen_ids`) before emitting. Array accesses whose name isn't a defined procedure produce no edge, so they can't fabricate spurious `calls`.

## Verification

- `f = g()` -> calls(f, g); `call sub()` still works; `arr(3)` array access -> **no** edge.
- Added a function + caller to the fixture and a regression test.
- `pytest tests/test_languages.py` -> **300 passed, 13 skipped** (13 fortran).
- `ruff check` -> clean.