### PR TITLE
fix(go): don't emit embeds for interface type-set constraints

### DIFF
--- a/graphify/extractors/go.py
+++ b/graphify/extractors/go.py
@@ -277,6 +277,16 @@ def extract_go(path: Path) -> dict:
                     for elem in type_body.children:
                         if elem.type != "type_elem":
                             continue
+                        # A type_elem that is a generics type-set constraint -
+                        # a union (`A | B`) or an approximation (`~T`) - is NOT
+                        # interface embedding. Go only embeds a lone interface
+                        # type; union/approximation terms can never be embedded,
+                        # so they must not emit `embeds` heritage edges. Keep the
+                        # type link as a `references` (type_constraint) edge.
+                        is_type_set = any(
+                            c.type == "|" or c.type == "negated_type"
+                            for c in elem.children
+                        )
                         refs = []
                         for sub in elem.children:
                             if sub.is_named:
@@ -285,7 +295,10 @@ def extract_go(path: Path) -> dict:
                             tgt = ensure_named_node(ref_name, elem.start_point[0] + 1)
                             if tgt == type_nid:
                                 continue
-                            if role == "type":
+                            if is_type_set:
+                                add_edge(type_nid, tgt, "references",
+                                         elem.start_point[0] + 1, context="type_constraint")
+                            elif role == "type":
                                 add_edge(type_nid, tgt, "embeds",
                                          elem.start_point[0] + 1)
                             else:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1526,6 +1526,47 @@ def test_go_receiver_uses_pkg_scope():
     assert "sample" not in server_nodes[0]["id"].split(":")[0]
 
 
+def test_go_interface_embedding_emits_embeds():
+    """`type ReaderLogger interface { Logger; Reader }` embeds both interfaces."""
+    r = extract_go(FIXTURES / "sample.go")
+    embeds = _edge_labels(r, "embeds")
+    assert ("ReaderLogger", "Logger") in embeds
+    assert ("ReaderLogger", "Reader") in embeds
+
+
+def test_go_struct_embedding_emits_embeds():
+    """`type DataProcessor struct { BaseProcessor }` embeds the base struct."""
+    r = extract_go(FIXTURES / "sample.go")
+    assert ("DataProcessor", "BaseProcessor") in _edge_labels(r, "embeds")
+
+
+def test_go_interface_type_union_is_not_embedding(tmp_path):
+    """A generics type-set constraint (`A | B`) is NOT interface embedding.
+
+    Go only allows *interfaces* to be embedded, and each embed is its own
+    element. A union of type terms (`MyInt | MyFloat`) is a constraint type
+    set that can never be embedded, so its terms must not emit `embeds`
+    heritage edges. They are reclassified as `references` (type_constraint)
+    so the type link is preserved without asserting false composition.
+    """
+    source = tmp_path / "constraint.go"
+    source.write_text(
+        "package p\n"
+        "type MyInt int\n"
+        "type MyFloat float64\n"
+        "type Number interface {\n"
+        "\tMyInt | MyFloat\n"
+        "}\n"
+    )
+    r = extract_go(source)
+    embeds = _edge_labels(r, "embeds")
+    assert ("Number", "MyInt") not in embeds
+    assert ("Number", "MyFloat") not in embeds
+    refs = _edge_labels(r, "references", "type_constraint")
+    assert ("Number", "MyInt") in refs
+    assert ("Number", "MyFloat") in refs
+
+
 # ---------------------------------------------------------------------------
 # Julia
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The Go extractor treats every interface `type_elem` as an embedded interface.
But a Go **type-set constraint** (generics) is not embedding — a union
`A | B` or an approximation `~T` is a set of type *terms*, and Go only ever
embeds a lone interface type. Because the branch walked union terms the same
way it walks an embedded interface, each non-predeclared term produced a
spurious `embeds` **heritage** edge.

### Reproduction on `v8` HEAD

```go
package p
type MyInt int
type MyFloat float64
type Number interface {
    MyInt | MyFloat
}
```

`extract_go` emits:

```
Number --embeds--> MyInt
Number --embeds--> MyFloat
```

`embeds` is a heritage relation (grouped with `inherits` / `implements` /
`mixes_in` in `extract.py`), so this asserts a composition/method-promotion
relationship that does not exist — `Number` cannot embed the concrete types
`MyInt`/`MyFloat`; they are constraint terms. This pollutes heritage queries
over the graph with false edges.

## Fix

Detect a type-set `type_elem` (it has a `|` or a `negated_type` child — both
tokens appear only in constraint position, never in embedding) and reclassify
its terms as `references` (`context="type_constraint"`) instead of `embeds`.
This keeps the type link but drops the false heritage claim. The edge count is
unchanged; only the relation/context is corrected.

Genuine interface embedding is untouched — a lone interface term
(`Reader`, `io.Reader`, `Sortable[int]`) has no `|`/`~`, so it still emits
`embeds`.

## Tests

Added to `tests/test_languages.py`:

- `test_go_interface_type_union_is_not_embedding` — **negative control**:
  union terms must not be `embeds`, and are present as
  `references`/`type_constraint`. **Fails on HEAD** (asserts the spurious
  `Number->MyInt` embed away), **passes with the fix**.
- `test_go_interface_embedding_emits_embeds` /
  `test_go_struct_embedding_emits_embeds` — positive guards that genuine
  embedding on the existing `sample.go` fixture (`ReaderLogger` embeds
  `Logger`/`Reader`; `DataProcessor` embeds `BaseProcessor`) still works.

`python3 -m pytest tests/test_languages.py -q` → `317 passed, 13 skipped`
(the 13 skips are the optional `tree-sitter-dm` grammar). No behavior change
outside Go interface type-set constraints.
