### PR TITLE
fix(extract): warn when files are skipped due to a missing optional dependency (#1745)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3742,6 +3742,20 @@ _DISPATCH: dict[str, Any] = {
 }
 
 
+# Extensions whose extractor depends on an optional-dependency extra
+# (pyproject [project.optional-dependencies]) and hard-fails without it,
+# rather than falling back like Pascal does. Used by the #1745 warning in
+# extract() to tell the user which extra restores the language.
+_EXTRA_FOR_EXTENSION = {
+    ".sql": "sql",
+    ".tf": "terraform",
+    ".tfvars": "terraform",
+    ".hcl": "terraform",
+    ".dm": "dm",
+    ".dme": "dm",
+}
+
+
 # Extensionless executables (CLI entry points like `devctl` or `manage`) carry
 # their language in the shebang, not the suffix. detect.classify_file already
 # routes them to the CODE path via _shebang_interpreter; _get_extractor must
@@ -4198,6 +4212,35 @@ def extract(
             f"  warning: {_tot} file(s) are classified as code but graphify has no AST "
             f"extractor for their language, so they contributed nothing to the graph: "
             f"{_by_count}. Please open an issue to request support for these (#1689).",
+            file=sys.stderr, flush=True,
+        )
+
+    # #1745: an extractor IS wired up for these files but bailed out because its
+    # dependency is missing (e.g. .sql needs tree-sitter-sql from the [sql]
+    # extra). Neither warning above fires — #1666 skips results that carry an
+    # error, #1689 only covers files with no extractor — so the graph builds
+    # "successfully" while every such file silently contributes nothing.
+    # Surface them grouped by extension, naming the extra that provides the
+    # dependency when there is one.
+    _missing_dep_count: dict[str, int] = {}
+    _missing_dep_error: dict[str, str] = {}
+    for i, _p in enumerate(paths):
+        _err = (per_file[i] or {}).get("error") or ""
+        if "not installed" in _err:
+            _ext = _p.suffix.lower()
+            _missing_dep_count[_ext] = _missing_dep_count.get(_ext, 0) + 1
+            _missing_dep_error.setdefault(_ext, _err)
+    for _ext, _n in sorted(_missing_dep_count.items(), key=lambda kv: (-kv[1], kv[0])):
+        _extra = _EXTRA_FOR_EXTENSION.get(_ext)
+        if _extra:
+            _reason = _missing_dep_error[_ext].split(". ")[0]
+            _hint = f' Install it with: pip install "graphifyy[{_extra}]"'
+        else:
+            _reason = _missing_dep_error[_ext]
+            _hint = ""
+        print(
+            f"  warning: {_n} {_ext} file(s) contributed nothing to the graph "
+            f"because a dependency is missing: {_reason}.{_hint} (#1745)",
             file=sys.stderr, flush=True,
         )
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,7 +1,11 @@
 import json
 import os
+import sys
 from collections import Counter
 from pathlib import Path
+
+import pytest
+
 from graphify.extract import extract_python, extract, collect_files, _make_id, extract_bash, extract_json, _DISPATCH
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -1826,6 +1830,36 @@ def test_extract_no_warning_when_all_code_has_extractors(tmp_path, capsys):
     extract([py], cache_root=tmp_path)
     err = capsys.readouterr().err
     assert "no AST extractor" not in err
+
+
+def test_extract_warns_when_sql_extra_missing(tmp_path, capsys, monkeypatch):
+    # #1745: .sql HAS a dispatch entry, so the #1689 warning can't fire, and
+    # extract_sql returns an "error" result when tree-sitter-sql is absent, so
+    # the #1666 warning skips it too. The files must not vanish silently:
+    # extract() surfaces them with the [sql] extra named.
+    monkeypatch.setitem(sys.modules, "tree_sitter_sql", None)  # import -> ImportError
+    s1 = tmp_path / "schema.sql"; s1.write_text("CREATE TABLE users (id INT);\n")
+    s2 = tmp_path / "views.sql"; s2.write_text("CREATE VIEW v AS SELECT * FROM users;\n")
+    py = tmp_path / "main.py"; py.write_text("def main():\n    return 1\n")
+
+    result = extract([s1, s2, py], cache_root=tmp_path)
+    err = capsys.readouterr().err
+
+    assert "2 .sql file(s)" in err
+    assert "tree_sitter_sql not installed" in err
+    assert 'graphifyy[sql]' in err
+    assert "#1745" in err
+    # the Python file still extracts normally
+    labels = [n.get("label") for n in result["nodes"]]
+    assert any(str(l).startswith("main") for l in labels)
+
+
+def test_extract_no_missing_dep_warning_when_sql_installed(tmp_path, capsys):
+    pytest.importorskip("tree_sitter_sql")
+    s = tmp_path / "schema.sql"; s.write_text("CREATE TABLE users (id INT);\n")
+    extract([s], cache_root=tmp_path)
+    err = capsys.readouterr().err
+    assert "#1745" not in err
 
 
 def test_extract_progress_final_line_uses_consistent_denominator(tmp_path, capsys):


### PR DESCRIPTION
Fixes #1745.

## Problem

When the `[sql]` extra isn't installed, `extract_sql` returns an `"error"` result for every `.sql` file — and nothing consumes it. Both existing safety nets deliberately miss this case:

- the **#1666** zero-node warning skips any result carrying an `error`
- the **#1689** no-extractor warning only covers extensions with no dispatch entry, and `.sql` has one

So the graph builds "successfully" while the entire SQL schema silently contributes nothing. The same mechanism affects the other optional grammars that hard-fail on import: `.tf`/`.tfvars`/`.hcl` (`[terraform]`) and `.dm`/`.dme` (`[dm]`). Pascal is unaffected — it falls back to its regex extractor.

## Fix

`extract()` now surfaces these files right after the #1689 block, grouped by extension, naming the extra that restores the language:

```
warning: 2 .sql file(s) contributed nothing to the graph because a dependency is missing: tree_sitter_sql not installed. Install it with: pip install "graphifyy[sql]" (#1745)
```

A new `_EXTRA_FOR_EXTENSION` map lives next to `_DISPATCH` so the two stay in sight of each other. For a missing *core* grammar (broken env), the extension isn't in the map and the extractor's own error is printed verbatim with no extra hint.

## Tests

Mirrors the #1689 regression tests: one simulates the missing dependency (`monkeypatch.setitem(sys.modules, "tree_sitter_sql", None)`) and asserts the warning fires while a sibling `.py` file still extracts normally; one asserts no warning when the extra is installed. Full `tests/test_extract.py` passes (117/117), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)