### PR TITLE
docs: replace unsupported .claudeignore with permissions.deny rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,12 +597,16 @@ graphify install  # overwrites the skill file
 ```
 
 **Claude Code prompt cache invalidated after every `graphify extract`**
-Graphify writes output files (`graph.json`, `graphify-out/`) into the workspace. If those paths aren't ignored, every write invalidates Claude Code's prompt cache, forcing a full re-upload at cache-write rates on the next turn. Add them to `.claudeignore`:
-```text
-# .claudeignore
-graph.json
-graphify-out/
+Graphify writes output files (`graph.json`, `graphify-out/`) into the workspace. If those paths aren't excluded, every write invalidates Claude Code's prompt cache, forcing a full re-upload at cache-write rates on the next turn. Claude Code does not read a `.claudeignore` file; use `permissions.deny` Read rules in `.claude/settings.json` instead:
+```json
+// .claude/settings.json
+{
+  "permissions": {
+    "deny": ["Read(./graph.json)", "Read(./graphify-out/**)"]
+  }
+}
 ```
+Note that deny rules gate *access*, so this also stops the assistant from reading `graphify-out/` directly (e.g. browsing the generated wiki as navigation). If you rely on that workflow, keep the paths readable and accept the cache cost instead.
 
 ---
 


### PR DESCRIPTION
Fixes #1843.

The README's troubleshooting section recommended adding `.claudeignore`
to prevent graph.json/graphify-out/ from invalidating Claude Code's
prompt cache. Claude Code doesn't read .claudeignore, so this was a
no-op — users following it saw no change.

Replaced it with the supported `permissions.deny` Read rules in
`.claude/settings.json`, and added a note that deny rules gate access
(not just cache visibility), which conflicts with workflows that browse
graphify-out/ as a navigable wiki.