### PR TITLE
fix(cli): hermes install --help text omits its AGENTS.md write

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -674,9 +674,9 @@ def _run_cli() -> None:
             "  antigravity uninstall   remove .agents/rules, .agents/workflows, and skill"
         )
         print(
-            "  hermes install          write skill to ~/.hermes/skills/graphify/ (Hermes)"
+            "  hermes install          write skill to ~/.hermes/skills/graphify/ + AGENTS.md section (Hermes)"
         )
-        print("  hermes uninstall        remove skill from ~/.hermes/skills/graphify/")
+        print("  hermes uninstall        remove skill from ~/.hermes/skills/graphify/ + AGENTS.md section")
         print(
             "  kiro install            write skill to .kiro/skills/graphify/ + steering file (Kiro IDE/CLI)"
         )


### PR DESCRIPTION
## Summary

Closes #1846.

Bare `graphify hermes install` (no `--project`) dispatches to the same `_agents_install()` helper that `aider`/`codex`/`opencode`/`claw`/`droid`/`trae`/`trae-cn` use to write a graphify section into `AGENTS.md` (see `install.py`'s `dispatch_install_cli()`, the shared `elif cmd in ("aider", "codex", "opencode", "claw", "droid", "trae", "trae-cn", "hermes"):` branch). So it does write to `AGENTS.md` — confirmed by reading the dispatch code.

But unlike every sibling platform's `--help` line, which says exactly what it does ("write graphify section to AGENTS.md (Aider)", etc.), hermes's line only said:

```
hermes install          write skill to ~/.hermes/skills/graphify/ (Hermes)
```

No mention of `AGENTS.md` at all — which is the silent-mutation / trust-boundary concern the issue raises. `README.md` already documents this correctly (`graphify hermes install # AGENTS.md + ~/.hermes/skills/ (Hermes)`), so this was `--help`-text staleness specifically, not a behavior bug.

## What changed

Updated the two `hermes install`/`hermes uninstall` lines in `__main__.py`'s help output to mention the `AGENTS.md` section, matching the phrasing pattern used by every sibling AGENTS.md-writing platform and matching what README.md already says.

**No runtime behavior change** — hermes stays grouped with its 8 sibling platforms that write/remove an AGENTS.md section on install/uninstall, which looks architecturally intentional and symmetric (uninstall correctly removes the section too). Happy to also look at making the behavior itself opt-in/declared at write-time if maintainers would prefer that over just fixing the help text — flagging that as an option per the issue's two suggested resolutions, but went with the smaller, non-behavior-changing fix first.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('graphify/__main__.py').read())"` — syntax valid
- [x] Confirmed via direct code read (not just the issue report) that bare `hermes install` really does route through `_agents_install()`, same as its AGENTS.md-writing siblings
- [x] Confirmed README.md's existing hermes row already matches the corrected help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)