### PR TITLE
fix: persist cluster-only analysis sidecar

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -3655,6 +3655,17 @@ def main() -> None:
         stages.mark("report")
         from graphify.export import backup_if_protected as _backup
         _backup(out)
+        analysis = {
+            "communities": {str(k): v for k, v in communities.items()},
+            "cohesion": {str(k): v for k, v in cohesion.items()},
+            "gods": gods,
+            "surprises": surprises,
+            "questions": questions,
+        }
+        (out / ".graphify_analysis.json").write_text(
+            json.dumps(analysis, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
         to_json(G, communities, str(out / "graph.json"), community_labels=labels)
         labels_path.write_text(json.dumps({str(k): v for k, v in labels.items()}, ensure_ascii=False), encoding="utf-8")
         # Membership signatures beside the labels so a later cluster-only can detect

--- a/tests/test_cli_export.py
+++ b/tests/test_cli_export.py
@@ -323,6 +323,36 @@ def test_cluster_only_creates_output_dir_when_missing(tmp_path):
 
 # Regression test for #1027 - cluster-only must remap labels via node overlap
 
+def test_cluster_only_persists_analysis_sidecar(tmp_path):
+    """cluster-only must refresh .graphify_analysis.json alongside graph.json.
+
+    Downstream export commands use the sidecar for community membership and
+    should not see stale or missing community analysis after a recluster.
+    """
+    out = _make_graph(tmp_path)
+    analysis_path = out / ".graphify_analysis.json"
+    analysis_path.unlink()
+
+    r = _run(["cluster-only", ".", "--no-viz"], tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert analysis_path.exists()
+
+    analysis = json.loads(analysis_path.read_text(encoding="utf-8"))
+    assert analysis["communities"]
+    assert analysis["cohesion"]
+    assert "gods" in analysis
+    assert "surprises" in analysis
+    assert "questions" in analysis
+
+    graph = json.loads((out / "graph.json").read_text(encoding="utf-8"))
+    graph_cids = {
+        str(node["community"])
+        for node in graph.get("nodes", [])
+        if node.get("community") is not None
+    }
+    assert graph_cids == set(analysis["communities"])
+
+
 def test_cluster_only_remaps_labels_to_previous_cids(tmp_path):
     """cluster-only must invoke remap_communities_to_previous so the existing
     .graphify_labels.json keeps tracking the same conceptual communities after


### PR DESCRIPTION
## Summary
- Persist `.graphify_analysis.json` during `graphify cluster-only` / `graphify label` runs.
- Add a regression test that verifies the refreshed sidecar matches the communities written to `graph.json`.

## Testing
- [x] `uv run --frozen pytest tests/test_cli_export.py -q --tb=short`
- [x] `uv run --frozen pytest tests/test_cli_export.py tests/test_serve.py -q --tb=short`
- [x] `uv run --frozen pytest tests/ -q --tb=short`
- [x] `uv run --frozen ruff check graphify/__main__.py tests/test_cli_export.py`
- [x] `uv run --frozen python -m tools.skillgen --check`
- [x] `uv run --frozen python -m tools.skillgen --audit-coverage`
- [x] `uv run --frozen python -m tools.skillgen --schema-singleton`
- [x] `uv run --frozen python -m tools.skillgen --monolith-roundtrip`
- [x] `uv run --frozen python -m tools.skillgen --always-on-roundtrip`
- [x] `uv run --frozen graphify --help`
- [x] `uv run --frozen graphify install`
- [x] `git diff --check`

Closes #1610
