### PR TITLE
fix(swift): emit references for enum associated-value types

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2598,16 +2598,37 @@ def _csharp_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: 
 
 def _swift_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
                       nodes: list, edges: list, seen_ids: set, function_bodies: list,
-                      parent_class_nid: str | None, add_node_fn, add_edge_fn) -> bool:
+                      parent_class_nid: str | None, add_node_fn, add_edge_fn,
+                      ensure_named_node_fn) -> bool:
     """Handle enum_entry for Swift. Returns True if handled."""
     if node.type == "enum_entry" and parent_class_nid:
+        line = node.start_point[0] + 1
         for child in node.children:
             if child.type == "simple_identifier":
                 case_name = _read_text(child, source)
                 case_nid = _make_id(parent_class_nid, case_name)
-                line = node.start_point[0] + 1
                 add_node_fn(case_nid, case_name, line)
                 add_edge_fn(parent_class_nid, case_nid, "case_of", line)
+        # Associated-value types nest as `enum_type_parameters -> user_type ->
+        # type_identifier` (a sibling of the case-name simple_identifier). The
+        # case-name loop above never descends into them, so `case started(Session)`
+        # used to drop the Event -> Session reference entirely. Mirror the Swift
+        # property/parameter emit style: collect the type refs and emit a
+        # `references` edge from the ENUM node to each collected type.
+        for child in node.children:
+            if child.type != "enum_type_parameters":
+                continue
+            for grand in child.children:
+                if not grand.is_named:
+                    continue
+                refs: list[tuple[str, str]] = []
+                _swift_collect_type_refs(grand, source, False, refs)
+                for ref_name, role in refs:
+                    ctx = "generic_arg" if role == "generic_arg" else "type"
+                    target_nid = ensure_named_node_fn(ref_name, line)
+                    if target_nid != parent_class_nid:
+                        add_edge_fn(parent_class_nid, target_nid, "references",
+                                    line, context=ctx)
         return True
     return False
 
@@ -4307,7 +4328,8 @@ def _extract_generic(
         if config.ts_module == "tree_sitter_swift":
             if _swift_extra_walk(node, source, file_nid, stem, str_path,
                                   nodes, edges, seen_ids, function_bodies,
-                                  parent_class_nid, add_node, add_edge):
+                                  parent_class_nid, add_node, add_edge,
+                                  ensure_named_node):
                 return
 
         # Python's `@property` / `@staticmethod` / `@classmethod` wrap the

--- a/tests/fixtures/sample.swift
+++ b/tests/fixtures/sample.swift
@@ -51,6 +51,7 @@ enum NetworkError {
     case timeout
     case connectionFailed
     case unauthorized
+    case failed(Config)
 
     func describe() -> String {
         return "error"

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -865,6 +865,10 @@ def test_swift_enum_cases_have_case_of_edge():
     case_edges = [e for e in r["edges"] if e["relation"] == "case_of"]
     assert len(case_edges) >= 2
 
+def test_swift_enum_associated_value_type_emits_references():
+    r = extract_swift(FIXTURES / "sample.swift")
+    assert ("NetworkError", "Config") in _edge_labels(r, "references", "type")
+
 def test_swift_finds_deinit():
     r = extract_swift(FIXTURES / "sample.swift")
     assert any("deinit" in l for l in _labels(r))


### PR DESCRIPTION
## Summary

Swift enum associated-value types are dropped. `case started(Session)` emits the `case_of` edge but never `Event → Session` — the associated payload types are invisible to the graph.

## Root cause

In `graphify/extract.py`, the Swift `enum_entry` handler iterates the entry's children only for the case name (`simple_identifier`) and never descends into the sibling `enum_type_parameters` node, which holds the associated-value types (`user_type → type_identifier`).

## Fix

After emitting `case_of`, descend into each `enum_type_parameters` child, collect its type refs via `_swift_collect_type_refs`, and emit a `references` edge from the enum to each type (context `type`, or `generic_arg` for generic roles). Cases with no associated value emit no reference.

## Verification

- Added `case failed(Config)` to the fixture's `NetworkError` enum and `test_swift_enum_associated_value_type_emits_references` (fails before, passes after).
- `test_languages.py` + `test_multilang.py`: 343 passed, 0 failed. `ruff` clean.

Before → after: `NetworkError → Config` (`references`, `type`) now emitted.
