### PR TITLE
Fix virtual Postgres source_file URI backslash normalization on Windows (#1672)

### DIFF
--- a/graphify/pg_introspect.py
+++ b/graphify/pg_introspect.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from graphify.extract import extract_sql
 
 
@@ -135,7 +135,7 @@ def introspect_postgres(dsn: str | None = None) -> dict:
     info = psycopg.conninfo.conninfo_to_dict(dsn or "")
     host = info.get("host", "localhost")
     dbname = info.get("dbname", "db")
-    virtual_path = Path(f"postgresql://{host}/{dbname}")
+    virtual_path = PurePosixPath(f"postgresql://{host}/{dbname}")
 
     # Pass virtual path and in-memory DDL content to extract_sql
     result = extract_sql(virtual_path, content=ddl_string)

--- a/tests/test_pg_introspect.py
+++ b/tests/test_pg_introspect.py
@@ -276,3 +276,17 @@ def test_pg_introspect_import_error():
     with patch.dict("sys.modules", {"psycopg": None}):
         with pytest.raises(ImportError, match="psycopg is required"):
             introspect_postgres("postgresql://localhost/db")
+
+
+def test_pg_introspect_uri_forward_slashes():
+    """Assert that the virtual path in postgresql introspection output uses forward slashes on all platforms."""
+    mock_psycopg = _make_mock_psycopg([], [], [], [], host="some-host", dbname="some-db")
+    with patch.dict("sys.modules", {"psycopg": mock_psycopg}):
+        res = introspect_postgres("postgresql://some-host/some-db")
+    
+    # We should have at least the file node
+    assert len(res["nodes"]) > 0
+    for node in res["nodes"]:
+        assert "\\" not in node["source_file"]
+        assert "postgresql:/some-host/some-db" in node["source_file"]
+


### PR DESCRIPTION
### Summary
This PR resolves issue #1672, where `introspect_postgres()` produces invalid `source_file` URIs on Windows (e.g., `postgresql:\myhost\mydb` instead of `postgresql:/myhost/mydb`). 

### Cause
In `graphify/pg_introspect.py`, the `virtual_path` was constructed using `pathlib.Path(f"postgresql://{host}/{dbname}")`. On Windows, this instantiates a `WindowsPath` object, which normalizes the path separators to backslashes (`\`). Because the path is a synthetic URI rather than a local file path, it should be OS-independent and retain forward slashes.

### Solution
- Imported and utilized `pathlib.PurePosixPath` to construct `virtual_path`. Since `PurePosixPath` uses POSIX path semantics regardless of the host operating system, the path string uses forward slashes on all platforms.
- Added the regression test `test_pg_introspect_uri_forward_slashes` in `tests/test_pg_introspect.py` to assert that the generated virtual paths always contain forward slashes and no backslashes, even when run on Windows.
- Successfully verified that all postgresql introspection tests pass on Windows.
- Executed `graphify update .` to rebuild the AST knowledge graph.
