### PR TITLE
fix: make label batching test independent of order

### DIFF
--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -273,8 +273,9 @@ def test_label_communities_batches_when_over_batch_size(monkeypatch):
     monkeypatch.setattr("graphify.llm._call_llm", fake_call)
     labels = label_communities(G, communities, backend="gemini", batch_size=100)
 
-    # 250 communities / 100 per batch -> 3 batches (100, 100, 50)
-    assert calls == [100, 100, 50]
+    # 250 communities / 100 per batch -> 3 batches (100, 100, 50).
+    # Concurrent workers may reach the backend in any order.
+    assert sorted(calls) == [50, 100, 100]
     # And every community got a real name, none left as a placeholder.
     assert all(name.startswith("Cluster ") for name in labels.values()), \
         f"some communities still have placeholders: {[k for k, v in labels.items() if not v.startswith('Cluster ')][:5]}"


### PR DESCRIPTION
## Summary

When building the project one of the tests failed randomly.

This fixes the flaky test.

`label_communities` runs batches in parallel, so the batches can be processed in a different order each time. The test was expecting the order to always be `100`, `100`, `50`, which isn't guaranteed.

The test now checks that the batch sizes are correct without depending on the order.

No production code was changed.

## Testing

- Ran the affected test multiple times
- Ran `tests/test_labeling.py`
- Ran the full test suite