### PR TITLE
fix(extract): don't bind TS/JS builtin static calls (Date.now(), …) to same-named user symbols (#1726)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -12026,6 +12026,13 @@ def _resolve_typescript_member_calls(
             type_name = type_table_by_file.get(rc.get("source_file", ""), {}).get(receiver)
         if not type_name:
             continue
+        # `Date.now()`, `Object.keys()`, `Math.max()`, `JSON.parse()` … the receiver
+        # is an ECMAScript built-in global, not a user type. `_key()` case-folds, so a
+        # capitalized builtin (`Date`) would otherwise bind to a same-spelled user
+        # symbol (a module-local `const DATE`), manufacturing a false god-node with
+        # hundreds of cross-file edges. Mirrors the call-edge builtin guard. (#1726)
+        if type_name in _LANGUAGE_BUILTIN_GLOBALS:
+            continue
         type_defs = type_def_nids.get(_key(type_name), [])
         if len(type_defs) != 1:
             continue

--- a/tests/test_case_sensitive_resolution.py
+++ b/tests/test_case_sensitive_resolution.py
@@ -85,3 +85,55 @@ def test_php_case_insensitive_resolution_preserved(tmp_path):
     calls = {(lbl.get(e["source"]), lbl.get(e["target"]))
              for e in r["edges"] if e["relation"] == "calls"}
     assert ("run()", "Greet()") in calls, "PHP identifiers are case-insensitive; fold must still apply"
+
+
+def test_ts_builtin_static_call_does_not_resolve_to_user_symbol(tmp_path):
+    """`Date.now()` must not bind to a same-spelled user `const DATE` (#1726).
+
+    The TS/JS member-call resolver treats a capitalized receiver as a type name and
+    matches it case-folded. Without a builtin guard, `Date.now()` in every file across
+    the corpus resolves to a lone module-local `const DATE`, turning it into a false
+    god-node with hundreds of cross-file edges.
+    """
+    r = _extract(tmp_path, {
+        "format.ts": (
+            "const DATE = new Intl.DateTimeFormat('en-US', {});\n"
+            "export function fmt(x: number): string { return DATE.format(x); }\n"
+        ),
+        # A typed param (`d: Date`) populates the file's TS type table, which is what
+        # arms the cross-file member-call resolver — the real-world service shape.
+        "svc.ts": (
+            "export class Svc {\n"
+            "  expiry(d: Date): Date { return d; }\n"
+            "  stamp(): number { return Date.now(); }\n"
+            "  when(): string { return new Date().toISOString(); }\n"
+            "}\n"
+        ),
+    })
+    lbl = _labels(r)
+    date_nid = next((n["id"] for n in r["nodes"] if n["label"] == "DATE"), None)
+    assert date_nid is not None
+    leaked = [
+        e for e in r["edges"]
+        if e["target"] == date_nid and lbl.get(e["source"], "").startswith((".stamp", ".when"))
+    ]
+    assert not leaked, f"builtin `Date` leaked onto user `const DATE`: {leaked}"
+
+
+def test_ts_receiver_typed_member_call_still_resolves(tmp_path):
+    """The builtin guard must not break the resolver's real job: constructor-injection
+    type tables (`this.repo.findById()` → `UserRepo.findById`)."""
+    r = _extract(tmp_path, {
+        "repo.ts": "export class UserRepo { findById(id: string): number { return 1; } }\n",
+        "svc.ts": (
+            "import { UserRepo } from './repo';\n"
+            "export class Svc {\n"
+            "  constructor(private repo: UserRepo) {}\n"
+            "  go(): number { return this.repo.findById('x'); }\n"
+            "}\n"
+        ),
+    })
+    lbl = _labels(r)
+    calls = {(lbl.get(e["source"]), lbl.get(e["target"]))
+             for e in r["edges"] if e["relation"] == "calls"}
+    assert (".go()", ".findById()") in calls


### PR DESCRIPTION
## What

Fixes #1726 — TS/JS static calls on ECMAScript built-in globals (`Date.now()`, `Object.keys()`, `Math.max()`, …) bind to a same-spelled user symbol, creating a false god-node.

## Root cause

`_resolve_typescript_member_calls` treats a capitalized member-call receiver as a **type name** and matches it through `_key()`, which case-folds:

```python
if receiver[:1].isupper():
    type_name = receiver            # "Date"
...
type_defs = type_def_nids.get(_key(type_name), [])   # _key("Date") == "date"
```

If the corpus has a lone user symbol whose name case-folds to the same key — e.g. a module-local `const DATE` (`_key("DATE") == "date"`) — it is the unique match. Since the const has no `now` method, the resolver falls to `relation = "references"` and emits a `references`/`call` edge onto it. `Date.now()` (and friends) appear in nearly every file, so the one user symbol accumulates hundreds of cross-file edges.

Observed on a real 3,368-file repo: a non-exported `const DATE` became the **#1 god-node — 472 edges, betweenness 0.435, bridging ~130 communities.** Every source was a method calling `new Date()` / `Date.now()` in unrelated packages.

The call-edge pass (`if callee in _LANGUAGE_BUILTIN_GLOBALS: continue`) and the raw-call pass already guard against exactly this. The member-call resolver was the one path that didn't.

## Fix

One guard, mirroring the existing ones — skip the receiver when it is a language builtin:

```python
if type_name in _LANGUAGE_BUILTIN_GLOBALS:
    continue
```

`Date` is already in `_LANGUAGE_BUILTIN_GLOBALS` (alongside `Object`, `Array`, `Math`, `JSON`, `Promise`, …), so no list changes are needed.

## Scope / safety

- Legitimate receiver-typed member calls are unaffected — the resolver's real job (constructor-injection type tables, `this.repo.findById()` → `UserRepo.findById`) still resolves. Covered by an added test.
- A user type genuinely named like a builtin (`class Date`) matched case-**sensitively** would have resolved before this branch anyway; a builtin receiver never legitimately targets an unrelated same-folded user symbol.

## Tests

`tests/test_case_sensitive_resolution.py`:
- `test_ts_builtin_static_call_does_not_resolve_to_user_symbol` — reproduces the leak (fails without the guard, passes with it).
- `test_ts_receiver_typed_member_call_still_resolves` — pins that legitimate cross-file member-call resolution is preserved.

Full suite green locally (2848 passed; the only failures are pre-existing `tree_sitter_hcl not installed` Terraform tests, unrelated to this change).

