### PR TITLE
fix(scala): emit heritage edges for qualified extends/with clauses

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2797,18 +2797,39 @@ def _extract_generic(
                             break
                 if extend is not None:
                     bases: list[tuple[str, int]] = []
-                    for c in extend.children:
-                        if c.type == "type_identifier":
-                            bases.append((_read_text(c, source), c.start_point[0] + 1))
-                        elif c.type == "generic_type":
-                            base = c.child_by_field_name("type")
+
+                    def scala_base_name(type_node) -> str | None:
+                        if type_node.type == "type_identifier":
+                            return _read_text(type_node, source)
+                        if type_node.type == "stable_type_identifier":
+                            tail = next(
+                                (
+                                    child
+                                    for child in reversed(type_node.children)
+                                    if child.type in ("type_identifier", "identifier")
+                                ),
+                                None,
+                            )
+                            return _read_text(tail, source) if tail is not None else None
+                        if type_node.type == "generic_type":
+                            base = type_node.child_by_field_name("type")
                             if base is None:
-                                for sc in c.children:
-                                    if sc.type == "type_identifier":
-                                        base = sc
-                                        break
-                            if base is not None:
-                                bases.append((_read_text(base, source), c.start_point[0] + 1))
+                                base = next(
+                                    (
+                                        child
+                                        for child in type_node.children
+                                        if child.type
+                                        in ("type_identifier", "stable_type_identifier")
+                                    ),
+                                    None,
+                                )
+                            return scala_base_name(base) if base is not None else None
+                        return None
+
+                    for c in extend.children:
+                        base_name = scala_base_name(c)
+                        if base_name is not None:
+                            bases.append((base_name, c.start_point[0] + 1))
                     for idx, (base_name, base_line) in enumerate(bases):
                         rel = "inherits" if idx == 0 else "mixes_in"
                         base_nid = ensure_named_node(base_name, base_line)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -745,6 +745,35 @@ def test_scala_splits_inherits_and_mixes_in():
     assert ("HttpClient", "Loggable") in _edge_labels(r, "mixes_in")
 
 
+def test_scala_qualified_extends_uses_tail_name(tmp_path):
+    """A qualified base like `pkg.Base` is a `stable_type_identifier` node in the
+    extends_clause. The handler only matched `type_identifier`/`generic_type`, so
+    qualified extends/with clauses were dropped. Resolve them to the tail type
+    name (`Base`, `Trait1`), not the package path.
+    """
+    f = tmp_path / "foo.scala"
+    f.write_text(
+        "class Foo extends pkg.Base with other.Trait1\n"
+        "class Generic extends pkg.Base[Int] with other.Trait1[String]\n"
+        "class Constructed extends outer.pkg.Base[Int](42) "
+        "with a.b.Trait1[String]\n"
+    )
+    r = extract_scala(f)
+    inherits = _edge_labels(r, "inherits")
+    mixes_in = _edge_labels(r, "mixes_in")
+    assert ("Foo", "Base") in inherits
+    assert ("Foo", "Trait1") in mixes_in
+    assert ("Generic", "Base") in inherits
+    assert ("Generic", "Trait1") in mixes_in
+    assert ("Constructed", "Base") in inherits
+    assert ("Constructed", "Trait1") in mixes_in
+    # Package qualifiers and generic arguments are not parent type names.
+    assert ("Generic", "pkg.Base") not in inherits
+    assert ("Generic", "other.Trait1") not in mixes_in
+    assert ("Constructed", "Int") not in inherits
+    assert ("Constructed", "String") not in mixes_in
+
+
 def test_scala_constructor_parameter_field_context():
     r = extract_scala(FIXTURES / "sample.scala")
     assert ("HttpClient", "Config") in _edge_labels(r, "references", "field")


### PR DESCRIPTION
## Bug

Scala qualified parents were either dropped or retained as package-qualified labels. For example, `class Foo extends pkg.Base with other.Trait` should emit `Foo -> Base` and `Foo -> Trait`.

## Root cause

The heritage walker handled `type_identifier` and a narrow `generic_type` shape. Qualified parents parse as `stable_type_identifier`; qualified generic parents wrap that node inside `generic_type`.

## Fix

Normalize heritage nodes through one bounded helper:

- plain `type_identifier` returns its name;
- `stable_type_identifier` returns its final type segment;
- `generic_type` recursively normalizes its base type.

Only direct heritage children are considered, so package segments, generic arguments and constructor arguments cannot become parent edges. The first parent remains `inherits`; subsequent `with` parents remain `mixes_in`.

## Validation

- Covers simple qualified parents.
- Covers qualified generic parents.
- Covers multi-segment packages and constructor arguments.
- Verifies package qualifiers and generic arguments are not emitted as parents.
- `tests/test_languages.py`: 319 passed, 13 optional-DM skips.
- Ruff and `git diff --check`: passed.

