### PR TITLE
fix(watch): forward community_labels to to_json in _rebuild_code

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -566,6 +566,7 @@ def _canonical_topology_for_compare(graph_data: dict) -> dict:
                 continue
             n = dict(node)
             n.pop("community", None)
+            n.pop("community_name", None)
             n.pop("norm_label", None)
             norm_nodes.append(n)
         canonical["nodes"] = sorted(
@@ -1043,7 +1044,7 @@ def _rebuild_code(
         report_path = out / "GRAPH_REPORT.md"
         labels_json = json.dumps({str(k): v for k, v in sorted(labels.items())}, ensure_ascii=False, indent=2) + "\n"
         graph_tmp = out / ".graph.tmp.json"
-        json_written = to_json(G, communities, str(graph_tmp), force=True, built_at_commit=commit)
+        json_written = to_json(G, communities, str(graph_tmp), force=True, built_at_commit=commit, community_labels=labels)
         if not json_written:
             return False
         candidate_graph_data = json.loads(graph_tmp.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

`graphify update` (and the `post-commit` / `post-checkout` git hooks, which share its code path) wrote `graph.json` with numeric-only community tags and no `community_name` field. Running `graphify cluster-only` right after immediately restored the names — so every auto-refresh silently stripped them again.

Fixes #1808.

## Root cause

`_rebuild_code` in `watch.py` builds a fully-populated `labels` dict (hub names via `label_communities_by_hub`) but never passed it into `to_json()`:

```python
json_written = to_json(G, communities, str(graph_tmp), force=True, built_at_commit=commit)
```

`to_json` only writes the `community_name` node field when `community_labels=` is passed. `cluster-only` already passes it (`cli.py:1203`) — which is exactly why `cluster-only` showed names and `update` did not.

## Fix

**1. `watch.py` — forward the labels (the reported bug):**

```python
json_written = to_json(G, communities, str(graph_tmp), force=True, built_at_commit=commit, community_labels=labels)
```

`labels` was already built a few lines above and `to_json` already iterates every node, so this is a zero-added-cost, one-line change that brings `update` in line with `cluster-only`.

**2. `watch.py` — a regression this surfaced (not in the original report):**

`_rebuild_code` has a separate performance path: before re-clustering, it compares the *topology* of the existing `graph.json` against a freshly-built (not-yet-clustered) graph, and skips a full re-cluster if nothing changed. That comparison already strips the `community` and `norm_label` fields from nodes before diffing (`_canonical_topology_for_compare`), because those only exist post-clustering and would otherwise cause a false "changed" result on every run.

Once fix #1 makes `community_name` show up in `graph.json`, the same problem applies to that field: the freshly-built graph (pre-cluster) never has `community_name`, but the on-disk graph now does — so the topology comparison would never match again, forcing a full re-cluster on *every* subsequent `update`, even with zero code changes.

Fixed by stripping `community_name` alongside the existing two fields:

```python
n.pop("community", None)
n.pop("community_name", None)
n.pop("norm_label", None)
```

I caught this because the existing test `test_rebuild_code_skips_cluster_when_topology_unchanged` started failing after fix #1 alone, and went green again once this was added.

## Testing

- `uv run pytest tests/test_watch.py tests/test_export.py -q` → 104 passed, 2 skipped
- `uv run pytest tests/ -q` (full suite) → 3135 passed, 31 skipped, 4 pre-existing failures unrelated to this change (`test_ollama_retry_cap.py`, missing `openai` module — fail identically on `v8` before this patch)
- Manual repro on this repo's own 216-file `graphify/` package:
  - `graphify update` on a fresh copy → 2881/2881 nodes now have `community_name` (e.g. `__init__.py`), where before the fix only numeric `community` IDs were present
  - Re-ran `graphify update` on the unchanged tree → correctly printed `No code-graph topology changes detected; outputs left untouched.` (confirms fix #2 didn't break the existing no-op fast path)

## Test plan (for reviewers)

- [ ] `uv run pytest tests/test_watch.py tests/test_export.py -q`
- [ ] Run `graphify update .` on any repo, confirm `graphify-out/graph.json` nodes carry `community_name`
- [ ] Re-run `graphify update .` immediately after with no code changes, confirm it still short-circuits via the topology-unchanged path instead of re-clustering
