### PR TITLE
fix(extract): recognize uppercase TypeScript extensions

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1051,9 +1051,10 @@ def extract_python(path: Path) -> dict:
 
 def extract_js(path: Path) -> dict:
     """Extract classes, functions, arrow functions, and imports from a .js/.ts/.tsx/.mts/.cts file."""
-    if path.suffix == ".tsx":
+    suffix = path.suffix.lower()
+    if suffix == ".tsx":
         config = _TSX_CONFIG
-    elif path.suffix in (".ts", ".mts", ".cts"):
+    elif suffix in (".ts", ".mts", ".cts"):
         config = _TS_CONFIG
     else:
         config = _JS_CONFIG

--- a/tests/test_typescript_module_extensions.py
+++ b/tests/test_typescript_module_extensions.py
@@ -78,6 +78,13 @@ def test_cts_uses_the_typescript_grammar(tmp_path):
     }
 
 
+def test_uppercase_typescript_extensions_use_typescript_grammar(tmp_path):
+    for ext in (".TS", ".TSX", ".MTS", ".CTS"):
+        labels = _labels(_extract(tmp_path, ext))
+        assert any("Mode" in label for label in labels), f"TS `type` alias missing for {ext}"
+        assert any("Options" in label for label in labels), f"TS `interface` missing for {ext}"
+
+
 def test_mts_cts_route_to_extract_js():
     from graphify.extract import _DISPATCH, extract_js
     assert _DISPATCH.get(".mts") is extract_js


### PR DESCRIPTION
## Summary

Normalize a file suffix once before grammar selection so uppercase TypeScript-family extensions (`.TS`, `.TSX`, `.MTS`, and `.CTS`) use the same TypeScript grammars as their lowercase forms.

Previously, `extract_js()` recognized uppercase JavaScript extensions through a lowercase check but compared the TypeScript branches against the original case-sensitive suffix. TypeScript-only declarations could therefore be omitted.

## Tests

- Regression failed before the source change on `.TS`
- Module-extension tests: **7 passed**
- Relevant extraction suite: **127 passed, 1 skipped**
- Ruff on both changed files: **passed**
- Required offline `graphify update .`: **passed** with no tracked generated changes
- `git diff --check`: **passed**