### PR TITLE
fix(skillgen): make --update append to cost.json like the initial build

### DIFF
--- a/graphify/skills/agents/references/update.md
+++ b/graphify/skills/agents/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/amp/references/update.md
+++ b/graphify/skills/amp/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/claude/references/update.md
+++ b/graphify/skills/claude/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/claw/references/update.md
+++ b/graphify/skills/claw/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/codex/references/update.md
+++ b/graphify/skills/codex/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/copilot/references/update.md
+++ b/graphify/skills/copilot/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/droid/references/update.md
+++ b/graphify/skills/droid/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/kilo/references/update.md
+++ b/graphify/skills/kilo/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/kiro/references/update.md
+++ b/graphify/skills/kiro/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/opencode/references/update.md
+++ b/graphify/skills/opencode/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/pi/references/update.md
+++ b/graphify/skills/pi/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/trae/references/update.md
+++ b/graphify/skills/trae/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/vscode/references/update.md
+++ b/graphify/skills/vscode/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/graphify/skills/windows/references/update.md
+++ b/graphify/skills/windows/references/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__agents__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__agents__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__amp__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__amp__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__claude__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claude__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__claw__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claw__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__codex__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__codex__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__copilot__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__copilot__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__droid__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__droid__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__kilo__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kilo__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__kiro__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kiro__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__opencode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__opencode__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__pi__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__pi__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__trae__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__trae__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__vscode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__vscode__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/expected/graphify__skills__windows__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__windows__references__update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 

--- a/tools/skillgen/fragments/references/shared/update.md
+++ b/tools/skillgen/fragments/references/shared/update.md
@@ -144,6 +144,32 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 save_manifest(incremental['files'], root='INPUT_PATH')
 print('[graphify update] Manifest saved.')
+
+# Append this run to the cumulative cost tracker. The initial full build
+# (core skill Step 8) does this, but --update has its own extraction path
+# and skipped it entirely, so cost.json only ever held the first run's
+# entry no matter how many incremental updates followed (#1769).
+from datetime import datetime, timezone
+input_tok = new_extraction.get('input_tokens', 0)
+output_tok = new_extraction.get('output_tokens', 0)
+
+cost_path = Path('graphify-out/cost.json')
+if cost_path.exists():
+    cost = json.loads(cost_path.read_text(encoding=\"utf-8\"))
+else:
+    cost = {'runs': [], 'total_input_tokens': 0, 'total_output_tokens': 0}
+
+cost['runs'].append({
+    'date': datetime.now(timezone.utc).isoformat(),
+    'input_tokens': input_tok,
+    'output_tokens': output_tok,
+    'files': incremental.get('new_total', 0),
+})
+cost['total_input_tokens'] += input_tok
+cost['total_output_tokens'] += output_tok
+cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'[graphify update] This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
+print(f'[graphify update] All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
 "
 ```
 


### PR DESCRIPTION
## Summary
- The initial full-build skill flow (core.md Step 8) appends each run to `graphify-out/cost.json` and updates running totals.
- The `--update` (incremental) flow never touched `cost.json` at all — it only calls `save_manifest`. So after the first full build, every subsequent `graphify update` printed its token usage to stdout and discarded it; `cost.json` stayed frozen on the initial run's single entry forever, matching the symptom in #1769 exactly.
- Adds the same append-a-run/update-totals block to the shared `references/update.md` fragment, right after `save_manifest`, using `new_extraction`'s token counts and `incremental['new_total']` for the file count.
- Regenerated all 14 per-host `update.md` artifacts and their `tools/skillgen/expected/` snapshots via `python -m tools.skillgen && python -m tools.skillgen --bless`.

Fixes #1769.

## Test plan
- [x] `python -m tools.skillgen --check` — clean after regenerating (no drift)
- [x] `uv run pytest tests/test_skillgen.py -q` — 58 passed
- [x] `uv run pytest tests/ -q` — full suite: 3264 passed (5 pre-existing failures unrelated to this change, missing optional `openai` dependency in this environment)
- [x] Manually verified the generated `graphify/skills/claude/references/update.md` contains the new cost.json block with correct variable references