### PR TITLE
docs: fix Claude Code prompt-cache troubleshooting — .claudeignore is a no-op, use .claude/settings.json deny rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,12 +597,12 @@ graphify install  # overwrites the skill file
 ```
 
 **Claude Code prompt cache invalidated after every `graphify extract`**
-Graphify writes output files (`graph.json`, `graphify-out/`) into the workspace. If those paths aren't ignored, every write invalidates Claude Code's prompt cache, forcing a full re-upload at cache-write rates on the next turn. Add them to `.claudeignore`:
-```text
-# .claudeignore
-graph.json
-graphify-out/
+Graphify writes output files (`graph.json`, `graphify-out/`) into the workspace. If those paths aren't ignored, every write invalidates Claude Code's prompt cache, forcing a full re-upload at cache-write rates on the next turn. Claude Code does not support `.claudeignore`; the supported mechanism is a `deny` rule in `.claude/settings.json`:
+```json
+// .claude/settings.json
+{ "permissions": { "deny": ["Read(./graphify-out/**)", "Read(./graph.json)"] } }
 ```
+> **Note:** `deny` rules gate Claude Code's *read access*, not just cache inclusion. This means Claude Code can no longer read files under `graphify-out/` — including `GRAPH_REPORT.md` and the wiki — which conflicts with navigation workflows that rely on those files. If you use `graphify-out/` as a navigation source, omit the deny rule and accept the cache invalidation cost, or scope it to specific files (e.g. only `Read(./graphify-out/graph.json)`).
 
 ---
 


### PR DESCRIPTION
Fixes #1843 

## Problem

The Troubleshooting section advised users to add `graph.json` and
`graphify-out/` to a `.claudeignore` file to prevent Claude Code's prompt
cache from being invalidated on every `graphify extract` run.

`.claudeignore` does not exist in Claude Code. Evidence from the issue:

- The official Claude Code docs document `permissions.deny` Read rules
  (in `.claude/settings.json`) as the supported mechanism, replacing the
  deprecated `ignorePatterns`. No page mentions `.claudeignore`.
- The original `.claudeignore` feature request
  (anthropic/claude-code#579) was closed with "you can do this now with
  deny permission rules" — no `.claudeignore` file was ever shipped.
- Multiple user bug reports confirm the file silently does nothing
  (anthropic/claude-code#36163, #16704, #46699, #56997, #65812).

So users following the README created a file that had no effect, and the
prompt-cache symptom persisted.

## Fix

Replaced the `.claudeignore` block with the supported equivalent —
a `deny` rule in `.claude/settings.json` — and added a plain-language
note explaining the tradeoff: `deny` rules gate Claude Code's read
*access*, not just cache inclusion, which means Claude Code can no longer
read `GRAPH_REPORT.md`, the wiki, or other files under `graphify-out/`.
Users who rely on those files for navigation need to know this before
applying the fix.

## Changes

**`README.md`** — Troubleshooting section, "Claude Code prompt cache
invalidated after every `graphify extract`":

- Removed the `.claudeignore` code block
- Added the correct `.claude/settings.json` `deny` rule
- Added a note about the access-vs-cache tradeoff and the option to
  scope the rule to specific files only