### PR TITLE
fix(csharp): classify interface base types as inherits, not implements

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2579,7 +2579,14 @@ def _extract_generic(
                                     "source_location": "",
                                 })
                                 seen_ids.add(base_nid)
-                        relation = _csharp_classify_base(base, csharp_interface_names)
+                        # An `interface`'s base_list holds base interfaces, so every
+                        # entry is interface inheritance (`inherits`) -- the same way the
+                        # Java extractor treats `extends_interfaces`. Only class/struct/
+                        # record declarations use the name-based class-vs-interface split.
+                        if t == "interface_declaration":
+                            relation = "inherits"
+                        else:
+                            relation = _csharp_classify_base(base, csharp_interface_names)
                         metadata = {"ref_token": base}
                         if qualified:
                             metadata["qualified"] = True

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -378,6 +378,35 @@ def test_csharp_splits_inherits_and_implements_edges():
     assert ("DataProcessor", "IProcessor") in _edge_labels(result, "implements")
 
 
+def test_csharp_interface_extends_is_inherits_not_implements(tmp_path):
+    # A C# `interface`'s base_list holds base interfaces, so extending another
+    # interface is interface *inheritance* -- mirroring how the Java extractor
+    # treats `extends_interfaces`. These edges used to be mislabeled `implements`,
+    # which is reserved for a class/struct/record realizing an interface.
+    source = tmp_path / "Interfaces.cs"
+    source.write_text(
+        "public interface IBase {}\n"
+        "public interface IOther {}\n"
+        "public interface IDerived : IBase {}\n"
+        "public interface IMulti : IBase, IOther {}\n"
+        "public class Impl : IBase {}\n"
+    )
+    result = extract_csharp(source)
+    inherits = _edge_labels(result, "inherits")
+    implements = _edge_labels(result, "implements")
+
+    # interface-extends-interface is inheritance, not implementation
+    assert ("IDerived", "IBase") in inherits
+    assert ("IMulti", "IBase") in inherits
+    assert ("IMulti", "IOther") in inherits
+    assert ("IDerived", "IBase") not in implements
+    assert ("IMulti", "IBase") not in implements
+
+    # a class realizing an interface is still `implements`
+    assert ("Impl", "IBase") in implements
+    assert ("Impl", "IBase") not in inherits
+
+
 def test_csharp_parameter_return_and_generic_contexts():
     result = extract_csharp(FIXTURES / "sample.cs")
     assert ("Build", "HttpClient") in _edge_labels(result, "references", "parameter_type")


### PR DESCRIPTION
## Summary

A C# `interface`'s base_list holds **base interfaces**, so extending another
interface is interface *inheritance*, not implementation. The C# base_list
emitter in `_extract_generic` classified **every** base-list entry with the
name-based class-vs-interface heuristic (`_csharp_classify_base`), so an
interface extending another interface produced an `implements` edge.

This diverges from the Java extractor in the same engine, which emits
`inherits` for `extends_interfaces`. The result is an inconsistent type
hierarchy: traversing `inherits` edges misses C# interface hierarchies that
it would capture for Java.

## Reproduction (v8 HEAD)

```csharp
public interface IBase {}
public interface IDerived : IBase {}
public class Impl : IBase {}
```

```
inherits:    <none>
implements:  IDerived -> IBase      # wrong: interface extension is inheritance
             Impl     -> IBase      # correct
```

The equivalent Java (`interface IDerived extends IBase`) already yields
`IDerived --inherits--> IBase`.

## Fix

When the declaring node is an `interface_declaration`, classify each base as
`inherits` (all interface base-list entries are inherited base interfaces).
Class/struct/record declarations keep the existing name-based split — the
first non-interface base stays `inherits`, interface bases stay `implements`
— so `implements` now means only a class/struct/record realizing an
interface, matching the other language extractors.

Base extraction, generic-argument `references` edges, and the
`ref_token`/`qualified`/`ref_qualifier` metadata used by cross-file
resolution are unchanged; only the emitted `relation` for interface-declared
bases changes.

## Testing

- New regression test `test_csharp_interface_extends_is_inherits_not_implements`
  covers single- and multi-interface extension and a class implementer as a
  negative control. It fails on `v8` HEAD (interface bases land in
  `implements`) and passes with this change.
- `tests/test_languages.py`: 315 passed, 13 skipped.
- C# suites `test_csharp_type_resolution.py`, `test_csharp_member_calls.py`,
  `test_dotnet.py`, `test_cross_language_call_resolution.py`: 89 passed.