### PR TITLE
feat: central graph store (graphify remote init/push/pull/delete) — graphify-out links into a store folder + repo-local sync hooks

### DIFF
--- a/docs/graph-store.md
+++ b/docs/graph-store.md
@@ -10,7 +10,10 @@ anything) and a clone carries its own sync behaviour.
 ## One-command setup
 
 ```bash
-graphify remote init
+graphify remote init                       # private S3/MinIO (default)
+graphify remote init --backend s3-public   # authenticated push, URL-only pull — readers need NO creds
+graphify remote init --backend git-lfs     # a git repo with git-lfs
+graphify remote init --backend rsync       # rsync / SSH / a mounted network share
 ```
 
 creates the repo's committed graphify home:
@@ -93,7 +96,9 @@ interpreter by extension, so it also works on Windows where shebangs are ignored
 **Secrets stay out of the repo.** The committed hooks read credentials from the
 environment (env vars, `~/.aws`, …) — the starter S3 hooks use `GRAPHIFY_BUCKET`
 / `GRAPHIFY_S3_ENDPOINT` plus boto3's standard credential chain, and skip
-`cache/` (a local-only accelerator). Extra non-secret keys you add to
+`cache/` (a local-only accelerator). With the **`s3-public`** backend only
+*pushers* need creds — readers pull from the committed public `store_url` over plain
+HTTP (a `_manifest.json` lists the keys, so no listing, no SDK, no keys). Extra non-secret keys you add to
 `config.json` are yours to read — hooks get its path as `GRAPHIFY_CONFIG`.
 
 ### Hook environment

--- a/docs/graph-store.md
+++ b/docs/graph-store.md
@@ -1,0 +1,131 @@
+# Central graph store + push/pull hooks
+
+By default graphify writes `graphify-out/` in the current directory. For teams —
+especially monorepos where graphs run 300MB–1GB per module — you can keep **all**
+graph data in a central **store folder** instead: the repo never holds the bytes,
+only a link. Sharing happens through **push/pull hooks committed in the repo**, so
+graphify stays backend-agnostic (S3, MinIO, git-lfs, rsync, a network share,
+anything) and a clone carries its own sync behaviour.
+
+## One-command setup
+
+```bash
+graphify remote init
+```
+
+creates the repo's committed graphify home:
+
+```
+.graphify/
+├── config.json     { "store": "~/graphify-store" }   ← edit if you want
+├── push.py         starter S3/MinIO hooks — swap for push.sh/.js/.ps1/.cmd
+└── pull.py         (same name) or any script via config.json {"push": "<path>"}
+```
+
+Commit `.graphify/` and the team is onboarded: teammates clone and run
+`graphify remote pull`. Existing files are never overwritten; a hook already present in
+another language is respected.
+
+## How the store works
+
+Any graphify command first makes sure `./graphify-out` is a **link** into the
+store:
+
+```
+~/graphify-store/                                ← the real data (outside the repo)
+└── myrepo/
+    └── mybranch/
+        ├── graphify-out/                        ← repo-root graphs
+        └── services/api/graphify-out/           ← that module's graphs
+
+myrepo/                                          ← the git repo
+├── .graphify/                                   ← committed (config + hooks)
+├── graphify-out         → ~/graphify-store/myrepo/mybranch/graphify-out
+└── services/api/graphify-out → …/mybranch/services/api/graphify-out
+```
+
+- POSIX: a symlink. Windows: a **directory junction** — no admin rights, but the
+  store must be a local path there (the hooks do the network leg).
+- Every write physically lands in the store; every literal `graphify-out/...`
+  path — CLI defaults, the agent skill's code blocks, plain `cat` — keeps working
+  through the link. **The skill needs no changes.**
+- `<repo>/<branch>` come from git — the repo name from the origin remote's
+  basename (so every clone keys the same, whatever its folder is called; no
+  remote → folder name; `{ "repo": "name" }` in the config overrides both).
+  Branches never collide, and switching branches retargets the link on the next
+  graphify run.
+- A monorepo gets one link per directory you build in, keyed by its repo-relative
+  path. `graphify remote pull` additionally fans links out for **every** module already
+  present in the store, so a fresh clone reads any module's graphs (e.g.
+  `merge-graphs ./services/api/graphify-out/graph.json` from the root) after one
+  pull.
+- A pre-existing real `graphify-out/` folder is **migrated** into the store once
+  (contents moved, folder replaced by the link).
+- No `.graphify/config.json` (or no `store` key) → the classic local
+  `./graphify-out`, nothing changes. An absolute `GRAPHIFY_OUT` env override also
+  disables linking.
+
+### git never sees the data
+
+When graphify creates a link it also ensures the repo-root `.gitignore` contains a
+bare `graphify-out` entry (creating the file if needed). Bare on purpose: the
+common `graphify-out/` pattern matches only *directories*, and git treats a POSIX
+symlink as a file — with the trailing slash the links themselves would appear in
+`git status`. The bare entry matches the symlink, the junction, and a plain folder
+alike, at any depth, so one line covers every module. Even unignored, a symlink
+commits as a ~100-byte target path — git never follows it into content.
+
+## Sync hooks
+
+`graphify remote push` / `graphify remote pull` run a hook — any executable: Python, Node,
+shell, PowerShell, `.cmd`/`.bat`, or a binary. The contract: mirror
+`GRAPHIFY_STORE_DIR` (the `<store>/<repo>/<branch>` tree) to/from your backend and
+exit non-zero on failure. If the store folder is already shared (NFS, Dropbox, …),
+you never need push/pull. To leave the store later, `graphify remote delete` turns every link back into a real local folder (a copy — the store is untouched); then delete `.graphify/` and commit.
+
+Resolution order:
+1. an explicit path in `.graphify/config.json`:
+   `{ "store": "...", "push": "./scripts/push.py", "pull": "./scripts/pull.py" }`
+2. `.graphify/<push|pull>.{py,js,mjs,cjs,sh,ps1,cmd,bat}` committed in the repo
+
+An executable hook runs directly (its shebang wins — e.g.
+`#!/usr/bin/env -S uv run --with boto3 python3`); otherwise graphify picks the
+interpreter by extension, so it also works on Windows where shebangs are ignored.
+
+**Secrets stay out of the repo.** The committed hooks read credentials from the
+environment (env vars, `~/.aws`, …) — the starter S3 hooks use `GRAPHIFY_BUCKET`
+/ `GRAPHIFY_S3_ENDPOINT` plus boto3's standard credential chain, and skip
+`cache/` (a local-only accelerator). Extra non-secret keys you add to
+`config.json` are yours to read — hooks get its path as `GRAPHIFY_CONFIG`.
+
+### Hook environment
+
+| Variable | Meaning |
+|---|---|
+| `GRAPHIFY_ACTION` | `push` or `pull` |
+| `GRAPHIFY_STORE_DIR` | `<store>/<repo>/<branch>` — the tree to mirror |
+| `GRAPHIFY_STORE` | the configured store base folder (expanded) |
+| `GRAPHIFY_CONFIG` | path to `.graphify/config.json` (read your own extra keys) |
+| `GRAPHIFY_REPO_ROOT` | repo top-level dir (context only — data is not here) |
+| `GRAPHIFY_REPO` / `GRAPHIFY_BRANCH` | store key parts |
+| `GRAPHIFY_PREFIX` | `"<repo>/<branch>"` — a natural object-key / path prefix |
+
+## Typical team flow
+
+```bash
+# publisher (once)
+graphify remote init   # .graphify/ with config + hooks; edit, then commit it
+graphify .             # writes through the link into the store (per module: cd m && graphify .)
+graphify remote push   # hook uploads <store>/<repo>/<branch>/
+
+# teammate
+git clone … && cd …
+graphify remote pull   # hook downloads the store tree AND recreates a graphify-out
+                       # link for every module found in it — the whole working set
+graphify query "how does auth work?"
+```
+
+Graphs never enter git; the repo carries only `.graphify/` and the auto-maintained
+`.gitignore` entry. Note `graphify update .` / `watch` write through the link too —
+keep the store on a local disk (hooks do the network leg) so incremental updates
+stay fast.

--- a/docs/graph-store.md
+++ b/docs/graph-store.md
@@ -17,7 +17,7 @@ creates the repo's committed graphify home:
 
 ```
 .graphify/
-├── config.json     { "store": "~/graphify-store" }   ← edit if you want
+├── config.json     { "store": "~/graphify-store/<repo>" }  ← edit to any path
 ├── push.py         starter S3/MinIO hooks — swap for push.sh/.js/.ps1/.cmd
 └── pull.py         (same name) or any script via config.json {"push": "<path>"}
 ```
@@ -32,16 +32,14 @@ Any graphify command first makes sure `./graphify-out` is a **link** into the
 store:
 
 ```
-~/graphify-store/                                ← the real data (outside the repo)
-└── myrepo/
-    └── mybranch/
-        ├── graphify-out/                        ← repo-root graphs
-        └── services/api/graphify-out/           ← that module's graphs
+~/graphify-store/myrepo/                         ← the store path you set (outside the repo)
+├── graphify-out/                                ← repo-root graphs
+└── services/api/graphify-out/                   ← that module's graphs
 
 myrepo/                                          ← the git repo
 ├── .graphify/                                   ← committed (config + hooks)
-├── graphify-out         → ~/graphify-store/myrepo/mybranch/graphify-out
-└── services/api/graphify-out → …/mybranch/services/api/graphify-out
+├── graphify-out         → ~/graphify-store/myrepo/graphify-out
+└── services/api/graphify-out → …/services/api/graphify-out
 ```
 
 - POSIX: a symlink. Windows: a **directory junction** — no admin rights, but the
@@ -49,11 +47,11 @@ myrepo/                                          ← the git repo
 - Every write physically lands in the store; every literal `graphify-out/...`
   path — CLI defaults, the agent skill's code blocks, plain `cat` — keeps working
   through the link. **The skill needs no changes.**
-- `<repo>/<branch>` come from git — the repo name from the origin remote's
-  basename (so every clone keys the same, whatever its folder is called; no
-  remote → folder name; `{ "repo": "name" }` in the config overrides both).
-  Branches never collide, and switching branches retargets the link on the next
-  graphify run.
+- **The store path is the whole key** — no `<repo>`/`<branch>` segments. The repo
+  points at the same store location on *every* branch (switch branches → no
+  retarget, no rebuild; `graphify update` refreshes the graph), and each repo
+  simply names its own store path in its config. `graphify remote init` defaults
+  the path to `~/graphify-store/<folder>`; change it to anything you like.
 - A monorepo gets one link per directory you build in, keyed by its repo-relative
   path. `graphify remote pull` additionally fans links out for **every** module already
   present in the store, so a fresh clone reads any module's graphs (e.g.
@@ -79,7 +77,7 @@ commits as a ~100-byte target path — git never follows it into content.
 
 `graphify remote push` / `graphify remote pull` run a hook — any executable: Python, Node,
 shell, PowerShell, `.cmd`/`.bat`, or a binary. The contract: mirror
-`GRAPHIFY_STORE_DIR` (the `<store>/<repo>/<branch>` tree) to/from your backend and
+`GRAPHIFY_STORE_DIR` (the `<store>` tree) to/from your backend and
 exit non-zero on failure. If the store folder is already shared (NFS, Dropbox, …),
 you never need push/pull. To leave the store later, `graphify remote delete` turns every link back into a real local folder (a copy — the store is untouched); then delete `.graphify/` and commit.
 
@@ -103,12 +101,11 @@ environment (env vars, `~/.aws`, …) — the starter S3 hooks use `GRAPHIFY_BUC
 | Variable | Meaning |
 |---|---|
 | `GRAPHIFY_ACTION` | `push` or `pull` |
-| `GRAPHIFY_STORE_DIR` | `<store>/<repo>/<branch>` — the tree to mirror |
-| `GRAPHIFY_STORE` | the configured store base folder (expanded) |
+| `GRAPHIFY_STORE_DIR` | the configured `<store>` path — the tree to mirror |
+| `GRAPHIFY_STORE` | the same store path, expanded |
 | `GRAPHIFY_CONFIG` | path to `.graphify/config.json` (read your own extra keys) |
 | `GRAPHIFY_REPO_ROOT` | repo top-level dir (context only — data is not here) |
-| `GRAPHIFY_REPO` / `GRAPHIFY_BRANCH` | store key parts |
-| `GRAPHIFY_PREFIX` | `"<repo>/<branch>"` — a natural object-key / path prefix |
+| `GRAPHIFY_PREFIX` | the store folder's basename — a natural object-key prefix |
 
 ## Typical team flow
 
@@ -116,7 +113,7 @@ environment (env vars, `~/.aws`, …) — the starter S3 hooks use `GRAPHIFY_BUC
 # publisher (once)
 graphify remote init   # .graphify/ with config + hooks; edit, then commit it
 graphify .             # writes through the link into the store (per module: cd m && graphify .)
-graphify remote push   # hook uploads <store>/<repo>/<branch>/
+graphify remote push   # hook uploads the <store> tree
 
 # teammate
 git clone … && cd …

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -575,6 +575,10 @@ def main() -> None:
         print("    --cargo                 extract crate→crate deps from Cargo.toml")
         print("    --global                also merge the resulting graph into the global graph")
         print("    --as <tag>              repo tag for --global (default: target directory name)")
+        print("  remote init              set up a central graph store: .graphify/ with config.json + push/pull hooks")
+        print("  remote push              run the push hook — upload the central graph store (docs/graph-store.md)")
+        print("  remote pull              run the pull hook — download the store + recreate graphify-out links")
+        print("  remote delete            leave the store — turn graphify-out links back into real local folders")
         print("  global add <graph.json>  add/update a project graph in the global graph (~/.graphify/global-graph.json)")
         print("    --as <tag>               repo tag (default: parent directory name)")
         print("  global remove <tag>      remove a repo's nodes from the global graph")
@@ -663,6 +667,19 @@ def main() -> None:
     if cmd not in _FREE_TEXT_CMDS and any(a in {"-h", "--help", "-?"} for a in sys.argv[2:]):
         print(f"Run 'graphify --help' for full usage.")
         return
+
+    # Central graph store (graphify.store): when .graphify/config.json selects a
+    # store folder, keep ./graphify-out linked into it before any command runs,
+    # so writes land in the store and literal graphify-out/... reads keep
+    # working. Skipped for the silent hook commands (must not print) and never
+    # blocks the actual command.
+    if cmd not in _silent_cmds:
+        try:
+            from graphify.store import ensure_out_link
+
+            ensure_out_link()
+        except Exception as exc:
+            print(f"warning: graph-store link upkeep failed: {exc}", file=sys.stderr)
 
     if dispatch_install_cli(cmd):
         return

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -1823,6 +1823,10 @@ def dispatch_command(cmd: str) -> None:
         result = run_benchmark(graph_path, corpus_words=corpus_words)
         print_benchmark(result)
 
+    elif cmd == "remote":
+        from graphify.remote import cmd_remote as _remote
+        _remote(sys.argv[2:])
+
     elif cmd == "global":
         subcmd = sys.argv[2] if len(sys.argv) > 2 else ""
         from graphify.global_graph import (

--- a/graphify/remote.py
+++ b/graphify/remote.py
@@ -130,7 +130,7 @@ def cmd_remote(argv: list[str]) -> None:
     else:
         print(
             "Usage: graphify remote <command>\n"
-            "  remote init      scaffold .graphify/ (store config + push/pull hooks)\n"
+            "  remote init      scaffold .graphify/ (config + hooks; --backend s3|s3-public|git-lfs|rsync)\n"
             "  remote push      run the push hook — upload the central graph store\n"
             "  remote pull      run the pull hook — download the store + recreate links\n"
             "  remote delete    leave the store — links become real local folders",
@@ -169,14 +169,24 @@ def cmd_deinit(argv: list[str]) -> None:
 # ---------------------------------------------------------------- scaffolding
 
 def cmd_init(argv: list[str]) -> None:
-    """`graphify remote init` — bootstrap the repo's committed ``.graphify/`` folder.
+    """`graphify remote init [--backend s3|s3-public|git-lfs|rsync]` — bootstrap ``.graphify/``.
 
-    Writes ``.graphify/config.json`` (if missing, with the default store) plus
-    starter ``push.py``/``pull.py`` hooks, so one command + one commit onboards
-    the whole team. Existing files are never overwritten, and a hook already
-    present under another extension (``push.sh``, ``pull.js``, …) is respected.
+    Writes ``.graphify/config.json`` (if missing) plus starter ``push``/``pull``
+    hooks for the chosen backend, so one command + one commit onboards the whole
+    team. Existing files are never overwritten, and a hook already present under
+    another extension (``push.sh``, ``pull.js``, …) is respected.
     """
     import json
+    from graphify import remote_hook_templates as tpl
+
+    backend = tpl.DEFAULT_BACKEND
+    if "--backend" in argv:
+        i = argv.index("--backend")
+        backend = argv[i + 1] if i + 1 < len(argv) else ""
+    if backend not in tpl.TEMPLATES:
+        opts = "\n".join(f"  {n:10} {t['desc']}" for n, t in tpl.TEMPLATES.items())
+        sys.exit(f"unknown --backend {backend!r}. Choose one:\n{opts}")
+    spec = tpl.TEMPLATES[backend]
 
     found = _store.find_config()
     if found:
@@ -186,15 +196,17 @@ def cmd_init(argv: list[str]) -> None:
         base = Path(toplevel) if toplevel else Path.cwd()
     dest_dir = base / _store.CONFIG_DIR
     dest_dir.mkdir(parents=True, exist_ok=True)
+
     config = _store.config_path(base)
     if config.is_file():
         print(f"kept existing {config}")
     else:
-        default_store = f"~/graphify-store/{base.name}"
-        config.write_text(json.dumps({"store": default_store}, indent=2) + "\n")
-        print(f"wrote {config}  (store: {default_store} — edit the path to anything you like)")
-    from graphify import remote_hook_templates as tpl
-    for action, body in (("push", tpl.PUSH_S3), ("pull", tpl.PULL_S3)):
+        cfg = {"store": f"~/graphify-store/{base.name}"}
+        cfg.update(spec.get("config", {}))
+        config.write_text(json.dumps(cfg, indent=2) + "\n")
+        print(f"wrote {config}  (backend: {backend} — edit the store path / keys to taste)")
+
+    for action in ("push", "pull"):
         existing = next(
             (dest_dir / f"{action}{ext}" for ext in _HOOK_EXTS
              if (dest_dir / f"{action}{ext}").is_file()),
@@ -203,11 +215,15 @@ def cmd_init(argv: list[str]) -> None:
         if existing:
             print(f"kept existing {existing}")
             continue
-        dest = dest_dir / f"{action}.py"
+        ext, body = spec[action]
+        dest = dest_dir / f"{action}{ext}"
         dest.write_text(body)
         os.chmod(dest, 0o755)
         print(f"wrote {dest}")
+
+    others = ", ".join(n for n in tpl.TEMPLATES if n != backend)
     print(
-        "edit the hooks (bucket via GRAPHIFY_BUCKET / GRAPHIFY_S3_ENDPOINT, creds stay in the "
-        "env — never in the repo), then commit .graphify/. Teammates just: graphify remote pull"
+        "edit the hooks (secrets stay in the env — never in the repo), then commit .graphify/. "
+        f"Teammates just: graphify remote pull.  Other backends: {others} "
+        "(graphify remote init --backend <name>)."
     )

--- a/graphify/remote.py
+++ b/graphify/remote.py
@@ -1,0 +1,215 @@
+"""Sync the central graph store via a pluggable push/pull hook.
+
+With a ``.graphify/config.json`` store configured (see graphify.store), the
+real graph data lives in ``<store>/<repo>/<branch>/...`` and the repo only
+holds links. ``graphify push`` / ``graphify pull`` hand that store tree to a
+**hook** — a script (Python, JS, shell, PowerShell, ``.cmd``, or any
+executable) that mirrors it to a backend (S3, git-lfs, rsync, a network
+share, …). graphify itself has no backend dependency; if the store folder is
+already shared (NFS/Dropbox/…) you never need push/pull at all.
+
+Hooks live **in the repo** by default — ``.graphify/push.py`` /
+``.graphify/pull.py`` (any supported extension) committed next to the config,
+so a clone carries its own sync behaviour and teammates need zero per-machine
+setup (``graphify remote init`` scaffolds the folder). Secrets never enter the
+repo: hooks read credentials from the environment (env vars, ``~/.aws``, …).
+
+Hook resolution for action ``push``/``pull``:
+  1. an explicit path in ``.graphify/config.json`` — ``{"push": "...", "pull": "..."}``
+     (relative paths resolve against the config's folder)
+  2. ``.graphify/<action>.{py,js,mjs,cjs,sh,ps1,cmd,bat}`` in the repo, or an
+     extension-less executable of the same name
+
+The hook receives (via environment):
+  GRAPHIFY_ACTION     "push" | "pull"
+  GRAPHIFY_STORE_DIR  <store>/<repo>/<branch> — the tree to mirror
+  GRAPHIFY_STORE      the configured store base folder (expanded)
+  GRAPHIFY_CONFIG     path to .graphify/config.json (extra keys are yours)
+  GRAPHIFY_REPO_ROOT  the repo top-level dir (context; data is NOT here)
+  GRAPHIFY_REPO       repo name (config "repo" override, else origin basename)
+  GRAPHIFY_BRANCH     current branch
+  GRAPHIFY_PREFIX     "<repo>/<branch>" (a natural object-key / path prefix)
+
+Interpreter selection: an executable hook is run directly (its shebang wins —
+an author can pin ``#!/usr/bin/env -S uv run --with boto3 python``). Otherwise
+graphify maps by extension (.py→python, .js→node, .sh→bash, .ps1→powershell,
+.cmd/.bat→cmd) so it also works on Windows where shebangs are ignored.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from graphify import store as _store
+
+_HOOK_EXTS = (".py", ".js", ".mjs", ".cjs", ".sh", ".ps1", ".cmd", ".bat", "")
+
+
+def _context() -> dict:
+    ctx = _store.store_context()
+    if ctx is None:
+        sys.exit(
+            'no store configured — add { "store": "~/graphify-store" } to '
+            ".graphify/config.json at the repo root  (try: graphify remote init)"
+        )
+    return ctx
+
+
+# ---------------------------------------------------------------- hook resolution
+
+def _find_hook(cfg: dict, cfg_dir: Path, action: str) -> Path | None:
+    explicit = cfg.get(action)
+    if explicit:
+        p = Path(os.path.expanduser(explicit))
+        return p if p.is_absolute() else cfg_dir / p
+    for ext in _HOOK_EXTS:
+        cand = cfg_dir / _store.CONFIG_DIR / f"{action}{ext}"
+        if cand.is_file():
+            return cand
+    return None
+
+
+def _interpreter(hook: Path) -> list[str]:
+    # An executable hook runs directly so its shebang wins (custom envs, uv, etc.).
+    if os.name != "nt" and os.access(hook, os.X_OK):
+        return []
+    ext = hook.suffix.lower()
+    if ext == ".py":
+        return [sys.executable]
+    if ext in (".js", ".mjs", ".cjs"):
+        return ["node"]
+    if ext == ".sh":
+        return ["bash"]
+    if ext == ".ps1":
+        return ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File"]
+    if ext in (".cmd", ".bat"):
+        return ["cmd", "/c"]
+    return []  # last resort: let the OS try (shebang / association)
+
+
+def _run_hook(action: str) -> dict:
+    ctx = _context()
+    hook = _find_hook(ctx["cfg"], ctx["cfg_dir"], action)
+    if not hook or not hook.is_file():
+        sys.exit(
+            f"no {action} hook found — create .graphify/{action}.py (or .sh/.js/…) in the "
+            f"repo, or set \"{action}\": \"<script>\" in .graphify/config.json  "
+            f"(try: graphify remote init)"
+        )
+    store_dir = ctx["store_root"]
+    store_dir.mkdir(parents=True, exist_ok=True)
+    env = {
+        **os.environ,
+        "GRAPHIFY_ACTION": action,
+        "GRAPHIFY_STORE_DIR": str(store_dir),
+        "GRAPHIFY_STORE": str(ctx["store_base"]),
+        "GRAPHIFY_CONFIG": str(_store.config_path(ctx["cfg_dir"])),
+        "GRAPHIFY_REPO_ROOT": str(ctx["root"]),
+        "GRAPHIFY_REPO": ctx["repo"],
+        "GRAPHIFY_BRANCH": ctx["branch"],
+        "GRAPHIFY_PREFIX": f"{ctx['repo']}/{ctx['branch']}",
+    }
+    cmd = _interpreter(hook) + [str(hook)]
+    print(f"{action}: running hook {hook}")
+    result = subprocess.run(cmd, env=env)
+    if result.returncode != 0:
+        sys.exit(f"{action} hook failed (exit {result.returncode})")
+    return ctx
+
+
+def cmd_remote(argv: list[str]) -> None:
+    """`graphify remote <init|push|pull|delete>` — the central-graph-store group."""
+    sub = argv[0] if argv else ""
+    if sub == "init":
+        cmd_init(argv[1:])
+    elif sub == "push":
+        cmd_push(argv[1:])
+    elif sub == "pull":
+        cmd_pull(argv[1:])
+    elif sub in ("delete", "deinit"):
+        cmd_deinit(argv[1:])
+    else:
+        print(
+            "Usage: graphify remote <command>\n"
+            "  remote init      scaffold .graphify/ (store config + push/pull hooks)\n"
+            "  remote push      run the push hook — upload the central graph store\n"
+            "  remote pull      run the pull hook — download the store + recreate links\n"
+            "  remote delete    leave the store — links become real local folders",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def cmd_push(argv: list[str]) -> None:
+    _run_hook("push")
+
+
+def cmd_pull(argv: list[str]) -> None:
+    ctx = _run_hook("pull")
+    # Recreate the working set: one graphify-out link per module now present in
+    # the store, so a fresh clone can read every module's graphs immediately.
+    linked = _store.link_all(ctx)
+    if linked:
+        print(f"pull: linked {linked} module folder(s) into the store")
+
+
+def cmd_deinit(argv: list[str]) -> None:
+    """`graphify remote delete` — leave the central store: links become real folders.
+
+    Every ``graphify-out`` link is replaced by a plain local folder holding a
+    COPY of its store data (the store is untouched — other branches/teammates
+    keep working). Finish by deleting ``.graphify/`` and committing; the
+    ``graphify-out`` .gitignore entry is left for you to keep or drop.
+    """
+    ctx = _context()
+    n = _store.materialize(ctx)
+    print(f"remote delete: materialized {n} folder(s); store untouched at {ctx['store_root']}")
+    print("to finish: git rm -r .graphify && commit  (keep or drop the .gitignore entry)")
+
+
+# ---------------------------------------------------------------- scaffolding
+
+def cmd_init(argv: list[str]) -> None:
+    """`graphify remote init` — bootstrap the repo's committed ``.graphify/`` folder.
+
+    Writes ``.graphify/config.json`` (if missing, with the default store) plus
+    starter ``push.py``/``pull.py`` hooks, so one command + one commit onboards
+    the whole team. Existing files are never overwritten, and a hook already
+    present under another extension (``push.sh``, ``pull.js``, …) is respected.
+    """
+    import json
+
+    found = _store.find_config()
+    if found:
+        base = found[1]
+    else:
+        toplevel = _store.git_out(Path.cwd(), "rev-parse", "--show-toplevel")
+        base = Path(toplevel) if toplevel else Path.cwd()
+    dest_dir = base / _store.CONFIG_DIR
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    config = _store.config_path(base)
+    if config.is_file():
+        print(f"kept existing {config}")
+    else:
+        config.write_text(json.dumps({"store": "~/graphify-store"}, indent=2) + "\n")
+        print(f"wrote {config}  (edit the store path if you want)")
+    from graphify import remote_hook_templates as tpl
+    for action, body in (("push", tpl.PUSH_S3), ("pull", tpl.PULL_S3)):
+        existing = next(
+            (dest_dir / f"{action}{ext}" for ext in _HOOK_EXTS
+             if (dest_dir / f"{action}{ext}").is_file()),
+            None,
+        )
+        if existing:
+            print(f"kept existing {existing}")
+            continue
+        dest = dest_dir / f"{action}.py"
+        dest.write_text(body)
+        os.chmod(dest, 0o755)
+        print(f"wrote {dest}")
+    print(
+        "edit the hooks (bucket via GRAPHIFY_BUCKET / GRAPHIFY_S3_ENDPOINT, creds stay in the "
+        "env — never in the repo), then commit .graphify/. Teammates just: graphify remote pull"
+    )

--- a/graphify/remote.py
+++ b/graphify/remote.py
@@ -1,8 +1,9 @@
 """Sync the central graph store via a pluggable push/pull hook.
 
 With a ``.graphify/config.json`` store configured (see graphify.store), the
-real graph data lives in ``<store>/<repo>/<branch>/...`` and the repo only
-holds links. ``graphify push`` / ``graphify pull`` hand that store tree to a
+real graph data lives under the configured ``<store>`` path (no repo/branch
+segment) and the repo only holds links. ``graphify push`` / ``graphify pull``
+hand that store tree to a
 **hook** — a script (Python, JS, shell, PowerShell, ``.cmd``, or any
 executable) that mirrors it to a backend (S3, git-lfs, rsync, a network
 share, …). graphify itself has no backend dependency; if the store folder is
@@ -22,13 +23,11 @@ Hook resolution for action ``push``/``pull``:
 
 The hook receives (via environment):
   GRAPHIFY_ACTION     "push" | "pull"
-  GRAPHIFY_STORE_DIR  <store>/<repo>/<branch> — the tree to mirror
-  GRAPHIFY_STORE      the configured store base folder (expanded)
+  GRAPHIFY_STORE_DIR  the configured <store> path — the tree to mirror
+  GRAPHIFY_STORE      the configured store folder, expanded (same as above)
   GRAPHIFY_CONFIG     path to .graphify/config.json (extra keys are yours)
   GRAPHIFY_REPO_ROOT  the repo top-level dir (context; data is NOT here)
-  GRAPHIFY_REPO       repo name (config "repo" override, else origin basename)
-  GRAPHIFY_BRANCH     current branch
-  GRAPHIFY_PREFIX     "<repo>/<branch>" (a natural object-key / path prefix)
+  GRAPHIFY_PREFIX     the store folder's basename (a natural object-key prefix)
 
 Interpreter selection: an executable hook is run directly (its shebang wins —
 an author can pin ``#!/usr/bin/env -S uv run --with boto3 python``). Otherwise
@@ -107,9 +106,7 @@ def _run_hook(action: str) -> dict:
         "GRAPHIFY_STORE": str(ctx["store_base"]),
         "GRAPHIFY_CONFIG": str(_store.config_path(ctx["cfg_dir"])),
         "GRAPHIFY_REPO_ROOT": str(ctx["root"]),
-        "GRAPHIFY_REPO": ctx["repo"],
-        "GRAPHIFY_BRANCH": ctx["branch"],
-        "GRAPHIFY_PREFIX": f"{ctx['repo']}/{ctx['branch']}",
+        "GRAPHIFY_PREFIX": store_dir.name,
     }
     cmd = _interpreter(hook) + [str(hook)]
     print(f"{action}: running hook {hook}")
@@ -193,8 +190,9 @@ def cmd_init(argv: list[str]) -> None:
     if config.is_file():
         print(f"kept existing {config}")
     else:
-        config.write_text(json.dumps({"store": "~/graphify-store"}, indent=2) + "\n")
-        print(f"wrote {config}  (edit the store path if you want)")
+        default_store = f"~/graphify-store/{base.name}"
+        config.write_text(json.dumps({"store": default_store}, indent=2) + "\n")
+        print(f"wrote {config}  (store: {default_store} — edit the path to anything you like)")
     from graphify import remote_hook_templates as tpl
     for action, body in (("push", tpl.PUSH_S3), ("pull", tpl.PULL_S3)):
         existing = next(

--- a/graphify/remote_hook_templates.py
+++ b/graphify/remote_hook_templates.py
@@ -1,0 +1,82 @@
+"""Starter push/pull hook bodies scaffolded by `graphify remote init` into .graphify/.
+
+Examples, not graphify dependencies — a hook can do anything (S3, git, rsync,
+gcs). It receives the store context in the environment (see graphify.remote):
+GRAPHIFY_ACTION / GRAPHIFY_STORE_DIR / GRAPHIFY_PREFIX / GRAPHIFY_REPO /
+GRAPHIFY_BRANCH. The contract: mirror GRAPHIFY_STORE_DIR (the
+``<store>/<repo>/<branch>`` tree holding every module's graphify-out) to the
+backend under GRAPHIFY_PREFIX. Exit non-zero on failure.
+
+The shebang pins an env with boto3 so the hook is self-contained; on Windows,
+graphify runs a ``.py`` hook with its own interpreter (shebang ignored), so
+install boto3 there or swap the body for the AWS CLI.
+"""
+
+_HEADER = """#!/usr/bin/env -S uv run --with boto3 python3
+# graphify {action} hook (scaffolded by `graphify remote init`) — S3/MinIO starter.
+# Not married to Python: replace this file with {action}.sh / {action}.js /
+# {action}.ps1 / {action}.cmd (same name, any supported extension), or point
+# .graphify/config.json {{"{action}": "<path>"}} at any script/binary.
+# Contract: mirror $GRAPHIFY_STORE_DIR {arrow} your backend under $GRAPHIFY_PREFIX;
+# exit non-zero on failure. Credentials come from the environment (env vars,
+# ~/.aws, ...) — never commit secrets.
+"""
+
+_COMMON = '''
+import os, pathlib
+
+ACTION = os.environ["GRAPHIFY_ACTION"]
+STORE  = pathlib.Path(os.environ["GRAPHIFY_STORE_DIR"])   # <store>/<repo>/<branch>
+PREFIX = os.environ["GRAPHIFY_PREFIX"]                      # <repo>/<branch>
+BUCKET = os.environ.get("GRAPHIFY_BUCKET", "graphify-graphs")
+ENDPOINT = os.environ.get("GRAPHIFY_S3_ENDPOINT")           # e.g. http://127.0.0.1:9000 for MinIO
+
+def client():
+    import boto3
+    return boto3.client("s3", endpoint_url=ENDPOINT or None)  # creds from env / ~/.aws
+
+def skip(rel):  # the AST cache is a local accelerator, not shared
+    return "/cache/" in f"/{rel}"
+'''
+
+PUSH_S3 = _HEADER.format(action="push", arrow="->") + _COMMON + '''
+def main():
+    c = client()
+    n = 0
+    for f in STORE.rglob("*"):
+        if f.is_file():
+            rel = f.relative_to(STORE).as_posix()   # e.g. services/api/graphify-out/graph.json
+            if skip(rel):
+                continue
+            c.upload_file(str(f), BUCKET, f"{PREFIX}/{rel}")
+            n += 1
+    print(f"pushed {n} file(s) -> s3://{BUCKET}/{PREFIX}/")
+
+main()
+'''
+
+PULL_S3 = _HEADER.format(action="pull", arrow="<-") + _COMMON + '''
+def main():
+    c = client()
+    token, n = None, 0
+    while True:
+        kw = {"Bucket": BUCKET, "Prefix": PREFIX + "/"}
+        if token:
+            kw["ContinuationToken"] = token
+        resp = c.list_objects_v2(**kw)
+        for o in resp.get("Contents", []):
+            rel = o["Key"][len(PREFIX) + 1:]        # services/api/graphify-out/graph.json
+            if not rel or skip(rel):
+                continue
+            dest = STORE / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            c.download_file(BUCKET, o["Key"], str(dest))
+            n += 1
+        if resp.get("IsTruncated"):
+            token = resp.get("NextContinuationToken")
+        else:
+            break
+    print(f"pulled {n} file(s) <- s3://{BUCKET}/{PREFIX}/")
+
+main()
+'''

--- a/graphify/remote_hook_templates.py
+++ b/graphify/remote_hook_templates.py
@@ -1,24 +1,31 @@
-"""Starter push/pull hook bodies scaffolded by `graphify remote init` into .graphify/.
+"""Starter push/pull hook bodies scaffolded by `graphify remote init --backend <name>`.
 
-Examples, not graphify dependencies — a hook can do anything (S3, git, rsync,
-gcs). It receives the store context in the environment (see graphify.remote):
-GRAPHIFY_ACTION / GRAPHIFY_STORE_DIR / GRAPHIFY_PREFIX. The contract: mirror
-GRAPHIFY_STORE_DIR (the ``<store>`` tree holding every module's graphify-out)
-to the backend under GRAPHIFY_PREFIX. Exit non-zero on failure.
+These are EXAMPLES, not graphify dependencies — a hook can be any executable and do
+anything. graphify only runs `.graphify/push.*` / `pull.*` (see graphify.remote) and
+hands it the store context in the environment:
 
-The shebang pins an env with boto3 so the hook is self-contained; on Windows,
-graphify runs a ``.py`` hook with its own interpreter (shebang ignored), so
-install boto3 there or swap the body for the AWS CLI.
+    GRAPHIFY_ACTION     "push" | "pull"
+    GRAPHIFY_STORE_DIR  the <store> tree to mirror (holds every module's graphify-out)
+    GRAPHIFY_PREFIX     the store folder's basename (a natural object-key / path prefix)
+    GRAPHIFY_CONFIG     path to .graphify/config.json (read your own extra keys)
+    GRAPHIFY_STORE / GRAPHIFY_REPO_ROOT
+
+The contract: mirror GRAPHIFY_STORE_DIR to/from your backend under GRAPHIFY_PREFIX,
+exit non-zero on failure. Secrets come from the environment (env vars, ~/.aws, ~/.ssh)
+— never from the repo.
+
+Backends below (pick with `--backend`):
+  s3         private S3/MinIO — authenticated read AND write (boto3)
+  s3-public  public-read bucket — authenticated push, URL-only pull (readers need NO creds)
+  git-lfs    a git repo with git-lfs — versioned graphs
+  rsync      rsync / SSH / a mounted network share
 """
 
+# --------------------------------------------------------------- s3 (private)
 _HEADER = """#!/usr/bin/env -S uv run --with boto3 python3
-# graphify {action} hook (scaffolded by `graphify remote init`) — S3/MinIO starter.
-# Not married to Python: replace this file with {action}.sh / {action}.js /
-# {action}.ps1 / {action}.cmd (same name, any supported extension), or point
-# .graphify/config.json {{"{action}": "<path>"}} at any script/binary.
-# Contract: mirror $GRAPHIFY_STORE_DIR {arrow} your backend under $GRAPHIFY_PREFIX;
-# exit non-zero on failure. Credentials come from the environment (env vars,
-# ~/.aws, ...) — never commit secrets.
+# graphify {action} hook (scaffolded by `graphify remote init`) — private S3/MinIO.
+# Contract: mirror $GRAPHIFY_STORE_DIR {arrow} your backend under $GRAPHIFY_PREFIX.
+# Credentials come from the environment (env vars, ~/.aws) — never commit secrets.
 """
 
 _COMMON = '''
@@ -28,7 +35,7 @@ ACTION = os.environ["GRAPHIFY_ACTION"]
 STORE  = pathlib.Path(os.environ["GRAPHIFY_STORE_DIR"])   # the <store> tree
 PREFIX = os.environ["GRAPHIFY_PREFIX"]                      # store folder basename
 BUCKET = os.environ.get("GRAPHIFY_BUCKET", "graphify-graphs")
-ENDPOINT = os.environ.get("GRAPHIFY_S3_ENDPOINT")           # e.g. http://127.0.0.1:9000 for MinIO
+ENDPOINT = os.environ.get("GRAPHIFY_S3_ENDPOINT")          # e.g. http://127.0.0.1:9000 for MinIO
 
 def client():
     import boto3
@@ -44,7 +51,7 @@ def main():
     n = 0
     for f in STORE.rglob("*"):
         if f.is_file():
-            rel = f.relative_to(STORE).as_posix()   # e.g. services/api/graphify-out/graph.json
+            rel = f.relative_to(STORE).as_posix()
             if skip(rel):
                 continue
             c.upload_file(str(f), BUCKET, f"{PREFIX}/{rel}")
@@ -64,7 +71,7 @@ def main():
             kw["ContinuationToken"] = token
         resp = c.list_objects_v2(**kw)
         for o in resp.get("Contents", []):
-            rel = o["Key"][len(PREFIX) + 1:]        # services/api/graphify-out/graph.json
+            rel = o["Key"][len(PREFIX) + 1:]
             if not rel or skip(rel):
                 continue
             dest = STORE / rel
@@ -79,3 +86,134 @@ def main():
 
 main()
 '''
+
+# --------------------------------------------------------------- s3-public
+PUSH_S3_PUBLIC = '''#!/usr/bin/env -S uv run --with boto3 python3
+# graphify push hook — S3 PUBLIC-READ. Authenticated WRITE; readers pull with only a
+# URL (see pull.py). One-time: give the bucket a policy allowing anonymous
+# s3:GetObject, and put its public base URL in .graphify/config.json as "store_url".
+# We also write _manifest.json so readers never need to LIST the bucket.
+import os, json, boto3
+
+STORE  = os.environ["GRAPHIFY_STORE_DIR"]
+PREFIX = os.environ.get("GRAPHIFY_PREFIX", "").strip("/")
+BUCKET = os.environ.get("GRAPHIFY_BUCKET", "graphify-graphs")
+ENDPOINT = os.environ.get("GRAPHIFY_S3_ENDPOINT")
+s3 = boto3.client("s3", endpoint_url=ENDPOINT or None)   # creds from env / ~/.aws
+rels = []
+for root, dirs, files in os.walk(STORE):
+    dirs[:] = [d for d in dirs if d != "cache"]
+    for f in files:
+        p = os.path.join(root, f); rel = os.path.relpath(p, STORE)
+        s3.upload_file(p, BUCKET, f"{PREFIX}/{rel}" if PREFIX else rel); rels.append(rel)
+key = f"{PREFIX}/_manifest.json" if PREFIX else "_manifest.json"
+s3.put_object(Bucket=BUCKET, Key=key,
+              Body=json.dumps({"files": sorted(rels)}).encode(), ContentType="application/json")
+print(f"pushed {len(rels)} file(s) + manifest -> s3://{BUCKET}/{PREFIX}/  (public-read)")
+'''
+
+PULL_S3_PUBLIC = '''#!/usr/bin/env python3
+# graphify pull hook — URL-ONLY, no creds, no SDK (stdlib). Reads "store_url" (the
+# public base URL) from .graphify/config.json, GETs _manifest.json, then GETs each file.
+import os, sys, json, pathlib, urllib.request
+
+def cfg(k):
+    p = os.environ.get("GRAPHIFY_CONFIG")
+    try:
+        return json.load(open(p)).get(k) if p else None
+    except Exception:
+        return None
+
+url = (os.environ.get("GRAPHIFY_STORE_URL") or cfg("store_url") or "").rstrip("/")
+if not url:
+    sys.exit('pull: set "store_url": "<public base URL>" in .graphify/config.json')
+PREFIX = os.environ.get("GRAPHIFY_PREFIX", "").strip("/")
+STORE = os.environ["GRAPHIFY_STORE_DIR"]
+base = f"{url}/{PREFIX}" if PREFIX else url
+
+def get(u):
+    return urllib.request.urlopen(
+        urllib.request.Request(u, headers={"User-Agent": "graphify-pull"}), timeout=60).read()
+
+man = json.loads(get(f"{base}/_manifest.json"))
+n = 0
+for rel in man.get("files", []):
+    dest = pathlib.Path(STORE) / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(get(f"{base}/{rel}"))
+    n += 1
+print(f"pulled {n} file(s) <- {base}/  (URL-only, no creds)")
+'''
+
+# --------------------------------------------------------------- git-lfs
+PUSH_GITLFS = '''#!/usr/bin/env bash
+# graphify push hook — a git repo with git-lfs (versioned graphs).
+# Set GRAPHIFY_GIT_REMOTE to the store repo URL (e.g. git@github.com:you/graph-store.git).
+set -euo pipefail
+REMOTE="${GRAPHIFY_GIT_REMOTE:?set GRAPHIFY_GIT_REMOTE to the store git repo URL}"
+WORK="${GRAPHIFY_GIT_WORK:-$HOME/.cache/graphify-store-git}"
+if [ ! -d "$WORK/.git" ]; then
+  git clone "$REMOTE" "$WORK" 2>/dev/null || { mkdir -p "$WORK"; git -C "$WORK" init -q; git -C "$WORK" remote add origin "$REMOTE"; }
+fi
+git -C "$WORK" lfs install --local >/dev/null 2>&1 || true
+printf '* filter=lfs diff=lfs merge=lfs -text\\n.gitattributes -filter\\n' > "$WORK/.gitattributes"
+rsync -a --delete --exclude '.git' --exclude '*/cache/*' "$GRAPHIFY_STORE_DIR/" "$WORK/$GRAPHIFY_PREFIX/"
+git -C "$WORK" add -A
+git -C "$WORK" commit -qm "graphify store update" 2>/dev/null || { echo "push: nothing changed"; exit 0; }
+git -C "$WORK" push -u origin HEAD 2>&1 | tail -1
+echo "push: mirrored store -> $REMOTE (git-lfs)"
+'''
+
+PULL_GITLFS = '''#!/usr/bin/env bash
+# graphify pull hook — git-lfs. See push.sh for GRAPHIFY_GIT_REMOTE.
+set -euo pipefail
+REMOTE="${GRAPHIFY_GIT_REMOTE:?set GRAPHIFY_GIT_REMOTE to the store git repo URL}"
+WORK="${GRAPHIFY_GIT_WORK:-$HOME/.cache/graphify-store-git}"
+if [ -d "$WORK/.git" ]; then git -C "$WORK" pull -q; else git clone "$REMOTE" "$WORK"; fi
+mkdir -p "$GRAPHIFY_STORE_DIR"
+rsync -a --exclude '.git' "$WORK/$GRAPHIFY_PREFIX/" "$GRAPHIFY_STORE_DIR/"
+echo "pull: mirrored $REMOTE -> store (git-lfs)"
+'''
+
+# --------------------------------------------------------------- rsync / share
+PUSH_RSYNC = '''#!/usr/bin/env bash
+# graphify push hook — rsync to SSH or a mounted share (NFS/Dropbox/…).
+# Set GRAPHIFY_RSYNC_DEST, e.g. user@host:/srv/graphify  or  /mnt/share/graphify.
+# (If the store already lives on a shared drive, you don't need push/pull at all.)
+set -euo pipefail
+DEST="${GRAPHIFY_RSYNC_DEST:?set GRAPHIFY_RSYNC_DEST (user@host:/path or /shared/path)}"
+rsync -a --delete --exclude '*/cache/*' "$GRAPHIFY_STORE_DIR/" "$DEST/$GRAPHIFY_PREFIX/"
+echo "push: rsynced store -> $DEST/$GRAPHIFY_PREFIX/"
+'''
+
+PULL_RSYNC = '''#!/usr/bin/env bash
+# graphify pull hook — rsync. See push.sh for GRAPHIFY_RSYNC_DEST.
+set -euo pipefail
+DEST="${GRAPHIFY_RSYNC_DEST:?set GRAPHIFY_RSYNC_DEST (user@host:/path or /shared/path)}"
+mkdir -p "$GRAPHIFY_STORE_DIR"
+rsync -a "$DEST/$GRAPHIFY_PREFIX/" "$GRAPHIFY_STORE_DIR/"
+echo "pull: rsynced $DEST/$GRAPHIFY_PREFIX/ -> store"
+'''
+
+# --------------------------------------------------------------- registry
+# name -> {desc, push: (ext, body), pull: (ext, body), config: extra config.json keys}
+TEMPLATES = {
+    "s3": {
+        "desc": "private S3/MinIO — authenticated read AND write (boto3)",
+        "push": (".py", PUSH_S3), "pull": (".py", PULL_S3),
+    },
+    "s3-public": {
+        "desc": "public-read S3 — authenticated push, URL-only pull (readers need NO creds)",
+        "push": (".py", PUSH_S3_PUBLIC), "pull": (".py", PULL_S3_PUBLIC),
+        "config": {"store_url": "https://<bucket>.<endpoint>  # public base URL, safe to commit"},
+    },
+    "git-lfs": {
+        "desc": "a git repo with git-lfs (set GRAPHIFY_GIT_REMOTE)",
+        "push": (".sh", PUSH_GITLFS), "pull": (".sh", PULL_GITLFS),
+    },
+    "rsync": {
+        "desc": "rsync / SSH / a mounted network share (set GRAPHIFY_RSYNC_DEST)",
+        "push": (".sh", PUSH_RSYNC), "pull": (".sh", PULL_RSYNC),
+    },
+}
+DEFAULT_BACKEND = "s3"

--- a/graphify/remote_hook_templates.py
+++ b/graphify/remote_hook_templates.py
@@ -2,10 +2,9 @@
 
 Examples, not graphify dependencies — a hook can do anything (S3, git, rsync,
 gcs). It receives the store context in the environment (see graphify.remote):
-GRAPHIFY_ACTION / GRAPHIFY_STORE_DIR / GRAPHIFY_PREFIX / GRAPHIFY_REPO /
-GRAPHIFY_BRANCH. The contract: mirror GRAPHIFY_STORE_DIR (the
-``<store>/<repo>/<branch>`` tree holding every module's graphify-out) to the
-backend under GRAPHIFY_PREFIX. Exit non-zero on failure.
+GRAPHIFY_ACTION / GRAPHIFY_STORE_DIR / GRAPHIFY_PREFIX. The contract: mirror
+GRAPHIFY_STORE_DIR (the ``<store>`` tree holding every module's graphify-out)
+to the backend under GRAPHIFY_PREFIX. Exit non-zero on failure.
 
 The shebang pins an env with boto3 so the hook is self-contained; on Windows,
 graphify runs a ``.py`` hook with its own interpreter (shebang ignored), so
@@ -26,8 +25,8 @@ _COMMON = '''
 import os, pathlib
 
 ACTION = os.environ["GRAPHIFY_ACTION"]
-STORE  = pathlib.Path(os.environ["GRAPHIFY_STORE_DIR"])   # <store>/<repo>/<branch>
-PREFIX = os.environ["GRAPHIFY_PREFIX"]                      # <repo>/<branch>
+STORE  = pathlib.Path(os.environ["GRAPHIFY_STORE_DIR"])   # the <store> tree
+PREFIX = os.environ["GRAPHIFY_PREFIX"]                      # store folder basename
 BUCKET = os.environ.get("GRAPHIFY_BUCKET", "graphify-graphs")
 ENDPOINT = os.environ.get("GRAPHIFY_S3_ENDPOINT")           # e.g. http://127.0.0.1:9000 for MinIO
 

--- a/graphify/store.py
+++ b/graphify/store.py
@@ -1,0 +1,317 @@
+"""Central graph store: keep the graph data out of the repo via a link.
+
+A committed ``.graphify/config.json`` at the repo root selects a store folder:
+
+    { "store": "~/graphify-store" }
+
+The ``.graphify/`` folder is the repo's graphify home — it also carries the
+team's push/pull sync hooks (see graphify.remote), so a clone brings its own
+sync behaviour with it.
+
+Every graphify command then makes sure ``./graphify-out`` is a **link** — a
+symlink on POSIX, a directory junction on Windows (``mklink /J`` semantics, no
+admin rights) — pointing at::
+
+    <store>/<repo>/<branch>/<module-relative-path>/graphify-out
+
+so every write physically lands in the central store, while every literal
+``graphify-out/...`` path (the CLI defaults, the agent skill's code blocks,
+a plain ``cat``) keeps working unchanged through the link. A monorepo gets one
+link per directory you build in, all keyed under the same store tree; the
+branch in the key means switching branches just retargets the link.
+``graphify push`` / ``pull`` (see graphify.remote) sync the store elsewhere.
+
+The ignore entry is written in the same step that creates a link, as a bare
+``graphify-out`` line: the usual trailing-slash form only matches directories,
+and git sees a POSIX symlink as a *file* — with ``graphify-out/`` the link
+itself would show up in ``git status``. The bare form matches the symlink, the
+junction (a directory to git, which would otherwise descend into it on
+Windows), and a plain local folder alike, at any depth.
+
+Without a ``.graphify/config.json`` (or without a ``store`` key) nothing here
+runs and graphify writes a plain local folder exactly like before. An absolute
+``GRAPHIFY_OUT`` env override also disables linking — it already points the
+output elsewhere.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+CONFIG_DIR = ".graphify"
+CONFIG_NAME = "config.json"
+
+
+def config_path(base: Path) -> Path:
+    """``<base>/.graphify/config.json`` — the repo's committed graphify config."""
+    return base / CONFIG_DIR / CONFIG_NAME
+
+
+def git_out(cwd: Path, *args: str) -> str | None:
+    """``git -C cwd <args>`` → stripped stdout, or None on any failure."""
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(cwd), *args], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+        return out or None
+    except Exception:
+        return None
+
+
+def find_config(start: Path | None = None) -> tuple[dict, Path] | None:
+    """Walk up from ``start`` (default cwd) for ``.graphify/config.json``.
+
+    Returns ``(config_dict, dir_containing_.graphify)``; a missing or malformed
+    file yields None so graphify falls back to plain local output.
+    """
+    cur = Path(start or Path.cwd()).resolve()
+    for d in (cur, *cur.parents):
+        f = config_path(d)
+        if f.is_file():
+            try:
+                cfg = json.loads(f.read_text(encoding="utf-8"))
+            except Exception:
+                return None
+            return (cfg, d) if isinstance(cfg, dict) else None
+    return None
+
+
+def _repo_name(root: Path, in_git: bool) -> str:
+    """Store key for the repo: origin-remote basename, else the folder name.
+
+    The origin URL is what clones share — a teammate who clones into a
+    differently-named folder must land on the same ``<repo>/<branch>`` key.
+    ``https://host/owner/repo.git`` and ``git@host:owner/repo.git`` both end in
+    ``repo(.git)``. A ``"repo"`` override in the config beats both.
+    """
+    url = git_out(root, "remote", "get-url", "origin") if in_git else None
+    if url:
+        name = url.rstrip("/").rsplit("/", 1)[-1]
+        if name.endswith(".git"):
+            name = name[:-4]
+        if name:
+            return name
+    return root.name
+
+
+def store_context(cwd: Path | None = None) -> dict | None:
+    """Resolve the store context for ``cwd``, or None when no store is configured.
+
+    Keys: ``cfg``/``cfg_dir`` (the config), ``root`` (git top-level, else the
+    config dir), ``in_git``, ``repo`` (config ``"repo"`` override, else the
+    origin-remote basename, else the root dir name — see ``_repo_name``),
+    ``branch``, ``store_base`` (the expanded ``store`` path) and ``store_root``
+    (``<store>/<repo>/<branch>`` — the tree push/pull hooks sync).
+    """
+    cwd = Path(cwd or Path.cwd()).resolve()
+    found = find_config(cwd)
+    if not found:
+        return None
+    cfg, cfg_dir = found
+    store = cfg.get("store")
+    if not store or not isinstance(store, str):
+        return None
+    toplevel = git_out(cwd, "rev-parse", "--show-toplevel")
+    root = Path(toplevel).resolve() if toplevel else cfg_dir
+    repo = cfg.get("repo") or _repo_name(root, in_git=toplevel is not None)
+    branch = git_out(root, "rev-parse", "--abbrev-ref", "HEAD") or "main"
+    store_base = Path(os.path.expanduser(store))
+    return {
+        "cfg": cfg,
+        "cfg_dir": cfg_dir,
+        "root": root,
+        "in_git": toplevel is not None,
+        "repo": repo,
+        "branch": branch,
+        "store_base": store_base,
+        "store_root": store_base / repo / branch,
+    }
+
+
+# ------------------------------------------------------------------ links
+
+def _is_link(p: Path) -> bool:
+    """True for a POSIX symlink or a Windows junction (reparse point)."""
+    try:
+        st = os.lstat(p)
+    except OSError:
+        return False
+    if stat.S_ISLNK(st.st_mode):
+        return True
+    if os.name == "nt":
+        return bool(
+            getattr(st, "st_file_attributes", 0)
+            & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+        )
+    return False
+
+
+def _make_link(link: Path, target: Path) -> None:
+    if os.name == "nt":
+        # A junction, not a symlink: junctions need no privilege/dev-mode and
+        # git+every tool treat them as normal directories. Local targets only.
+        import _winapi
+
+        _winapi.CreateJunction(str(target), str(link))
+    else:
+        os.symlink(str(target), str(link), target_is_directory=True)
+
+
+def _remove_link(link: Path) -> None:
+    try:
+        link.unlink()  # symlink (and junctions on py3.8+ where unlink works)
+    except OSError:
+        os.rmdir(link)  # a junction removes like an empty dir — contents survive
+
+
+def _migrate(local_dir: Path, target: Path) -> int:
+    """Move a pre-existing real ``graphify-out`` into the store. Local wins on
+    collision — it is the freshest build."""
+    target.mkdir(parents=True, exist_ok=True)
+    moved = 0
+    for child in list(local_dir.iterdir()):
+        dest = target / child.name
+        if dest.is_dir() and not _is_link(dest):
+            shutil.rmtree(dest)
+        elif dest.exists() or _is_link(dest):
+            dest.unlink()
+        shutil.move(str(child), str(dest))
+        moved += 1
+    local_dir.rmdir()
+    return moved
+
+
+def _ensure_gitignore(root: Path, name: str) -> None:
+    gi = root / ".gitignore"
+    text = gi.read_text(encoding="utf-8") if gi.is_file() else ""
+    patterns = {line.strip() for line in text.splitlines()}
+    if name in patterns or f"**/{name}" in patterns:
+        return
+    entry = name + "\n"
+    if text and not text.endswith("\n"):
+        entry = "\n" + entry
+    gi.write_text(text + entry, encoding="utf-8")
+
+
+def ensure_out_link(cwd: Path | None = None) -> Path | None:
+    """Make ``<cwd>/graphify-out`` a link into the configured store.
+
+    Called once at CLI dispatch. Returns the store-side directory when a store
+    is configured (creating/retargeting/migrating as needed), else None.
+    Idempotent: the common case is a single ``lstat``.
+    """
+    from graphify import paths
+
+    out_name = paths.GRAPHIFY_OUT
+    if os.path.isabs(out_name):
+        return None  # GRAPHIFY_OUT already redirects output; nothing to link
+    cwd = Path(cwd or Path.cwd()).resolve()
+    ctx = store_context(cwd)
+    if ctx is None:
+        return None
+    try:
+        rel = cwd.relative_to(ctx["root"])
+    except ValueError:
+        return None  # cwd outside the repo the config governs
+    target = (ctx["store_root"] / rel / paths.GRAPHIFY_OUT_NAME).resolve()
+    link = cwd / out_name
+
+    if _ensure_link_at(link, target) and ctx["in_git"]:
+        _ensure_gitignore(ctx["root"], paths.GRAPHIFY_OUT_NAME)
+    return target
+
+
+def _ensure_link_at(link: Path, target: Path) -> bool:
+    """Point ``link`` at ``target`` (creating/retargeting/migrating as needed).
+
+    Returns True when a link was created or retargeted, False when it was
+    already correct — the caller only touches .gitignore on a real change.
+    """
+    if _is_link(link):
+        if Path(os.path.realpath(link)) == target:
+            target.mkdir(parents=True, exist_ok=True)
+            return False
+        _remove_link(link)  # branch switch / store move: retarget
+    elif link.is_dir():
+        moved = _migrate(link, target)
+        if moved:
+            print(f"store: migrated {moved} entrie(s) from {link} into {target}")
+    elif link.exists():
+        # a regular FILE named graphify-out — never clobber user data
+        print(f"store: {link} exists and is not a directory — not linking", file=sys.stderr)
+        return False
+
+    target.mkdir(parents=True, exist_ok=True)
+    link.parent.mkdir(parents=True, exist_ok=True)
+    _make_link(link, target)
+    print(f"store: {link} -> {target}", file=sys.stderr)
+    return True
+
+
+def materialize(ctx: dict) -> int:
+    """Replace every ``graphify-out`` link with a real folder holding a copy of
+    its store data — the exit path from the central store (``graphify deinit``).
+
+    Copies (never moves): the store keeps serving other branches and teammates.
+    Returns the number of links materialized.
+    """
+    import shutil
+
+    from graphify import paths
+
+    candidates = {ctx["root"] / paths.GRAPHIFY_OUT}
+    if ctx["store_root"].is_dir():
+        for t in sorted(ctx["store_root"].rglob(paths.GRAPHIFY_OUT_NAME)):
+            if t.is_dir():
+                rel = t.parent.relative_to(ctx["store_root"])
+                candidates.add(ctx["root"] / rel / paths.GRAPHIFY_OUT)
+    n = 0
+    for link in sorted(candidates):
+        if not _is_link(link):
+            continue
+        src = Path(os.path.realpath(link))
+        _remove_link(link)
+        if src.is_dir():
+            shutil.copytree(src, link)
+        else:
+            link.mkdir(parents=True, exist_ok=True)
+        print(f"store: materialized {link} (local copy of {src})")
+        n += 1
+    return n
+
+
+def link_all(ctx: dict) -> int:
+    """Create/refresh a repo link for every module present in the store.
+
+    Walks ``<store>/<repo>/<branch>`` for ``graphify-out`` dirs and mirrors each
+    as a link at the matching repo path, so ``graphify pull`` recreates the whole
+    working set — a fresh clone can immediately read any module's graphs (e.g.
+    root-level ``merge-graphs ./services/api/graphify-out/graph.json``) without
+    first running a command inside that module. Modules absent from the working
+    tree (removed on this branch) are skipped, never invented. Returns the
+    number of links created/retargeted.
+    """
+    from graphify import paths
+
+    if os.path.isabs(paths.GRAPHIFY_OUT):
+        return 0
+    store_root = ctx["store_root"]
+    if not store_root.is_dir():
+        return 0
+    changed = 0
+    for target in sorted(store_root.rglob(paths.GRAPHIFY_OUT_NAME)):
+        if not target.is_dir():
+            continue
+        module_dir = ctx["root"] / target.parent.relative_to(store_root)
+        if not module_dir.is_dir():
+            continue
+        if _ensure_link_at(module_dir / paths.GRAPHIFY_OUT, target.resolve()):
+            changed += 1
+    if changed and ctx["in_git"]:
+        _ensure_gitignore(ctx["root"], paths.GRAPHIFY_OUT_NAME)
+    return changed

--- a/graphify/store.py
+++ b/graphify/store.py
@@ -12,14 +12,16 @@ Every graphify command then makes sure ``./graphify-out`` is a **link** — a
 symlink on POSIX, a directory junction on Windows (``mklink /J`` semantics, no
 admin rights) — pointing at::
 
-    <store>/<repo>/<branch>/<module-relative-path>/graphify-out
+    <store>/<module-relative-path>/graphify-out
 
 so every write physically lands in the central store, while every literal
 ``graphify-out/...`` path (the CLI defaults, the agent skill's code blocks,
 a plain ``cat``) keeps working unchanged through the link. A monorepo gets one
-link per directory you build in, all keyed under the same store tree; the
-branch in the key means switching branches just retargets the link.
-``graphify push`` / ``pull`` (see graphify.remote) sync the store elsewhere.
+link per directory you build in, keyed only by its path within the repo; the
+repo root's link is simply ``<store>/graphify-out``. There is **no repo or
+branch segment** — the repo points at the same store location on every branch,
+and each repo names its own store path in its config. ``graphify push`` /
+``pull`` (see graphify.remote) sync the store elsewhere.
 
 The ignore entry is written in the same step that creates a link, as a bare
 ``graphify-out`` line: the usual trailing-slash form only matches directories,
@@ -81,32 +83,17 @@ def find_config(start: Path | None = None) -> tuple[dict, Path] | None:
     return None
 
 
-def _repo_name(root: Path, in_git: bool) -> str:
-    """Store key for the repo: origin-remote basename, else the folder name.
-
-    The origin URL is what clones share — a teammate who clones into a
-    differently-named folder must land on the same ``<repo>/<branch>`` key.
-    ``https://host/owner/repo.git`` and ``git@host:owner/repo.git`` both end in
-    ``repo(.git)``. A ``"repo"`` override in the config beats both.
-    """
-    url = git_out(root, "remote", "get-url", "origin") if in_git else None
-    if url:
-        name = url.rstrip("/").rsplit("/", 1)[-1]
-        if name.endswith(".git"):
-            name = name[:-4]
-        if name:
-            return name
-    return root.name
-
-
 def store_context(cwd: Path | None = None) -> dict | None:
     """Resolve the store context for ``cwd``, or None when no store is configured.
 
     Keys: ``cfg``/``cfg_dir`` (the config), ``root`` (git top-level, else the
-    config dir), ``in_git``, ``repo`` (config ``"repo"`` override, else the
-    origin-remote basename, else the root dir name — see ``_repo_name``),
-    ``branch``, ``store_base`` (the expanded ``store`` path) and ``store_root``
-    (``<store>/<repo>/<branch>`` — the tree push/pull hooks sync).
+    config dir), ``in_git``, ``store_base``/``store_root`` (the expanded ``store``
+    path — the tree push/pull hooks sync).
+
+    The store path *is* the key: the graph lives directly under it, with no
+    ``<repo>``/``<branch>`` segments. So a repo points at the same store
+    location no matter which branch is checked out, and each repo simply names
+    its own store path in its committed config (change it to whatever you like).
     """
     cwd = Path(cwd or Path.cwd()).resolve()
     found = find_config(cwd)
@@ -118,18 +105,14 @@ def store_context(cwd: Path | None = None) -> dict | None:
         return None
     toplevel = git_out(cwd, "rev-parse", "--show-toplevel")
     root = Path(toplevel).resolve() if toplevel else cfg_dir
-    repo = cfg.get("repo") or _repo_name(root, in_git=toplevel is not None)
-    branch = git_out(root, "rev-parse", "--abbrev-ref", "HEAD") or "main"
     store_base = Path(os.path.expanduser(store))
     return {
         "cfg": cfg,
         "cfg_dir": cfg_dir,
         "root": root,
         "in_git": toplevel is not None,
-        "repo": repo,
-        "branch": branch,
         "store_base": store_base,
-        "store_root": store_base / repo / branch,
+        "store_root": store_base,
     }
 
 
@@ -257,7 +240,7 @@ def materialize(ctx: dict) -> int:
     """Replace every ``graphify-out`` link with a real folder holding a copy of
     its store data — the exit path from the central store (``graphify deinit``).
 
-    Copies (never moves): the store keeps serving other branches and teammates.
+    Copies (never moves): the store keeps serving teammates who share it.
     Returns the number of links materialized.
     """
     import shutil
@@ -288,7 +271,7 @@ def materialize(ctx: dict) -> int:
 def link_all(ctx: dict) -> int:
     """Create/refresh a repo link for every module present in the store.
 
-    Walks ``<store>/<repo>/<branch>`` for ``graphify-out`` dirs and mirrors each
+    Walks the ``<store>`` tree for ``graphify-out`` dirs and mirrors each
     as a link at the matching repo path, so ``graphify pull`` recreates the whole
     working set — a fresh clone can immediately read any module's graphs (e.g.
     root-level ``merge-graphs ./services/api/graphify-out/graph.json``) without

--- a/tests/test_remote_sync.py
+++ b/tests/test_remote_sync.py
@@ -591,3 +591,32 @@ def test_template_skip_excludes_cache_only(tmp_path, monkeypatch):
     assert ns["skip"]("services/api/graphify-out/cache/x.json")
     assert not ns["skip"]("graphify-out/graph.json")
     assert not ns["skip"]("services/api/graphify-out/wiki/index.md")
+
+
+def test_init_backend_s3_public(tmp_path, monkeypatch):
+    # --backend s3-public → .py hooks + a store_url config key; pull is URL-only (no boto3)
+    repo = _git_repo(tmp_path / "r")
+    monkeypatch.chdir(repo)
+    remote.cmd_init(["--backend", "s3-public"])
+    cfg = json.loads((repo / ".graphify" / "config.json").read_text())
+    assert "store_url" in cfg
+    pull = (repo / ".graphify" / "pull.py").read_text()
+    assert "urllib" in pull and "boto3" not in pull
+    assert "_manifest.json" in (repo / ".graphify" / "push.py").read_text()
+
+
+def test_init_backend_git_lfs_and_rsync_write_shell(tmp_path, monkeypatch):
+    for backend, marker in (("git-lfs", "GRAPHIFY_GIT_REMOTE"), ("rsync", "GRAPHIFY_RSYNC_DEST")):
+        repo = _git_repo(tmp_path / backend)
+        monkeypatch.chdir(repo)
+        remote.cmd_init(["--backend", backend])
+        assert (repo / ".graphify" / "push.sh").is_file()
+        assert (repo / ".graphify" / "pull.sh").is_file()
+        assert not (repo / ".graphify" / "push.py").exists()
+        assert marker in (repo / ".graphify" / "push.sh").read_text()
+
+
+def test_init_unknown_backend_errors(tmp_path, monkeypatch):
+    monkeypatch.chdir(_git_repo(tmp_path / "r"))
+    with pytest.raises(SystemExit):
+        remote.cmd_init(["--backend", "carrier-pigeon"])

--- a/tests/test_remote_sync.py
+++ b/tests/test_remote_sync.py
@@ -56,17 +56,18 @@ def test_store_context_none_without_store_key(tmp_path):
     assert store.store_context(tmp_path) is None
 
 
-def test_store_context_repo_override(tmp_path):
+def test_store_root_is_store_base_no_repo_branch(tmp_path):
+    # the store path IS the key — no <repo>/<branch> segments appended
     repo = _git_repo(tmp_path / "some-local-name")
-    _write_config(repo, store=str(tmp_path / "s"), repo="shared-name")
+    _write_config(repo, store=str(tmp_path / "s"))
     ctx = store.store_context(repo)
     assert ctx is not None
-    assert ctx["repo"] == "shared-name"
-    assert ctx["store_root"] == tmp_path / "s" / "shared-name" / "main"
+    assert ctx["store_root"] == (tmp_path / "s")
+    assert ctx["store_base"] == (tmp_path / "s")
 
 
-def test_repo_name_from_origin_remote(tmp_path):
-    # a clone under any folder name keys the store by the shared origin URL
+def test_origin_remote_does_not_affect_store_path(tmp_path):
+    # the origin URL is irrelevant now — the config's store path is the whole key
     clone = _git_repo(tmp_path / "whatever-local-name")
     subprocess.run(
         ["git", "-C", str(clone), "remote", "add", "origin",
@@ -76,8 +77,7 @@ def test_repo_name_from_origin_remote(tmp_path):
     _write_config(clone, store=str(tmp_path / "s"))
     ctx = store.store_context(clone)
     assert ctx is not None
-    assert ctx["repo"] == "mono"
-    assert ctx["store_root"] == tmp_path / "s" / "mono" / "main"
+    assert ctx["store_root"] == (tmp_path / "s")
 
 
 def test_find_config_non_dict_json_returns_none(tmp_path):
@@ -100,18 +100,6 @@ def test_store_tilde_expands_home(tmp_path, monkeypatch):
     assert ctx["store_base"] == tmp_path / "gstore"
 
 
-def test_repo_name_from_https_origin_with_trailing_slash(tmp_path):
-    clone = _git_repo(tmp_path / "x")
-    subprocess.run(
-        ["git", "-C", str(clone), "remote", "add", "origin",
-         "https://github.com/acme/mono/"],
-        check=True,
-    )
-    _write_config(clone, store=str(tmp_path / "s"))
-    ctx = store.store_context(clone)
-    assert ctx is not None and ctx["repo"] == "mono"
-
-
 # --------------------------------------------------------------- ensure_out_link
 
 def test_no_config_is_noop(tmp_path):
@@ -123,7 +111,7 @@ def test_link_created_and_writes_land_in_store(tmp_path):
     repo = _git_repo(tmp_path / "myrepo")
     _write_config(repo, store=str(tmp_path / "store"))
     target = store.ensure_out_link(repo)
-    assert target == (tmp_path / "store" / "myrepo" / "main" / "graphify-out").resolve()
+    assert target == (tmp_path / "store" / "graphify-out").resolve()
     link = repo / "graphify-out"
     assert store._is_link(link)
     # a write through the link physically lands in the store
@@ -139,7 +127,7 @@ def test_module_link_keyed_by_relpath(tmp_path):
     _write_config(repo, store=str(tmp_path / "store"))
     target = store.ensure_out_link(module)
     assert target == (
-        tmp_path / "store" / "mono" / "main" / "services" / "api" / "graphify-out"
+        tmp_path / "store" / "services" / "api" / "graphify-out"
     ).resolve()
     assert store._is_link(module / "graphify-out")
 
@@ -155,7 +143,9 @@ def test_idempotent_second_call(tmp_path):
     assert lines.count("graphify-out") == 1
 
 
-def test_branch_switch_retargets_link(tmp_path):
+def test_branch_switch_keeps_same_link(tmp_path):
+    # the repo points at the same store location on every branch — no retarget,
+    # no rebuild. The graph built on one branch is right there on the next.
     repo = _git_repo(tmp_path / "r")
     _write_config(repo, store=str(tmp_path / "store"))
     env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
@@ -163,14 +153,13 @@ def test_branch_switch_retargets_link(tmp_path):
     subprocess.run(["git", "-C", str(repo), "commit", "--allow-empty", "-q", "-m", "x"],
                    check=True, env=env)
     main_target = store.ensure_out_link(repo)
-    (main_target / "graph.json").write_text('{"branch": "main"}')
+    (main_target / "graph.json").write_text('{"built": true}')
 
     subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", "feat/x"], check=True)
     feat_target = store.ensure_out_link(repo)
-    assert feat_target == (tmp_path / "store" / "r" / "feat" / "x" / "graphify-out").resolve()
-    # the link now points at the feature branch; main's data is untouched
-    assert not (repo / "graphify-out" / "graph.json").exists()
-    assert (main_target / "graph.json").is_file()
+    assert feat_target == main_target  # same store location, regardless of branch
+    # the graph built on main is immediately visible on the new branch
+    assert (repo / "graphify-out" / "graph.json").read_text() == '{"built": true}'
 
 
 def test_migrates_existing_local_dir(tmp_path, capsys):
@@ -192,7 +181,7 @@ def test_migration_collision_local_wins(tmp_path):
     # store already has an (older) graph; the local build is freshest and wins
     repo = _git_repo(tmp_path / "r")
     _write_config(repo, store=str(tmp_path / "store"))
-    target = tmp_path / "store" / "r" / "main" / "graphify-out"
+    target = tmp_path / "store" / "graphify-out"
     target.mkdir(parents=True)
     (target / "graph.json").write_text('{"stale": true}')
     local = repo / "graphify-out"
@@ -231,7 +220,7 @@ def test_custom_relative_out_name_links_too(tmp_path, monkeypatch):
     repo = _git_repo(tmp_path / "r")
     _write_config(repo, store=str(tmp_path / "store"))
     target = store.ensure_out_link(repo)
-    assert target == (tmp_path / "store" / "r" / "main" / "graphify-out-feature").resolve()
+    assert target == (tmp_path / "store" / "graphify-out-feature").resolve()
     assert store._is_link(repo / "graphify-out-feature")
     assert "graphify-out-feature" in (repo / ".gitignore").read_text().splitlines()
 
@@ -324,12 +313,12 @@ def test_absolute_graphify_out_env_disables_linking(tmp_path, monkeypatch):
 
 
 def test_works_without_git(tmp_path):
-    # no git repo: root falls back to the config dir, branch to "main"
+    # no git repo: root falls back to the config dir; the store path is the key
     repo = tmp_path / "plain"
     repo.mkdir()
     _write_config(repo, store=str(tmp_path / "store"))
     target = store.ensure_out_link(repo)
-    assert target == (tmp_path / "store" / "plain" / "main" / "graphify-out").resolve()
+    assert target == (tmp_path / "store" / "graphify-out").resolve()
     assert not (repo / ".gitignore").exists()  # gitignore upkeep only inside git
 
 
@@ -341,7 +330,6 @@ _RECORD_HOOK = (
     "  os.environ['GRAPHIFY_ACTION'],\n"
     "  os.environ['GRAPHIFY_STORE_DIR'],\n"
     "  os.environ['GRAPHIFY_PREFIX'],\n"
-    "  os.environ['GRAPHIFY_BRANCH'],\n"
     "]))\n"
 )
 
@@ -361,11 +349,10 @@ def test_push_runs_explicit_hook_with_context(tmp_path, monkeypatch):
     repo, marker = _hook_setup(tmp_path, monkeypatch, push=str(hook))
 
     remote.cmd_push([])
-    action, store_dir, prefix, branch = marker.read_text().split("|")
+    action, store_dir, prefix = marker.read_text().split("|")
     assert action == "push"
-    assert store_dir == str(tmp_path / "store" / "repo" / "main")
-    assert prefix == "repo/main"
-    assert branch == "main"
+    assert store_dir == str(tmp_path / "store")     # the store path itself — no repo/branch
+    assert prefix == "store"                          # the store folder's basename
     assert Path(store_dir).is_dir()  # push pre-creates the store tree
 
 
@@ -396,16 +383,14 @@ def test_hook_env_includes_config_store_and_root(tmp_path, monkeypatch):
         "  os.environ['GRAPHIFY_CONFIG'],\n"
         "  os.environ['GRAPHIFY_STORE'],\n"
         "  os.environ['GRAPHIFY_REPO_ROOT'],\n"
-        "  os.environ['GRAPHIFY_REPO'],\n"
         "]))\n"
     )
     repo, marker = _hook_setup(tmp_path, monkeypatch, push=str(hook))
     remote.cmd_push([])
-    cfg_path, store_base, repo_root, repo_name = marker.read_text().split("|")
+    cfg_path, store_base, repo_root = marker.read_text().split("|")
     assert cfg_path == str(repo / ".graphify" / "config.json")
     assert store_base == str(tmp_path / "store")
     assert Path(repo_root) == repo.resolve()
-    assert repo_name == "repo"
 
 
 def test_hook_extension_priority_is_deterministic(tmp_path, monkeypatch):
@@ -501,7 +486,7 @@ def test_init_bootstraps_repo_dot_graphify(tmp_path, monkeypatch):
     monkeypatch.chdir(repo)
     remote.cmd_init([])
     cfg = json.loads((repo / ".graphify" / "config.json").read_text())
-    assert cfg["store"] == "~/graphify-store"
+    assert cfg["store"] == "~/graphify-store/r"  # default: ~/graphify-store/<folder>
     push = repo / ".graphify" / "push.py"
     pull = repo / ".graphify" / "pull.py"
     assert push.is_file() and pull.is_file()
@@ -599,7 +584,7 @@ def test_template_skip_excludes_cache_only(tmp_path, monkeypatch):
     from graphify import remote_hook_templates as tpl
     monkeypatch.setenv("GRAPHIFY_ACTION", "push")
     monkeypatch.setenv("GRAPHIFY_STORE_DIR", str(tmp_path))
-    monkeypatch.setenv("GRAPHIFY_PREFIX", "r/main")
+    monkeypatch.setenv("GRAPHIFY_PREFIX", "store")
     ns: dict = {}
     exec(tpl._COMMON, ns)
     assert ns["skip"]("graphify-out/cache/ast.json")

--- a/tests/test_remote_sync.py
+++ b/tests/test_remote_sync.py
@@ -1,0 +1,608 @@
+"""Tests for the central graph store (graphify.store) and push/pull hooks (graphify.remote).
+
+Covers:
+  - graphify.store.find_config / store_context        (.graphify/config.json discovery)
+  - graphify.store.ensure_out_link                    (graphify-out -> store link, migration,
+                                                       branch retarget, .gitignore upkeep)
+  - graphify.remote push/pull                         (hook resolution + invocation)
+
+All offline: no network, no boto3. Git repos are real `git init` under tmp_path;
+hooks are tiny local scripts. No side effects outside tmp_path.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from graphify import remote, store
+
+
+def _git_repo(d: Path) -> Path:
+    d.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", str(d)], check=True)
+    return d
+
+
+def _write_config(d: Path, **cfg) -> None:
+    (d / ".graphify").mkdir(exist_ok=True)
+    (d / ".graphify" / "config.json").write_text(json.dumps(cfg))
+
+
+# --------------------------------------------------------------- config discovery
+
+def test_find_config_walks_up(tmp_path):
+    repo = tmp_path / "r"
+    (repo / "a" / "b").mkdir(parents=True)
+    _write_config(repo, store=str(tmp_path / "s"))
+    found = store.find_config(repo / "a" / "b")
+    assert found is not None
+    cfg, root = found
+    assert root == (repo).resolve() and cfg["store"] == str(tmp_path / "s")
+
+
+def test_find_config_malformed_returns_none(tmp_path):
+    (tmp_path / ".graphify").mkdir()
+    (tmp_path / ".graphify" / "config.json").write_text("{ not json")
+    assert store.find_config(tmp_path) is None
+
+
+def test_store_context_none_without_store_key(tmp_path):
+    _write_config(tmp_path, push="./x.py")  # config exists but no "store"
+    assert store.store_context(tmp_path) is None
+
+
+def test_store_context_repo_override(tmp_path):
+    repo = _git_repo(tmp_path / "some-local-name")
+    _write_config(repo, store=str(tmp_path / "s"), repo="shared-name")
+    ctx = store.store_context(repo)
+    assert ctx is not None
+    assert ctx["repo"] == "shared-name"
+    assert ctx["store_root"] == tmp_path / "s" / "shared-name" / "main"
+
+
+def test_repo_name_from_origin_remote(tmp_path):
+    # a clone under any folder name keys the store by the shared origin URL
+    clone = _git_repo(tmp_path / "whatever-local-name")
+    subprocess.run(
+        ["git", "-C", str(clone), "remote", "add", "origin",
+         "git@github.com:acme/mono.git"],
+        check=True,
+    )
+    _write_config(clone, store=str(tmp_path / "s"))
+    ctx = store.store_context(clone)
+    assert ctx is not None
+    assert ctx["repo"] == "mono"
+    assert ctx["store_root"] == tmp_path / "s" / "mono" / "main"
+
+
+def test_find_config_non_dict_json_returns_none(tmp_path):
+    (tmp_path / ".graphify").mkdir()
+    (tmp_path / ".graphify" / "config.json").write_text('["not", "a", "dict"]')
+    assert store.find_config(tmp_path) is None
+
+
+def test_store_context_non_string_store_returns_none(tmp_path):
+    _write_config(tmp_path, store=123)
+    assert store.store_context(tmp_path) is None
+
+
+def test_store_tilde_expands_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store="~/gstore")
+    ctx = store.store_context(repo)
+    assert ctx is not None
+    assert ctx["store_base"] == tmp_path / "gstore"
+
+
+def test_repo_name_from_https_origin_with_trailing_slash(tmp_path):
+    clone = _git_repo(tmp_path / "x")
+    subprocess.run(
+        ["git", "-C", str(clone), "remote", "add", "origin",
+         "https://github.com/acme/mono/"],
+        check=True,
+    )
+    _write_config(clone, store=str(tmp_path / "s"))
+    ctx = store.store_context(clone)
+    assert ctx is not None and ctx["repo"] == "mono"
+
+
+# --------------------------------------------------------------- ensure_out_link
+
+def test_no_config_is_noop(tmp_path):
+    assert store.ensure_out_link(tmp_path) is None
+    assert not (tmp_path / "graphify-out").exists()
+
+
+def test_link_created_and_writes_land_in_store(tmp_path):
+    repo = _git_repo(tmp_path / "myrepo")
+    _write_config(repo, store=str(tmp_path / "store"))
+    target = store.ensure_out_link(repo)
+    assert target == (tmp_path / "store" / "myrepo" / "main" / "graphify-out").resolve()
+    link = repo / "graphify-out"
+    assert store._is_link(link)
+    # a write through the link physically lands in the store
+    (link / "graph.json").write_text("{}")
+    assert (target / "graph.json").is_file()
+    assert not (repo / "graphify-out" / "graph.json").resolve().is_relative_to(repo.resolve())
+
+
+def test_module_link_keyed_by_relpath(tmp_path):
+    repo = _git_repo(tmp_path / "mono")
+    module = repo / "services" / "api"
+    module.mkdir(parents=True)
+    _write_config(repo, store=str(tmp_path / "store"))
+    target = store.ensure_out_link(module)
+    assert target == (
+        tmp_path / "store" / "mono" / "main" / "services" / "api" / "graphify-out"
+    ).resolve()
+    assert store._is_link(module / "graphify-out")
+
+
+def test_idempotent_second_call(tmp_path):
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))
+    first = store.ensure_out_link(repo)
+    second = store.ensure_out_link(repo)
+    assert first == second and store._is_link(repo / "graphify-out")
+    # gitignore entry not duplicated
+    lines = (repo / ".gitignore").read_text().splitlines()
+    assert lines.count("graphify-out") == 1
+
+
+def test_branch_switch_retargets_link(tmp_path):
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "-C", str(repo), "commit", "--allow-empty", "-q", "-m", "x"],
+                   check=True, env=env)
+    main_target = store.ensure_out_link(repo)
+    (main_target / "graph.json").write_text('{"branch": "main"}')
+
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", "feat/x"], check=True)
+    feat_target = store.ensure_out_link(repo)
+    assert feat_target == (tmp_path / "store" / "r" / "feat" / "x" / "graphify-out").resolve()
+    # the link now points at the feature branch; main's data is untouched
+    assert not (repo / "graphify-out" / "graph.json").exists()
+    assert (main_target / "graph.json").is_file()
+
+
+def test_migrates_existing_local_dir(tmp_path, capsys):
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))
+    local = repo / "graphify-out"
+    (local / "wiki").mkdir(parents=True)
+    (local / "graph.json").write_text('{"old": true}')
+    (local / "wiki" / "index.md").write_text("# hi")
+
+    target = store.ensure_out_link(repo)
+    assert store._is_link(local)
+    assert (target / "graph.json").read_text() == '{"old": true}'
+    assert (target / "wiki" / "index.md").is_file()
+    assert "migrated" in capsys.readouterr().out
+
+
+def test_migration_collision_local_wins(tmp_path):
+    # store already has an (older) graph; the local build is freshest and wins
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))
+    target = tmp_path / "store" / "r" / "main" / "graphify-out"
+    target.mkdir(parents=True)
+    (target / "graph.json").write_text('{"stale": true}')
+    local = repo / "graphify-out"
+    local.mkdir()
+    (local / "graph.json").write_text('{"fresh": true}')
+
+    store.ensure_out_link(repo)
+    assert (target / "graph.json").read_text() == '{"fresh": true}'
+
+
+def test_dangling_link_self_heals(tmp_path):
+    import shutil
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))
+    target = store.ensure_out_link(repo)
+    shutil.rmtree(tmp_path / "store")  # store wiped (new machine, cleanup, …)
+    assert store.ensure_out_link(repo) == target
+    assert target.is_dir()  # recreated; link still valid
+
+
+def test_regular_file_named_graphify_out_is_never_clobbered(tmp_path, capsys):
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))
+    rogue = repo / "graphify-out"
+    rogue.write_text("user data, not a dir")
+    store.ensure_out_link(repo)  # must not raise
+    assert rogue.read_text() == "user data, not a dir"
+    assert not store._is_link(rogue)
+    assert "not linking" in capsys.readouterr().err
+
+
+def test_custom_relative_out_name_links_too(tmp_path, monkeypatch):
+    from graphify import paths
+    monkeypatch.setattr(paths, "GRAPHIFY_OUT", "graphify-out-feature")
+    monkeypatch.setattr(paths, "GRAPHIFY_OUT_NAME", "graphify-out-feature")
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))
+    target = store.ensure_out_link(repo)
+    assert target == (tmp_path / "store" / "r" / "main" / "graphify-out-feature").resolve()
+    assert store._is_link(repo / "graphify-out-feature")
+    assert "graphify-out-feature" in (repo / ".gitignore").read_text().splitlines()
+
+
+def test_gitignore_created_with_bare_entry(tmp_path):
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))
+    store.ensure_out_link(repo)
+    lines = (repo / ".gitignore").read_text().splitlines()
+    # bare entry: "graphify-out/" (dirs only) would NOT match a symlink
+    assert "graphify-out" in lines
+
+
+def test_gitignore_slash_only_entry_gets_bare_added(tmp_path):
+    repo = _git_repo(tmp_path / "r")
+    (repo / ".gitignore").write_text("node_modules\ngraphify-out/\n")
+    _write_config(repo, store=str(tmp_path / "store"))
+    store.ensure_out_link(repo)
+    lines = (repo / ".gitignore").read_text().splitlines()
+    assert "graphify-out" in lines and "node_modules" in lines
+
+
+def test_gitignore_existing_bare_entry_untouched(tmp_path):
+    repo = _git_repo(tmp_path / "r")
+    (repo / ".gitignore").write_text("graphify-out\n")
+    _write_config(repo, store=str(tmp_path / "store"))
+    store.ensure_out_link(repo)
+    assert (repo / ".gitignore").read_text() == "graphify-out\n"
+
+
+def test_gitignore_doublestar_entry_accepted(tmp_path):
+    repo = _git_repo(tmp_path / "r")
+    (repo / ".gitignore").write_text("**/graphify-out\n")
+    _write_config(repo, store=str(tmp_path / "store"))
+    store.ensure_out_link(repo)
+    assert (repo / ".gitignore").read_text() == "**/graphify-out\n"  # no duplicate
+
+
+def test_gitignore_without_trailing_newline(tmp_path):
+    repo = _git_repo(tmp_path / "r")
+    (repo / ".gitignore").write_text("node_modules")  # no trailing \n
+    _write_config(repo, store=str(tmp_path / "store"))
+    store.ensure_out_link(repo)
+    assert (repo / ".gitignore").read_text().splitlines() == ["node_modules", "graphify-out"]
+
+
+def test_link_all_without_store_dir_returns_zero(tmp_path):
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))  # store never created
+    ctx = store.store_context(repo)
+    assert store.link_all(ctx) == 0
+
+
+def test_materialize_skips_real_dirs_and_handles_dangling(tmp_path):
+    import shutil
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))
+    ctx = store.store_context(repo)
+    # a real local dir (already materialized / never linked) must be untouched
+    real = repo / "graphify-out"
+    real.mkdir()
+    (real / "keep.json").write_text("{}")
+    assert store.materialize(ctx) == 0
+    assert (real / "keep.json").is_file()
+    # a dangling link (store deleted) becomes an empty real folder, no crash
+    shutil.rmtree(real)
+    target = store.ensure_out_link(repo)
+    shutil.rmtree(tmp_path / "store")
+    assert store.materialize(store.store_context(repo)) == 1
+    assert real.is_dir() and not store._is_link(real)
+
+
+def test_link_is_invisible_to_git(tmp_path):
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))
+    store.ensure_out_link(repo)
+    ((repo / "graphify-out") / "graph.json").write_text("{}")
+    out = subprocess.check_output(
+        ["git", "-C", str(repo), "status", "--porcelain"], text=True
+    )
+    assert "graphify-out" not in out
+
+
+def test_absolute_graphify_out_env_disables_linking(tmp_path, monkeypatch):
+    from graphify import paths
+    monkeypatch.setattr(paths, "GRAPHIFY_OUT", str(tmp_path / "abs-out"))
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))
+    assert store.ensure_out_link(repo) is None
+
+
+def test_works_without_git(tmp_path):
+    # no git repo: root falls back to the config dir, branch to "main"
+    repo = tmp_path / "plain"
+    repo.mkdir()
+    _write_config(repo, store=str(tmp_path / "store"))
+    target = store.ensure_out_link(repo)
+    assert target == (tmp_path / "store" / "plain" / "main" / "graphify-out").resolve()
+    assert not (repo / ".gitignore").exists()  # gitignore upkeep only inside git
+
+
+# --------------------------------------------------------------- push/pull hooks
+
+_RECORD_HOOK = (
+    "import os, pathlib\n"
+    "pathlib.Path(os.environ['MARKER']).write_text('|'.join([\n"
+    "  os.environ['GRAPHIFY_ACTION'],\n"
+    "  os.environ['GRAPHIFY_STORE_DIR'],\n"
+    "  os.environ['GRAPHIFY_PREFIX'],\n"
+    "  os.environ['GRAPHIFY_BRANCH'],\n"
+    "]))\n"
+)
+
+
+def _hook_setup(tmp_path, monkeypatch, **cfg_extra):
+    repo = _git_repo(tmp_path / "repo")
+    _write_config(repo, store=str(tmp_path / "store"), **cfg_extra)
+    monkeypatch.chdir(repo)
+    marker = tmp_path / "marker.txt"
+    monkeypatch.setenv("MARKER", str(marker))
+    return repo, marker
+
+
+def test_push_runs_explicit_hook_with_context(tmp_path, monkeypatch):
+    hook = tmp_path / "myhook.py"
+    hook.write_text(_RECORD_HOOK)
+    repo, marker = _hook_setup(tmp_path, monkeypatch, push=str(hook))
+
+    remote.cmd_push([])
+    action, store_dir, prefix, branch = marker.read_text().split("|")
+    assert action == "push"
+    assert store_dir == str(tmp_path / "store" / "repo" / "main")
+    assert prefix == "repo/main"
+    assert branch == "main"
+    assert Path(store_dir).is_dir()  # push pre-creates the store tree
+
+
+def test_relative_hook_path_resolves_against_repo_root(tmp_path, monkeypatch):
+    repo, marker = _hook_setup(tmp_path, monkeypatch, pull="hooks/pull.py")
+    (repo / "hooks").mkdir()
+    (repo / "hooks" / "pull.py").write_text(_RECORD_HOOK)
+    sub = repo / "sub"
+    sub.mkdir()
+    monkeypatch.chdir(sub)  # run from a subdir: config + hook still found
+    remote.cmd_pull([])
+    assert marker.read_text().startswith("pull|")
+
+
+def test_repo_local_hook_found_without_config_key(tmp_path, monkeypatch):
+    # the committed .graphify/pull.py is auto-discovered — no config key needed
+    repo, marker = _hook_setup(tmp_path, monkeypatch)
+    (repo / ".graphify" / "pull.py").write_text(_RECORD_HOOK)
+    remote.cmd_pull([])
+    assert marker.read_text().startswith("pull|")
+
+
+def test_hook_env_includes_config_store_and_root(tmp_path, monkeypatch):
+    hook = tmp_path / "envhook.py"
+    hook.write_text(
+        "import os, pathlib\n"
+        "pathlib.Path(os.environ['MARKER']).write_text('|'.join([\n"
+        "  os.environ['GRAPHIFY_CONFIG'],\n"
+        "  os.environ['GRAPHIFY_STORE'],\n"
+        "  os.environ['GRAPHIFY_REPO_ROOT'],\n"
+        "  os.environ['GRAPHIFY_REPO'],\n"
+        "]))\n"
+    )
+    repo, marker = _hook_setup(tmp_path, monkeypatch, push=str(hook))
+    remote.cmd_push([])
+    cfg_path, store_base, repo_root, repo_name = marker.read_text().split("|")
+    assert cfg_path == str(repo / ".graphify" / "config.json")
+    assert store_base == str(tmp_path / "store")
+    assert Path(repo_root) == repo.resolve()
+    assert repo_name == "repo"
+
+
+def test_hook_extension_priority_is_deterministic(tmp_path, monkeypatch):
+    # both pull.py and pull.sh committed: .py wins (first in _HOOK_EXTS)
+    repo, marker = _hook_setup(tmp_path, monkeypatch)
+    (repo / ".graphify" / "pull.py").write_text(_RECORD_HOOK)
+    (repo / ".graphify" / "pull.sh").write_text("exit 9")
+    remote.cmd_pull([])
+    assert marker.read_text().startswith("pull|")
+
+
+def test_missing_hook_errors(tmp_path, monkeypatch):
+    _hook_setup(tmp_path, monkeypatch)
+    with pytest.raises(SystemExit):
+        remote.cmd_push([])
+
+
+def test_hook_failure_propagates(tmp_path, monkeypatch):
+    hook = tmp_path / "bad.py"
+    hook.write_text("import sys; sys.exit(3)")
+    _hook_setup(tmp_path, monkeypatch, push=str(hook))
+    with pytest.raises(SystemExit):
+        remote.cmd_push([])
+
+
+def test_no_store_config_errors(tmp_path, monkeypatch):
+    monkeypatch.chdir(_git_repo(tmp_path / "repo"))
+    with pytest.raises(SystemExit):
+        remote.cmd_pull([])
+
+
+_POPULATE_STORE_HOOK = (
+    # a "pull" that simulates downloading: writes root + module graphs into the store
+    "import os, pathlib\n"
+    "s = pathlib.Path(os.environ['GRAPHIFY_STORE_DIR'])\n"
+    "for mod in ('graphify-out', 'services/api/graphify-out', 'gone/graphify-out'):\n"
+    "    d = s / mod\n"
+    "    d.mkdir(parents=True, exist_ok=True)\n"
+    "    (d / 'graph.json').write_text('{}')\n"
+)
+
+
+def test_pull_recreates_module_links(tmp_path, monkeypatch, capsys):
+    hook = tmp_path / "pull.py"
+    hook.write_text(_POPULATE_STORE_HOOK)
+    repo, _ = _hook_setup(tmp_path, monkeypatch, pull=str(hook))
+    (repo / "services" / "api").mkdir(parents=True)  # module exists in the clone
+    # note: repo has NO graphify-out anywhere yet — fresh clone
+
+    remote.cmd_pull([])
+
+    # root + module links exist and read the store data; 'gone' (module absent
+    # from the working tree) was skipped, not invented
+    assert store._is_link(repo / "graphify-out")
+    assert (repo / "graphify-out" / "graph.json").is_file()
+    assert store._is_link(repo / "services" / "api" / "graphify-out")
+    assert (repo / "services" / "api" / "graphify-out" / "graph.json").is_file()
+    assert not (repo / "gone").exists()
+    assert "linked" in capsys.readouterr().out
+
+
+def test_link_all_idempotent_and_counts(tmp_path):
+    repo = _git_repo(tmp_path / "r")
+    (repo / "m").mkdir()
+    _write_config(repo, store=str(tmp_path / "store"))
+    ctx = store.store_context(repo)
+    for mod in ("graphify-out", "m/graphify-out"):
+        (ctx["store_root"] / mod).mkdir(parents=True)
+    assert store.link_all(ctx) == 2
+    assert store.link_all(ctx) == 0  # second pass: everything already correct
+
+
+def test_interpreter_by_extension(tmp_path):
+    assert remote._interpreter(tmp_path / "h.py") == [sys.executable]
+    assert remote._interpreter(tmp_path / "h.js") == ["node"]
+    assert remote._interpreter(tmp_path / "h.sh") == ["bash"]
+    assert remote._interpreter(tmp_path / "h.ps1")[0] == "powershell"
+    assert remote._interpreter(tmp_path / "h.cmd") == ["cmd", "/c"]
+    assert remote._interpreter(tmp_path / "h.bat") == ["cmd", "/c"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX exec bit")
+def test_executable_hook_runs_directly(tmp_path):
+    hook = tmp_path / "push"
+    hook.write_text("#!/bin/sh\nexit 0\n")
+    os.chmod(hook, 0o755)
+    assert remote._interpreter(hook) == []
+
+
+def test_init_bootstraps_repo_dot_graphify(tmp_path, monkeypatch):
+    # one command in a bare repo: .graphify/ with config.json + both hooks appears
+    repo = _git_repo(tmp_path / "r")
+    monkeypatch.chdir(repo)
+    remote.cmd_init([])
+    cfg = json.loads((repo / ".graphify" / "config.json").read_text())
+    assert cfg["store"] == "~/graphify-store"
+    push = repo / ".graphify" / "push.py"
+    pull = repo / ".graphify" / "pull.py"
+    assert push.is_file() and pull.is_file()
+    assert "GRAPHIFY_STORE_DIR" in push.read_text()
+    assert "GRAPHIFY_STORE_DIR" in pull.read_text()
+    # rerun keeps existing config and hooks
+    push.write_text("# customized")
+    (repo / ".graphify" / "config.json").write_text('{"store": "/custom"}')
+    remote.cmd_init([])
+    assert push.read_text() == "# customized"
+    assert json.loads((repo / ".graphify" / "config.json").read_text())["store"] == "/custom"
+
+
+def test_init_from_subdir_lands_at_config_root(tmp_path, monkeypatch):
+    repo = _git_repo(tmp_path / "r")
+    _write_config(repo, store=str(tmp_path / "store"))
+    sub = repo / "deep" / "down"
+    sub.mkdir(parents=True)
+    monkeypatch.chdir(sub)
+    remote.cmd_init([])
+    assert (repo / ".graphify" / "push.py").is_file()
+    assert not (sub / ".graphify").exists()
+
+
+def test_remote_group_dispatch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(remote, "cmd_init", lambda a: calls.append(("init", a)))
+    monkeypatch.setattr(remote, "cmd_push", lambda a: calls.append(("push", a)))
+    monkeypatch.setattr(remote, "cmd_pull", lambda a: calls.append(("pull", a)))
+    monkeypatch.setattr(remote, "cmd_deinit", lambda a: calls.append(("delete", a)))
+    for sub in ("init", "push", "pull", "delete", "deinit"):
+        remote.cmd_remote([sub])
+    assert [c[0] for c in calls] == ["init", "push", "pull", "delete", "delete"]
+    with pytest.raises(SystemExit):
+        remote.cmd_remote([])
+    with pytest.raises(SystemExit):
+        remote.cmd_remote(["bogus"])
+
+
+def test_remote_delete_materializes_links(tmp_path, monkeypatch, capsys):
+    # adopt: repo with root + module data in the store, links in place
+    repo = _git_repo(tmp_path / "r")
+    module = repo / "m"
+    module.mkdir()
+    _write_config(repo, store=str(tmp_path / "store"))
+    root_target = store.ensure_out_link(repo)
+    mod_target = store.ensure_out_link(module)
+    (root_target / "graph.json").write_text('{"root": true}')
+    (mod_target / "graph.json").write_text('{"mod": true}')
+    monkeypatch.chdir(repo)
+
+    remote.cmd_deinit([])
+
+    for d, key in ((repo / "graphify-out", "root"), (module / "graphify-out", "mod")):
+        assert not store._is_link(d) and d.is_dir()
+        assert key in (d / "graph.json").read_text()
+    # the store keeps its copy — other teammates/branches unaffected
+    assert (root_target / "graph.json").is_file()
+    assert (mod_target / "graph.json").is_file()
+    assert "materialized 2" in capsys.readouterr().out
+
+
+def test_init_respects_hook_in_other_language(tmp_path, monkeypatch):
+    # a team already using push.sh must not get a competing push.py scaffolded
+    repo = _git_repo(tmp_path / "r")
+    (repo / ".graphify").mkdir()
+    (repo / ".graphify" / "push.sh").write_text("#!/bin/sh\n")
+    monkeypatch.chdir(repo)
+    remote.cmd_init([])
+    assert not (repo / ".graphify" / "push.py").exists()
+    assert (repo / ".graphify" / "pull.py").is_file()
+
+
+def test_init_outside_git_uses_cwd(tmp_path, monkeypatch):
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    monkeypatch.chdir(plain)
+    remote.cmd_init([])
+    assert (plain / ".graphify" / "config.json").is_file()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX exec bit")
+def test_init_scaffolded_hooks_are_executable(tmp_path, monkeypatch):
+    repo = _git_repo(tmp_path / "r")
+    monkeypatch.chdir(repo)
+    remote.cmd_init([])
+    for name in ("push.py", "pull.py"):
+        hook = repo / ".graphify" / name
+        assert os.access(hook, os.X_OK)  # shebang path: hook runs directly
+        assert hook.read_text().startswith("#!")
+
+
+def test_template_skip_excludes_cache_only(tmp_path, monkeypatch):
+    # execute the shared template preamble offline and probe its skip()
+    from graphify import remote_hook_templates as tpl
+    monkeypatch.setenv("GRAPHIFY_ACTION", "push")
+    monkeypatch.setenv("GRAPHIFY_STORE_DIR", str(tmp_path))
+    monkeypatch.setenv("GRAPHIFY_PREFIX", "r/main")
+    ns: dict = {}
+    exec(tpl._COMMON, ns)
+    assert ns["skip"]("graphify-out/cache/ast.json")
+    assert ns["skip"]("services/api/graphify-out/cache/x.json")
+    assert not ns["skip"]("graphify-out/graph.json")
+    assert not ns["skip"]("services/api/graphify-out/wiki/index.md")


### PR DESCRIPTION
## What

Teams with large graphs (hundreds of MB per module, monorepos with many modules) need `graphify-out` **out of git** and shared through a central place. This PR adds that without touching the skill: a committed `.graphify/config.json` selects a **store folder**, graphify keeps every `./graphify-out` as a *link* into it, and `push`/`pull` hooks **committed in the repo** sync the store anywhere (S3, rsync, git-lfs, a network share).

One command group:

```bash
graphify remote init      # scaffold .graphify/ (config.json + starter push/pull hooks) — commit it
graphify remote push      # run the push hook — upload the store tree
graphify remote pull      # run the pull hook — download the store tree + recreate all links
graphify remote delete    # leave the store — links become real local folders again
```

## Why a link (and not path rewriting)

The skill, the CLI defaults, and users' habits all use the literal `graphify-out/...` path (75 references in `skill.md` alone). A link keeps every one of those working unchanged while the bytes live outside the repo — **`graphify/skill*.md`, `graphify/skills/`, and `tools/skillgen/` are byte-identical to `v8`** in this PR (`--check`: 134 artifacts OK). The filesystem does the redirection, so the CLI and the skill can never disagree.

## Behaviour

- Any graphify command ensures the link first (one `lstat` when already correct). No config → identical to today.
- The link target is `<store>/<module-relpath>/graphify-out` — POSIX symlink, Windows **directory junction** (no admin rights).
- **The store path is the whole key — no `<repo>`/`<branch>` segment.** The repo points at the same store location on *every* branch (switch branches → no retarget, no rebuild; `graphify update` refreshes). Each repo names its own store path in its config; `remote init` defaults it to `~/graphify-store/<folder>`, editable to anything.
- Monorepos: one link per directory you build in, keyed by its repo-relative path.
- **Adoption is safe:** a pre-existing real `graphify-out/` — even one *tracked in git* — is migrated into the store once; committing then records the graph files leaving git.
- **Exit is safe:** `remote delete` replaces each link with a real folder holding a *copy* of its store data (the store is untouched), so a team can adopt and later go back. Both directions verified live.
- `.gitignore` gets a bare `graphify-out` entry in the same step (bare on purpose: `graphify-out/` matches only directories — git sees a symlink as a file, and on Windows git would descend into an unignored junction). Even unignored, a symlink commits as a ~100-byte path, never data.
- A regular *file* named `graphify-out` is never clobbered (warns and skips).
- `GRAPHIFY_OUT` (absolute) still overrides everything and disables linking.

## Sync hooks

`remote push`/`pull` run a hook — Python, Node, shell, PowerShell, `.cmd`/`.bat`, or any executable. Resolution: config `"push"`/`"pull"` path → `.graphify/<action>.*` committed in the repo. Repo-local hooks mean a clone carries its own sync behaviour — zero per-machine setup; secrets stay in the environment (`~/.aws`, env vars), never in the repo.

The hook gets `GRAPHIFY_STORE_DIR` (the `<store>` tree), `GRAPHIFY_PREFIX` (the store folder basename), `GRAPHIFY_CONFIG`, `GRAPHIFY_STORE`, `GRAPHIFY_REPO_ROOT`, and the action in the env and mirrors that tree; graphify has **no backend dependency**. An executable hook runs directly (shebang wins); otherwise the interpreter is picked by extension, so it also works on Windows. `remote pull` also fans a link out for every module found in the store, so one pull on a fresh clone recreates the whole working set. If the store folder is already shared (NFS/Dropbox), push/pull are unnecessary.

### Backend templates — `remote init --backend <name>`

`remote init` scaffolds working starter hooks for the chosen backend (default **s3**), non-destructively:

| backend | write | read |
|---|---|---|
| **s3** *(default)* | creds (boto3) | creds (boto3) |
| **s3-public** | creds (boto3) | **URL only — no creds, no SDK** (public bucket + `_manifest.json`, stdlib `urllib`) |
| **git-lfs** | `GRAPHIFY_GIT_REMOTE` | same |
| **rsync** | `GRAPHIFY_RSYNC_DEST` (SSH / mounted share) | same |

An unknown `--backend` prints the valid choices. The **s3-public** template is the asymmetric-access case — authenticated push to a public-read bucket, readers pull the committed `store_url` over plain HTTP; only pushers touch credentials.

## Files

- `graphify/store.py` (new) — config discovery, store keying, link/junction creation, migration, materialization, gitignore upkeep
- `graphify/remote.py` (new) — the `graphify remote <init|push|pull|delete>` group: hook resolution + invocation, `--backend` bootstrap, exit
- `graphify/remote_hook_templates.py` (new) — the 4-backend starter-hook registry (s3, s3-public, git-lfs, rsync)
- `graphify/__main__.py` / `graphify/cli.py` — dispatch + help
- `docs/graph-store.md` (follows the existing `docs/` feature-doc convention), `tests/test_remote_sync.py` (51 offline unit tests)

## Testing

- `pytest tests/` → all pass (Python 3.10 + 3.12), `python -m tools.skillgen --check` → 134 artifacts OK, ruff/pyright clean.
- The 51 unit tests cover the full matrix: config discovery edge cases (malformed/non-dict JSON, non-string store, `~` expansion, the store path as the sole key), linking (idempotency, **branch-independence** — same link target across branches, origin-remote independence, dangling-link self-heal, custom `GRAPHIFY_OUT` names, file-collision safety), migration (incl. collisions — local wins), gitignore variants (bare/slash/`**`, missing trailing newline), hook resolution (auto-discovery without a config key, extension priority, all six interpreters, executable/shebang path), the full hook env contract, `remote` dispatch incl. the `deinit` alias, init bootstrap/idempotency/other-language respect, **all four `--backend` templates** (incl. unknown-backend error, s3-public config keys, shell-hook backends), materialization, and the S3 template's `cache/` exclusion executed offline.
- **Live end-to-end on the Linux kernel monorepo** + a synthetic multi-module sandbox: builds land physically in the store through the links; `git status` clean; branch switch keeps the same link (branch-independent, no rebuild); a nested module (`kernel/time`) reads through its link. Publisher `remote push` + fresh-clone teammate `remote pull` verified against a real S3 bucket (Hetzner Object Storage) with the scaffolded hooks. **s3-public verified end-to-end**: authenticated multi-module push to a public-read bucket, then a fresh clone with credentials stripped from the environment pulled every module **by URL only** and queried a module it never built. Adoption + exit verified live with graphs previously committed to git (tracked → 0 → tracked).

Implements #1751.
