### PR TITLE
fix(extract): emit inherits edge for Python parameterized bases

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2430,8 +2430,16 @@ def _extract_generic(
                 args = node.child_by_field_name("superclasses")
                 if args:
                     for arg in args.children:
-                        if arg.type == "identifier":
-                            base = _read_text(arg, source)
+                        base_node = arg
+                        # A parameterized base (`Base[T]`, `Generic[T]`,
+                        # `Repo[User]`) parses as a `subscript` whose `value`
+                        # field is the actual base type; the `[...]` holds only
+                        # type parameters. Unwrap to the value so the heritage
+                        # edge points at the base instead of being dropped.
+                        if base_node.type == "subscript":
+                            base_node = base_node.child_by_field_name("value") or base_node
+                        if base_node.type == "identifier":
+                            base = _read_text(base_node, source)
                             base_nid = ensure_named_node(base, line)
                             add_edge(class_nid, base_nid, "inherits", line)
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 import pytest
 from graphify.extract import (
+    extract_python,
     extract_java, extract_c, extract_cpp, extract_ruby,
     extract_csharp, extract_kotlin, extract_scala, extract_php,
     extract_swift, extract_go, extract_julia, extract_js, extract_fortran,
@@ -331,6 +332,39 @@ def test_ruby_inherits_edge():
         for e in r["edges"] if e["relation"] == "inherits"
     )
     assert found, "TimeoutApiClient should have inherits edge to ApiClient"
+
+
+# ── Python ──────────────────────────────────────────────────────────────────
+
+def test_python_parameterized_base_inherits_edge(tmp_path):
+    """`class C(Base[T])` must still emit an inherits edge to the base type.
+
+    The Python heritage handler only matched bare `identifier` bases in the
+    `superclasses` list. A parameterized base parses as a `subscript` node
+    (its `value` field is the base type; the `[...]` holds only type params),
+    so it fell through and the heritage edge was silently dropped -- every
+    `Generic[T]` / `Repo[User]` base lost its `inherits` edge.
+    """
+    source = tmp_path / "heritage.py"
+    source.write_text(
+        "class Base: pass\n"
+        "class Mixin: pass\n"
+        "class Repo(Base[int]): pass\n"
+        "class Multi(Mixin, Base[list[str]]): pass\n"
+        "def make_base(): return Base\n"
+        "class Dynamic(make_base()): pass\n"
+    )
+    result = extract_python(source)
+    inherits = _edge_labels(result, "inherits")
+    # Parameterized base must resolve to the base type, not be dropped.
+    assert ("Repo", "Base") in inherits
+    assert ("Multi", "Base") in inherits
+    # Bare-identifier bases must keep working (regression guard).
+    assert ("Multi", "Mixin") in inherits
+    # Generic arguments and dynamic base factories are not concrete parents.
+    assert ("Multi", "list") not in inherits
+    assert ("Multi", "str") not in inherits
+    assert ("Dynamic", "make_base") not in inherits
 
 
 # ── C# ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Bug

Python parameterized bases were dropped. `class Repo(Base[int])` emitted no `inherits` edge even though `class Repo(Base)` worked.

## Root cause

The Python heritage walker accepted only `identifier` nodes. A parameterized base parses as `subscript`, with the concrete base in its `value` field and type arguments inside the brackets.

## Fix

For a `subscript` heritage entry, unwrap its `value` before applying the existing identifier-only rule. Bare bases are unchanged.

The scope is intentionally narrow: qualified attribute bases and runtime expressions are separate resolution problems. They remain skipped instead of creating a potentially incorrect local target.

## Validation

- Covers single and mixed parameterized bases.
- Covers nested type arguments such as `Base[list[str]]`.
- Retains bare-identifier inheritance.
- Verifies generic arguments do not become parent edges.
- Verifies a runtime base factory does not fabricate an inheritance edge.
- `tests/test_languages.py`: 319 passed, 13 optional-DM skips.
- Ruff and `git diff --check`: passed.

