### PR TITLE
fix(scala): emit field type references for var declarations

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3868,7 +3868,7 @@ def _extract_generic(
             return
 
         if (config.ts_module == "tree_sitter_scala"
-                and t == "val_definition"
+                and t in ("val_definition", "var_definition")
                 and parent_class_nid):
             type_node = node.child_by_field_name("type")
             if type_node is not None:

--- a/tests/fixtures/sample.scala
+++ b/tests/fixtures/sample.scala
@@ -7,6 +7,7 @@ abstract class BaseClient
 
 class HttpClient(config: Config) extends BaseClient with Loggable {
   val source: Config = config
+  var fallback: BaseClient = null
 
   def get(path: String): String = {
     buildRequest("GET", path)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -655,6 +655,11 @@ def test_scala_val_definition_field_context():
     assert ("HttpClient", "Config") in _edge_labels(r, "references", "field")
 
 
+def test_scala_var_definition_field_context():
+    r = extract_scala(FIXTURES / "sample.scala")
+    assert ("HttpClient", "BaseClient") in _edge_labels(r, "references", "field")
+
+
 def test_scala_method_return_type_context():
     r = extract_scala(FIXTURES / "sample.scala")
     assert ("create", "HttpClient") in _edge_labels(r, "references", "return_type")


### PR DESCRIPTION
## Summary

Scala mutable fields (`var x: T`) have their type reference silently dropped from the graph — only `val` fields are handled.

## Root cause

In `graphify/extract.py`, the Scala field handler guards on `t == "val_definition"`. A `var` field parses as `var_definition`, which is never matched, so its type reference is skipped. `val_definition` and `var_definition` are structurally identical — both expose a `type` field consumed by `child_by_field_name("type")`.

## Fix

Widen the guard to `t in ("val_definition", "var_definition")`. Generics/tuples flow through `_scala_collect_type_refs` unchanged; the `val` path is untouched.

## Verification

- Added `var fallback: BaseClient` to the Scala fixture + `test_scala_var_definition_field_context` (fails before the fix, passes after).
- All 11 Scala tests pass; `ruff` clean.

Before → after: `HttpClient → BaseClient` (`references`, `field`) is now emitted for the `var` field.
