### PR TITLE
fix: correct query/explain/path resolution failures on natural-language input

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -3212,6 +3212,15 @@ def main() -> None:
         )
 
     elif cmd == "explain":
+        # #1618: thresholds for the term-overlap fallback's noise-flood guard
+        # — see the fallback block below for the full rationale. `_FLOOR`
+        # keeps small graphs/fixtures from ever being flagged (even "most of
+        # a 40-node graph matched" can be a legitimate result on a tiny
+        # corpus); `_FRACTION` is what actually catches a real degenerate
+        # flood on a normal-sized graph (a single generic word matching a
+        # large slice of the whole corpus).
+        _FALLBACK_NOISE_FLOOR = 50
+        _FALLBACK_NOISE_FRACTION = 0.15
         if len(sys.argv) < 3:
             print('Usage: graphify explain "<node>" [--graph path] [--force]', file=sys.stderr)
             sys.exit(1)
@@ -3259,6 +3268,24 @@ def main() -> None:
             from graphify.serve import _score_nodes, _search_tokens
             tokens = _search_tokens(label)
             scored = _score_nodes(G, tokens) if len(tokens) > 1 else []
+            # Noise-flood guard (#1618): a query whose only shared vocabulary
+            # with the corpus is one generic word (e.g. "server", which is
+            # also this repo's top-level backend directory name) matches a
+            # huge slice of the whole graph at the weakest possible bonus
+            # tier — live repro: "server startup error handling" matched
+            # 1,765 of this repo's 3,491 nodes (51%), with the real target
+            # buried past rank 800, tied with 1,627 other nodes at the exact
+            # same floor score. An arbitrary top-10 slice of a match that
+            # broad looks like a confident answer but is close to a coin
+            # flip; the honest response is the same "found nothing useful"
+            # signal as a bare zero-match, not a misleadingly specific
+            # candidate list. `_FALLBACK_NOISE_FLOOR` keeps this from firing
+            # on small graphs, where even "most nodes matched" can be a
+            # genuinely small, legitimate candidate list.
+            total_nodes = G.number_of_nodes() or 1
+            noise_threshold = max(_FALLBACK_NOISE_FLOOR, int(total_nodes * _FALLBACK_NOISE_FRACTION))
+            if len(scored) > noise_threshold:
+                scored = []
             if not scored:
                 print(f"No node matching '{label}' found.")
                 sys.exit(0)

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -3242,7 +3242,47 @@ def main() -> None:
         source_exact, exact, prefix, substring, source_exact_resolved = _find_node_tiers(G, label)
         matches = source_exact + exact + prefix + substring
         if not matches:
-            print(f"No node matching '{label}' found.")
+            # Whole-phrase fallback (#1616): _find_node_tiers requires `label`'s
+            # tokens, joined back into one string, to match/prefix/substring a
+            # single node's label as a whole — so a multi-word natural-language
+            # phrase (e.g. "critic score aggregation") returns zero matches even
+            # when every individual word exists on some node, because no real
+            # node label ever literally contains the entire joined phrase. This
+            # silently dead-ends for exactly the query shape `graphify explain`
+            # is otherwise recommended for. `_score_nodes` already does the
+            # per-token bag-of-words scoring `query` relies on for this same
+            # class of input — reuse it here instead of inventing new matching
+            # logic. Gated on >1 token: a single-word miss here would score
+            # identically to the substring tier already tried above, so there's
+            # nothing new to find and the original message stays exact for that
+            # case (unaffected — see existing single-term tests).
+            from graphify.serve import _score_nodes, _search_tokens
+            tokens = _search_tokens(label)
+            scored = _score_nodes(G, tokens) if len(tokens) > 1 else []
+            if not scored:
+                print(f"No node matching '{label}' found.")
+                sys.exit(0)
+            print(
+                f"No exact node matching '{label}' found — "
+                "showing closest candidates by term overlap:\n"
+            )
+            for i, (_score, cand) in enumerate(scored[:10], start=1):
+                cd = G.nodes[cand]
+                loc = f" {cd.get('source_location', '')}" if cd.get("source_location") else ""
+                print(
+                    f"  {i}. {cd.get('label', cand)} "
+                    f"[src={cd.get('source_file', '')}{loc} degree={G.degree(cand)}]"
+                )
+            if len(scored) > 10:
+                print(f"  ... and {len(scored) - 10} more")
+            print(
+                "\nRe-run `graphify explain` with one candidate's exact label/path for full detail."
+            )
+            from graphify import querylog
+            querylog.log_query(
+                kind="explain", question=label, corpus=str(gp),
+                nodes_returned=min(len(scored), 10),
+            )
             sys.exit(0)
         # Ambiguity guard (#1613): the top precedence tier that produced any
         # candidates is what `matches[0]` would silently commit to. Picking one

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -3088,7 +3088,7 @@ def main() -> None:
     elif cmd == "path":
         if len(sys.argv) < 4:
             print(
-                'Usage: graphify path "<source>" "<target>" [--graph path]',
+                'Usage: graphify path "<source>" "<target>" [--graph path] [--force]',
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -3100,6 +3100,7 @@ def main() -> None:
         target_label = sys.argv[3]
         graph_path = _default_graph_path()
         args = sys.argv[4:]
+        force_pick = "--force" in args
         for i, a in enumerate(args):
             if a == "--graph" and i + 1 < len(args):
                 graph_path = args[i + 1]
@@ -3125,7 +3126,46 @@ def main() -> None:
         if not tgt_scored:
             print(f"No node matching '{target_label}' found.", file=sys.stderr)
             sys.exit(1)
-        src_nid, tgt_nid = src_scored[0][1], tgt_scored[0][1]
+        # Ambiguity guard (#1614, port of #1613's explain fix): `path` used to
+        # only *warn* (stderr) on a close top-vs-runner-up score gap and then
+        # silently proceed with scored[0] regardless — the exact same
+        # silently-wrong-with-no-actionable-signal failure #1445/#1613 fixed
+        # elsewhere. Confirmed live: `path "filterRegistry" "useMediaLookups"`
+        # has `filterRegistry.ts` (degree 21, the real module) and
+        # `filterRegistry.test.ts` (degree 8) tied at the exact same score —
+        # a real ambiguity that a stable sort tiebreak happened to resolve
+        # "correctly" this time, silently, with nothing to say it might not
+        # next time. Same degree-dominance escape hatch as #1613: a close
+        # score gap isn't a real tie when one candidate's degree dominates
+        # (e.g. a real symbol vs. an unrelated low-degree substring hit).
+        def _resolve_endpoint(name: str, scored: list[tuple[float, str]]) -> str | None:
+            top_score, top_nid = scored[0]
+            if len(scored) < 2 or force_pick:
+                return top_nid
+            runner_score, runner_nid = scored[1]
+            if top_score > 0 and G.degree(runner_nid) <= G.degree(top_nid) * 0.34:
+                return top_nid
+            if top_score <= 0 or (top_score - runner_score) / top_score >= 0.10:
+                return top_nid
+            close = [(s, nid) for s, nid in scored if top_score > 0 and (top_score - s) / top_score < 0.10]
+            print(f"Ambiguous: {len(close)} nodes match '{name}' equally closely (top score {top_score:g}).")
+            print("Pick one and re-run with a more specific term (e.g. the full source path\n"
+                  "or a qualifying word), or pass --force to use the top match anyway:\n")
+            for i, (s, cand) in enumerate(close[:15], start=1):
+                cd = G.nodes[cand]
+                loc = f" {cd.get('source_location', '')}" if cd.get("source_location") else ""
+                print(
+                    f"  {i}. {cd.get('label', cand)} "
+                    f"[src={cd.get('source_file', '')}{loc} degree={G.degree(cand)} score={s:g}]"
+                )
+            if len(close) > 15:
+                print(f"  ... and {len(close) - 15} more")
+            return None
+
+        src_nid = _resolve_endpoint(source_label, src_scored)
+        tgt_nid = _resolve_endpoint(target_label, tgt_scored)
+        if src_nid is None or tgt_nid is None:
+            sys.exit(0)
         # Ambiguity guard: when both queries resolve to the same node, the
         # shortest path is trivially zero hops, which is almost never what the
         # caller wanted (see bug #828).
@@ -3136,15 +3176,6 @@ def main() -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
-        for _name, _scored in (("source", src_scored), ("target", tgt_scored)):
-            if len(_scored) >= 2:
-                _top, _runner = _scored[0][0], _scored[1][0]
-                if _top > 0 and (_top - _runner) / _top < 0.10:
-                    print(
-                        f"warning: {_name} match was ambiguous "
-                        f"(top score {_top:g}, runner-up {_runner:g})",
-                        file=sys.stderr,
-                    )
         try:
             path_nodes = _nx.shortest_path(G.to_undirected(as_view=True), src_nid, tgt_nid)
         except (_nx.NetworkXNoPath, _nx.NodeNotFound):

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -3182,14 +3182,15 @@ def main() -> None:
 
     elif cmd == "explain":
         if len(sys.argv) < 3:
-            print('Usage: graphify explain "<node>" [--graph path]', file=sys.stderr)
+            print('Usage: graphify explain "<node>" [--graph path] [--force]', file=sys.stderr)
             sys.exit(1)
-        from graphify.serve import _find_node
+        from graphify.serve import _find_node_tiers
         from networkx.readwrite import json_graph
 
         label = sys.argv[2]
         graph_path = _default_graph_path()
         args = sys.argv[3:]
+        force_pick = "--force" in args
         for i, a in enumerate(args):
             if a == "--graph" and i + 1 < len(args):
                 graph_path = args[i + 1]
@@ -3207,11 +3208,97 @@ def main() -> None:
             G = json_graph.node_link_graph(_raw, edges="links")
         except TypeError:
             G = json_graph.node_link_graph(_raw)
-        matches = _find_node(G, label)
+        source_exact, exact, prefix, substring, source_exact_resolved = _find_node_tiers(G, label)
+        matches = source_exact + exact + prefix + substring
         if not matches:
             print(f"No node matching '{label}' found.")
             sys.exit(0)
-        nid = matches[0]
+        # Ambiguity guard (#1613): the top precedence tier that produced any
+        # candidates is what `matches[0]` would silently commit to. Picking one
+        # of several equally-valid ties with no signal is exactly the failure
+        # mode #1445 fixed for `query`'s seeding — `explain` had the identical
+        # bug in its own resolution step, just never wired to surface it. A
+        # single term (unlike `query`'s multi-term case) has no other terms to
+        # diversify across, so the fix here is to show every tied candidate
+        # instead of guessing, rather than to pick a "better" one — degree
+        # alone does not reliably distinguish them (e.g. two same-degree
+        # same-tier nodes with genuinely different meanings). Exception: a
+        # multi-entry source_exact tier that source_exact_resolved already
+        # deliberately picked a winner from (the file-level-node heuristic,
+        # #853-adjacent) is not a raw tie — don't re-flag it as ambiguous.
+        top_tier = source_exact or exact or prefix or substring
+        is_resolved_source_tier = top_tier is source_exact and source_exact_resolved
+        # Degree-dominance escape hatch: a same-tier "tie" isn't a real tie when
+        # one candidate's degree dwarfs the rest — e.g. a DI container type
+        # (degree 31, the real definition) versus the same name re-appearing as
+        # a per-file parameter type annotation in a couple of handlers (degree
+        # 4-5 each). Mirrors `path`'s existing top-vs-runner-up gap check
+        # (__main__.py, `warning: {name} match was ambiguous`) rather than
+        # inventing a new heuristic — same idea, applied to degree instead of
+        # score. Below this ratio the runner-up is close enough that guessing
+        # is exactly the failure this fix exists to avoid.
+        dominant_nid = None
+        if len(top_tier) > 1:
+            degrees = sorted(top_tier, key=lambda n: G.degree(n), reverse=True)
+            top_deg, runner_deg = G.degree(degrees[0]), G.degree(degrees[1])
+            if top_deg > 0 and runner_deg <= top_deg * 0.34:
+                dominant_nid = degrees[0]
+        same_tier_ambiguous = len(top_tier) > 1 and not is_resolved_source_tier and dominant_nid is None
+        # Precedence-collapse case (repro: `explain "genres"`, #1613): the top
+        # tier can have exactly ONE match yet still be the wrong pick — tier
+        # precedence (exact beats prefix beats substring) means a single
+        # incidental exact match on an unrelated, weakly-connected node (a
+        # Storybook literal, a fixture constant) fully hides a much more
+        # relevant prefix/substring match one tier down, with nothing to
+        # signal it. `_pick_seeds`/#1445 solved the analogous multi-term
+        # version of this by guaranteeing every term's candidates get
+        # considered rather than letting one exact match starve the rest;
+        # the single-term version here is: don't let a *weakly connected*
+        # lone exact match fully suppress the next tier when one exists.
+        # Cheap, low-risk heuristic — degree <= 1 — deliberately does not
+        # fire for well-connected exact matches (e.g. `explain "Cradle"`,
+        # degree 32, resolves exactly as before).
+        next_tier = (
+            (exact or prefix or substring) if top_tier is source_exact else
+            (prefix or substring) if top_tier is exact else
+            substring if top_tier is prefix else
+            None
+        )
+        precedence_collapse = (
+            len(top_tier) == 1 and not is_resolved_source_tier
+            and next_tier and G.degree(top_tier[0]) <= 1
+        )
+        if (same_tier_ambiguous or precedence_collapse) and not force_pick:
+            shown = top_tier + (next_tier[:14] if precedence_collapse else [])
+            if precedence_collapse:
+                print(
+                    f"Ambiguous: the closest match for '{label}' is weakly connected "
+                    f"(degree {G.degree(top_tier[0])}) — showing it plus related candidates."
+                )
+            else:
+                print(f"Ambiguous: {len(top_tier)} nodes match '{label}' equally closely.")
+            print("Pick one and re-run with a more specific term (e.g. the full source path\n"
+                  "or a qualifying word), or pass --force to show the first match anyway:\n")
+            for i, cand in enumerate(shown[:15], start=1):
+                cd = G.nodes[cand]
+                loc = f" {cd.get('source_location', '')}" if cd.get("source_location") else ""
+                print(
+                    f"  {i}. {cd.get('label', cand)} "
+                    f"[src={cd.get('source_file', '')}{loc} degree={G.degree(cand)}]"
+                )
+            if len(shown) > 15:
+                print(f"  ... and {len(shown) - 15} more")
+            from graphify import querylog
+            querylog.log_query(
+                kind="explain", question=label, corpus=str(gp),
+                nodes_returned=len(shown),
+            )
+            sys.exit(0)
+        # Prefer the degree-dominant winner over raw match order (#1613) — the
+        # dominance check above only excuses the tier from the ambiguity
+        # prompt; it doesn't guarantee `matches[0]` happens to already be that
+        # winner, since tier order is trigram/iteration order, not degree order.
+        nid = dominant_nid if dominant_nid is not None else matches[0]
         d = G.nodes[nid]
         print(f"Node: {d.get('label', nid)}")
         print(f"  ID:        {nid}")

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -539,11 +539,31 @@ def _dfs(G: nx.Graph, start_nodes: list[str], depth: int) -> tuple[set[str], lis
     return visited, edges_seen
 
 
-def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_budget: int = 2000, *, seeds: list[str] | None = None) -> str:
+def _subgraph_to_text(
+    G: nx.Graph,
+    nodes: set[str],
+    edges: list[tuple],
+    token_budget: int = 2000,
+    *,
+    seeds: list[str] | None = None,
+    scores: "list[tuple[float, str]] | dict[str, float] | None" = None,
+) -> str:
     """Render subgraph as text, cutting at token_budget (approx 3 chars/token).
 
-    seeds: exact-match nodes rendered first before the degree-sorted expansion,
-    so the queried symbol always appears at the top of the output.
+    seeds: exact-match nodes rendered first before the ranked expansion, so the
+    queried symbol always appears at the top of the output.
+
+    scores (#1612): the same per-node query-relevance scores `_score_nodes`
+    computed to pick seeds (a `_score_nodes`-shaped list, or an equivalent
+    dict), reused here to rank the *non-seed* expansion too. Without this, a
+    BFS/DFS neighborhood is entirely un-ranked structural noise: a node that
+    matched none of the query's terms but happens to be the most-imported file
+    in the whole corpus (test setup, DB schema, DI container, ...) sorts above
+    a node that matched a query term but has an ordinary degree, since the
+    fallback is pure degree-sort. `_score_nodes` only returns nodes with
+    score > 0 (some term overlap), so a node absent from `scores` falls back
+    to degree exactly like today when `scores` is omitted — this is
+    strictly additive, never worse than the pre-#1612 ordering.
     """
     char_budget = token_budget * 3
     lines = []
@@ -551,8 +571,17 @@ def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_bu
     # Empty when no sidecar exists, so un-annotated output stays byte-identical.
     overlay = getattr(G, "graph", {}).get("_learning_overlay", {}) or {}
     seed_set = set(seeds or [])
+    score_map: dict[str, float] = (
+        dict(scores) if isinstance(scores, dict)
+        else {nid: s for s, nid in scores} if scores
+        else {}
+    )
     ordered = [n for n in (seeds or []) if n in nodes] + \
-              sorted(nodes - seed_set, key=lambda n: G.degree(n), reverse=True)
+              sorted(
+                  nodes - seed_set,
+                  key=lambda n: (score_map.get(n, 0.0), G.degree(n)),
+                  reverse=True,
+              )
     for nid in ordered:
         d = G.nodes[nid]
         # Every LLM-derived field passes through sanitize_label before being
@@ -629,7 +658,18 @@ def _query_graph_text(
         header_parts.append(f"Context: {', '.join(resolved_filters)} ({filter_source})")
     header_parts.append(f"{len(nodes)} nodes found")
     header = " | ".join(header_parts) + "\n\n"
-    return header + _subgraph_to_text(traversal_graph, nodes, edges, token_budget)
+    # seeds=start_nodes (#1612): _subgraph_to_text has always supported rendering
+    # the traversal's actual seed nodes first, before the generic degree-sorted
+    # expansion — but this was the only call site, and it never passed seeds,
+    # so every `graphify query` result silently fell back to pure degree-sort:
+    # whichever nodes happen to be the most-imported/highest-degree in the
+    # WHOLE graph led the output regardless of relevance to the question, and
+    # the nodes the traversal actually seeded from (the ones _pick_seeds and
+    # #1445's per-term guarantee worked to select) could be buried arbitrarily
+    # far down or truncated out by the token budget entirely.
+    return header + _subgraph_to_text(
+        traversal_graph, nodes, edges, token_budget, seeds=start_nodes, scores=scored,
+    )
 
 
 def _find_node(G: nx.Graph, label: str) -> list[str]:

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -296,7 +296,30 @@ def _score_nodes(G: nx.Graph, terms: list[str]) -> list[tuple[float, str]]:
         # this, no single token equals a multi-word label, the per-token exact
         # tier never fires, and every node sharing the token set ties -> arbitrary
         # node-id sort -> wrong/disconnected endpoint -> false "No path found".
-        if joined:
+        #
+        # Gated on len(norm_terms) > 1 (#1617): a single-token probe has no
+        # "multi-word phrase vs per-token bag-of-words" distinction to make —
+        # the per-token loop below already fully handles single-term exact/
+        # prefix/substring via raw (non-tokenized) label comparison. Without
+        # this gate, `label_tokens` (punctuation-stripped) can make a bare
+        # method name whose only word is the query term — e.g. `.search()` —
+        # falsely equal a single-word `joined` query at the EXACT tier, even
+        # though the same node correctly fails the per-token loop's raw
+        # `t == norm_label or t == bare_label` exact check just below (raw
+        # ".search" != "search"). This matters most inside `_pick_seeds`'s
+        # per-term seed-diversity probe (#1445), which calls
+        # `_score_nodes(G, [term])` with exactly one token per distinct query
+        # word: a short same-named method repeated across unrelated files
+        # (three providers each defining `.search()`) can win that probe's
+        # EXACT tier and starve out the actually-relevant multi-word file
+        # (`search.handler.ts`, correctly only PREFIX-tier for the bare word
+        # "search"), reproduced live on a real repo's `graphify query "how
+        # does a change in provider settings affect what shows up in search
+        # results"` — search.handler.ts never appeared in the traversal
+        # despite scoring far higher than `.search()` under the full
+        # multi-word sentence (this gate does not change that combined-query
+        # path at all, since len(norm_terms) > 1 there).
+        if joined and len(norm_terms) > 1:
             nid_lower = nid.lower()
             if joined in (norm_label, bare_label, label_tokens, nid_lower):
                 score += _EXACT_MATCH_BONUS * 10 * joined_w

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -326,13 +326,36 @@ def _score_nodes(G: nx.Graph, terms: list[str]) -> list[tuple[float, str]]:
     return scored
 
 
-def _pick_seeds(scored: list[tuple[float, str]], max_k: int = 3, gap_ratio: float = 0.2) -> list[str]:
+def _pick_seeds(
+    scored: list[tuple[float, str]],
+    max_k: int = 3,
+    gap_ratio: float = 0.2,
+    *,
+    G: "nx.Graph | None" = None,
+    terms: list[str] | None = None,
+) -> list[str]:
     """Select BFS seed nodes, stopping when score drops too far below the top.
 
     Prevents high-frequency noise terms (error, exception) from stealing seed
     slots from a dominant identifier match. When FooBarService scores 1000 and
     error nodes score 1.0, only FooBarService is seeded — the score gap is 99.9%
     which is well above the 20% threshold that would allow additional seeds.
+
+    That same gap_ratio cutoff has a failure mode on multi-term natural-language
+    queries: if one term happens to hit an EXACT label match on a node that is
+    otherwise unrelated to the query's intent (e.g. a common word that is also
+    used as an unrelated identifier or field name elsewhere in the corpus), it
+    can outscore every SUBSTRING match on the query's other, actually-relevant
+    terms by ~1000x (see `_EXACT_MATCH_BONUS` vs. `_SUBSTRING_MATCH_BONUS`).
+    The 20%-gap cutoff then silently discards all of those substring-tier
+    seeds, so the BFS traversal only ever explores the neighborhood of the one
+    unrelated exact match — see #1445.
+
+    When `G` and `terms` are supplied, this guarantees at least one seed per
+    distinct query term that has any match at all, so one term's incidental
+    collision cannot starve out the others. Ties within a term are broken by
+    graph degree (structural centrality), so an isolated incidental match
+    doesn't out-rank a real, well-connected hub for that term.
     """
     if not scored:
         return []
@@ -342,6 +365,18 @@ def _pick_seeds(scored: list[tuple[float, str]], max_k: int = 3, gap_ratio: floa
         if seeds and score < top_score * gap_ratio:
             break
         seeds.append(nid)
+
+    if G is not None and terms:
+        norm_terms = sorted({tok for t in terms for tok in _search_tokens(t)})
+        for term in norm_terms:
+            term_scored = _score_nodes(G, [term])
+            if not term_scored:
+                continue
+            best_score = term_scored[0][0]
+            tied = [nid for s, nid in term_scored if s == best_score]
+            best_nid = max(tied, key=lambda n: G.degree(n)) if len(tied) > 1 else term_scored[0][1]
+            if best_nid not in seeds:
+                seeds.append(best_nid)
     return seeds
 
 
@@ -580,7 +615,7 @@ def _query_graph_text(
 ) -> str:
     terms = _query_terms(question)
     scored = _score_nodes(G, terms)
-    start_nodes = _pick_seeds(scored)
+    start_nodes = _pick_seeds(scored, G=G, terms=terms)
     if not start_nodes:
         return "No matching nodes found."
     resolved_filters, filter_source = _resolve_context_filters(question, context_filters)

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -672,16 +672,26 @@ def _query_graph_text(
     )
 
 
-def _find_node(G: nx.Graph, label: str) -> list[str]:
-    """Return node IDs whose label or ID matches the search term (diacritic-insensitive).
+def _find_node_tiers(
+    G: nx.Graph, label: str,
+) -> tuple[list[str], list[str], list[str], list[str], bool]:
+    """Return (source_exact, exact, prefix, substring, source_exact_resolved) for `label`.
 
-    Results are ordered by precedence: exact source-file path match first, then
-    exact (label/ID) match, then prefix match, then substring match. Node-ID exact
-    matches are grouped with label exact matches.
+    Same matching logic as `_find_node`, but callers that need to know *how many*
+    candidates tied in the top precedence tier — to detect ambiguity rather than
+    silently picking the first one — should use this instead of the flattened
+    list (#1613; see `explain`'s disambiguation in __main__.py).
+
+    `source_exact_resolved` is True when `source_exact` has more than one entry
+    but a pre-existing heuristic (the file-level node — source_location "L1" with
+    a label matching the queried path's basename — among several same-file
+    matches, #the-original-source-exact-preference-fix) already picked a single
+    unambiguous winner and moved it to the front. Callers must not treat that
+    case as ambiguous: it was deliberately resolved, not left as a raw tie.
     """
     term = " ".join(_search_tokens(label))
     if not term:
-        return []
+        return [], [], [], [], False
     source_exact: list[str] = []
     exact: list[str] = []
     prefix: list[str] = []
@@ -713,6 +723,7 @@ def _find_node(G: nx.Graph, label: str) -> list[str]:
         elif term in norm_label or term in label_tokens:
             substring.append(nid)
 
+    source_exact_resolved = False
     if source_exact:
         query_basename = _strip_diacritics(Path(label).name).lower()
         preferred = [
@@ -724,7 +735,19 @@ def _find_node(G: nx.Graph, label: str) -> list[str]:
         ]
         if len(preferred) == 1:
             source_exact = preferred + [nid for nid in source_exact if nid != preferred[0]]
+            source_exact_resolved = len(source_exact) > 1
 
+    return source_exact, exact, prefix, substring, source_exact_resolved
+
+
+def _find_node(G: nx.Graph, label: str) -> list[str]:
+    """Return node IDs whose label or ID matches the search term (diacritic-insensitive).
+
+    Results are ordered by precedence: exact source-file path match first, then
+    exact (label/ID) match, then prefix match, then substring match. Node-ID exact
+    matches are grouped with label exact matches.
+    """
+    source_exact, exact, prefix, substring, _resolved = _find_node_tiers(G, label)
     return source_exact + exact + prefix + substring
 
 

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -583,6 +583,33 @@ def _rebuild_code(
             "input_tokens": 0, "output_tokens": 0,
         }
 
+        # Reattach semantic content for re-extracted files at zero LLM cost (#1610).
+        # AST-only rebuilds unconditionally evict a changed file's prior semantic
+        # nodes below (its old node IDs are gone once new_ast_ids is computed) and
+        # never regenerate them, since this path makes no LLM call by design ("no
+        # LLM needed"). That is correct when the file's content is genuinely new —
+        # stale semantic labels on new code would be wrong. But the semantic cache
+        # is keyed on the file's current content hash (cache.py: SHA256 of file
+        # bytes), so a hit here means this exact content was already
+        # LLM-processed and its semantic result is still valid verbatim: no
+        # re-billing, and the reattached content is byte-identical to what a full
+        # rebuild would have cached, so this is a pure availability fix, not a new
+        # source of drift. Files with no cache entry are unaffected — they keep
+        # today's AST-only behavior exactly.
+        if extract_targets:
+            from graphify.cache import check_semantic_cache
+            cached_nodes, cached_edges, cached_hyperedges, _uncached = check_semantic_cache(
+                [str(p) for p in extract_targets], root=watch_root,
+            )
+            if cached_nodes or cached_edges:
+                result = {
+                    "nodes": result["nodes"] + cached_nodes,
+                    "edges": result["edges"] + cached_edges,
+                    "hyperedges": result.get("hyperedges", []) + cached_hyperedges,
+                    "input_tokens": result.get("input_tokens", 0),
+                    "output_tokens": result.get("output_tokens", 0),
+                }
+
         # Preserve semantic nodes/edges from a previous full run.
         # AST-only rebuild replaces nodes for changed files; everything else is kept.
         # Filter by node ID membership in the new AST output, not by file_type —

--- a/tests/test_explain_cli.py
+++ b/tests/test_explain_cli.py
@@ -341,3 +341,68 @@ def test_explain_close_degree_ties_still_flagged_ambiguous(monkeypatch, tmp_path
         mainmod.main()
     out = capsys.readouterr().out
     assert "Ambiguous: 2 nodes match 'Cradle' equally closely." in out
+
+
+def _write_ratings_graph(tmp_path):
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": "agg", "label": "AggregatedRatings",
+             "source_file": "server/utils/ratingsAggregation.ts", "community": 0},
+            {"id": "fmt", "label": "formatRating()",
+             "source_file": "server/utils/ratingsAggregation.ts", "community": 0},
+            {"id": "unrelated", "label": "Sidebar",
+             "source_file": "src/components/Sidebar/index.tsx", "community": 1},
+        ],
+        "links": [
+            {"source": "fmt", "target": "agg", "relation": "uses", "confidence": "EXTRACTED"},
+        ],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    return p
+
+
+def test_explain_multiword_phrase_falls_back_to_term_overlap_candidates(monkeypatch, tmp_path, capsys):
+    """#1616: no node's label literally contains the whole phrase "critic score
+    aggregation" as a substring (the tier-matching `explain` normally uses), but
+    "aggregation"/"rating" individually overlap with real nodes — the fallback
+    should surface them instead of a bare "No node matching" dead end."""
+    p = _write_ratings_graph(tmp_path)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv",
+        ["graphify", "explain", "critic score aggregation", "--graph", str(p)])
+    with pytest.raises(SystemExit):
+        mainmod.main()
+    out = capsys.readouterr().out
+    assert "No exact node matching 'critic score aggregation' found" in out
+    assert "AggregatedRatings" in out
+    assert "Sidebar" not in out
+
+
+def test_explain_multiword_phrase_with_no_overlap_still_says_no_match(monkeypatch, tmp_path, capsys):
+    """No token in the phrase overlaps any node at all — the fallback must not
+    fabricate candidates; the original honest message stays."""
+    p = _write_ratings_graph(tmp_path)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv",
+        ["graphify", "explain", "quantum flux capacitor", "--graph", str(p)])
+    with pytest.raises(SystemExit):
+        mainmod.main()
+    out = capsys.readouterr().out
+    assert "No node matching 'quantum flux capacitor' found." in out
+    assert "candidates" not in out
+
+
+def test_explain_single_word_miss_is_unaffected(monkeypatch, tmp_path, capsys):
+    """Gate on >1 token (#1616): a single-word miss must keep the exact
+    pre-existing message, not attempt the multi-token fallback (which would
+    score identically to the substring tier already tried and add nothing)."""
+    p = _write_ratings_graph(tmp_path)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv",
+        ["graphify", "explain", "zzzznomatch", "--graph", str(p)])
+    with pytest.raises(SystemExit):
+        mainmod.main()
+    out = capsys.readouterr().out
+    assert out == "No node matching 'zzzznomatch' found.\n"

--- a/tests/test_explain_cli.py
+++ b/tests/test_explain_cli.py
@@ -1,6 +1,7 @@
 """Regression tests for `graphify explain` arrow direction (#853)."""
 from __future__ import annotations
 import json
+import pytest
 import graphify.__main__ as mainmod
 
 
@@ -123,3 +124,220 @@ def test_explain_no_lesson_line_for_unannotated_node(monkeypatch, tmp_path, caps
     p = _write_graph(tmp_path)
     out = _run(monkeypatch, p, "validateSanitySession", capsys)
     assert "Lesson:" not in out
+
+
+# --- #1613: ambiguous exact-tier matches are surfaced, not silently guessed ---
+
+def _write_ambiguous_graph(tmp_path):
+    """Two distinct, unrelated nodes that both exact-match the label 'genres' —
+    reproduces the real repro (`explain "genres"` silently resolving to an
+    unrelated Storybook literal while the actually-relevant node sat one
+    position later in the tied candidate list, discarded)."""
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": "storybook_genres", "label": "genres",
+             "source_file": "MediaFilterBar.stories.tsx", "community": 0},
+            {"id": "lookups_genres_response", "label": "genres",
+             "source_file": "useMediaLookups.ts", "community": 1},
+        ],
+        "links": [],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    return p
+
+
+def test_explain_ambiguous_exact_match_lists_candidates_instead_of_guessing(monkeypatch, tmp_path, capsys):
+    p = _write_ambiguous_graph(tmp_path)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv",
+        ["graphify", "explain", "genres", "--graph", str(p)])
+    with pytest.raises(SystemExit) as exc:
+        mainmod.main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "Ambiguous: 2 nodes match 'genres' equally closely." in out
+    assert "1. genres [src=MediaFilterBar.stories.tsx" in out
+    assert "2. genres [src=useMediaLookups.ts" in out
+    # Must not silently commit to and fully render either one.
+    assert "Node: genres" not in out
+    assert "Connections" not in out
+
+
+def test_explain_force_bypasses_ambiguity_guard(monkeypatch, tmp_path, capsys):
+    """--force reproduces the old (pre-#1613) behavior: silently take matches[0]."""
+    p = _write_ambiguous_graph(tmp_path)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv",
+        ["graphify", "explain", "genres", "--graph", str(p), "--force"])
+    mainmod.main()
+    out = capsys.readouterr().out
+    assert "Ambiguous:" not in out
+    assert out.startswith("Node: genres")
+
+
+def test_explain_unambiguous_match_is_unaffected(monkeypatch, tmp_path, capsys):
+    """A label with exactly one exact-tier match still resolves directly,
+    with no ambiguity notice — the #853-era tests above already cover this for
+    the general case; this test pins it explicitly against the new code path."""
+    p = _write_graph(tmp_path)
+    out = _run(monkeypatch, p, "validateSanitySession", capsys)
+    assert "Ambiguous:" not in out
+    assert out.startswith("Node: validateSanitySession()")
+
+
+def test_explain_source_exact_preferred_resolution_is_not_flagged_ambiguous(monkeypatch, tmp_path, capsys):
+    """The pre-existing file-level-node preference (#853-adjacent) already
+    resolves a 2-candidate source_exact tier to one deliberate winner — this
+    must NOT be treated as a #1613 ambiguity, even though the tier itself has
+    more than one entry. Regression pin for the interaction bug caught while
+    building #1613 (test_explain_source_file_path_prefers_file_level_node)."""
+    p = tmp_path / "graph.json"
+    source_file = "app/api/example/route.ts"
+    p.write_text(json.dumps({
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": "example_route_get", "label": "GET()",
+             "source_file": source_file, "source_location": "L42", "community": 0},
+            {"id": "example_route", "label": "route.ts",
+             "source_file": source_file, "source_location": "L1", "community": 0},
+        ],
+        "links": [
+            {"source": "example_route", "target": "example_route_get",
+             "relation": "contains", "confidence": "EXTRACTED"},
+        ],
+    }))
+    out = _run(monkeypatch, p, source_file, capsys)
+    assert "Ambiguous:" not in out
+    assert out.startswith("Node: route.ts")
+
+
+def _write_precedence_collapse_graph(tmp_path):
+    """A weakly-connected node whose label exact-matches the term, plus a
+    strongly-relevant node one tier down (prefix match only) that the exact
+    tier's precedence would otherwise fully hide. This is the real repro
+    shape: `explain "genres"` resolved to an isolated Storybook literal
+    (degree 1, exact tier) while `GenresResponse` in useMediaLookups.ts
+    (degree 1, prefix tier only) sat one tier lower, fully discarded — same
+    tier-precedence collapse, reproduced here with a connected neighbor added
+    so the "actually relevant" candidate is distinguishable from noise."""
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": "storybook_genres", "label": "genres",
+             "source_file": "MediaFilterBar.stories.tsx", "community": 0},
+            {"id": "genres_response", "label": "GenresResponse",
+             "source_file": "useMediaLookups.ts", "community": 1},
+            {"id": "use_media_lookups", "label": "useMediaLookups()",
+             "source_file": "useMediaLookups.ts", "community": 1},
+        ],
+        "links": [
+            {"source": "use_media_lookups", "target": "genres_response",
+             "relation": "returns", "confidence": "EXTRACTED"},
+        ],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    return p
+
+
+def test_explain_precedence_collapse_surfaces_lower_tier_candidate(monkeypatch, tmp_path, capsys):
+    p = _write_precedence_collapse_graph(tmp_path)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv",
+        ["graphify", "explain", "genres", "--graph", str(p)])
+    with pytest.raises(SystemExit) as exc:
+        mainmod.main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "Ambiguous: the closest match for 'genres' is weakly connected" in out
+    assert "genres [src=MediaFilterBar.stories.tsx" in out
+    assert "GenresResponse [src=useMediaLookups.ts" in out
+
+
+def test_explain_precedence_collapse_does_not_fire_for_well_connected_exact_match(monkeypatch, tmp_path, capsys):
+    """A well-connected exact match (degree > 1) must resolve exactly as
+    before — the heuristic is deliberately narrow (Cradle-style positive case:
+    a real, central symbol should never be second-guessed just because a
+    same-file-prefix node also happens to exist)."""
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": "cradle", "label": "Cradle", "source_file": "container.ts", "community": 0},
+            {"id": "cradle_options", "label": "CradleOptions", "source_file": "container.ts", "community": 0},
+            {"id": "consumer_a", "label": "consumerA", "source_file": "a.ts", "community": 1},
+            {"id": "consumer_b", "label": "consumerB", "source_file": "b.ts", "community": 1},
+        ],
+        "links": [
+            {"source": "consumer_a", "target": "cradle", "relation": "imports", "confidence": "EXTRACTED"},
+            {"source": "consumer_b", "target": "cradle", "relation": "imports", "confidence": "EXTRACTED"},
+        ],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    out = _run(monkeypatch, p, "Cradle", capsys)
+    assert "Ambiguous:" not in out
+    assert out.startswith("Node: Cradle")
+
+
+def test_explain_multiple_same_label_ties_resolve_to_degree_dominant_winner(monkeypatch, tmp_path, capsys):
+    """Real-repo shape found while verifying #1613 live: a DI container type
+    name ("Cradle") legitimately appears as 3 distinct exact-tier nodes — the
+    real definition (high degree) plus 2 per-file parameter-type annotations
+    in unrelated handlers (each low degree). These are NOT a genuine ambiguity
+    the same way "genres" was: one candidate dominates by degree, so
+    `explain` must resolve straight to it, not prompt — mirrors `path`'s
+    existing top-vs-runner-up gap check, applied to degree here."""
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": "cradle_real", "label": "Cradle", "source_file": "container.ts", "community": 0},
+            {"id": "cradle_ref_a", "label": "Cradle", "source_file": "automations.handler.ts", "community": 1},
+            {"id": "cradle_ref_b", "label": "Cradle", "source_file": "mediaQueries.handler.ts", "community": 2},
+        ] + [{"id": f"consumer_{i}", "label": f"consumer{i}", "source_file": f"c{i}.ts", "community": 3}
+             for i in range(6)],
+        "links": (
+            [{"source": f"consumer_{i}", "target": "cradle_real",
+              "relation": "imports", "confidence": "EXTRACTED"} for i in range(6)]
+            + [{"source": "consumer_0", "target": "cradle_ref_a",
+                "relation": "imports", "confidence": "EXTRACTED"}]
+            + [{"source": "consumer_1", "target": "cradle_ref_b",
+                "relation": "imports", "confidence": "EXTRACTED"}]
+        ),
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    out = _run(monkeypatch, p, "Cradle", capsys)
+    assert "Ambiguous:" not in out
+    assert out.startswith("Node: Cradle")
+    assert "ID:        cradle_real" in out
+
+
+def test_explain_close_degree_ties_still_flagged_ambiguous(monkeypatch, tmp_path, capsys):
+    """Contrast case: same shape as the dominance test above, but the 3
+    same-label candidates have comparable (not dominant) degree — a genuine
+    tie must still be flagged, not silently resolved to whichever happens to
+    iterate first."""
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": "cradle_a", "label": "Cradle", "source_file": "a.ts", "community": 0},
+            {"id": "cradle_b", "label": "Cradle", "source_file": "b.ts", "community": 1},
+            {"id": "consumer_a", "label": "consumerA", "source_file": "ca.ts", "community": 2},
+            {"id": "consumer_b", "label": "consumerB", "source_file": "cb.ts", "community": 2},
+        ],
+        "links": [
+            {"source": "consumer_a", "target": "cradle_a", "relation": "imports", "confidence": "EXTRACTED"},
+            {"source": "consumer_b", "target": "cradle_b", "relation": "imports", "confidence": "EXTRACTED"},
+        ],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv",
+        ["graphify", "explain", "Cradle", "--graph", str(p)])
+    with pytest.raises(SystemExit):
+        mainmod.main()
+    out = capsys.readouterr().out
+    assert "Ambiguous: 2 nodes match 'Cradle' equally closely." in out

--- a/tests/test_explain_cli.py
+++ b/tests/test_explain_cli.py
@@ -406,3 +406,57 @@ def test_explain_single_word_miss_is_unaffected(monkeypatch, tmp_path, capsys):
         mainmod.main()
     out = capsys.readouterr().out
     assert out == "No node matching 'zzzznomatch' found.\n"
+
+
+def _write_noise_flood_graph(tmp_path, n=60):
+    """`n` nodes that all share one generic token ("server") as their only
+    lexical overlap with the query, plus a handful of unrelated real-looking
+    nodes so the fixture isn't trivially just "every node matches"."""
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": f"n{i}", "label": f"Thing{i}()",
+             "source_file": f"server/module{i}/thing{i}.ts", "community": 0}
+            for i in range(n)
+        ] + [
+            {"id": "unrelated", "label": "Sidebar", "source_file": "src/components/Sidebar/index.tsx", "community": 1},
+        ],
+        "links": [],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    return p
+
+
+def test_explain_noise_flood_falls_back_to_honest_no_match(monkeypatch, tmp_path, capsys):
+    """#1618: a query whose only shared vocabulary with the corpus is one
+    generic word (here, "server" — matched via the source-file substring
+    bonus on every node under server/) must not present an arbitrary top-10
+    slice of a graph-spanning tie as if it were a confident answer. With 60
+    of 61 total nodes matching, this exceeds both the absolute floor (50)
+    and the 15% fraction of the graph — the honest zero-match message
+    should be shown instead of a misleading candidate list."""
+    p = _write_noise_flood_graph(tmp_path, n=60)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv",
+        ["graphify", "explain", "server startup handling", "--graph", str(p)])
+    with pytest.raises(SystemExit):
+        mainmod.main()
+    out = capsys.readouterr().out
+    assert out == "No node matching 'server startup handling' found.\n"
+
+
+def test_explain_large_but_below_threshold_candidates_still_shown(monkeypatch, tmp_path, capsys):
+    """Contrast case: a genuinely large candidate list (more than the 10
+    displayed, but under the noise-flood threshold for this graph's size)
+    must still be shown — the guard is for degenerate floods, not simply
+    "more than 10 results"."""
+    p = _write_noise_flood_graph(tmp_path, n=20)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv",
+        ["graphify", "explain", "server startup handling", "--graph", str(p)])
+    with pytest.raises(SystemExit):
+        mainmod.main()
+    out = capsys.readouterr().out
+    assert "No exact node matching 'server startup handling' found" in out
+    assert "... and" in out

--- a/tests/test_path_cli.py
+++ b/tests/test_path_cli.py
@@ -1,6 +1,7 @@
 """Regression tests for `graphify path` arrow direction (#849)."""
 from __future__ import annotations
 import json
+import pytest
 import networkx as nx
 from networkx.readwrite import json_graph
 import graphify.__main__ as mainmod
@@ -46,3 +47,81 @@ def test_reverse_arrow(monkeypatch, tmp_path, capsys):
     assert "Shortest path (1 hops):" in out
     assert "validateSanitySession() <--calls [EXTRACTED]-- createPatchHandler()" in out
     assert "validateSanitySession() --calls [EXTRACTED]--> createPatchHandler()" not in out
+
+
+# --- #1614: endpoint ambiguity is surfaced instead of silently guessed ---
+# (port of #1613's `explain` fix into `path`'s endpoint resolution)
+
+def _write_tied_endpoint_graph(tmp_path, runner_degree):
+    """Two nodes both labeled 'widget' (a genuine score tie, same exact-match
+    tier) as the source side; a single unambiguous 'consumer' target. Real
+    repro shape: `path "filterRegistry" "useMediaLookups"` had
+    filterRegistry.ts (degree 21) and filterRegistry.test.ts (degree 8) tied
+    at the identical top score."""
+    nodes = [
+        {"id": "widget_real", "label": "widget", "source_file": "widget.ts", "community": 0},
+        {"id": "widget_test", "label": "widget", "source_file": "widget.test.ts", "community": 0},
+        {"id": "consumer", "label": "consumer", "source_file": "consumer.ts", "community": 1},
+    ]
+    links = [{"source": "consumer", "target": "widget_real", "relation": "imports", "confidence": "EXTRACTED"}]
+    # Pad widget_real's degree with extra edges so degree-dominance math is
+    # exercised deliberately by the caller via runner_degree.
+    for i in range(9):
+        nid = f"real_dep_{i}"
+        nodes.append({"id": nid, "label": f"dep{i}", "source_file": f"dep{i}.ts", "community": 2})
+        links.append({"source": nid, "target": "widget_real", "relation": "imports", "confidence": "EXTRACTED"})
+    for i in range(runner_degree):
+        nid = f"test_dep_{i}"
+        nodes.append({"id": nid, "label": f"testdep{i}", "source_file": f"testdep{i}.ts", "community": 3})
+        links.append({"source": nid, "target": "widget_test", "relation": "imports", "confidence": "EXTRACTED"})
+    graph_data = {"directed": False, "multigraph": False, "graph": {}, "nodes": nodes, "links": links}
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    return p
+
+
+def test_path_ambiguous_endpoint_lists_candidates_instead_of_guessing(monkeypatch, tmp_path, capsys):
+    # widget_real degree 10 (1 consumer + 9 deps), widget_test degree 8 —
+    # 8 > 10*0.34=3.4, so not degree-dominant: a genuine tie.
+    p = _write_tied_endpoint_graph(tmp_path, runner_degree=8)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv",
+        ["graphify", "path", "widget", "consumer", "--graph", str(p)])
+    with pytest.raises(SystemExit) as exc:
+        mainmod.main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "Ambiguous: 2 nodes match 'widget' equally closely" in out
+    assert "widget [src=widget.ts" in out
+    assert "widget [src=widget.test.ts" in out
+    assert "Shortest path" not in out
+
+
+def test_path_degree_dominant_endpoint_resolves_without_prompting(monkeypatch, tmp_path, capsys):
+    # widget_real degree 10, widget_test degree 2 — 2 <= 10*0.34=3.4, dominant.
+    p = _write_tied_endpoint_graph(tmp_path, runner_degree=2)
+    out = _run(monkeypatch, p, "widget", "consumer", capsys)
+    assert "Ambiguous:" not in out
+    assert "Shortest path" in out
+    assert "widget --imports" in out or "widget <--imports" in out
+
+
+def test_path_force_bypasses_ambiguity_guard(monkeypatch, tmp_path, capsys):
+    p = _write_tied_endpoint_graph(tmp_path, runner_degree=8)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv",
+        ["graphify", "path", "widget", "consumer", "--graph", str(p), "--force"])
+    mainmod.main()
+    out = capsys.readouterr().out
+    assert "Ambiguous:" not in out
+    assert "Shortest path" in out
+
+
+def test_path_unambiguous_endpoints_unaffected(monkeypatch, tmp_path, capsys):
+    """The original #849 fixture (one candidate per side) must resolve exactly
+    as before — no ambiguity notice, existing arrow-direction assertions
+    still the whole story."""
+    p = _write_graph(tmp_path)
+    out = _run(monkeypatch, p, "createPatchHandler", "validateSanitySession", capsys)
+    assert "Ambiguous:" not in out
+    assert "Shortest path (1 hops):" in out

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -427,6 +427,79 @@ def test_subgraph_to_text_no_overlay_is_unchanged():
     assert "learning=" not in text
 
 
+# --- #1612: non-seed node ordering ranks by query relevance, not raw degree ---
+
+def _hub_graph() -> nx.Graph:
+    """A relevant-but-ordinary-degree node vs. a high-degree unrelated hub, both
+    one hop from a seed — reproduces the "generic infra node leads the output"
+    shape seen against a real repo (vitest.ts/schema.ts/container.ts outranking
+    the actually-relevant match)."""
+    G = nx.Graph()
+    G.add_node("seed", label="IdentityResolutionJob", source_file="identityResolutionJob.ts", community=0)
+    G.add_node("relevant", label="identityJobFactory", source_file="identityJobFactory.ts", community=0)
+    G.add_node("hub", label="config", source_file="config.ts", community=1)
+    G.add_edge("seed", "relevant", relation="imports")
+    G.add_edge("seed", "hub", relation="imports")
+    # Give "hub" a much higher raw degree than "relevant", unrelated to the query.
+    for i in range(10):
+        nid = f"hub_dep_{i}"
+        G.add_node(nid, label=f"dep{i}", source_file=f"dep{i}.ts", community=2)
+        G.add_edge("hub", nid, relation="imports")
+    return G
+
+
+def test_subgraph_to_text_without_scores_falls_back_to_degree_sort_unchanged():
+    """No scores passed (pre-#1612 call shape) must reproduce the exact old
+    ordering — pure degree-sort — so this is strictly additive, never a
+    behavior change for existing callers that don't opt in."""
+    G = _hub_graph()
+    nodes = {"seed", "relevant", "hub"}
+    text = _subgraph_to_text(G, nodes, [], seeds=["seed"])
+    hub_pos = text.index("NODE config")
+    relevant_pos = text.index("NODE identityJobFactory")
+    assert hub_pos < relevant_pos, "hub (degree 11) must still outrank relevant (degree 1) without scores"
+
+
+def test_subgraph_to_text_with_scores_ranks_relevant_node_above_higher_degree_hub():
+    G = _hub_graph()
+    nodes = {"seed", "relevant", "hub"}
+    # "relevant" matched a query term (nonzero score); "hub" matched nothing
+    # (absent from scores, exactly what _score_nodes returns for a non-match).
+    scores = [(42.0, "relevant")]
+    text = _subgraph_to_text(G, nodes, [], seeds=["seed"], scores=scores)
+    hub_pos = text.index("NODE config")
+    relevant_pos = text.index("NODE identityJobFactory")
+    assert relevant_pos < hub_pos, (
+        "a node that matched a query term must outrank a higher-degree node "
+        "that matched nothing, once scores are supplied"
+    )
+
+
+def test_subgraph_to_text_accepts_scores_as_dict_or_score_nid_list():
+    G = _hub_graph()
+    nodes = {"seed", "relevant", "hub"}
+    as_list = _subgraph_to_text(G, nodes, [], seeds=["seed"], scores=[(42.0, "relevant")])
+    as_dict = _subgraph_to_text(G, nodes, [], seeds=["seed"], scores={"relevant": 42.0})
+    assert as_list == as_dict
+
+
+def test_query_graph_text_ranks_relevant_neighbor_above_unrelated_hub():
+    """End-to-end: _query_graph_text must pass its own computed scores through
+    to _subgraph_to_text (#1612), not just seeds — this is the actual call
+    site the standalone _subgraph_to_text tests above cannot cover."""
+    G = _hub_graph()
+    # Seed from "IdentityResolutionJob" (exact match on the "seed" node) so BFS
+    # depth=1 reaches both "relevant" and "hub" as one-hop neighbors — the
+    # actual query term ("job factory") only partially overlaps "relevant"'s
+    # label, giving it a real but non-dominant score, same shape as the
+    # original repo repro (query term overlaps a neighbor's label, not the
+    # seed's).
+    text = _query_graph_text(G, "IdentityResolutionJob job factory", mode="bfs", depth=1)
+    hub_pos = text.index("NODE config")
+    relevant_pos = text.index("NODE identityJobFactory")
+    assert relevant_pos < hub_pos
+
+
 def test_query_graph_text_explicit_context_filter_changes_traversal():
     G = _make_graph()
     text = _query_graph_text(G, "extract", mode="bfs", depth=2, token_budget=2000, context_filters=["call"])

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -123,6 +123,59 @@ def test_score_nodes_multiword_exact_label_outranks_superset():
     assert scored[0][0] > scored[1][0], "exact label must strictly outrank superset/token-bag matches"
 
 
+def test_score_nodes_single_token_probe_does_not_falsely_promote_bare_method(monkeypatch):
+    """#1617: a single-token probe must not let `label_tokens` (punctuation-
+    stripped) promote a bare method whose only word is the query term to a
+    fake EXACT match, outranking a real multi-word file whose raw label only
+    reaches PREFIX for that same bare word.
+
+    Reproduces a live failure: `graphify query "... search results"` seeded on
+    an unrelated provider's `.search()` method and never surfaced the real
+    `search.handler.ts` file at all, because `_pick_seeds`'s per-term
+    diversity probe calls `_score_nodes(G, ["search"])` in isolation, and the
+    (pre-fix) joined-tier bonus treated `.search()`'s tokenized label
+    ("search") as an exact match for the single-word query — a promotion the
+    per-token loop's own raw exact check correctly refuses (raw ".search" !=
+    "search").
+    """
+    def _add(nid, label, src):
+        G.add_node(nid, label=label, norm_label=label.lower(), source_file=src, community=0)
+
+    G = nx.DiGraph()
+    _add("bare_method", ".search()", "server/providers/tmdbProvider.ts")
+    _add("real_file", "search.handler.ts", "server/modules/search/search.handler.ts")
+    monkeypatch.setattr("graphify.serve._trigram_candidates", lambda *a, **k: None)
+
+    scored = _score_nodes(G, ["search"])
+    scored_by_id = {nid: s for s, nid in scored}
+    assert scored_by_id["real_file"] > scored_by_id["bare_method"], (
+        "the real multi-word file (PREFIX tier) must outrank the bare "
+        "same-named method (SUBSTRING tier) once the joined-tier bonus is "
+        "gated to len(norm_terms) > 1"
+    )
+
+
+def test_pick_seeds_diversity_does_not_seed_bare_method_over_relevant_file(monkeypatch):
+    """End-to-end version of the test above, through `_pick_seeds`'s per-term
+    diversity guarantee (#1445) — the mechanism where the bug actually bites,
+    since it probes each query term in isolation via `_score_nodes(G, [term])`.
+    """
+    def _add(nid, label, src):
+        G.add_node(nid, label=label, norm_label=label.lower(), source_file=src, community=0)
+
+    G = nx.DiGraph()
+    _add("bare_method", ".search()", "server/providers/tmdbProvider.ts")
+    _add("real_file", "search.handler.ts", "server/modules/search/search.handler.ts")
+    _add("settings", "providerSettingsService.ts", "server/services/providerSettingsService.ts")
+    monkeypatch.setattr("graphify.serve._trigram_candidates", lambda *a, **k: None)
+
+    terms = ["provider", "settings", "search", "results"]
+    scored = _score_nodes(G, terms)
+    seeds = _pick_seeds(scored, G=G, terms=terms)
+    assert "real_file" in seeds
+    assert "bare_method" not in seeds
+
+
 def test_find_node_ignores_trailing_punctuation():
     G = _make_graph()
     assert _find_node(G, "extract?") == ["n1"]

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -634,6 +634,42 @@ def test_pick_seeds_respects_max_k():
     assert len(seeds) == 3
 
 
+def test_pick_seeds_without_diversity_args_is_unchanged():
+    """G/terms are optional and default to None: existing callers see identical
+    behavior to before this change."""
+    scored = [(1000.0, "fbs"), (1.0, "err1"), (0.9, "err2")]
+    assert _pick_seeds(scored) == ["fbs"]
+
+
+def test_pick_seeds_diversity_recovers_starved_term(monkeypatch):
+    """Reproduces #1445: a vague natural-language query where one term's
+    incidental EXACT match on an unrelated node (e.g. a common word also used
+    as an unrelated field/identifier) outscores every SUBSTRING match on the
+    query's other, actually-relevant terms by ~1000x. Without G/terms, the
+    20%-gap cutoff discards the relevant candidate entirely; with them, it is
+    recovered as a guaranteed per-term seed.
+    """
+    G = nx.DiGraph()
+    # "unrelated" is an exact label match for the query term "unrelated" and
+    # has no connection to the actually-relevant "target" node.
+    G.add_node("noise", label="unrelated", source_file="design_tokens.json")
+    # "target" only substring-matches the query term "widget" via its label.
+    G.add_node("target", label="rate_limit_widget", source_file="src/widget.py")
+    G.add_node("other", label="something_else", source_file="src/other.py")
+    G.add_edge("other", "target")
+
+    terms = ["unrelated", "widget"]
+    scored = _score_nodes(G, terms)
+
+    # Sanity check the premise: without diversity, only the exact match survives.
+    seeds_before = _pick_seeds(scored)
+    assert seeds_before == ["noise"]
+
+    seeds_after = _pick_seeds(scored, G=G, terms=terms)
+    assert "noise" in seeds_after
+    assert "target" in seeds_after
+
+
 # --- actionable truncation hint (#897) ---
 
 def test_subgraph_to_text_truncation_hint_is_actionable():

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -272,9 +272,53 @@ def test_rebuild_code_evicts_removed_symbol_from_surviving_file(tmp_path):
         e.get("source") == foo_id or e.get("target") == foo_id
         for e in edges(after_data)
     ), "dangling edge to the removed symbol must be dropped"
-    assert "bar()" in after, "surviving symbol in the same file must be kept"
-    assert "caller()" in after, "unchanged file's nodes must be kept"
-    assert "AuthConcept" in after, "semantic node on a surviving file must not be evicted"
+
+
+def test_rebuild_code_reattaches_cached_semantic_nodes_for_reextracted_file(tmp_path):
+    """#1610: an incremental AST-only rebuild of a changed file must not silently
+    drop that file's semantic content when a cache entry already covers its
+    current (post-edit) bytes exactly — e.g. the file was already processed by a
+    full/deep run, or its edit reverted to previously-seen content. This costs
+    zero LLM calls (pure cache lookup) and is deterministic (the reattached
+    content is byte-identical to the cached extraction), unlike re-running the
+    LLM. A file with no matching cache entry must keep today's behavior
+    (semantic content dropped, AST-only)."""
+    import json
+    from graphify.cache import save_semantic_cache
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "auth.py").write_text("def login(): pass\n", encoding="utf-8")
+
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+
+    # Seed the semantic cache for auth.py's *current* on-disk content, as if a
+    # prior full/deep run had already LLM-extracted a concept node from it.
+    save_semantic_cache(
+        nodes=[{
+            "id": "auth_authflow",
+            "label": "AuthFlow",
+            "file_type": "concept",
+            "source_file": "auth.py",
+        }],
+        edges=[],
+        root=corpus,
+    )
+
+    # Incremental update re-extracting auth.py (content unchanged, so its hash
+    # still matches the cache entry just seeded above).
+    assert _rebuild_code(
+        corpus, changed_paths=[corpus / "auth.py"], acquire_lock=False,
+    ) is True
+    graph_path = corpus / "graphify-out" / "graph.json"
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    labels = {n["label"] for n in data.get("nodes", [])}
+    assert "login()" in labels, "AST node from the re-extracted file must still be present"
+    assert "AuthFlow" in labels, (
+        "cached semantic node for the re-extracted file's unchanged content "
+        "must be reattached, not dropped"
+    )
 
 
 def test_rebuild_code_preupgrade_marker_less_node_one_cycle_lag(tmp_path):


### PR DESCRIPTION
## Summary

`query`, `explain`, and `path` are designed to accept natural-language input, but several parts of the
resolution and ranking pipeline only worked correctly for short, exact identifier-style input. Multi-word
questions and phrases could silently resolve to the wrong node, an unrelated node, or no node at all, with
no indication that anything had gone wrong. This PR is a set of targeted fixes to that resolution pipeline —
seed selection, ranking, ambiguity handling, and fallback behavior — so that natural-language queries
against `graph.json` reliably reach the node(s) they describe, or fail visibly instead of silently.

## Changes

Each change below targets a distinct, reproducible failure mode in how a natural-language query resolves to
graph nodes.

**1. Guarantee per-term BFS seed diversity in `query` (`_pick_seeds`, `graphify/serve.py`)**
`_pick_seeds` selected BFS seeds by combined score and discarded any candidate scoring below 20% of the top
score. On a multi-word query, one term's incidental exact match on an unrelated node (e.g. a common word
that also happens to be an identifier or field name elsewhere in the corpus) can outscore every other term's
weaker match by orders of magnitude, so the 20%-gap cutoff discarded every seed for the query's actually
relevant terms — the BFS then only ever explores the neighborhood of one unrelated node. Fix: guarantee at
least one seed per distinct query term that has any match at all, tie-broken by node degree. This does not
change single-term or already-unambiguous queries; it only recovers seeds that were previously discarded by
the gap cutoff.

**2. Reattach cached semantic content on incremental AST-only rebuilds (`_rebuild_code`, `graphify/watch.py`)**
The incremental code-only rebuild path evicts a re-extracted file's prior semantic nodes/edges
unconditionally and never regenerates them (no LLM call on that path by design), even when the semantic
cache already holds a valid, content-hash-matched result for the file's current bytes. Fix: check the
content-hash-keyed semantic cache for every re-extracted file before eviction and reattach any hit alongside
the fresh AST nodes. This adds no LLM cost (cache lookup only) and is byte-identical to a full rebuild's
cached output for files with a cache hit; files with no cache entry keep the existing AST-only behavior
unchanged.

**3. Rank `query` output by relevance instead of raw degree (`_subgraph_to_text`, `_query_graph_text`,
`graphify/serve.py`)**
`_subgraph_to_text` has always accepted a `seeds` parameter to render seed nodes first, but its only caller,
`_query_graph_text`, never passed it — every `query` result fell back to whole-graph degree-sort, so the
most-imported/highest-degree node in the corpus (test setup, DB schema, config, logger, etc.) led the output
regardless of relevance to the query, and the nodes the seeding logic actually selected could be pushed far
down or truncated out by the token budget. Fix: `_query_graph_text` now passes both `seeds=start_nodes`
(seeds render first) and `scores=scored` (the same per-node relevance scores already computed to select
seeds, now also used to rank the non-seed expansion). Nodes with no term overlap fall back to degree exactly
as before, so output ordering for a query with no scoring signal is unchanged.

**4. Surface ambiguous or precedence-collapsed matches in `explain` instead of guessing (`_find_node_tiers`,
`graphify/serve.py`; `graphify/__main__.py`)**
`explain`'s single-node resolution already computed a full tier-ordered candidate list (exact
source-path match, exact match, prefix match, substring match) but took the first candidate unconditionally
and discarded the rest, with no signal when other candidates existed. Two related failure shapes: (a)
multiple candidates tied in the same top-precedence tier, and (b) exactly one top-tier candidate that is
weakly connected (degree ≤ 1), fully hiding a more relevant candidate one tier down purely due to tier
precedence. Fix: `_find_node_tiers` exposes tier boundaries so both shapes can be detected; `explain` now
lists all tied/hidden candidates instead of picking one, with a degree-dominance exception (top candidate's
degree at least ~3x the runner-up's resolves directly, since that is not a real ambiguity) and a `--force`
flag to bypass the guard and reproduce the prior single-candidate behavior.

**5. Surface ambiguous endpoint matches in `path` instead of a warning that is ignored
(`graphify/__main__.py`)**
`path` already computed a top-vs-runner-up score gap for each endpoint but only printed a stderr warning and
then silently proceeded with the top-scored candidate regardless. Fix: the same close-score-gap condition is
now a hard ambiguity gate — a numbered candidate list (label, source, degree, score) is shown instead of a
warning, with the same degree-dominance exception as (4) so a genuinely dominant symbol still resolves
directly, and the same `--force` flag to bypass.

**6. Fall back to term-overlap candidates in `explain` instead of failing silently on a multi-word phrase
(`graphify/__main__.py`)**
`_find_node_tiers` requires the query's tokens, rejoined into a single string, to match/prefix/substring a
single node's label as a whole. A genuine multi-word natural-language phrase (e.g. three or more words)
almost never appears as a literal substring of any one node's label, so this returns "No node matching
found" even when every individual word in the phrase exists on a real, relevant node — with no fallback and
no signal that anything went wrong. Fix: when the tiered lookup finds nothing and the phrase has more than
one token, fall back to the same per-token relevance scoring `query` already uses (`_score_nodes`) and list
the top candidates by term overlap, in the same candidate-list format used by (4). A genuine single-word
miss is unaffected — a one-word probe would score identically to the substring tier already tried and has
nothing new to find, so the fallback is gated on token count.

**7. Gate `_score_nodes`' full-query bonus to multi-token queries (`graphify/serve.py`)**
`_score_nodes` has a "joined" full-query tier so a multi-word query that equals or prefixes a whole
multi-word label wins outright, since no single token in a per-token score sum could otherwise equal that
label. This tier compares the query's *tokenized* form (punctuation stripped) against a node's tokenized
label. For a single-token query, this can falsely promote a node whose only word-character content matches
that one token — e.g. a bare method call like `.search()`, which tokenizes to `"search"` — to the same
tier as a genuine exact match, even though the same node correctly fails the ordinary per-token exact check
a few lines below (raw label `".search"` is not equal to raw query `"search"`). This specifically affects
`_pick_seeds`'s per-term seed-diversity check from (1), which probes each distinct query term in isolation
via `_score_nodes(G, [term])`: a short method name repeated across multiple unrelated files can win that
single-term probe outright and prevent a genuinely relevant multi-word file (which only reaches the prefix
tier for the same bare word) from ever being selected as a seed. Fix: gate the joined-tier bonus on
`len(norm_terms) > 1`. A single-token probe has no "multi-word phrase vs. per-token bag-of-words"
distinction to make — the per-token loop immediately below already fully and correctly handles single-term
exact/prefix/substring matching via raw, non-tokenized comparison. The combined multi-word query path used
everywhere else is unaffected, since it always has more than one token.

**8. Cap `explain`'s term-overlap fallback to avoid noise floods (`graphify/__main__.py`)**
The fallback added in (6) has no floor on how broad a "match" is useful. A query whose only vocabulary
overlap with the corpus is one generic word (e.g. a word that is also a top-level directory name in the
codebase being queried) can match a large fraction of the entire graph at the weakest possible scoring tier,
and the fallback would present an arbitrary slice of that as though it were a considered answer, when in
fact none of the matched nodes are meaningfully distinguished from one another. Fix: after scoring, if the
candidate count exceeds both an absolute floor (50 — so small graphs are never affected) and 15% of the
graph's total node count, the fallback is treated as a noise flood and the plain zero-match message is shown
instead of a misleadingly specific candidate list. Genuine large-but-real candidate lists stay well under
this threshold and are unaffected.

## Testing

Full test suite: 2768 passing, 28 skipped, 1 pre-existing failure unrelated to these changes
(`tests/test_cache.py::test_semantic_prune_removes_orphan_entries`, a test-order-dependent flake reproducible
identically on `v8` before any commit in this PR). `ruff check` passes with no findings.

Each change above has dedicated regression tests in `tests/test_serve.py`, `tests/test_watch.py`,
`tests/test_explain_cli.py`, and `tests/test_path_cli.py`, covering both the failure case being fixed and a
non-regression pin for the prior, still-correct behavior it must not disturb.