### PR TITLE
docs: expand team-setup gitignore recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,12 @@ dist/
 **Recommended `.gitignore` additions:**
 ```
 graphify-out/cost.json        # local only
+graphify-out/memory/          # personal Q&A annotations (graphify save-result)
+graphify-out/reflections/     # derived from memory/, local only
+graphify-out/.graphify_*      # local metadata (paths, markers, incremental caches)
+graphify-out/????-??-??/      # dated backup snapshots
 # graphify-out/cache/         # optional: commit for speed, skip to keep repo small
+# graphify-out/.graphify_labels.json  # un-ignore if your team curates community labels together
 ```
 
 > `manifest.json` is now portable — keys are stored as relative paths and re-anchored on load, so committing it is safe and avoids a full rebuild on first checkout.


### PR DESCRIPTION
## Summary

The [Team setup](https://github.com/Graphify-Labs/graphify#team-setup) section recommends gitignoring `graphify-out/cost.json` and optionally `cache/`, but several other local-only artifacts are missing from the list. Teams that follow the current guidance will inadvertently commit machine-specific metadata, personal Q&A annotations, and backup snapshots.

This PR expands the recommended `.gitignore` additions to cover:

- `graphify-out/memory/` — personal Q&A annotations written by `graphify save-result` (per-developer, not shared)
- `graphify-out/reflections/` — derived from `memory/` (LESSONS.md + `.graphify_learning.json`), local only
- `graphify-out/.graphify_*` — hidden metadata files (`.graphify_root` with local path, `.graphify_semantic_marker`, `.graphify_cached.json`, `.graphify_uncached.txt`, `.graphify_analysis.json`)
- `graphify-out/????-??-??/` — dated backup snapshot directories created automatically to protect semantic artifacts
- A commented hint to un-ignore `.graphify_labels.json` for teams that collaboratively curate community labels