### PR TITLE
fix(systemverilog): emit field references for qualified class properties

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -6637,7 +6637,11 @@ def _augment_systemverilog_semantics(
             body,
             flags=re.DOTALL,
         )
-        for field in re.finditer(r"^\s*([A-Za-z_]\w*(?:\s*#\s*\([^;]+?\))?)\s+\w+\s*;", body_without_functions, re.MULTILINE):
+        # Optional leading class-property qualifiers (rand/local/protected/etc.)
+        # must be consumed: otherwise a qualified field like `rand Config x;`
+        # (three tokens) fails the `<type> <name>;` shape and its type reference
+        # is silently dropped.
+        for field in re.finditer(r"^\s*(?:(?:rand|randc|local|protected|static|const|automatic|var)\s+)*([A-Za-z_]\w*(?:\s*#\s*\([^;]+?\))?)\s+\w+\s*;", body_without_functions, re.MULTILINE):
             # Count to the start of the type token (group 1), not the match
             # start: `^\s*` consumes the leading newline(s), so field.start()
             # would resolve to the class's line instead of the field's.

--- a/tests/fixtures/sample.sv
+++ b/tests/fixtures/sample.sv
@@ -10,12 +10,17 @@ endclass
 class Payload;
 endclass
 
+class Config;
+endclass
+
 class Result #(type T = Payload);
   T value;
 endclass
 
 class DataProcessor extends BaseProcessor implements Processor;
   Result #(Payload) current;
+  rand Config m_cfg;
+  protected BaseProcessor m_parent;
 
   function Result #(Payload) build(Payload input);
     return current;

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -2637,6 +2637,18 @@ def test_systemverilog_field_parameter_return_and_generic_contexts():
     assert ("build", "Payload") in _edge_labels(r, "references", "generic_arg")
 
 
+def test_systemverilog_qualified_field_references():
+    """Class properties with leading qualifiers (rand/local/protected/etc.) must
+    still emit `references` field edges. The field regex only matched unqualified
+    `<type> <name>;` declarations, so `rand Config x;` (three tokens) failed to
+    match and its type reference was silently dropped.
+    """
+    r = extract_verilog(FIXTURES / "sample.sv")
+    field_refs = _edge_labels(r, "references", "field")
+    assert ("DataProcessor", "Config") in field_refs, "rand-qualified field dropped"
+    assert ("DataProcessor", "BaseProcessor") in field_refs, "protected-qualified field dropped"
+
+
 def test_systemverilog_does_not_emit_type_parameter_refs():
     r = extract_verilog(FIXTURES / "sample.sv")
     assert ("Result", "T") not in _edge_labels(r, "references", "field")


### PR DESCRIPTION
## Summary

SystemVerilog class properties declared with a leading qualifier (`rand`, `local`, `protected`, …) have their type references silently dropped from the graph. The class-body field extractor in `_augment_systemverilog_semantics` matched only unqualified `<type> <name>;` declarations.

## Symptom

```systemverilog
class Packet;
  Payload   m_unqualified;   // edge emitted: Packet -> Payload
  rand Config    m_qualified; // DROPPED
  local Header   m_local;     // DROPPED
  protected Meta m_meta;      // DROPPED
endclass
```

Only `Packet -> Payload` (`references`, `field`) is emitted; the `rand`/`local`/`protected` field type references never appear.

## Root cause

In `graphify/extract.py`, the class-body field loop in `_augment_systemverilog_semantics`:

```python
for field in re.finditer(r"^\s*([A-Za-z_]\w*(?:\s*#\s*\([^;]+?\))?)\s+\w+\s*;", body_without_functions, re.MULTILINE):
```

The pattern is `^\s* <type> \s+ <name> ;`. `^\s*` consumes only leading whitespace, so a qualified declaration like `rand Config m_cfg;` presents three tokens (`rand`, `Config`, `m_cfg`) to a two-token shape: the regex binds `rand` as the type and `Config` as the name, then the trailing `\s*;` fails (there is ` m_cfg;` left), so the whole line fails to match and the field is skipped.

## Fix

Consume optional leading class-property qualifiers before the type token:

```python
r"^\s*(?:(?:rand|randc|local|protected|static|const|automatic|var)\s+)*([A-Za-z_]\w*(?:\s*#\s*\([^;]+?\))?)\s+\w+\s*;"
```

The qualifier group is `*` (zero-or-more), so unqualified fields keep their exact current behavior and the type/name capture is unchanged. The listed qualifiers are reserved SV keywords, so there is no risk of consuming a real type name.

## Verification

- New regression test `test_systemverilog_qualified_field_references` — fails before the fix, passes after — covering `rand`- and `protected`-qualified fields.
- `tests/test_languages.py` + `tests/test_multilang.py`: **340 passed / 22 skipped**.
- `ruff check graphify/extract.py tests/test_languages.py` clean.

Before → after on the example above:

```
before: references[field] = {(Packet, Payload)}
after:  references[field] = {(Packet, Payload), (Packet, Config),
                             (Packet, Header), (Packet, Meta)}
```
