### PR TITLE
fix(extract): emit Java enum constants as nodes with case_of edges

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2933,6 +2933,32 @@ def _swift_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: s
     return False
 
 
+# ── Java extra walk for enum constants ───────────────────────────────────────
+
+def _java_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
+                     nodes: list, edges: list, seen_ids: set, function_bodies: list,
+                     parent_class_nid: str | None, add_node_fn, add_edge_fn,
+                     walk_fn) -> bool:
+    """Handle enum_constant for Java. Returns True if handled."""
+    if node.type == "enum_constant" and parent_class_nid:
+        name_node = node.child_by_field_name("name")
+        if name_node is None:
+            return True
+        const_name = _read_text(name_node, source)
+        line = node.start_point[0] + 1
+        const_nid = _make_id(parent_class_nid, const_name)
+        add_node_fn(const_nid, const_name, line)
+        add_edge_fn(parent_class_nid, const_nid, "case_of", line)
+        # Anonymous-body constants (`MONDAY { void greet(){} }`): descend so the
+        # body's methods aren't dropped; const_nid attaches them to the constant.
+        for child in node.children:
+            if child.type == "class_body":
+                for member in child.children:
+                    walk_fn(member, parent_class_nid=const_nid)
+        return True
+    return False
+
+
 # ── Language configs ──────────────────────────────────────────────────────────
 
 _PYTHON_CONFIG = LanguageConfig(
@@ -4853,6 +4879,12 @@ def _extract_generic(
                                   nodes, edges, seen_ids, function_bodies,
                                   parent_class_nid, add_node, add_edge,
                                   ensure_named_node):
+                return
+
+        if config.ts_module == "tree_sitter_java":
+            if _java_extra_walk(node, source, file_nid, stem, str_path,
+                                nodes, edges, seen_ids, function_bodies,
+                                parent_class_nid, add_node, add_edge, walk):
                 return
 
         if config.ts_module == "tree_sitter_ruby":

--- a/tests/fixtures/sample.java
+++ b/tests/fixtures/sample.java
@@ -39,3 +39,14 @@ public class DataProcessor extends BaseProcessor implements Processor {
 interface Processor {
     List<String> process();
 }
+
+enum ErrorCode {
+    OK(0),
+    GAME_DONE(1001);
+
+    private final int code;
+
+    ErrorCode(int code) {
+        this.code = code;
+    }
+}

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -115,6 +115,15 @@ def test_java_no_dangling_edges():
         assert e["source"] in node_ids
 
 
+def test_java_enum_constants_have_case_of_edge():
+    r = extract_java(FIXTURES / "sample.java")
+    labels = _labels(r)
+    assert "OK" in labels
+    assert "GAME_DONE" in labels
+    assert ("ErrorCode", "OK") in _edge_labels(r, "case_of")
+    assert ("ErrorCode", "GAME_DONE") in _edge_labels(r, "case_of")
+
+
 # ── C ────────────────────────────────────────────────────────────────────────
 
 def test_c_no_error():


### PR DESCRIPTION
Addresses #1700 (Java only)

## Problem
Java enum constants aren't extracted as nodes. The enum *type* node is created,
but its members (`ErrorCode.GAME_DONE`) don't exist in the graph, so
"where is this constant defined/used" can't find them. `enum_declaration` is in
Java's class_types, so the walker recurses into the enum body, but
`enum_constant` matches no handled type and falls through, dropping the constant.

## Fix
Add `_java_extra_walk` (dispatched for `tree_sitter_java`) that emits each
`enum_constant` as a child node with a `case_of` edge to the enum, mirroring the
existing Swift `enum_entry` handling.

Before:
    NODE  ErrorCode
    EDGE  ErrorCode.java --contains--> ErrorCode

 After:
    NODE  ErrorCode
    NODE  OK
    NODE  GAME_DONE
    EDGE  ErrorCode.java --contains--> ErrorCode
    EDGE  ErrorCode      --case_of-->  OK
    EDGE  ErrorCode      --case_of-->  GAME_DONE

## Note for reviewer
For a constant with an anonymous body (`MONDAY { void greet(){} }`), the handler
descends into the body and attaches its methods to the constant node rather than
letting them fall to file scope. Without descending, those methods would be dropped. Side effect: it de-collides a
constant's method from a same-named enum method. 

## Out of scope
- Kotlin enum entries — same root gap, not addressed here; can follow up separately.
- Usage edges (`isSystem() --references--> SYSTEM`) — definitions only.
- Pre-existing duplicate `file --contains--> enum` edge (constructor shares the enum's name) — unrelated, untouched.