### PR TITLE
fix(rust): emit field type references for tuple structs

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -8160,6 +8160,27 @@ def extract_rust(path: Path) -> dict:
                                 if tgt != item_nid:
                                     add_edge(item_nid, tgt, "references",
                                              field.start_point[0] + 1, context=ctx)
+                    # Tuple structs (`struct Wrapper(pub Logger, Config);`) nest their
+                    # positional field types directly under ordered_field_declaration_list
+                    # with no field_declaration wrapper -- the same shape handled for tuple
+                    # enum variants below. Without this branch these field type references
+                    # are silently dropped.
+                    for c in node.children:
+                        if c.type != "ordered_field_declaration_list":
+                            continue
+                        fline = c.start_point[0] + 1
+                        for tc in c.children:
+                            if tc.type not in ("type_identifier", "generic_type",
+                                               "scoped_type_identifier", "reference_type",
+                                               "primitive_type", "tuple_type", "array_type"):
+                                continue
+                            refs = []
+                            _rust_collect_type_refs(tc, source, False, refs)
+                            for ref_name, role in refs:
+                                ctx = "generic_arg" if role == "generic_arg" else "field"
+                                tgt = ensure_named_node(ref_name, fline)
+                                if tgt != item_nid:
+                                    add_edge(item_nid, tgt, "references", fline, context=ctx)
                 if t == "enum_item":
                     # Variant payload types nest under enum_variant_list ->
                     # enum_variant -> ordered_field_declaration_list (tuple variant,

--- a/tests/fixtures/sample.rs
+++ b/tests/fixtures/sample.rs
@@ -56,3 +56,5 @@ enum GraphEvent {
     NodeAdded(Graph),
     Processed { proc: DataProcessor },
 }
+
+struct GraphPair(Graph, Result<DataProcessor>);

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -365,6 +365,19 @@ def test_rust_struct_field_emits_field_context():
     assert ("DataProcessor", "DataProcessor") not in _edge_labels(r, "references", "field")
 
 
+def test_rust_tuple_struct_field_references():
+    """Tuple struct fields (`struct Wrapper(A, B);`) nest their positional types
+    under ordered_field_declaration_list with no field_declaration wrapper -- the
+    same shape as tuple enum variants. That path was not traversed for structs, so
+    tuple-struct field type references were silently dropped.
+    """
+    r = extract_rust(FIXTURES / "sample.rs")
+    field_refs = _edge_labels(r, "references", "field")
+    assert ("GraphPair", "Graph") in field_refs, "tuple-struct field reference missing"
+    assert ("GraphPair", "Result") in field_refs, "tuple-struct generic field reference missing"
+    assert ("GraphPair", "DataProcessor") in _edge_labels(r, "references", "generic_arg")
+
+
 def test_rust_method_parameter_return_and_generic_contexts():
     r = extract_rust(FIXTURES / "sample.rs")
     assert ("build", "DataProcessor") in _edge_labels(r, "references", "parameter_type")


### PR DESCRIPTION
## Summary

Tuple-struct fields are dropped from the graph. `extract_rust()` only traverses `field_declaration_list` (named-struct bodies), so a tuple struct like `struct Wrapper(Logger, Config);` emits **no** field type-reference edges — even when the field types are defined in the same file.

## Symptom

Given:

```rust
struct Logger {}
struct Config {}
struct TupleWrap(Logger, Config);
struct NamedWrap { lg: Logger, cf: Config }
```

`extract_rust` emits `references[field]` edges for `NamedWrap` → `Logger`/`Config`, but **nothing** for `TupleWrap` — both in-file edges are silently dropped.

## Root cause

In the `struct_item` branch of `extract_rust()` (`graphify/extract.py`), the field loop is gated on `field_declaration_list`:

```python
if t == "struct_item":
    for c in node.children:
        if c.type != "field_declaration_list":   # named-struct bodies only
            continue
        ...
```

Tuple-struct positional fields do not use `field_declaration_list` / `field_declaration`. Per the tree-sitter-rust grammar, `struct Wrapper(pub Logger, Config);` parses as:

```
struct_item
  type_identifier "Wrapper"
  ordered_field_declaration_list        <-- NOT field_declaration_list
    type_identifier "Logger"            <-- positional type, direct child
    type_identifier "Config"
```

The extractor never inspects `ordered_field_declaration_list`, so those type refs are dropped. This is the **same** node shape the `enum_item` handler right below already accounts for (its docstring notes tuple variants nest types under `ordered_field_declaration_list`, "so every enum-variant type reference was silently dropped") — the struct path was simply left behind.

## Fix

An additive branch in the `struct_item` handler that iterates `ordered_field_declaration_list` children, feeds each type node to the existing `_rust_collect_type_refs`, and emits `references` edges with the appropriate `field` / `generic_arg` context — mirroring both the named-struct path and the tuple-enum-variant handling. The existing named-struct loop is left byte-for-byte unchanged (zero behavior change for named structs).

## Verification

- New regression test `test_rust_tuple_struct_field_references` — fails before the fix, passes after — covering both a plain positional type and a generic one (`Result<DataProcessor>`, which also exercises `generic_arg` context).
- Extraction suites green: `tests/test_multilang.py` 39 passed / 9 skipped, `tests/test_languages.py` 301 passed / 13 skipped.
- `ruff check graphify/extract.py tests/test_multilang.py` clean.

Before → after on the example above:

```
before: references[field] = {(NamedWrap, Logger), (NamedWrap, Config)}
after:  references[field] = {(NamedWrap, Logger), (NamedWrap, Config),
                             (TupleWrap, Logger), (TupleWrap, Config)}
```
