### PR TITLE
fix(objc): emit implements edge for protocol-to-protocol adoption

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -11609,6 +11609,18 @@ def extract_objc(path: Path) -> dict:
                 proto_nid = _make_id(stem, name)
                 add_node(proto_nid, f"<{name}>", line)
                 add_edge(file_nid, proto_nid, "contains", line)
+                # Adopted protocols: `@protocol Derived <Base, Other>`. These
+                # nest under a protocol_reference_list node (distinct from the
+                # parameterized_arguments node used by @interface adoption), so
+                # they were never emitted. Emit an `implements` edge for each,
+                # matching how @interface protocol adoption is handled.
+                for child in node.children:
+                    if child.type == "protocol_reference_list":
+                        for sub in child.children:
+                            if sub.type == "identifier":
+                                base_nid = ensure_named_node(_read(sub), line)
+                                if base_nid != proto_nid:
+                                    add_edge(proto_nid, base_nid, "implements", line)
                 for child in node.children:
                     walk(child, proto_nid)
             return

--- a/tests/fixtures/sample.m
+++ b/tests/fixtures/sample.m
@@ -40,3 +40,15 @@
 }
 
 @end
+
+@protocol Base
+
+- (void)baseMethod;
+
+@end
+
+@protocol Derived <Base>
+
+- (void)derivedMethod;
+
+@end

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1059,6 +1059,16 @@ def test_objc_splits_inherits_and_implements():
     assert ("Animal", "SampleDelegate") in _edge_labels(r, "implements")
 
 
+def test_objc_protocol_adopts_protocol():
+    """`@protocol Derived <Base>` must emit an implements edge Derived->Base.
+    Protocol-on-protocol adoption nests under a protocol_reference_list node
+    (distinct from the parameterized_arguments node used by @interface
+    adoption), so the edge was previously dropped. Protocol nodes are labeled
+    `<Name>`, so the edge reads (<Derived>, <Base>)."""
+    r = extract_objc(FIXTURES / "sample.m")
+    assert ("<Derived>", "<Base>") in _edge_labels(r, "implements")
+
+
 def test_objc_property_type_context():
     r = extract_objc(FIXTURES / "sample.m")
     assert ("Animal", "NSString") in _edge_labels(r, "references", "field")


### PR DESCRIPTION
## Summary

Objective-C protocol-to-protocol adoption is dropped: `@protocol Derived <Base>` never emits the `Derived → Base` edge — even though the same extractor emits `implements` for class adoption `@interface Foo <Proto>`.

## Root cause

In `graphify/extract.py`, the `protocol_declaration` handler walks children only for methods and ignores the `protocol_reference_list` node holding the adopted protocols. That node type is distinct from the `parameterized_arguments` node used by `@interface` adoption — so the interface path emits `implements` but the protocol path drops it.

## Fix

In `protocol_declaration`, iterate the `protocol_reference_list` children and emit an `implements` edge for each adopted protocol (a direct `identifier` child), mirroring the `@interface` adoption behaviour.

## Verification

- Added `@protocol Base` + `@protocol Derived <Base>` to the fixture and `test_objc_protocol_adopts_protocol` (fails before the fix, passes after).
- `test_languages.py` + `test_multilang.py`: 343 passed, 0 failed. `ruff` clean.
- AST-confirmed the adopted-protocol name is a direct `identifier` child of `protocol_reference_list`.

Before → after: `<Derived> → <Base>` (`implements`) is now emitted.
