### PR TITLE
fix(powershell): emit inherits/implements edges for class base types

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -8495,6 +8495,22 @@ def extract_powershell(path: Path) -> dict:
                 class_nid = _make_id(stem, class_name)
                 add_node(class_nid, class_name, line)
                 add_edge(file_nid, class_nid, "contains", line)
+                # Base type(s) after ':'. PowerShell has no syntactic base vs
+                # interface split, so (matching the C# convention) treat the
+                # first base as the superclass (inherits) and the rest as
+                # interfaces (implements). Bases are the simple_name children
+                # after the ':' token.
+                colon_seen = False
+                base_index = 0
+                for child in node.children:
+                    if child.type == ":":
+                        colon_seen = True
+                    elif colon_seen and child.type == "simple_name":
+                        base_nid = ensure_named_node(_read_text(child, source), line)
+                        if base_nid != class_nid:
+                            rel = "inherits" if base_index == 0 else "implements"
+                            add_edge(class_nid, base_nid, rel, line)
+                        base_index += 1
                 for child in node.children:
                     walk(child, parent_class_nid=class_nid)
             return

--- a/tests/fixtures/sample.ps1
+++ b/tests/fixtures/sample.ps1
@@ -30,3 +30,19 @@ class DataProcessor {
         Set-Content -Path $path -Value $this.Source
     }
 }
+
+class Shape {
+    [string]$Kind
+
+    [double] Area() {
+        return 0.0
+    }
+}
+
+class Circle : Shape {
+    [double]$Radius
+
+    [double] Area() {
+        return 3.14159 * $this.Radius * $this.Radius
+    }
+}

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1626,6 +1626,13 @@ def test_powershell_finds_class_and_method():
     assert any("Transform" in l for l in labels)
 
 
+def test_powershell_class_base_type_emits_inherits_edge():
+    # `class Circle : Shape` — the base type after ':' was previously dropped
+    # because the handler only read the first simple_name (the class name).
+    r = extract_powershell(FIXTURES / "sample.ps1")
+    assert ("Circle", "Shape") in _edge_labels(r, "inherits")
+
+
 def test_powershell_property_field_type_context():
     r = extract_powershell(FIXTURES / "sample.ps1")
     assert ("DataProcessor", "string") in _edge_labels(r, "references", "field")


### PR DESCRIPTION
## Summary

PowerShell class inheritance is dropped: `class Dog : Animal` never emits the `Dog → Animal` inherits edge, so derived classes become isolated nodes.

## Root cause

In `graphify/extract.py`, the `class_statement` handler reads only the first `simple_name` child (the class name) and never inspects the base type(s) after the `:` token. Multi-base declarations (`class Dog : Animal, IBark`) drop the interfaces too.

## Fix

Walk the `class_statement` children; once the `:` token is seen, treat each following `simple_name` as a base type. PowerShell has no syntactic base-vs-interface split, so — matching the existing C# convention — the first base is emitted as `inherits` and the rest as `implements` (resolved via `ensure_named_node`).

## Verification

- Added a `Shape` base + `Circle : Shape` pair to the fixture and `test_powershell_class_base_type_emits_inherits_edge` (fails before the fix, passes after).
- `test_languages.py` + `test_multilang.py`: 343 passed, 0 failed. `ruff` clean.

Before → after: `Circle → Shape` (`inherits`) is now emitted.
