### PR TITLE
fix: to_graphml crashes on dict/list-valued graph, node, and edge attributes

### DIFF
--- a/graphify/export.py
+++ b/graphify/export.py
@@ -912,14 +912,24 @@ def to_graphml(
         for k in [k for k in attrs if k.startswith("_")]:
             del attrs[k]
     # nx.write_graphml raises ValueError on None attribute values; replace with "".
+    # It also only accepts scalar attribute values, so dict/list-valued
+    # attributes (e.g. per-node "metadata", graph-level "hyperedges") must be
+    # serialized to a JSON string first, or the writer raises TypeError.
+    def _scrub(val):
+        if val is None:
+            return ""
+        if isinstance(val, (dict, list)):
+            return json.dumps(val)
+        return val
+
+    for key, val in list(H.graph.items()):
+        H.graph[key] = _scrub(val)
     for node_id in H.nodes():
         for key, val in list(H.nodes[node_id].items()):
-            if val is None:
-                H.nodes[node_id][key] = ""
+            H.nodes[node_id][key] = _scrub(val)
     for u, v in H.edges():
         for key, val in list(H.edges[u, v].items()):
-            if val is None:
-                H.edges[u, v][key] = ""
+            H.edges[u, v][key] = _scrub(val)
     nx.write_graphml(H, output_path)
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -99,6 +99,25 @@ def test_to_graphml_tolerates_none_attribute_values():
         content = out.read_text()
         assert "<graphml" in content
 
+def test_to_graphml_tolerates_dict_and_list_attribute_values():
+    """nx.write_graphml only accepts scalar attribute values and raises
+    TypeError on a dict or list — e.g. a node's "metadata" dict, or a
+    graph-level "hyperedges" list (attach_hyperedges()). to_graphml must
+    JSON-serialize these instead of passing them through unmodified."""
+    G = make_graph()
+    communities = cluster(G)
+    a_node = next(iter(G.nodes()))
+    G.nodes[a_node]["metadata"] = {"kind": "file"}
+    if G.number_of_edges():
+        u, v = next(iter(G.edges()))
+        G.edges[u, v]["tags"] = ["a", "b"]
+    G.graph["hyperedges"] = [{"nodes": [a_node], "label": "x"}]
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "graph.graphml"
+        to_graphml(G, communities, str(out))  # must not raise
+        content = out.read_text()
+        assert "<graphml" in content
+
 def test_to_html_creates_file():
     G = make_graph()
     communities = cluster(G)


### PR DESCRIPTION
## Summary

`nx.write_graphml` only accepts scalar attribute values. `to_graphml` already coerces `None -> ""` (fixing a prior `ValueError`, #1502), but a `dict` or `list` value still raises:

```
TypeError: GraphML does not support type <class 'dict'> as data values.
TypeError: GraphML does not support type <class 'list'> as data values.
```

This hits real graphs in practice, not just synthetic edge cases:
- a per-node `"metadata"` dict attribute
- `attach_hyperedges()`'s graph-level `"hyperedges"` list (`G.graph["hyperedges"]`)

Both crash `graphify export graphml` outright on any graph that uses them — confirmed against a real ~2,300-node/4,300-edge project graph.

## Fix

Extends the existing scrub step in `to_graphml` (the one that already coerces `None -> ""`) to also JSON-serialize any dict/list-valued attribute — across graph-level, node, and edge scopes — before calling `nx.write_graphml`.

## Test plan

- Added `test_to_graphml_tolerates_dict_and_list_attribute_values` (`tests/test_export.py`), mirroring the existing `test_to_graphml_tolerates_none_attribute_values` test — injects a node `metadata` dict, an edge `list` attribute, and a graph-level `hyperedges` list, asserts `to_graphml` doesn't raise.
- Ran full `tests/test_export.py` (all passing) and the full suite (`57 failed, 2891 passed, 165 skipped` — the 57 failures are pre-existing, all in `test_read_hook.py`/`test_reflect.py`/`test_search_hook.py`/`test_terraform.py`, unrelated to `export.py`/GraphML and present before this change).
- Verified against a real project graph that previously crashed on export — now produces a valid file that round-trips through `networkx.read_graphml`.