### PR TITLE
fix(update): preserve surviving hyperedges

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -407,6 +407,7 @@ def _reconcile_existing_graph(
             source_paths.absolute_identity(str(path), project_root) for path in extract_targets
         }
         node_evicted_source_identities = set(deleted_source_identities)
+        hyperedge_evicted_source_identities = set(deleted_source_identities)
         if not full_rebuild:
             node_evicted_source_identities.update(rebuilt_source_identities)
         edge_evicted_source_identities = (
@@ -431,6 +432,7 @@ def _reconcile_existing_graph(
                 if identity:
                     node_evicted_source_identities.add(identity)
                     edge_evicted_source_identities.add(identity)
+                    hyperedge_evicted_source_identities.add(identity)
 
         # A full re-extraction owns every AST node under watch_root. Incremental
         # extraction owns only nodes from rebuilt or deleted sources. Semantic
@@ -473,7 +475,7 @@ def _reconcile_existing_graph(
         for edge in existing.get("hyperedges", []):
             members = edge.get("nodes", edge.get("members", edge.get("node_ids", [])))
             if edge.get("id") in new_hyperedge_ids or source_paths.is_evicted(
-                edge, edge_evicted_source_identities
+                edge, hyperedge_evicted_source_identities
             ):
                 continue
             if isinstance(members, list) and any(member not in all_ids for member in members):

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -278,6 +278,57 @@ def _add_unrelated_semantic_pair(graph_path):
 
 @pytest.mark.parametrize(
     "changed_paths",
+    [None, [Path("doc.md")]],
+    ids=["full-update", "incremental-doc-update"],
+)
+def test_rebuild_code_preserves_hyperedges_for_rebuilt_surviving_source(
+    tmp_path, changed_paths
+):
+    """#1755: AST-only updates must not drop semantic hyperedges whose members survive."""
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "doc.md").write_text(
+        "# Design\n\n## Flow\n\nDetails.\n", encoding="utf-8"
+    )
+
+    assert _rebuild_code(corpus, no_cluster=True, acquire_lock=False) is True
+    graph_path = corpus / "graphify-out" / "graph.json"
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    assert {"doc", "doc_design"} <= {node["id"] for node in data["nodes"]}
+    data["hyperedges"] = [{
+        "id": "doc_flow_group",
+        "label": "Doc flow group",
+        "nodes": ["doc", "doc_design"],
+        "relation": "implements",
+        "confidence": "EXTRACTED",
+        "confidence_score": 1.0,
+        "source_file": "doc.md",
+    }]
+    graph_path.write_text(json.dumps(data), encoding="utf-8")
+
+    assert _rebuild_code(
+        corpus,
+        changed_paths=changed_paths,
+        no_cluster=True,
+        acquire_lock=False,
+    ) is True
+
+    after = json.loads(graph_path.read_text(encoding="utf-8"))
+    assert after["hyperedges"] == [{
+        "id": "doc_flow_group",
+        "label": "Doc flow group",
+        "nodes": ["doc", "doc_design"],
+        "relation": "implements",
+        "confidence": "EXTRACTED",
+        "confidence_score": 1.0,
+        "source_file": "doc.md",
+    }]
+
+
+@pytest.mark.parametrize(
+    "changed_paths",
     [None, [Path("only.py")]],
     ids=["full-update", "incremental-update"],
 )


### PR DESCRIPTION
## Summary

- preserve existing hyperedges during watcher/AST-only `graphify update` reconciliation when their source file is re-extracted but their member nodes still survive
- keep deletion and dangling-member pruning behavior unchanged
- cover full update and incremental doc update paths

Fixes #1755

## Result

Regression fixture keeps the doc-sourced semantic hyperedge after a no-op update:

```text
Before: graphify update removed doc_flow_group
After:  graphify update keeps doc_flow_group -> [doc, doc_design]
```

## Testing

- `uv run --frozen pytest tests/test_watch.py -q -k hyperedges` (2 passed, 56 deselected)
- `uv run --frozen pytest tests/ -q --tb=short` (3137 passed, 3 skipped)
- `uv run --frozen ruff check graphify/watch.py tests/test_watch.py` (passed)
- `uv run --frozen python -m tools.skillgen --check` (134 artifacts matched)
- `uv run --frozen graphify update .` (rebuilt graph.json and GRAPH_REPORT.md; no tracked changes)
