### PR TITLE
fix(cpp): emit generic_arg references for base-class template arguments

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3668,6 +3668,7 @@ def _extract_generic(
                         continue
                     for sub in child.children:
                         base = ""
+                        template_args_node = None
                         if sub.type == "type_identifier":
                             base = _read_text(sub, source)
                         elif sub.type == "qualified_identifier":
@@ -3679,6 +3680,12 @@ def _extract_generic(
                         elif sub.type == "template_type":
                             tname = sub.child_by_field_name("name")
                             base = _read_text(tname, source) if tname else _read_text(sub, source)
+                            # The base's template_argument_list carries generic
+                            # type arguments (class Car : public Base<Dep>). The
+                            # Java handler (_emit_java_parent_type) emits these as
+                            # generic_arg references; C++ dropped them because we
+                            # only emitted the `inherits` edge on the base name.
+                            template_args_node = sub.child_by_field_name("arguments")
                         else:
                             continue
                         if not base:
@@ -3696,6 +3703,19 @@ def _extract_generic(
                                 })
                                 seen_ids.add(base_nid)
                         add_edge(class_nid, base_nid, "inherits", line)
+                        # Emit a generic_arg reference for each type argument on the
+                        # base (Base<Dep> -> Car references Dep). _cpp_collect_type_refs
+                        # handles nested/qualified args (Base<std::vector<Dep>>) too.
+                        if template_args_node is not None:
+                            arg_refs: list[tuple[str, str]] = []
+                            for arg in template_args_node.children:
+                                if arg.is_named:
+                                    _cpp_collect_type_refs(arg, source, True, arg_refs)
+                            for ref_name, _role in arg_refs:
+                                target_nid = ensure_named_node(ref_name, line)
+                                if target_nid != class_nid:
+                                    add_edge(class_nid, target_nid, "references",
+                                             line, context="generic_arg")
 
             # Find body and recurse
             body = _find_body(node, config)

--- a/tests/fixtures/sample.cpp
+++ b/tests/fixtures/sample.cpp
@@ -36,6 +36,17 @@ struct RetryingHttpClient : HttpClient {
     int maxRetries;
 };
 
+template <typename T>
+class Connection {
+public:
+    T resource;
+};
+
+class PooledClient : public Connection<HttpClient> {
+public:
+    int poolSize;
+};
+
 int main() {
     HttpClient client("https://api.example.com");
     std::string response = client.get("/users");

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -227,6 +227,15 @@ def test_cpp_struct_inherits_edge():
     assert found, "RetryingHttpClient (struct) should have inherits edge to HttpClient"
 
 
+def test_cpp_generic_parents_include_type_argument_references():
+    """`class PooledClient : public Connection<HttpClient>` must emit the inherits
+    edge to Connection AND a generic_arg reference to the HttpClient type argument,
+    matching the Java base-class behaviour (_emit_java_parent_type)."""
+    r = extract_cpp(FIXTURES / "sample.cpp")
+    assert ("PooledClient", "Connection") in _edge_labels(r, "inherits")
+    assert ("PooledClient", "HttpClient") in _edge_labels(r, "references", "generic_arg")
+
+
 # ── CUDA ──────────────────────────────────────────────────────────────────────
 # CUDA is a C++ superset, so .cu/.cuh route through the C++ (tree-sitter-cpp)
 # extractor. These tests guard that __global__/__device__ kernels, host


### PR DESCRIPTION
## Summary

C++ base-class template arguments are dropped. `class Car : public Base<Dep>` emits `Car → Base` (inherits) but never `Car → Dep` — even though the tool emits these for fields, method params/returns, and for Java base classes.

## Root cause

In `graphify/extract.py`, the C++ inheritance handler's `template_type` branch reads only the base's `name` (`Base`) and never descends into its `template_argument_list`.

## Fix

After emitting the `inherits` edge, collect the base's template arguments via `_cpp_collect_type_refs` (generic=True) and emit a `generic_arg` reference for each — mirroring Java's `_emit_java_parent_type`. `_cpp_collect_type_refs` already handles nested/qualified args, so `Base<std::vector<Dep>>` is covered.

## Verification

- Added a `Connection<T>` base + `PooledClient : Connection<HttpClient>` to the fixture and `test_cpp_generic_parents_include_type_argument_references` (fails before, passes after).
- `test_languages.py` + `test_multilang.py`: 343 passed, 0 failed. `ruff` clean.

Before → after: `PooledClient → HttpClient` (`references`, `generic_arg`) now emitted; `inherits` unchanged.
