### PR TITLE
fix(kotlin): emit `implements` edge for interface delegation (`by`)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3648,6 +3648,17 @@ def _extract_generic(
                             if sub.type == "user_type":
                                 user_type_node = sub
                                 break
+                            # `class Foo : Bar by baz` wraps the delegated
+                            # interface `Bar` in an `explicit_delegation`
+                            # node; grab its first `user_type` descendant so
+                            # the implements edge (and generic-arg recovery)
+                            # still fire.
+                            if sub.type == "explicit_delegation":
+                                for inner in sub.children:
+                                    if inner.type == "user_type":
+                                        user_type_node = inner
+                                        break
+                                break
                         if user_type_node is None:
                             continue
                         base = _kotlin_user_type_name(user_type_node, source)

--- a/tests/fixtures/sample.kt
+++ b/tests/fixtures/sample.kt
@@ -35,6 +35,8 @@ class DataProcessor : BaseProcessor(), Loggable {
     override fun log() {}
 }
 
+class LoggingList<T>(inner: MutableList<T>) : MutableList<T> by inner
+
 fun createClient(baseUrl: String): HttpClient {
     val config = Config(baseUrl, 30)
     return HttpClient(config)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -623,6 +623,13 @@ def test_kotlin_splits_inherits_and_implements():
     assert ("DataProcessor", "Loggable") in _edge_labels(r, "implements")
 
 
+def test_kotlin_interface_delegation_emits_implements():
+    """`class Foo : Bar by baz` wraps the delegated interface in an
+    `explicit_delegation` node — it must still emit an implements edge."""
+    r = extract_kotlin(FIXTURES / "sample.kt")
+    assert ("LoggingList", "MutableList") in _edge_labels(r, "implements")
+
+
 def test_kotlin_parameter_return_generic_and_field_contexts():
     r = extract_kotlin(FIXTURES / "sample.kt")
     assert ("run", "DataProcessor") in _edge_labels(r, "references", "parameter_type")


### PR DESCRIPTION
## What it fixes

Kotlin interface delegation — `class Foo : Bar by baz` — emitted **no** edge, so the delegated interface `Bar` was silently dropped from the graph.

The `delegation_specifier` loop only handled `constructor_invocation` (→ `inherits`) and a bare `user_type` (→ `implements`) child. The `by` form produces an `explicit_delegation` node that *wraps* the `user_type`, so neither branch fired and no edge was emitted. Delegation is idiomatic Kotlin (the whole point of `by`).

## Fix

Add an `explicit_delegation` branch in that loop: take its wrapped `user_type` child and emit the `implements` edge, leaving the existing generic type-argument recovery intact.

```kotlin
class LoggingList<T>(inner: MutableList<T>) : MutableList<T> by inner
```
now emits `implements: LoggingList -> MutableList` (and `references: LoggingList -> T` for the generic arg).

## Test

- `tests/fixtures/sample.kt`: added the delegation example above.
- `tests/test_languages.py`: `test_kotlin_interface_delegation_emits_implements` asserts the `implements` edge.
- `pytest tests/test_languages.py -k kotlin` → 9 passed (negative control without the fix fails on the missing edge).
