### PR TITLE
docs(security): clarify stdio-only claim now that HTTP transport exists

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,7 +42,7 @@ graphify is a **local development tool**. It runs as a Claude Code skill and opt
 
 ### What graphify does NOT do
 
-- Does not run a network listener (MCP server communicates over stdio only)
+- Does not run a network listener by default (stdio transport); `--transport http` is opt-in, documented in the README, and binds to `127.0.0.1` unless `--host 0.0.0.0` is passed
 - Does not execute code from source files (tree-sitter parses ASTs - no eval/exec)
 - Does not use `shell=True` in any subprocess call
 - Does not store credentials or API keys


### PR DESCRIPTION
## Summary
- `SECURITY.md` states graphify "does not run a network listener" and that the MCP server "communicates over stdio only".
- `README.md` documents an opt-in `--transport http` mode (`python -m graphify.serve ... --transport http --host 0.0.0.0 --api-key ...`) for sharing one graphify server across a team, which does open a real network listener.
- This updates the claim to describe the actual default (stdio, no listener) plus the documented opt-in HTTP exception, so the security doc stays accurate.

## Test plan
- Docs-only change (single bullet in `SECURITY.md`); no code paths affected.
- Confirmed the referenced HTTP transport flags (`--transport`, `--host`, `--api-key`) exist in `README.md` (lines ~443-476).