### PR TITLE
fix(extract): emit inherits edge for JavaScript class extends

### DIFF
--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -1363,19 +1363,34 @@ def _ts_walk_class_members(class_node, source: bytes, path: Path, class_nid: str
     line = class_node.start_point[0] + 1
     for child in class_node.children:
         if child.type == "class_heritage":
+            saw_clause = False
             for clause in child.children:
                 if clause.type == "extends_clause":
+                    saw_clause = True
                     for name in _ts_heritage_clause_entries(clause, source):
                         facts.uses.append(
                             _SymbolUseFact(path, class_nid, name, "inherits", "type",
                                            clause.start_point[0] + 1)
                         )
                 elif clause.type == "implements_clause":
+                    saw_clause = True
                     for name in _ts_heritage_clause_entries(clause, source):
                         facts.uses.append(
                             _SymbolUseFact(path, class_nid, name, "implements", "type",
                                            clause.start_point[0] + 1)
                         )
+            if not saw_clause:
+                # The JavaScript grammar carries the base directly under
+                # class_heritage (`extends Base` -> [extends, identifier]) with no
+                # extends_clause/implements_clause wrapper like the TypeScript
+                # grammar. Treat the heritage node itself as the extends clause so
+                # `class Derived extends Base {}` in a .js file still emits an
+                # inherits edge. Mirrors the extends_type_clause branch below.
+                for name in _ts_heritage_clause_entries(child, source):
+                    facts.uses.append(
+                        _SymbolUseFact(path, class_nid, name, "inherits", "type",
+                                       child.start_point[0] + 1)
+                    )
         elif child.type == "extends_type_clause":
             # Interface heritage (`interface A extends B, C`) is an
             # extends_type_clause node, NOT a class_heritage. Its base entries

--- a/tests/test_ts_inheritance.py
+++ b/tests/test_ts_inheritance.py
@@ -56,6 +56,42 @@ def test_class_extends_same_file(tmp_path):
     assert _has_inherits(result, "src/a.ts", "Dog", "src/a.ts", "Animal")
 
 
+def test_js_class_extends_same_file(tmp_path):
+    """`class Dog extends Animal {}` in a plain .js file must emit an inherits edge.
+
+    The JavaScript grammar stores the base identifier directly under the
+    `class_heritage` node (no `extends_clause` wrapper as in the TypeScript
+    grammar), so the heritage walk dropped the edge for .js classes while the
+    equivalent .ts file (test_class_extends_same_file) already worked.
+    """
+    f = _write(tmp_path / "src" / "a.js",
+               "class Animal {}\n"
+               "class Dog extends Animal {}\n")
+    result = extract([f], cache_root=tmp_path)
+    assert _has_inherits(result, "src/a.js", "Dog", "src/a.js", "Animal")
+
+
+def test_js_class_extends_imported(tmp_path):
+    """The JavaScript grammar path must retain import-guided resolution."""
+    base = _write(tmp_path / "src" / "base.js", "export class Animal {}\n")
+    derived = _write(tmp_path / "src" / "derived.js",
+                     "import { Animal } from './base.js';\n"
+                     "export class Dog extends Animal {}\n")
+    result = extract([derived, base], cache_root=tmp_path)
+    assert _has_inherits(result, "src/derived.js", "Dog", "src/base.js", "Animal")
+
+
+def test_js_dynamic_class_base_does_not_fabricate_inherits(tmp_path):
+    """A runtime base expression has no statically resolvable parent symbol."""
+    f = _write(tmp_path / "src" / "a.js",
+               "class Animal {}\n"
+               "function mixin(base) { return class extends base {}; }\n"
+               "class Dog extends mixin(Animal) {}\n")
+    result = extract([f], cache_root=tmp_path)
+    assert not _has_inherits(result, "src/a.js", "Dog", "src/a.js", "Animal")
+    assert not _has_inherits(result, "src/a.js", "Dog", "src/a.js", "mixin")
+
+
 def test_interface_extends_generic_base_same_file(tmp_path):
     f = _write(tmp_path / "src" / "a.ts",
                "interface Base<T> { x: T; }\n"


### PR DESCRIPTION
## Bug

Plain JavaScript class heritage was dropped: `class Dog extends Animal {}` emitted no `inherits` edge, while the equivalent TypeScript did.

## Root cause

The JavaScript grammar stores `extends` and its identifier directly under `class_heritage`. TypeScript wraps the base in an `extends_clause`. The walker only handled the wrapped shape.

## Fix

When a `class_heritage` node has no `extends_clause` or `implements_clause`, treat the heritage node itself as the JavaScript extends clause. The guard preserves the existing TypeScript path and prevents duplicate edges.

The implementation remains precision-first: direct same-file and imported identifiers resolve; runtime expressions such as `extends mixin(Animal)` are not converted into fabricated static inheritance. Qualified member expressions require namespace-aware resolution and remain outside this focused fix.

## Validation

- Added same-file JavaScript inheritance coverage.
- Added imported JavaScript inheritance coverage.
- Added a dynamic-base negative control.
- Existing TypeScript interface, generic, imported and implements cases remain covered.
- `tests/test_ts_inheritance.py`: 10 passed.
- Ruff and `git diff --check`: passed.

