### PR TITLE
fix: prune scan-excluded files from manifest during full rebuild

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1466,6 +1466,7 @@ def save_manifest(
     *,
     kind: str = "both",
     root: Path | None = None,
+    prune_to_scan: bool = False,
 ) -> None:
     """Save current file mtimes + content hashes for change detection.
 
@@ -1481,6 +1482,13 @@ def save_manifest(
     machines and checkout locations (#777). Out-of-root entries are written
     as absolute so they continue to round-trip on the saving machine.
     When ``root`` is None the legacy absolute-keyed format is preserved.
+
+    ``prune_to_scan`` (default False) — when True, ``files`` is treated as the
+    complete corpus of a full-root scan: existing manifest entries absent
+    from it are pruned even if the underlying file still exists on disk (a
+    physically-present-but-scan-excluded file, e.g. now ignored or
+    generated). Leave this False for callers passing only a changed subset,
+    so unrelated manifest rows are preserved (#917).
     """
     existing = load_manifest(manifest_path, root=root)
 
@@ -1493,14 +1501,21 @@ def save_manifest(
             return entry
         return None
 
+    all_files = [f for file_list in files.values() for f in file_list]
+    scanned = set(all_files) if prune_to_scan else None
+
     # Seed from the existing manifest so incremental callers passing a subset
     # of files don't silently erase entries for untouched files (#917).
     # Prune entries whose file no longer exists on disk — those are genuine
-    # deletions that detect_incremental() should treat as gone.
+    # deletions that detect_incremental() should treat as gone. When
+    # ``prune_to_scan`` is set, also prune entries absent from the current
+    # full scan even if the file still physically exists.
     manifest: dict[str, dict] = {}
     for f, entry in existing.items():
         normalised = _normalise_entry(entry)
         if normalised is None:
+            continue
+        if scanned is not None and f not in scanned:
             continue
         try:
             if Path(f).exists():
@@ -1508,7 +1523,6 @@ def save_manifest(
         except OSError:
             continue
 
-    all_files = [f for file_list in files.values() for f in file_list]
     with ThreadPoolExecutor() as pool:
         raw = pool.map(_stat_and_hash, all_files)
     hashed: dict[str, tuple[float, str]] = {

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1021,7 +1021,7 @@ def _rebuild_code(
 
             try:
                 from graphify.detect import save_manifest
-                save_manifest(detected["files"], kind="ast", root=project_root)
+                save_manifest(detected["files"], kind="ast", root=project_root, prune_to_scan=True)
             except Exception:
                 pass
 
@@ -1060,7 +1060,7 @@ def _rebuild_code(
             if same_topology:
                 try:
                     from graphify.detect import save_manifest
-                    save_manifest(detected["files"], kind="ast", root=project_root)
+                    save_manifest(detected["files"], kind="ast", root=project_root, prune_to_scan=True)
                 except Exception:
                     pass
                 flag = out / "needs_update"
@@ -1138,7 +1138,7 @@ def _rebuild_code(
 
         try:
             from graphify.detect import save_manifest
-            save_manifest(detected["files"], kind="ast", root=project_root)
+            save_manifest(detected["files"], kind="ast", root=project_root, prune_to_scan=True)
         except Exception:
             pass
 

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1591,6 +1591,71 @@ def test_save_manifest_without_root_keeps_absolute_keys(tmp_path):
     )
 
 
+def test_save_manifest_prune_to_scan_drops_scan_excluded_existing_file(tmp_path):
+    """A file that is physically present but no longer part of the current
+    full-root scan (e.g. now ignored, or generated) must be pruned from the
+    manifest when ``prune_to_scan=True`` — otherwise detect_incremental()
+    reports it as a permanent false-positive deletion (#1908)."""
+    from graphify.detect import save_manifest, load_manifest
+
+    tracked = tmp_path / "tracked.py"
+    tracked.write_text("pass\n")
+    excluded = tmp_path / "excluded.py"
+    excluded.write_text("pass\n")
+    manifest_path = str(tmp_path / "graphify-out" / "manifest.json")
+
+    # First save sees both files.
+    save_manifest({"code": [str(tracked), str(excluded)]}, manifest_path, root=tmp_path)
+    assert set(load_manifest(manifest_path, root=tmp_path)) == {
+        str(tracked.resolve()), str(excluded.resolve()),
+    }
+
+    # Second save is a full-corpus rebuild where `excluded` is no longer
+    # returned by detect() but still exists on disk.
+    save_manifest({"code": [str(tracked)]}, manifest_path, root=tmp_path, prune_to_scan=True)
+    assert set(load_manifest(manifest_path, root=tmp_path)) == {str(tracked.resolve())}
+
+
+def test_save_manifest_prune_to_scan_still_drops_missing_files(tmp_path):
+    """``prune_to_scan=True`` must not regress the existing
+    physically-missing-file pruning behavior."""
+    from graphify.detect import save_manifest, load_manifest
+
+    tracked = tmp_path / "tracked.py"
+    tracked.write_text("pass\n")
+    deleted = tmp_path / "deleted.py"
+    deleted.write_text("pass\n")
+    manifest_path = str(tmp_path / "graphify-out" / "manifest.json")
+
+    save_manifest({"code": [str(tracked), str(deleted)]}, manifest_path, root=tmp_path)
+    deleted.unlink()
+
+    save_manifest({"code": [str(tracked)]}, manifest_path, root=tmp_path, prune_to_scan=True)
+    assert set(load_manifest(manifest_path, root=tmp_path)) == {str(tracked.resolve())}
+
+
+def test_save_manifest_without_prune_to_scan_preserves_subset_entries(tmp_path):
+    """Default (``prune_to_scan=False``) behavior is unchanged: a partial
+    save (e.g. an incremental caller passing only changed files) must not
+    erase manifest rows for untouched-but-still-existing files (#917)."""
+    from graphify.detect import save_manifest, load_manifest
+
+    changed = tmp_path / "changed.py"
+    changed.write_text("pass\n")
+    untouched = tmp_path / "untouched.py"
+    untouched.write_text("pass\n")
+    manifest_path = str(tmp_path / "graphify-out" / "manifest.json")
+
+    save_manifest({"code": [str(changed), str(untouched)]}, manifest_path, root=tmp_path)
+
+    # Subsequent partial save only re-stamps `changed`; `untouched` is not
+    # part of the current `files` corpus but must survive.
+    save_manifest({"code": [str(changed)]}, manifest_path, root=tmp_path)
+    assert set(load_manifest(manifest_path, root=tmp_path)) == {
+        str(changed.resolve()), str(untouched.resolve()),
+    }
+
+
 def test_load_manifest_absolutizes_relative_keys(tmp_path):
     """``load_manifest(root=...)`` re-anchors stored relative keys so the
     in-memory shape matches what :func:`detect` returns."""


### PR DESCRIPTION
## Summary
- `save_manifest()` only dropped a manifest entry when its file was physically gone from disk, so a file still present but excluded from the current `detect()` scan (newly ignored, generated, etc.) stayed in the manifest forever.
- `detect_incremental()` then reported that entry in `deleted_files` on every subsequent run — a permanent false positive.
- Adds `save_manifest(prune_to_scan=True)`: when set, entries absent from the current full-scan corpus are pruned even if the file still exists. Default (`False`) is unchanged, so partial/incremental callers passing a subset of files still preserve untouched entries (#917).
- Wired into all three `save_manifest` call sites in `watch._rebuild_code`, which already holds the complete `detect(watch_path)` result for the watched root.

Fixes #1908.

(Re-opened from a fresh fork; identical content to the earlier #1913, which was closed to purge a stray commit-author email from fork history.)

## Test plan
- [x] Added `test_save_manifest_prune_to_scan_drops_scan_excluded_existing_file` — reproduces the reported bug (physically-present, scan-excluded file is pruned)
- [x] Added `test_save_manifest_prune_to_scan_still_drops_missing_files` — existing missing-file pruning still works under the new flag
- [x] Added `test_save_manifest_without_prune_to_scan_preserves_subset_entries` — default behavior (#917) unchanged
- [x] `uv run pytest tests/test_detect.py tests/test_watch.py -q` — all pass
- [x] `uv run pytest tests/ -q` — full suite: 3189 passed (5 pre-existing failures unrelated to this change, missing optional `openai` dependency in this environment)