### PR TITLE
fix: scale per-term exact/prefix score tiers by squared term coverage (#1602)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,11 @@
 </div>
 
 <p align="center">
-  <a href="https://www.ycombinator.com/companies/graphify"><img src="https://img.shields.io/badge/Y%20Combinator-S26-F0652F?style=flat&logo=ycombinator&logoColor=white" alt="YC S26"/></a>
-  <a href="https://discord.gg/598Ad9zQZ"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord"/></a>
-  <a href="https://safishamsi.gumroad.com/l/qetvlo"><img src="https://img.shields.io/badge/Book-The%20Memory%20Layer-2ea44f?style=flat&logo=gitbook&logoColor=white" alt="The Memory Layer"/></a>
-  <a href="https://github.com/safishamsi/graphify/actions/workflows/ci.yml"><img src="https://github.com/safishamsi/graphify/actions/workflows/ci.yml/badge.svg?branch=v8" alt="CI"/></a>
   <a href="https://pypi.org/project/graphifyy/"><img src="https://img.shields.io/pypi/v/graphifyy" alt="PyPI"/></a>
   <a href="https://pepy.tech/project/graphifyy"><img src="https://img.shields.io/pepy/dt/graphifyy?color=blue&label=downloads" alt="Downloads"/></a>
-  <a href="https://github.com/sponsors/safishamsi"><img src="https://img.shields.io/badge/sponsor-safishamsi-ea4aaa?logo=github-sponsors" alt="Sponsor"/></a>
-  <a href="https://www.linkedin.com/company/graphify-labs"><img src="https://img.shields.io/badge/LinkedIn-Graphify%20Labs-0077B5?logo=linkedin" alt="LinkedIn"/></a>
-  <a href="https://x.com/graphifyy"><img src="https://img.shields.io/badge/X-graphifyy-000000?logo=x&logoColor=white" alt="X"/></a>
+  <a href="https://github.com/safishamsi/graphify/actions/workflows/ci.yml"><img src="https://github.com/safishamsi/graphify/actions/workflows/ci.yml/badge.svg?branch=v8" alt="CI"/></a>
+  <a href="https://discord.gg/598Ad9zQZ"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord"/></a>
+  <a href="https://www.ycombinator.com/companies/graphify"><img src="https://img.shields.io/badge/Y%20Combinator-S26-F0652F?style=flat&logo=ycombinator&logoColor=white" alt="YC S26"/></a>
 </p>
 
 Type `/graphify` in your AI coding assistant and it maps your entire project (code, docs, PDFs, images, videos) into a **knowledge graph** you can **query instead of grepping** through files.
@@ -757,6 +753,7 @@ graphify label ./my-project --backend=openai --model gpt-4o   # force a specific
 - [How it works](docs/how-it-works.md) — the extraction pipeline, community detection, confidence scoring, benchmarks
 - [ARCHITECTURE.md](ARCHITECTURE.md) — module breakdown, how to add a language
 - [Optional integrations](docs/docker-mcp-sqlite.md) — Docker MCP Toolkit + SQLite
+- [The Memory Layer](https://safishamsi.gumroad.com/l/qetvlo) — the book on the ideas behind graphify, the architecture end to end
 
 ---
 
@@ -827,4 +824,15 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module responsibilities and how to ad
   <a href="https://star-history.com/#safishamsi/graphify&Date">
     <img src="https://api.star-history.com/svg?repos=safishamsi/graphify&type=Date" alt="Star History Chart" width="370"/>
   </a>
+</p>
+
+---
+
+## Community and links
+
+<p align="center">
+  <a href="https://discord.gg/598Ad9zQZ"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord"/></a>
+  <a href="https://x.com/graphifyy"><img src="https://img.shields.io/badge/X-graphifyy-000000?logo=x&logoColor=white" alt="X"/></a>
+  <a href="https://github.com/sponsors/safishamsi"><img src="https://img.shields.io/badge/sponsor-safishamsi-ea4aaa?logo=github-sponsors" alt="Sponsor"/></a>
+  <a href="https://safishamsi.gumroad.com/l/qetvlo"><img src="https://img.shields.io/badge/Book-The%20Memory%20Layer-2ea44f?style=flat&logo=gitbook&logoColor=white" alt="The Memory Layer"/></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 <p align="center">
   <a href="https://pypi.org/project/graphifyy/"><img src="https://img.shields.io/pypi/v/graphifyy" alt="PyPI"/></a>
   <a href="https://pepy.tech/project/graphifyy"><img src="https://img.shields.io/pepy/dt/graphifyy?color=blue&label=downloads" alt="Downloads"/></a>
-  <a href="https://github.com/safishamsi/graphify/actions/workflows/ci.yml"><img src="https://github.com/safishamsi/graphify/actions/workflows/ci.yml/badge.svg?branch=v8" alt="CI"/></a>
   <a href="https://discord.gg/598Ad9zQZ"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord"/></a>
+  <a href="https://www.linkedin.com/company/graphify-labs"><img src="https://img.shields.io/badge/LinkedIn-Graphify%20Labs-0077B5?logo=linkedin" alt="LinkedIn"/></a>
   <a href="https://www.ycombinator.com/companies/graphify"><img src="https://img.shields.io/badge/Y%20Combinator-S26-F0652F?style=flat&logo=ycombinator&logoColor=white" alt="YC S26"/></a>
 </p>
 

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -285,7 +285,11 @@ def _trigram_candidates(G: nx.Graph, needles: list[str], *, guard_frac: float = 
 
 def _score_nodes(G: nx.Graph, terms: list[str]) -> list[tuple[float, str]]:
     scored = []
-    norm_terms = [tok for t in terms for tok in _search_tokens(t)]
+    # Dedupe tokens, order-preserving (as _pick_seeds already does): a repeated
+    # query word must not double-count every tier, and with coverage scaling
+    # below it would also inflate the matched-term ratio (#1602).
+    norm_terms = list(dict.fromkeys(tok for t in terms for tok in _search_tokens(t)))
+    n_terms = len(norm_terms)
     idf = _compute_idf(G, norm_terms)
     # Whole-query string for full-label matching (mirrors _find_node's `term`).
     joined = " ".join(norm_terms)
@@ -328,18 +332,38 @@ def _score_nodes(G: nx.Graph, terms: list[str]) -> list[tuple[float, str]]:
                 or label_tokens.startswith(joined)
             ):
                 score += _PREFIX_MATCH_BONUS * 10 * joined_w
+        # Term coverage (#1602): scale the per-term exact/prefix tiers by the
+        # squared fraction of query terms the node's LABEL matches, so a lone
+        # generic word that happens to equal a short label (query term "home"
+        # vs. a home() leaf) cannot bury nodes that match several of the
+        # query's terms. Squaring matters because the exact tier is 10x the
+        # prefix tier: at linear coverage a 1-of-10-terms exact match still
+        # outscores a 3-of-10 prefix+substring match. Single-term and
+        # full-coverage queries are unchanged (coverage == 1), so identifier
+        # lookups keep exact-match dominance. Source-file hits score but do
+        # not count as coverage: a colliding leaf whose directory shares
+        # tokens with the query (common near the intended target) must not
+        # win back its exact tier via path fragments. The substring/source
+        # bonuses and the full-query tier above stay unscaled.
+        matched = 0
+        tiered = 0.0
         for t in norm_terms:
             w = idf.get(t, 1.0)
             # Three-tier precedence: exact > prefix > substring (take the
             # strongest tier per term so a single term cannot double-count).
             if t == norm_label or t == bare_label:
-                score += _EXACT_MATCH_BONUS * w
+                tiered += _EXACT_MATCH_BONUS * w
+                matched += 1
             elif norm_label.startswith(t) or bare_label.startswith(t):
-                score += _PREFIX_MATCH_BONUS * w
+                tiered += _PREFIX_MATCH_BONUS * w
+                matched += 1
             elif t in norm_label:
                 score += _SUBSTRING_MATCH_BONUS * w
+                matched += 1
             if t in source:
                 score += _SOURCE_MATCH_BONUS * w
+        if tiered:
+            score += tiered * (matched / n_terms) ** 2
         if score > 0:
             scored.append((score, nid))
     # Sort by score desc; break ties toward the shorter label so a concise exact
@@ -378,6 +402,12 @@ def _pick_seeds(
     collision cannot starve out the others. Ties within a term are broken by
     graph degree (structural centrality), so an isolated incidental match
     doesn't out-rank a real, well-connected hub for that term.
+
+    Coverage scaling in _score_nodes (#1602) now dampens a lone collision's
+    exact tier on multi-term queries, which brings label-matching relevant
+    nodes back inside the gap window; this per-term guarantee remains
+    load-bearing for relevant nodes matched only via substrings, whose flat
+    scores a dampened collision can still exceed.
     """
     if not scored:
         return []

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -8,6 +8,8 @@ from graphify.serve import (
     _communities_from_graph,
     _score_nodes,
     _compute_idf,
+    _EXACT_MATCH_BONUS,
+    _SOURCE_MATCH_BONUS,
     _pick_seeds,
     _bfs,
     _dfs,
@@ -121,6 +123,66 @@ def test_score_nodes_multiword_exact_label_outranks_superset():
     # Resolves uniquely to the exact label, strictly ahead of the superset.
     assert scored[0][1] == "exact"
     assert scored[0][0] > scored[1][0], "exact label must strictly outrank superset/token-bag matches"
+
+
+def test_score_nodes_coverage_lone_generic_exact_hit_loses_to_multi_term_match():
+    """A lone generic-word exact match must not bury a multi-term match.
+
+    Reproduces #1602: in a multi-term query, a single generic term that
+    exactly equals a short leaf label (query term "list" vs a list() function
+    node) received the full exact-tier bonus and outranked every node matching
+    several of the query's terms, even when the query contained the target's
+    literal identifier. The per-term exact/prefix tiers are now scaled by
+    squared term coverage, so a 1-of-5-terms collision drops below a
+    multi-term match. The leaves live in the same directory as the target
+    (the realistic case) to pin that source-path hits do not count as
+    coverage and hand the collision its exact tier back.
+    """
+    G = nx.Graph()
+
+    def _add(nid, label, src):
+        G.add_node(nid, label=label, norm_label=label.lower(),
+                   source_file=src, community=0)
+
+    _add("target", "ClientLive.Index", "lib/clients_live/index.ex")
+    _add("form", "ClientLive.Form", "lib/clients_live/form.ex")
+    _add("show", "ClientLive.Show", "lib/clients_live/show.ex")
+    # Same-named tiny leaf functions: "list" == bare label fires the exact
+    # tier. Placed in the target's own directory so their source paths also
+    # substring-match the query term "clients": a path hit must not inflate
+    # the coverage that multiplies the exact tier.
+    for i in range(3):
+        _add(f"leaf{i}", "list()", f"lib/clients_live/helpers{i}.ex")
+    # Filler making "list" a common (low-IDF) token, as in a real graph where
+    # list()/get()/new() style names are ubiquitous.
+    for i in range(24):
+        _add(f"filler{i}", f"shopping list {i}", f"lib/filler{i}.ex")
+
+    # The user pastes the real identifier plus context words; tokenization
+    # yields 5 terms: clientlive, index, clients, list, columns.
+    scored = _score_nodes(G, [t.lower() for t in "ClientLive.Index clients list columns".split()])
+    by_id = {nid: s for s, nid in scored}
+
+    assert scored[0][1] == "target"
+    assert by_id["target"] > by_id["leaf0"], (
+        "a 1-of-5-terms exact collision must not outrank the node matching 3 of 5 terms"
+    )
+
+
+def test_score_nodes_coverage_full_coverage_query_is_unchanged():
+    """Coverage scaling must not touch full-coverage queries (coverage == 1).
+
+    A single-term identifier lookup keeps the exact tier's full magnitude, so
+    `query "FooBarService"` behavior is byte-identical to before #1602.
+    """
+    G = _make_graph()
+    scored = _score_nodes(G, ["extract"])
+    w = _compute_idf(G, ["extract"])["extract"]
+    assert scored[0][1] == "n1"
+    # Full-query exact tier (10x) + per-term exact tier + source hit
+    # ("extract" in "extract.py"), all undampened.
+    expected = (_EXACT_MATCH_BONUS * 10 + _EXACT_MATCH_BONUS + _SOURCE_MATCH_BONUS) * w
+    assert scored[0][0] == pytest.approx(expected)
 
 
 def test_find_node_ignores_trailing_punctuation():


### PR DESCRIPTION
Fixes #1602. Follows up on the discussion there; builds on the per-term seed guarantee from #1596 (`d56ee83`) and fixes the scoring half that was left open.

## Root cause

In a multi-term query, a single generic term that exactly equals a short leaf label (`home` vs a `home()` controller action, `list` vs a `list()` function) receives `_EXACT_MATCH_BONUS x IDF` and outscores every node matching several of the query's terms by roughly 10x. `_pick_seeds`' 20% gap cutoff then discards the genuinely relevant candidates. #1596 guarantees each term still contributes a seed, which stops the starvation; but nothing in `_score_nodes` rewarded matching *more* of the query, so the collision still owned the top of the ranking (and `path`-style consumers of `scored[0]` have no per-term backstop).

## The change

`_score_nodes` now scales the per-term exact/prefix tier contributions by squared term coverage:

```
score += tiered * (matched_terms / total_terms) ** 2
```

Design decisions, each of which came out of testing against a real graph (below):

1. **Squared, not linear.** The exact tier is 10x the prefix tier; at linear coverage a 1-of-10-terms exact hit still edges out a 3-of-10-terms prefix+substring match. The regression test pins this coupling: retuning either tier constant re-fails it.
2. **Coverage counts label hits only (exact/prefix/substring).** Source-path hits still score, but do not count toward coverage. Without this, a colliding leaf that lives in the target's own directory (the common case) wins back most of its exact tier via path fragments: on the regression scenario the leaf scored 122.5 vs the target's 66.3 when path hits counted, vs 30.9 / 40.1 when they do not.
3. **Substring and source bonuses stay unscaled**, as does the full-query tier (a full-label match already implies full coverage).
4. **Query tokens are deduped, order-preserving**, as `_pick_seeds` already does. A repeated query word previously double-added every tier; under coverage scaling it would also inflate the matched ratio, quadratically restoring the collision (a query with `list` twice re-ranked the `list()` leaf above the intended target, 154.0 vs 84).
5. **Single-term and full-coverage queries are unchanged** (coverage == 1), so identifier lookups keep exact-match dominance. A test pins the exact pre-change score.

## Results on a real graph

Production graph: 5,700 nodes / 7,899 edges (Phoenix/Elixir codebase plus design docs; the graph both #1602 repros came from). Methodology: run `_query_terms -> _score_nodes -> _pick_seeds` (the `_query_graph_text` flow) on base `v8` (`8a608d1`, which already includes #1596) and on this branch, and diff the top of the ranking and the seed set.

### Identifier queries: byte-identical

`ClientLive.Index` and `DashboardLive` produce identical rankings and identical seeds before and after. Example (`ClientLive.Index`):

| rank | before | after |
|---|---|---|
| 1 | 60028.71 ClientLive.Index | 60028.71 ClientLive.Index |
| 2 | 60026.57 ClientLive.Index (doc) | 60026.57 ClientLive.Index (doc) |
| 3 | 594.28 ClientLive.Form | 148.57 ClientLive.Form |

(Partial-coverage neighbors like `ClientLive.Form` scale down as intended; rank order and seeds are unchanged.)

### Natural-language query: seeds byte-identical

`dashboard KPI alerts` seeds `['Dashboard COI Alerts Integration', 'dashboard_live.ex', 'Dashboard (/) Rebuild Implementation Plan', 'Placement-location seam for overlap alerts', 'kpi.ex']` both before and after.

### Repro 1: `dashboard home page LiveView content KPI cards alerts today grid`

Before (v8 with #1596):

```
6087.92  home()                                   <- 1-term exact collision, rank 1
 703.97  grid_view()
 703.97  gridline_size_pct()
 626.73  Home / Today Dashboard (Iris)            <- intended cluster, below gap window
 621.12  Home Today Mock
seeds: home() first; cluster recovered only via the per-term guarantee
```

After:

```
  72.94  Home / Today Dashboard (Iris)            <- intended cluster, rank 1
  71.92  Dashboard (/) Rebuild to Home-Today Mock (Design)
  63.23  home()                                   <- collision dampened 6087.9 -> 63.2 (96x)
  36.91  Home Today Mock
seeds: ['Home / Today Dashboard (Iris)', 'Dashboard (/) Rebuild to Home-Today Mock (Design)', 'home()', ...]
```

The relevant cluster is now inside the gap window on its own merit, not only via the per-term guarantee, and it also becomes the top-ranked answer for `scored[0]` consumers.

### Repro 2: `ClientLive.Index clients list columns`

Before: three `list()` nodes at 4871.72 vs `ClientLive.Index` at 600.72 (8.1x, outside the 20% gap window; seeded only via the per-term guarantee).

After: `list()` drops to 194.87 (25x reduction) and `ClientLive.Index` at 101.52 is back inside the gap window. `list()` still ranks first (it is a legitimate 1-of-5 exact match), but its dominance collapses from 8.1x to 1.9x and the intended identifier is seeded through the gap window itself.

## Known residual (why #1596 stays load-bearing)

A relevant node matched only via interior substrings (camelCase mid-label terms) still scores below a dampened collision: flat substring scores are ~1 x IDF per term vs `exact/n^2` for the collision. The per-term seed guarantee from #1596 covers exactly this class, which is now documented in `_pick_seeds`' docstring alongside the coverage note. A symmetric coverage boost for the flat tier would be a larger behavioral change than this PR wants to take on; happy to explore it separately if you think it is worth it.

One more trade-off worth naming: on very long queries (10+ content terms after stopword filtering), a node matching exactly one term via prefix (`100/n^2`) can score below a node matching one term via substring (flat 1.0). Both are weak candidates for such queries, and the per-term guarantee still seeds each term's best node (single-term coverage == 1), but it is a place where the eval could be extended if you want stricter tier monotonicity.

## Tests

- New regression test reproducing the second #1602 repro: the query contains the target's literal identifier, yet three same-directory `list()` leaves outrank it on base `v8`. Fails on `v8`, passes with this change, with a 30% score margin so IDF drift will not flake it.
- New no-change test pinning the exact full-coverage score (`query "FooBarService"` class), so identifier dominance is provably untouched.
- `tests/test_serve.py`: 78/78 pass. `ruff check`: clean. The full suite's only failures on this machine are environment-specific (local provider env vars, XAML grammar) and reproduce identically on the unpatched base.
