### PR TITLE
fix(extract): disambiguate unresolved base-class stubs by file

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3424,10 +3424,16 @@ def _ruby_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: st
                         if base_nid not in seen_ids:
                             base_nid = _make_id(base)
                             if base_nid not in seen_ids:
+                                # origin_file lets _disambiguate_colliding_node_ids
+                                # tell this file's unresolved reference apart from
+                                # another file's same-named one, instead of every
+                                # file's stub collapsing onto one shared bare id
+                                # (see ensure_named_node(), which sets the same
+                                # field for this exact reason).
                                 nodes.append({
                                     "id": base_nid, "label": base,
                                     "file_type": "code", "source_file": "",
-                                    "source_location": "",
+                                    "source_location": "", "origin_file": str_path,
                                 })
                                 seen_ids.add(base_nid)
                         add_edge(class_nid, base_nid, "inherits", line)
@@ -3681,18 +3687,7 @@ def _extract_generic(
                     for arg in args.children:
                         if arg.type == "identifier":
                             base = _read_text(arg, source)
-                            base_nid = _make_id(stem, base)
-                            if base_nid not in seen_ids:
-                                base_nid = _make_id(base)
-                                if base_nid not in seen_ids:
-                                    nodes.append({
-                                        "id": base_nid,
-                                        "label": base,
-                                        "file_type": "code",
-                                        "source_file": "",
-                                        "source_location": "",
-                                    })
-                                    seen_ids.add(base_nid)
+                            base_nid = ensure_named_node(base, line)
                             add_edge(class_nid, base_nid, "inherits", line)
 
             # Swift-specific: conformance / inheritance
@@ -3831,18 +3826,7 @@ def _extract_generic(
                         base = _kotlin_user_type_name(user_type_node, source)
                         if not base:
                             continue
-                        base_nid = _make_id(stem, base)
-                        if base_nid not in seen_ids:
-                            base_nid = _make_id(base)
-                            if base_nid not in seen_ids:
-                                nodes.append({
-                                    "id": base_nid,
-                                    "label": base,
-                                    "file_type": "code",
-                                    "source_file": "",
-                                    "source_location": "",
-                                })
-                                seen_ids.add(base_nid)
+                        base_nid = ensure_named_node(base, line)
                         add_edge(class_nid, base_nid, relation, line)
                         for arg_child in user_type_node.children:
                             if arg_child.type != "type_arguments":
@@ -3876,18 +3860,7 @@ def _extract_generic(
                                 base = _read_text(consts[-1], source)
                             break
                     if base:
-                        base_nid = _make_id(stem, base)
-                        if base_nid not in seen_ids:
-                            base_nid = _make_id(base)
-                            if base_nid not in seen_ids:
-                                nodes.append({
-                                    "id": base_nid,
-                                    "label": base,
-                                    "file_type": "code",
-                                    "source_file": "",
-                                    "source_location": "",
-                                })
-                                seen_ids.add(base_nid)
+                        base_nid = ensure_named_node(base, line)
                         add_edge(class_nid, base_nid, "inherits", line)
 
                 # `include`/`extend`/`prepend <Const>` in the class/module body ->
@@ -4153,18 +4126,7 @@ def _extract_generic(
                             continue
                         if not base:
                             continue
-                        base_nid = _make_id(stem, base)
-                        if base_nid not in seen_ids:
-                            base_nid = _make_id(base)
-                            if base_nid not in seen_ids:
-                                nodes.append({
-                                    "id": base_nid,
-                                    "label": base,
-                                    "file_type": "code",
-                                    "source_file": "",
-                                    "source_location": "",
-                                })
-                                seen_ids.add(base_nid)
+                        base_nid = ensure_named_node(base, line)
                         add_edge(class_nid, base_nid, "inherits", line)
                         # Emit a generic_arg reference for each type argument on the
                         # base (Base<Dep> -> Car references Dep). _cpp_collect_type_refs

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -100,6 +100,37 @@ def test_extract_disambiguates_duplicate_symbol_ids_by_source_path(tmp_path):
             assert edge["target"] in node_ids, f"Dangling structural target: {edge}"
 
 
+def test_cpp_unresolved_base_class_stubs_stay_disambiguated_by_file(tmp_path):
+    """Two different files' same-named, otherwise-undefined base class must not
+    collapse onto one shared stub node.
+
+    The C++ base_class_clause handler used to build its stub inline instead of
+    calling ensure_named_node(), so it never tagged the stub with origin_file.
+    Without that tag, _disambiguate_colliding_node_ids couldn't tell file A's
+    reference to unresolved `Base` apart from file B's, and every file's
+    unresolved base class merged onto one bare id -- which could then collide
+    with an unrelated same-named real definition anywhere else in the corpus.
+    """
+    first = tmp_path / "a" / "Foo.cpp"
+    second = tmp_path / "b" / "Bar.cpp"
+    first.parent.mkdir(parents=True)
+    second.parent.mkdir(parents=True)
+    first.write_text("class Foo : public Base {};\n", encoding="utf-8")
+    second.write_text("class Bar : public Base {};\n", encoding="utf-8")
+
+    result = extract([first, second], cache_root=tmp_path)
+    base_stubs = [
+        node for node in result["nodes"]
+        if node["label"] == "Base" and not node.get("source_file")
+    ]
+    assert len(base_stubs) == 2
+    assert len({node["id"] for node in base_stubs}) == 2
+
+    inherits_edges = [e for e in result["edges"] if e["relation"] == "inherits"]
+    assert len(inherits_edges) == 2
+    assert len({e["target"] for e in inherits_edges}) == 2
+
+
 def test_cross_file_type_annotation_refs_resolve_to_single_node(tmp_path):
     """#1402: a class defined once but referenced via type annotations in N other
     files must NOT create 1+N phantom duplicate nodes (with the referencing file's


### PR DESCRIPTION
## What's wrong
When a class extends a base class that isn't defined in the same file, graphify creates a placeholder "stub" node for that unknown base class. `ensure_named_node()` — the helper that creates these stubs — tags each one with `origin_file`, so a later pass (`_disambiguate_colliding_node_ids`) can tell "file A's reference to `Base`" apart from "file B's reference to `Base`".
Five places in the extractor build this same kind of stub *inline*, bypassing `ensure_named_node()` entirely — and none of them set `origin_file`. Without that tag, every file's reference to the same-named base class gets merged into one shared stub instead of staying separate. That shared stub can then collide with an unrelated real class somewhere else in the codebase that happens to have the same name.
Affected inheritance handlers:
- C++ `base_class_clause`
- Python class inheritance
- Kotlin delegation-specifier inheritance/conformance
- Ruby `class Foo < Base`
- Ruby `Class.new(Super)`
## The fix
Four of the five sit directly inside `_extract_generic`, where `ensure_named_node()` is already available — those now just call it instead of duplicating its logic.
The fifth (Ruby's `Class.new(Super)`) lives in a separate helper, `_ruby_extra_walk()`, that doesn't have `ensure_named_node()` in scope. Rather than change that helper's signature, it gets the same `origin_file` tag added directly to its own stub dict.
A sixth, similar occurrence exists in `extract_apex()`, a fully separate regex-based extractor with no `ensure_named_node()` of its own. Left out here to keep this PR scoped to the shared `_extract_generic` path and its one directly-related helper.
## How we found this
We hit a concrete case: ~163 different C++ files each had a class extending `mTimer`, a real, shared C++ base class. Because none of those references were disambiguated by file, they all collapsed onto one stub — and that stub's label happened to exact-case-match an unrelated class also named `MTimer` in a different language entirely. Result: 218 wrong `inherits` edges from unrelated C++ server code into that unrelated class.
## Testing
Added a regression test: two different C++ files, each inheriting from the same undefined base class, must produce two distinct stub nodes — not one shared one. It fails on `v8` (both files share one `'base'` id) and passes with this fix.
Full `tests/test_extract.py` suite: 94 passing (was 93; +1 new test), same 19 pre-existing failures before and after this change (unrelated — missing optional tree-sitter grammar packages in this environment).