### PR TITLE
fix(llm): unwrap FileSlice via unit_path in the checkpoint allowlist (#1870)

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -1918,9 +1918,9 @@ def extract_corpus_parallel(
             # (#1757). The model can attribute a node's source_file to another
             # corpus file; without this bound, that stray node would clobber the
             # other file's complete cache entry (or, with merge_existing, pollute
-            # it). A FileSlice reports its file via `.rel`; a bare Path is the
-            # relative source_file itself.
-            allowed = [getattr(item, "rel", None) or item for item in chunk]
+            # it). unit_path unwraps a FileSlice to its parent file (#1870); a
+            # bare Path is the relative source_file itself.
+            allowed = [unit_path(item) for item in chunk]
             _scs(
                 result.get("nodes", []),
                 result.get("edges", []),

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -203,6 +203,43 @@ def test_corpus_parallel_sequential_when_max_concurrency_is_one(tmp_path):
     assert call_order == [("f0.py",), ("f1.py",), ("f2.py",)]
 
 
+# ---- Incremental cache checkpoint --------------------------------------------
+
+def test_checkpoint_allowlist_unwraps_file_slices(tmp_path, monkeypatch):
+    """#1870: a chunk containing FileSlice units must checkpoint with the
+    slice's parent path in allowed_source_files — leaking the FileSlice
+    object itself made save_semantic_cache raise, silently skipping the
+    checkpoint for every chunk with a sliced document."""
+    from graphify import llm
+    from graphify.llm import extract_corpus_parallel
+
+    big = tmp_path / "big.md"
+    big.write_text("# heading\n" + "paragraph line\n" * 40)
+
+    captured = {}
+
+    def _capture_cache(*args, **kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("graphify.cache.save_semantic_cache", _capture_cache)
+    monkeypatch.delenv("GRAPHIFY_NO_INCREMENTAL_CACHE", raising=False)
+
+    with patch.object(llm, "_FILE_CHAR_CAP", 100), \
+         patch("graphify.llm.extract_files_direct",
+               side_effect=lambda chunk, **kw: _stub_chunk_result(len(chunk), 0)):
+        extract_corpus_parallel(
+            [big], backend="kimi", token_budget=None, chunk_size=16, max_concurrency=1
+        )
+
+    allowed = captured.get("allowed_source_files")
+    assert allowed, "checkpoint should have written the chunk to the cache"
+    assert all(isinstance(p, Path) for p in allowed), (
+        f"allowed_source_files must hold real paths, got: {allowed!r}"
+    )
+    assert set(map(str, allowed)) == {str(big)}
+
+
 def test_corpus_parallel_merge_order_is_submission_order_not_completion(tmp_path):
     """#1632: merged node/edge order must be deterministic (submission order),
     not the order chunks' network calls happen to finish. We skew latencies so


### PR DESCRIPTION
Fixes #1870

`_checkpoint_chunk` resolved each unit's source file with `getattr(item, "rel", None) or item`, but `FileSlice` carries its file in `.path` — it has no `.rel` — so for every sliced document the `FileSlice` object itself leaked into `allowed_source_files`. `save_semantic_cache` then raised on `Path(FileSlice)`, the best-effort guard downgraded that to the `incremental cache checkpoint failed` warning, and every chunk containing a slice silently lost its checkpoint — so a resumed run re-billed those chunks instead of reusing the cache.

- `llm.py`: build the allowlist with `unit_path(...)` — `file_slice.py`'s canonical unwrap (parent `Path` for a slice, bare `Path` unchanged), already imported and used elsewhere in the module — and fix the stale `.rel` comment
- `tests/test_chunking.py`: regression test that drives `extract_corpus_parallel` over a corpus whose document slices into 7 units and asserts the checkpoint fires with real paths; on current `v8` it fails with the exact `FileSlice` leak from the report

Since a slice's `.path` is the same value the file would have had as a bare `Path`, the allowlist entries for sliced files now match unsliced behavior exactly.
