### PR TITLE
fix(extract): create json_config reference target nodes

### DIFF
--- a/graphify/extractors/json_config.py
+++ b/graphify/extractors/json_config.py
@@ -90,10 +90,10 @@ def extract_json(path: Path) -> dict:
         "optionalDependencies", "bundleDependencies", "bundledDependencies",
     })
 
-    def add_node(nid: str, label: str, line: int) -> None:
+    def add_node(nid: str, label: str, line: int, file_type: str = "code") -> None:
         if nid and nid not in seen_ids:
             seen_ids.add(nid)
-            nodes.append({"id": nid, "label": label, "file_type": "code",
+            nodes.append({"id": nid, "label": label, "file_type": file_type,
                           "source_file": str_path, "source_location": f"L{line}"})
 
     def add_edge(src: str, tgt: str, relation: str, line: int,
@@ -165,6 +165,7 @@ def extract_json(path: Path) -> dict:
                         if ref:
                             ref_nid = _make_id("ref", ref)
                             if ref_nid:
+                                add_node(ref_nid, ref, line, file_type="concept")
                                 add_edge(key_nid, ref_nid, "extends", line, context="import")
 
             elif val.type == "string":
@@ -175,6 +176,7 @@ def extract_json(path: Path) -> dict:
                     # Namespace external refs to avoid ID collision with file nodes (J-4)
                     ref_nid = _make_id("ref", val_text)
                     if ref_nid:
+                        add_node(ref_nid, val_text, line, file_type="concept")
                         add_edge(file_nid, ref_nid, "extends", line, context="import")
 
                 elif key == "$ref" and val_text:
@@ -186,6 +188,7 @@ def extract_json(path: Path) -> dict:
                 elif parent_key in _DEP_KEYS and val_text:
                     dep_nid = _make_id(key)
                     if dep_nid:
+                        add_node(dep_nid, key, line, file_type="concept")
                         add_edge(key_nid, dep_nid, "imports", line, context="import")
 
     # Entry: find root document → object

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from graphify.build import build_from_json
 from graphify.extract import extract_python, extract, collect_files, _make_id, extract_bash, extract_json, _DISPATCH
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -1466,6 +1467,49 @@ def test_extract_json_extends_resolved():
     extends_edges = [e for e in result["edges"] if e["relation"] == "extends"]
     assert len(extends_edges) >= 1
     assert extends_edges[0].get("context") == "import"
+
+
+def test_extract_json_import_and_extends_targets_are_real_nodes(tmp_path):
+    package_json = tmp_path / "package.json"
+    package_json.write_text(json.dumps({
+        "name": "demo",
+        "dependencies": {"left-pad": "^1.3.0"},
+        "devDependencies": {"bats": "^1.11.0"},
+    }))
+    tsconfig = tmp_path / "tsconfig.json"
+    tsconfig.write_text(json.dumps({
+        "extends": "./tsconfig.base.json",
+        "compilerOptions": {"strict": True},
+    }))
+
+    results = [extract_json(package_json), extract_json(tsconfig)]
+    combined = {
+        "nodes": [node for result in results for node in result["nodes"]],
+        "edges": [edge for result in results for edge in result["edges"]],
+    }
+    node_ids = {node["id"] for node in combined["nodes"]}
+    dangling = [
+        edge for edge in combined["edges"]
+        if edge["source"] not in node_ids or edge["target"] not in node_ids
+    ]
+    assert dangling == []
+    assert {"left-pad", "bats", "./tsconfig.base.json"} <= {
+        node["label"] for node in combined["nodes"] if node["file_type"] == "concept"
+    }
+
+    graph = build_from_json(combined, directed=True)
+    import_targets = {
+        graph.nodes[data["_tgt"]]["label"]
+        for _, _, data in graph.edges(data=True)
+        if data.get("relation") == "imports"
+    }
+    extends_targets = {
+        graph.nodes[data["_tgt"]]["label"]
+        for _, _, data in graph.edges(data=True)
+        if data.get("relation") == "extends"
+    }
+    assert {"left-pad", "bats"} <= import_targets
+    assert extends_targets == {"./tsconfig.base.json"}
 
 
 def test_extract_json_large_file_skipped(tmp_path):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1497,7 +1497,8 @@ def test_extract_json_import_and_extends_targets_are_real_nodes(tmp_path):
         node["label"] for node in combined["nodes"] if node["file_type"] == "concept"
     }
 
-    graph = build_from_json(combined, directed=True)
+    extracted = extract([package_json, tsconfig], cache_root=tmp_path, parallel=False)
+    graph = build_from_json(extracted, directed=True)
     import_targets = {
         graph.nodes[data["_tgt"]]["label"]
         for _, _, data in graph.edges(data=True)
@@ -1508,6 +1509,11 @@ def test_extract_json_import_and_extends_targets_are_real_nodes(tmp_path):
         for _, _, data in graph.edges(data=True)
         if data.get("relation") == "extends"
     }
+    self_loops = [
+        data for _, _, data in graph.edges(data=True)
+        if data.get("relation") in {"imports", "extends"} and data["_src"] == data["_tgt"]
+    ]
+    assert self_loops == []
     assert {"left-pad", "bats"} <= import_targets
     assert extends_targets == {"./tsconfig.base.json"}
 


### PR DESCRIPTION
## Summary

- Create real concept nodes for `json_config` dependency and `extends` targets before emitting `imports` / `extends` edges.
- Add regression coverage that the issue fixture has no dangling endpoints and that `build_from_json` keeps the edges.

Fixes #1764

## Result

```text
dangling_endpoint_edges: 0
kept_edges: [('extends', './tsconfig.base.json'), ('imports', 'bats'), ('imports', 'left-pad')]
```

## Testing

- `pytest tests/test_extract.py -q -k 'json'` (14 passed, 104 deselected)
- `pytest tests/test_manifest_ingest.py tests/test_extract.py -q -k 'manifest or json'` (22 passed, 104 deselected)
- `ruff check graphify/extractors/json_config.py tests/test_extract.py` (passed)
- `python -m tools.skillgen --check` (passed)
- `pytest tests/ -q --tb=short` (3136 passed, 3 skipped)
- `graphify update .` (completed; graph.json and GRAPH_REPORT.md updated locally, no tracked graph output changes)
