### PR TITLE
fix(extract): four TS/JS extractor gaps — generators, namespace containers, decorators, import-equals

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1787,12 +1787,23 @@ def _import_js(node, source: bytes, file_nid: str, stem: str, edges: list, str_p
                 return
 
     resolved_path: "Path | None" = None
+    module_string = None
     for child in node.children:
         if child.type == "string":
-            raw = _read_text(child, source).strip("'\"` ")
-            resolved = _resolve_js_import_target(raw, str_path)
-            if resolved is None:
-                break
+            module_string = child
+            break
+        if child.type == "import_require_clause":
+            # TS import-equals form: `import x = require("./m")`. The module
+            # string sits inside the clause, not on the import_statement
+            # itself, so the direct-child scan above never sees it.
+            module_string = next(
+                (sub for sub in child.children if sub.type == "string"), None
+            )
+            break
+    if module_string is not None:
+        raw = _read_text(module_string, source).strip("'\"` ")
+        resolved = _resolve_js_import_target(raw, str_path)
+        if resolved is not None:
             tgt_nid, resolved_path = resolved
             edges.append({
                 "source": file_nid,
@@ -1804,7 +1815,6 @@ def _import_js(node, source: bytes, file_nid: str, stem: str, edges: list, str_p
                 "source_location": f"L{node.start_point[0] + 1}",
                 "weight": 1.0,
             })
-            break
 
     # Emit symbol-level edges for named imports/re-exports from local/aliased files.
     # e.g. `import { Foo, type Bar } from './bar'` → file → Foo, file → Bar (EXTRACTED)

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3357,6 +3357,12 @@ def _extract_generic(
             callable_def_nids.add(class_nid)  # a class is callable (constructor)
             add_edge(file_nid, class_nid, "contains", line)
 
+            # TS/JS decorators on the class and its members (@Component, @Injectable,
+            # @Input, @Inject, @Entity, …). Decorators live only in class subtrees.
+            if config.ts_module in ("tree_sitter_javascript", "tree_sitter_typescript"):
+                _ts_emit_decorator_edges(node, class_nid, stem, source,
+                                         ensure_named_node, add_edge)
+
             if config.ts_module == "tree_sitter_swift" and any(
                 c.type == "extension" for c in node.children
             ):
@@ -9901,6 +9907,125 @@ _JS_PRIMITIVE_TYPES = frozenset({
     "string", "number", "boolean", "any", "unknown", "void", "never",
     "object", "null", "undefined", "bigint", "symbol", "this",
 })
+
+
+def _ts_decorator_name(deco_node, source: bytes) -> str | None:
+    """Return the head symbol of a TS `decorator` node.
+
+    `@Injectable` -> the identifier; `@Component({...})` / `@Input()` -> the
+    `function` of the call_expression; `@ng.Component()` / `@core.Injectable` ->
+    the `property` of the member_expression (the imported symbol, not the
+    namespace alias).
+    """
+    for child in deco_node.children:
+        if not child.is_named:
+            continue
+        target = child
+        if target.type == "call_expression":
+            target = target.child_by_field_name("function") or target
+        if target.type == "member_expression":
+            prop = target.child_by_field_name("property")
+            return _read_text(prop, source) if prop else None
+        if target.type == "identifier":
+            return _read_text(target, source)
+        return None
+    return None
+
+
+def _ts_method_name(method_node, source: bytes) -> str | None:
+    """Name of a `method_definition`, matching the id the function-types branch
+    builds (`_make_id(class_nid, name)`)."""
+    name_node = method_node.child_by_field_name("name")
+    return _read_text(name_node, source) if name_node else None
+
+
+def _ts_descendant_decorators(node) -> list:
+    """Collect `decorator` nodes under `node` (e.g. parameter decorators inside a
+    method's formal_parameters, or a field's own decorator), without crossing into
+    a nested class or a nested method, which own their own decorators."""
+    out: list = []
+
+    def rec(n, top: bool) -> None:
+        for child in n.children:
+            ct = child.type
+            if ct == "decorator":
+                out.append(child)
+            elif ct in ("class_declaration", "abstract_class_declaration"):
+                continue
+            elif ct == "method_definition" and not top:
+                continue
+            else:
+                rec(child, False)
+
+    rec(node, True)
+    return out
+
+
+def _ts_emit_decorator_edges(class_node, class_nid: str, stem: str, source: bytes,
+                             ensure_named_node, add_edge) -> None:
+    """Emit `references` edges (context="decorator") from a class and its members
+    to the symbols of the TS decorators applied to them.
+
+    Decorators only occur on classes, class members, and parameters, so a single
+    pass over the class declaration covers them. Members that are graph nodes
+    (methods, incl. the constructor) own their decorators and their parameter
+    decorators; members that are not nodes (fields, parameters) attribute to the
+    enclosing class. Targets go through `ensure_named_node`, so a decorator
+    imported from another module (the common case — `@Component` from
+    `@angular/core`) becomes a sourceless stub the corpus rewire collapses onto
+    the real definition.
+    """
+    def emit(deco_node, owner_nid: str) -> None:
+        name = _ts_decorator_name(deco_node, source)
+        if not name:
+            return
+        line = deco_node.start_point[0] + 1
+        target = ensure_named_node(name, line)
+        if target != owner_nid:
+            add_edge(owner_nid, target, "references", line, context="decorator")
+
+    # Class-level decorators: direct children of the class node (`@Deco class C`),
+    # plus — when exported (`@Deco export class C`) — the decorators that sit on
+    # the wrapping export_statement, before the class.
+    for child in class_node.children:
+        if child.type == "decorator":
+            emit(child, class_nid)
+    parent = class_node.parent
+    if parent is not None and parent.type == "export_statement":
+        for child in parent.children:
+            if child.type == "decorator":
+                emit(child, class_nid)
+            elif child.type in ("class_declaration", "abstract_class_declaration"):
+                break
+
+    # Member decorators inside the class body.
+    body = next((c for c in class_node.children if c.type == "class_body"), None)
+    if body is None:
+        return
+    for member in body.children:
+        mt = member.type
+        if mt == "decorator":
+            # A method decorator is a sibling preceding the method; skip past any
+            # stacked decorators to find it.
+            owner = class_nid
+            sib = member.next_named_sibling
+            while sib is not None and sib.type == "decorator":
+                sib = sib.next_named_sibling
+            if sib is not None and sib.type == "method_definition":
+                mname = _ts_method_name(sib, source)
+                if mname:
+                    owner = _make_id(class_nid, mname)
+            emit(member, owner)
+        elif mt == "method_definition":
+            mname = _ts_method_name(member, source)
+            m_nid = _make_id(class_nid, mname) if mname else class_nid
+            for deco in _ts_descendant_decorators(member):
+                emit(deco, m_nid)
+        else:
+            # Fields / accessors: the member is not a node, so attribute its
+            # decorators (e.g. `@Input()`, `@Column()`) to the class.
+            for deco in _ts_descendant_decorators(member):
+                emit(deco, class_nid)
 
 
 def _ts_heritage_clause_entries(clause_node, source: bytes) -> list[str]:

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2396,7 +2396,7 @@ def _require_imports_js(node, source: bytes, file_nid: str, stem: str, edges: li
 # Node types whose value is a callable, for the JS/TS assignment / class-field
 # / function-expression forms below. Older tree-sitter-javascript grammars
 # label a function expression `function`; current ones use `function_expression`.
-_JS_FUNCTION_VALUE_TYPES = frozenset({"arrow_function", "function_expression", "function"})
+_JS_FUNCTION_VALUE_TYPES = frozenset({"arrow_function", "function_expression", "function", "generator_function"})
 
 
 def _js_member_assignment_target(left, source: bytes):
@@ -2691,14 +2691,14 @@ _PYTHON_CONFIG = LanguageConfig(
 _JS_CONFIG = LanguageConfig(
     ts_module="tree_sitter_javascript",
     class_types=frozenset({"class_declaration"}),
-    function_types=frozenset({"function_declaration", "method_definition"}),
+    function_types=frozenset({"function_declaration", "generator_function_declaration", "method_definition"}),
     import_types=frozenset({"import_statement", "export_statement"}),
     call_types=frozenset({"call_expression", "new_expression"}),
     call_function_field="function",
     call_accessor_node_types=frozenset({"member_expression"}),
     call_accessor_field="property",
     call_accessor_object_field="object",
-    function_boundary_types=frozenset({"function_declaration", "arrow_function", "method_definition"}),
+    function_boundary_types=frozenset({"function_declaration", "generator_function_declaration", "arrow_function", "method_definition"}),
     import_handler=_import_js,
 )
 
@@ -2712,14 +2712,14 @@ _TS_CONFIG = LanguageConfig(
         "enum_declaration",        # named enums
         "type_alias_declaration",  # named type aliases
     }),
-    function_types=frozenset({"function_declaration", "method_definition", "method_signature"}),
+    function_types=frozenset({"function_declaration", "generator_function_declaration", "method_definition", "method_signature"}),
     import_types=frozenset({"import_statement", "export_statement"}),
     call_types=frozenset({"call_expression", "new_expression"}),
     call_function_field="function",
     call_accessor_node_types=frozenset({"member_expression"}),
     call_accessor_field="property",
     call_accessor_object_field="object",
-    function_boundary_types=frozenset({"function_declaration", "arrow_function", "method_definition"}),
+    function_boundary_types=frozenset({"function_declaration", "generator_function_declaration", "arrow_function", "method_definition"}),
     import_handler=_import_js,
 )
 

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2577,6 +2577,56 @@ def _js_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
     return False
 
 
+# ── TS extra walk for namespace / module declarations ─────────────────────────
+
+def _ts_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
+                   nodes: list, edges: list, seen_ids: set, function_bodies: list,
+                   parent_class_nid: str | None, add_node_fn, add_edge_fn,
+                   walk_fn) -> bool:
+    """Emit a container node for a TS `namespace`/`module` declaration.
+
+    `namespace Foo {}` parses as `internal_module` (with `name`/`body` fields);
+    `module Bar {}` and ambient `declare module "pkg" {}` parse as a named
+    `module` node that exposes no fields, so its name and body are found
+    positionally. Without this the container was never a node — its members were
+    still reached by the default recurse but lost their namespace context. The
+    members stay file-contained (parity with C#'s `_csharp_extra_walk`); the
+    namespace becomes a sibling marker node so it is queryable. Returns True if
+    handled.
+
+    The guard requires `is_named` because the anonymous `module` keyword token
+    shares the `module` type string and would otherwise match here.
+    """
+    if node.is_named and node.type in ("internal_module", "module"):
+        name_node = node.child_by_field_name("name")
+        if name_node is None:
+            for child in node.children:
+                if child.is_named and child.type in (
+                        "identifier", "nested_identifier", "string"):
+                    name_node = child
+                    break
+        body = node.child_by_field_name("body")
+        if body is None:
+            for child in node.children:
+                if child.type == "statement_block":
+                    body = child
+                    break
+        if name_node is not None:
+            ns_name = _read_text(name_node, source)
+            if name_node.type == "string":
+                ns_name = ns_name.strip("'\"`")
+            if ns_name:
+                ns_nid = _make_id(stem, ns_name)
+                line = node.start_point[0] + 1
+                add_node_fn(ns_nid, ns_name, line)
+                add_edge_fn(file_nid, ns_nid, "contains", line)
+        if body is not None:
+            for child in body.children:
+                walk_fn(child, parent_class_nid)
+        return True
+    return False
+
+
 # ── C# extra walk for namespace declarations ──────────────────────────────────
 
 def _csharp_namespace_name(node, source: bytes) -> str:
@@ -4429,6 +4479,13 @@ def _extract_generic(
                               nodes, edges, seen_ids, function_bodies,
                               parent_class_nid, add_node, add_edge,
                               callable_def_nids, local_bound_names):
+                return
+
+        # TS namespace / module containers (internal_module, module)
+        if config.ts_module == "tree_sitter_typescript":
+            if _ts_extra_walk(node, source, file_nid, stem, str_path,
+                              nodes, edges, seen_ids, function_bodies,
+                              parent_class_nid, add_node, add_edge, walk):
                 return
 
         if config.ts_module == "tree_sitter_c_sharp":

--- a/tests/test_ts_decorators.py
+++ b/tests/test_ts_decorators.py
@@ -1,0 +1,153 @@
+"""Regression tests: TypeScript/JavaScript decorator references.
+
+`@Component`, `@Injectable`, `@Input`, `@Inject`, `@Entity`, … emitted no edge
+to the decorator symbol — the `decorator` node kind was never walked. This is
+framework-critical (Angular, NestJS, Vue class components, TypeORM).
+
+Decorators are emitted as `references` edges with context="decorator" from the
+decorated entity: the class for class/field/parameter decorators, the method
+for method (and its parameter) decorators. Targets resolve through the same
+sourceless-stub path as type references, so a decorator imported from another
+module collapses onto its real definition.
+"""
+from pathlib import Path
+
+from graphify.extract import _file_stem, _make_id, extract
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _class_nid(file: str, cls: str) -> str:
+    return _make_id(_file_stem(Path(file)), cls)
+
+
+def _method_nid(file: str, cls: str, method: str) -> str:
+    return _make_id(_class_nid(file, cls), method)
+
+
+def _has_deco(result: dict, owner_nid: str, deco: str) -> bool:
+    """True if owner_nid references the (cross-file, bare-stub) decorator symbol."""
+    tgt = _make_id(deco)
+    return any(
+        e["source"] == owner_nid
+        and e["target"] == tgt
+        and e["relation"] == "references"
+        and e.get("context") == "decorator"
+        for e in result["edges"]
+    )
+
+
+def test_class_decorator_on_exported_class(tmp_path):
+    # The canonical Angular shape: decorator sits on the wrapping export_statement.
+    f = _write(tmp_path / "src" / "c.ts",
+               "@Component({ selector: 'app' })\n"
+               "export class AppComponent {}\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_deco(r, _class_nid("src/c.ts", "AppComponent"), "Component")
+
+
+def test_class_decorator_on_plain_class(tmp_path):
+    f = _write(tmp_path / "src" / "s.ts",
+               "@Injectable()\nclass Service {}\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_deco(r, _class_nid("src/s.ts", "Service"), "Injectable")
+
+
+def test_stacked_class_decorators(tmp_path):
+    f = _write(tmp_path / "src" / "s.ts",
+               "@Injectable()\n@Entity()\nexport class Repo {}\n")
+    r = extract([f], cache_root=tmp_path)
+    nid = _class_nid("src/s.ts", "Repo")
+    assert _has_deco(r, nid, "Injectable")
+    assert _has_deco(r, nid, "Entity")
+
+
+def test_method_decorator_attributes_to_method(tmp_path):
+    f = _write(tmp_path / "src" / "c.ts",
+               "export class C {\n"
+               "  @HostListener('click') onClick() {}\n"
+               "}\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_deco(r, _method_nid("src/c.ts", "C", "onClick"), "HostListener")
+    # and NOT to the class
+    assert not _has_deco(r, _class_nid("src/c.ts", "C"), "HostListener")
+
+
+def test_stacked_method_decorators(tmp_path):
+    f = _write(tmp_path / "src" / "c.ts",
+               "export class C {\n"
+               "  @Get('/') @UseGuards(Auth) list() {}\n"
+               "}\n")
+    r = extract([f], cache_root=tmp_path)
+    nid = _method_nid("src/c.ts", "C", "list")
+    assert _has_deco(r, nid, "Get")
+    assert _has_deco(r, nid, "UseGuards")
+
+
+def test_field_decorator_attributes_to_class(tmp_path):
+    # The field is not a graph node, so its decorator attributes to the class.
+    f = _write(tmp_path / "src" / "c.ts",
+               "export class C {\n"
+               "  @Input() name: string;\n"
+               "  @Column() age: number;\n"
+               "}\n")
+    r = extract([f], cache_root=tmp_path)
+    nid = _class_nid("src/c.ts", "C")
+    assert _has_deco(r, nid, "Input")
+    assert _has_deco(r, nid, "Column")
+
+
+def test_parameter_decorator_attributes_to_constructor(tmp_path):
+    f = _write(tmp_path / "src" / "c.ts",
+               "export class C {\n"
+               "  constructor(@Inject(TOKEN) private s: Svc) {}\n"
+               "}\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_deco(r, _method_nid("src/c.ts", "C", "constructor"), "Inject")
+
+
+def test_namespaced_decorator_uses_property_name(tmp_path):
+    f = _write(tmp_path / "src" / "c.ts",
+               "@core.Component({})\nexport class Widget {}\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_deco(r, _class_nid("src/c.ts", "Widget"), "Component")
+
+
+def test_external_decorator_stub_disambiguated_per_file(tmp_path):
+    """An external decorator (definition absent from the corpus — the common
+    framework case) still emits a `references`/`decorator` edge from every class
+    that applies it — the core behavior of this fix.
+
+    Convergence note (v0.9.0+): the edges no longer collapse onto a single shared
+    bare-name stub. v0.9.0 embeds the full repo-relative path in node IDs and
+    #1462 disambiguates imported type stubs across files, so the same external
+    `Injectable` referenced from two files now resolves to two distinct per-file
+    stubs (`src_a_ts_injectable`, `src_b_ts_injectable`) rather than one hub. (A
+    single in-corpus reference still keeps the bare `injectable` stub — only
+    cross-file, unresolved references are split.)"""
+    a = _write(tmp_path / "src" / "a.ts", "@Injectable()\nexport class A {}\n")
+    b = _write(tmp_path / "src" / "b.ts", "@Injectable()\nexport class B {}\n")
+    r = extract([a, b], cache_root=tmp_path)
+
+    # Each class emits exactly one decorator-context edge to an `Injectable`
+    # node (checked by label, since the stub id is now path-qualified).
+    id_to_label = {n["id"]: n.get("label") for n in r["nodes"]}
+    deco_edges = [
+        e for e in r["edges"]
+        if e["relation"] == "references" and e.get("context") == "decorator"
+    ]
+    a_targets = [e["target"] for e in deco_edges if e["source"] == _class_nid("src/a.ts", "A")]
+    b_targets = [e["target"] for e in deco_edges if e["source"] == _class_nid("src/b.ts", "B")]
+    assert len(a_targets) == 1 and id_to_label.get(a_targets[0]) == "Injectable"
+    assert len(b_targets) == 1 and id_to_label.get(b_targets[0]) == "Injectable"
+
+    # v0.9.0 full-path IDs + #1462 stub disambiguation: external stubs are split
+    # per file, so the two no longer converge on one shared hub.
+    assert a_targets[0] != b_targets[0], (
+        "external decorator stubs are disambiguated per file in v0.9.0+; "
+        "they no longer converge on a single shared stub"
+    )

--- a/tests/test_ts_generators.py
+++ b/tests/test_ts_generators.py
@@ -1,0 +1,74 @@
+"""Regression tests: TypeScript/JavaScript generator functions as nodes.
+
+Before the fix, `function* g()` (generator_function_declaration) was absent from
+`function_types`, so it produced no node, and the expression form
+`const h = function*(){}` (generator_function) was absent from the JS
+function-value types, so it was never captured either. Generator *methods*
+(`*gen()` inside a class) were already covered — they parse as `method_definition`.
+"""
+from pathlib import Path
+
+from graphify.extract import _file_stem, _make_id, extract
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _has_node(result: dict, file: str, sym: str) -> bool:
+    nid = _make_id(_file_stem(Path(file)), sym)
+    return any(n["id"] == nid for n in result["nodes"])
+
+
+def _contains(result: dict, file: str, sym: str) -> bool:
+    tgt = _make_id(_file_stem(Path(file)), sym)
+    return any(
+        e["target"] == tgt and e["relation"] == "contains"
+        for e in result["edges"]
+    )
+
+
+def test_generator_declaration_is_node_ts(tmp_path):
+    f = _write(tmp_path / "src" / "g.ts",
+               "export function* counter() { yield 1; yield 2; }\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_node(r, "src/g.ts", "counter")
+    assert _contains(r, "src/g.ts", "counter")
+
+
+def test_generator_declaration_is_node_js(tmp_path):
+    f = _write(tmp_path / "src" / "g.js",
+               "function* gen() { yield 42; }\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_node(r, "src/g.js", "gen")
+
+
+def test_generator_expression_is_node(tmp_path):
+    f = _write(tmp_path / "src" / "h.ts",
+               "export const stream = function* () { yield 'a'; };\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_node(r, "src/h.ts", "stream")
+
+
+def test_generator_body_calls_are_attributed(tmp_path):
+    """A call inside a generator's body should be attributed to the generator,
+    proving its body is walked (generator is a function boundary like a normal fn)."""
+    f = _write(tmp_path / "src" / "g.ts",
+               "function helper() {}\n"
+               "function* producer() { helper(); yield 1; }\n")
+    r = extract([f], cache_root=tmp_path)
+    src = _make_id(_file_stem(Path("src/g.ts")), "producer")
+    tgt = _make_id(_file_stem(Path("src/g.ts")), "helper")
+    assert any(
+        e["source"] == src and e["target"] == tgt and e["relation"] == "calls"
+        for e in r["edges"]
+    ), "call from generator body should resolve to helper()"
+
+
+def test_async_generator_declaration_is_node(tmp_path):
+    f = _write(tmp_path / "src" / "ag.ts",
+               "export async function* pages() { yield await Promise.resolve(1); }\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_node(r, "src/ag.ts", "pages")

--- a/tests/test_ts_import_require.py
+++ b/tests/test_ts_import_require.py
@@ -1,0 +1,111 @@
+"""Regression tests for the TypeScript import-equals form: `import x = require("./m")`.
+
+Before the fix, the module string of an import-equals declaration was invisible:
+tree-sitter parses it as an `import_statement` whose string sits inside an
+`import_require_clause`, not as a direct child of the statement — so the
+direct-child string scan in `_import_js` never found it and the file produced
+no `imports_from` edge at all (while the equivalent ESM `import * as x from
+"./m"` did). The fix gives the import-equals form exact parity with the ESM
+namespace import: one file-level `imports_from` edge.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify.extract import _file_node_id, _make_id, extract
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _has_edge(result: dict, source: str, target: str, relation: str = "imports_from") -> bool:
+    expected = (_file_node_id(Path(source)), _file_node_id(Path(target)), relation)
+    actual = {
+        (edge["source"], edge["target"], edge["relation"])
+        for edge in result["edges"]
+    }
+    return expected in actual
+
+
+def test_import_require_relative_emits_file_edge(tmp_path: Path):
+    target = _write(tmp_path / "src/lib/legacy.ts", "export function foo(): number { return 1 }\n")
+    importer = _write(
+        tmp_path / "src/lib/consumer.ts",
+        'import legacy = require("./legacy");\nconst n = legacy.foo();\n',
+    )
+
+    result = extract([target, importer], cache_root=tmp_path)
+
+    assert _has_edge(result, "src/lib/consumer.ts", "src/lib/legacy.ts")
+
+
+def test_import_require_single_quotes(tmp_path: Path):
+    target = _write(tmp_path / "src/util.ts", "export const V = 1\n")
+    importer = _write(
+        tmp_path / "src/main.ts",
+        "import util = require('./util');\nexport const x = util.V;\n",
+    )
+
+    result = extract([target, importer], cache_root=tmp_path)
+
+    assert _has_edge(result, "src/main.ts", "src/util.ts")
+
+
+def test_import_require_bare_module_targets_stub(tmp_path: Path):
+    importer = _write(
+        tmp_path / "src/io.ts",
+        'import fs = require("fs");\nexport const data = fs.readFileSync("x");\n',
+    )
+
+    result = extract([importer], cache_root=tmp_path)
+
+    src = _file_node_id(Path("src/io.ts"))
+    tgt = _make_id("fs")
+    assert any(
+        e["source"] == src and e["target"] == tgt and e["relation"] == "imports_from"
+        for e in result["edges"]
+    ), "bare-module import-equals should target the module-name stub, like ESM"
+
+
+def test_import_require_parity_with_namespace_import(tmp_path: Path):
+    """`import x = require("./m")` must produce the same file-level edge as
+    `import * as x from "./m"` — no more, no less."""
+    _write(tmp_path / "a/dep.ts", "export function f() {}\n")
+    req = _write(tmp_path / "a/via_require.ts", 'import dep = require("./dep");\ndep.f();\n')
+    esm = _write(tmp_path / "a/via_esm.ts", 'import * as dep from "./dep";\ndep.f();\n')
+
+    result = extract([tmp_path / "a/dep.ts", req, esm], cache_root=tmp_path)
+
+    def edges_from(source_file: str):
+        src = _file_node_id(Path(source_file))
+        return sorted(
+            (e["target"], e["relation"])
+            for e in result["edges"]
+            if e["source"] == src and e["relation"] != "contains"
+        )
+
+    assert _has_edge(result, "a/via_require.ts", "a/dep.ts")
+    assert edges_from("a/via_require.ts") == edges_from("a/via_esm.ts")
+
+
+def test_esm_imports_unaffected(tmp_path: Path):
+    """Regression guard: the restructured string scan must not change ESM handling
+    (file-level edge + named-import symbol edge both still emitted)."""
+    target = _write(tmp_path / "src/bar.ts", "export class Bar {}\n")
+    importer = _write(
+        tmp_path / "src/app.ts",
+        'import { Bar } from "./bar";\nexport const b = new Bar();\n',
+    )
+
+    result = extract([target, importer], cache_root=tmp_path)
+
+    assert _has_edge(result, "src/app.ts", "src/bar.ts")
+    src = _file_node_id(Path("src/app.ts"))
+    sym = [
+        e for e in result["edges"]
+        if e["source"] == src and e["relation"] == "imports"
+    ]
+    assert sym, "named-import symbol edge should still be emitted"

--- a/tests/test_ts_namespace.py
+++ b/tests/test_ts_namespace.py
@@ -1,0 +1,73 @@
+"""Regression tests: TypeScript namespace/module container nodes.
+
+`namespace Foo {}` parses as `internal_module`, `module Bar {}` and ambient
+`declare module "pkg" {}` as `module`. Neither was in `class_types`/`function_types`
+nor handled by an extra-walk, so the container produced no node. Members were
+still reached by the default recurse but the namespace itself was invisible.
+"""
+from pathlib import Path
+
+from graphify.extract import _file_stem, _make_id, extract
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _node_label(result: dict, file: str, sym: str):
+    nid = _make_id(_file_stem(Path(file)), sym)
+    return next((n["label"] for n in result["nodes"] if n["id"] == nid), None)
+
+
+def _has_node(result: dict, file: str, sym: str) -> bool:
+    return _node_label(result, file, sym) is not None
+
+
+def test_namespace_is_node(tmp_path):
+    f = _write(tmp_path / "src" / "n.ts",
+               "export namespace Geometry { export const PI = 3.14; }\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_node(r, "src/n.ts", "Geometry")
+
+
+def test_module_keyword_is_node(tmp_path):
+    f = _write(tmp_path / "src" / "m.ts",
+               "module Legacy { export class Thing {} }\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_node(r, "src/m.ts", "Legacy")
+
+
+def test_nested_namespace_name(tmp_path):
+    f = _write(tmp_path / "src" / "nn.ts",
+               "namespace App.Core.Util { export const v = 1; }\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _node_label(r, "src/nn.ts", "App.Core.Util") == "App.Core.Util"
+
+
+def test_namespace_members_still_extracted(tmp_path):
+    """The container node must not cost us the members the default recurse reached."""
+    f = _write(tmp_path / "src" / "n.ts",
+               "namespace Shapes {\n"
+               "  export class Circle {}\n"
+               "  export function area() { return 0; }\n"
+               "}\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_node(r, "src/n.ts", "Shapes")
+    assert _has_node(r, "src/n.ts", "Circle")
+    assert _has_node(r, "src/n.ts", "area")
+
+
+def test_ambient_string_module_quotes_stripped(tmp_path):
+    f = _write(tmp_path / "src" / "amb.ts",
+               'declare module "pkg-name" { export const z = 3; }\n')
+    r = extract([f], cache_root=tmp_path)
+    assert _node_label(r, "src/amb.ts", "pkg-name") == "pkg-name"
+
+
+def test_namespace_node_not_emitted_in_js(tmp_path):
+    """The handler is TS-only; plain JS has no namespace syntax to confuse it."""
+    f = _write(tmp_path / "src" / "p.js", "function ok() {}\n")
+    r = extract([f], cache_root=tmp_path)
+    assert _has_node(r, "src/p.js", "ok")


### PR DESCRIPTION
## Summary

Four independent gaps in the TS/JS extractor, found while running graphify against a large TypeScript front end. One commit per fix so they can be reviewed — or cherry-picked — individually. Each commit carries its own regression tests, and none of them changes existing behavior for code that was already extracted (the ESM import path is regression-guarded explicitly).

### 1. Generator functions were not nodes (`0bb8895`)

The declaration form `function* g()` parses as `generator_function_declaration`, which was absent from the JS/TS `function_types`, so it produced no node; the expression form `const h = function*(){}` parses as `generator_function`, which was absent from the JS function-value types. Generator *methods* (`*gen()` in a class) were already covered via `method_definition`.

The fix adds `generator_function_declaration` to the JS/TS `function_types` and `function_boundary_types` (so a generator is a node and its body's calls attribute to it, parity with `function_declaration`), and `generator_function` to the JS function-value types (so the const-assigned form is captured like `function_expression`).

### 2. TS namespace / module containers were not nodes (`d4418fc`)

`namespace Foo {}` (`internal_module`) and `module Bar {}` / ambient `declare module "pkg" {}` (`module`) were not in any type set and had no extra-walk, so the container produced no node — members were still reached by the default recurse, but the namespace itself was invisible and its members lost their namespace context.

The fix adds `_ts_extra_walk` (dispatched for TypeScript after `_js_extra_walk`, mirroring the C# extra-walk): it emits a container node plus a file→container `contains` edge and recurses the body, leaving members file-contained exactly as before. An `is_named` guard skips the anonymous `module` keyword token, which shares the `module` type string.

### 3. Decorators produced no edges (`71632b2`)

`@Component`, `@Injectable`, `@Input`, `@Inject`, `@Entity`, … — the `decorator` node kind was never walked, so decorators produced no edge at all. This is framework-critical signal (Angular, NestJS, Vue class components, TypeORM): decorators are often the primary statement of what a class is and does.

The fix emits a `references` edge (context=`"decorator"`) from the decorated entity to the decorator symbol: class decorators → the class (both `@Deco class C` and `@Deco export class C`, plus stacked decorators), method decorators → the method node, field/accessor decorators → the class (the field is not a graph node), parameter decorators (`@Inject(T)`) → the enclosing method/constructor. The symbol is the head identifier (`@Injectable`, the function of `@Component({...})`, or the property of `@ns.Component()`), routed through `ensure_named_node` so out-of-corpus decorators become sourceless stubs consistent with type references.

### 4. The TS import-equals form was invisible (`31aed9a`)

`import x = require("./m")` produced no edge at all: tree-sitter parses it as an `import_statement` whose module string sits inside an `import_require_clause`, not as a direct child of the statement, so the direct-child string scan in `_import_js` never found it — while the equivalent ESM `import * as x from "./m"` was captured.

The fix restructures the scan to locate the module string in either position and emits the `imports_from` edge from the single shared path. Relative paths, tsconfig aliases, and bare modules all resolve through the same `_resolve_js_import_target` as ESM, giving the import-equals form exact parity with a namespace import (verified by a require-vs-ESM parity test). Plain JS is unaffected (its grammar has no `import_require_clause`), and the pure alias form `import A = B.C` is deliberately out of scope — it has no module string and models an intra-code alias, not an import.

## Testing

- 25 new tests across four files: `test_ts_generators.py` (5), `test_ts_namespace.py` (6), `test_ts_decorators.py` (9), `test_ts_import_require.py` (5).
- Full relevant suites green on top of `v8` @ `d89ec68`: `test_languages`, `test_js_import_resolution`, `test_symbol_resolution`, `test_language_resolvers`, `test_ts_inheritance`, `test_vue_extraction` + the four new files — **451 passed, 13 skipped**.
- Each fix was validated against real-world code from a large production TypeScript/Vue codebase before being reduced to the minimal test fixtures here.

🤖 Generated with [Claude Code](https://claude.ai/code)
