### PR TITLE
fix(analyze): exclude rationale nodes from gap questions

### DIFF
--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -504,7 +504,10 @@ def suggest_questions(
     # 4. Isolated or weakly-connected nodes → exploration questions
     isolated = [
         n for n in G.nodes()
-        if G.degree(n) <= 1 and not _is_file_node(G, n) and not _is_concept_node(G, n)
+        if G.degree(n) <= 1
+        and not _is_file_node(G, n)
+        and not _is_concept_node(G, n)
+        and G.nodes[n].get("file_type") != "rationale"
     ]
     if isolated:
         labels = [G.nodes[n].get("label", n) for n in isolated[:3]]

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -5,7 +5,7 @@ import pytest
 from pathlib import Path
 from graphify.build import build_from_json
 from graphify.cluster import cluster
-from graphify.analyze import god_nodes, surprising_connections, _is_concept_node, graph_diff, _surprise_score, _file_category, _is_json_key_node, find_import_cycles
+from graphify.analyze import god_nodes, surprising_connections, _is_concept_node, graph_diff, _surprise_score, _file_category, _is_json_key_node, find_import_cycles, suggest_questions
 from graphify.extract import _make_id
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -601,6 +601,19 @@ def test_god_nodes_filter_is_case_insensitive():
     labels = [r["label"] for r in result]
     for variant in ("Start", "START", "Name", "ID"):
         assert variant not in labels, f"`{variant}` should be filtered as JSON-key noise"
+
+
+def test_suggest_questions_excludes_rationale_nodes_from_isolated_count():
+    G = nx.Graph()
+    G.add_node("service", label="Service", file_type="code", source_file="service.py")
+    G.add_node("reason", label="Explains service", file_type="rationale", source_file="service.py")
+
+    questions = suggest_questions(G, communities={}, community_labels={}, top_n=10)
+    isolated = next(question for question in questions if question["type"] == "isolated_nodes")
+
+    assert isolated["why"].startswith("1 weakly-connected node")
+    assert "`Service`" in isolated["question"]
+    assert "Explains service" not in isolated["question"]
 
 
 # ── find_import_cycles tests ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Keep the isolated-node count in suggested questions consistent with the report's Knowledge Gaps section.

## Root cause

`report.py` excludes `rationale` nodes from knowledge gaps because their expected shape is a single edge to the symbol they explain. `suggest_questions()` applied the other report filters but omitted that exclusion, so the same graph could show two different isolated-node counts.

## Changes

- Apply the existing `file_type != "rationale"` filter in `suggest_questions()`.
- Add a regression test that keeps a normal isolated node while excluding the rationale node from the count and question text.

This intentionally does not change cohesion scoring or add JSON/TypeScript naming heuristics.

## Validation

- `python -m pytest tests/test_analyze.py tests/test_report.py tests/test_cluster.py -q` (`74 passed`)
- `python -m py_compile graphify/analyze.py tests/test_analyze.py`
- `python -m graphify update .`
- `git diff --check origin/v8...HEAD`

The full local suite was not repeated because Windows Store Python crashed in existing `ProcessPoolExecutor` pipeline tests during the earlier full-suite attempt. GitHub CI remains the full-suite check.

Addresses the count mismatch in #1768.
