### PR TITLE
fix(scala): capture trait declarations as class-like nodes

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -780,7 +780,9 @@ _KOTLIN_CONFIG = LanguageConfig(
 
 _SCALA_CONFIG = LanguageConfig(
     ts_module="tree_sitter_scala",
-    class_types=frozenset({"class_definition", "object_definition"}),
+    # traits are class-like containers with their own heritage (extends / with),
+    # so they need a node and the heritage walk just like classes and objects.
+    class_types=frozenset({"class_definition", "object_definition", "trait_definition"}),
     function_types=frozenset({"function_definition"}),
     import_types=frozenset({"import_declaration"}),
     call_types=frozenset({"call_expression"}),

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -691,6 +691,19 @@ def test_scala_splits_inherits_and_mixes_in():
     assert ("HttpClient", "Loggable") in _edge_labels(r, "mixes_in")
 
 
+def test_scala_trait_definition_heritage(tmp_path):
+    """A `trait` is a class-like container and must get a node plus heritage
+    edges. `trait_definition` was missing from the Scala class_types, so traits
+    produced no node and their `extends`/`with` edges were dropped.
+    """
+    f = tmp_path / "greeter.scala"
+    f.write_text("trait Greeter extends Base with Logging { def greet(): Unit }\n")
+    r = extract_scala(f)
+    assert any("Greeter" in l for l in _labels(r))
+    assert ("Greeter", "Base") in _edge_labels(r, "inherits")
+    assert ("Greeter", "Logging") in _edge_labels(r, "mixes_in")
+
+
 def test_scala_constructor_parameter_field_context():
     r = extract_scala(FIXTURES / "sample.scala")
     assert ("HttpClient", "Config") in _edge_labels(r, "references", "field")


### PR DESCRIPTION
## Bug

Scala `trait` declarations produce **no node** and **no heritage edges**. A `trait` that `extends`/`with`-mixes other types loses all of that structure.

### Root cause

`_SCALA_CONFIG.class_types` contained only `class_definition` and `object_definition`. The tree-sitter-scala grammar parses a trait as a `trait_definition` node, which was therefore never treated as class-like — so it never became a node and the Scala heritage handler never ran for it.

## Minimal repro

```scala
trait Greeter extends Base with Logging { def greet(): Unit }
```

Before: no `Greeter` node, no `inherits`/`mixes_in` edges.

## Fix

Add `trait_definition` to `_SCALA_CONFIG.class_types`. The existing Scala `extends_clause` handler already splits the first base (`inherits`) from subsequent `with` mixins (`mixes_in`), so once the trait becomes a class-like node the edges are emitted correctly.

After the fix:
- `Greeter --inherits--> Base`
- `Greeter --mixes_in--> Logging`

## Testing

- Added `test_scala_trait_definition_heritage` to `tests/test_languages.py`, mirroring the existing `test_scala_splits_inherits_and_mixes_in`. Fails before, passes after.
- `tests/test_languages.py`: 315 passed, 13 skipped.