### PR TITLE
fix(apex): emit `extends` edges for interface multiple inheritance

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -6297,6 +6297,16 @@ def extract_apex(path: Path) -> dict:
             add_node(iface_nid, iface_name, lineno)
             add_edge(file_nid if current_class_nid is None else current_class_nid,
                      iface_nid, "contains", lineno)
+            if im.group(2):
+                for parent in im.group(2).split(","):
+                    parent = parent.strip()
+                    if parent:
+                        parent_nid = _make_id(stem, parent)
+                        if parent_nid not in seen_ids:
+                            parent_nid = _make_id(parent)
+                        if parent_nid not in seen_ids:
+                            add_node(parent_nid, parent, lineno)
+                        add_edge(iface_nid, parent_nid, "extends", lineno, confidence="INFERRED")
             pending_annotations = []
             continue
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -2627,6 +2627,16 @@ def test_apex_interface_extraction():
     labels = _labels(r)
     assert "Notifiable" in labels
 
+def test_apex_interface_extends(tmp_path):
+    source = tmp_path / "PaymentProcessor.cls"
+    source.write_text(
+        "public interface PaymentProcessor extends Processor, Auditable { void process(); }\n"
+    )
+    result = extract_apex(source)
+    inheritance = _edge_labels(result, "extends") | _edge_labels(result, "implements")
+    assert ("PaymentProcessor", "Processor") in inheritance
+    assert ("PaymentProcessor", "Auditable") in inheritance
+
 def test_apex_method_extraction():
     r = extract_apex(FIXTURES / "sample.cls")
     labels = _labels(r)


### PR DESCRIPTION
## What it fixes

An Apex `interface X extends A, B` emitted only a `contains` edge — the parent interface list was dropped from the graph.

`iface_re` captures the `extends` parent list in group 2, but the interface handler read only group 1 (the interface name); group 2 was never used. (The class branch already splits its parent list and emits an edge per parent.)

## Fix

After the interface node / `contains` edge, iterate the captured parent list and emit one `extends` edge per parent, mirroring the class branch's node resolution (`extends` matches the keyword Apex interfaces use for inheritance; the class branch already emits `extends`). Apex interfaces support multiple inheritance.

```apex
public interface PaymentProcessor extends Processor, Auditable { void process(); }
```
now emits:
```
extends: PaymentProcessor -> Processor
extends: PaymentProcessor -> Auditable
```

## Test

- `tests/test_languages.py`: `test_apex_interface_extends` asserts both parents appear as inheritance edges.
- `pytest tests/test_languages.py -k apex` → 13 passed (negative control without the fix fails with an empty inheritance set).
