### PR TITLE
fix(watch): check-update walks the corpus, not just the pending flag

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -233,6 +233,7 @@ from graphify.detect import (
     IMAGE_EXTENSIONS,
     _load_graphifyignore,
     _is_ignored,
+    detect_incremental,
 )
 
 _WATCHED_EXTENSIONS = CODE_EXTENSIONS | DOC_EXTENSIONS | PAPER_EXTENSIONS | IMAGE_EXTENSIONS
@@ -1266,17 +1267,51 @@ def _rebuild_code(
 
 
 def check_update(watch_path: Path) -> bool:
-    """Check for pending semantic update flag and notify the user if set.
+    """Check for pending semantic update flag and corpus drift, notify if either is set.
 
     Cron-safe: always returns True so cron jobs do not alarm.
     Non-code file changes (docs, papers, images) require LLM-backed
-    re-extraction via `/graphify --update` — this function only signals
-    that the update is needed.
+    re-extraction via `/graphify --update` — the pending-flag check only
+    signals that the update is needed.
+
+    Also walks the corpus with the same include/exclude rules as extract and
+    diffs it against the manifest, so files created (not just modified) since
+    the last extract are caught too — the flag alone only covers changes seen
+    by a running `graphify watch` daemon, and stayed silent for anyone who
+    doesn't run one (#1765).
     """
-    flag = Path(watch_path) / _GRAPHIFY_OUT / "needs_update"
-    if flag.exists():
+    watch_path = Path(watch_path)
+    out = watch_path / _GRAPHIFY_OUT
+    flag_pending = (out / "needs_update").exists()
+    if flag_pending:
         print(f"[graphify check-update] Pending non-code changes in {watch_path}.")
+
+    drift_reported = False
+    if (out / "manifest.json").exists():
+        try:
+            result = detect_incremental(
+                watch_path,
+                str(out / "manifest.json"),
+                kind="ast",
+                extra_excludes=_read_build_excludes(out) or None,
+            )
+            new_total = result.get("new_total", 0)
+            deleted_total = len(result.get("deleted_files", []))
+            if new_total or deleted_total:
+                drift_reported = True
+                parts = []
+                if new_total:
+                    parts.append(f"{new_total} new/changed")
+                if deleted_total:
+                    parts.append(f"{deleted_total} deleted")
+                print(f"[graphify check-update] {', '.join(parts)} file(s) since the last extract in {watch_path}.")
+        except Exception as exc:
+            print(f"[graphify check-update] warning: could not check corpus drift: {exc}", file=sys.stderr)
+
+    if flag_pending or drift_reported:
         print("[graphify check-update] Run `/graphify --update` to apply semantic re-extraction.")
+    else:
+        print(f"[graphify check-update] Up to date — no changes detected in {watch_path}.")
     return True
 
 

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -59,7 +59,8 @@ def test_watched_extensions_excludes_noise():
 # --- watch() import error without watchdog ---
 
 def test_check_update_no_flag_returns_true(tmp_path):
-    """check_update returns True and is silent when needs_update flag is absent."""
+    """check_update returns True and reports up-to-date when nothing is pending
+    and there's no manifest yet to diff against."""
     from graphify.watch import check_update
     assert check_update(tmp_path) is True
 
@@ -84,6 +85,40 @@ def test_check_update_does_not_clear_flag(tmp_path):
     flag.write_text("1")
     check_update(tmp_path)
     assert flag.exists()
+
+
+def test_check_update_reports_new_file_absent_from_manifest(tmp_path, capsys):
+    """A file created after the last extract has no manifest row at all — the
+    old flag-only check never caught this since only a running `graphify
+    watch` daemon set the flag. check_update must now detect it directly by
+    diffing the corpus against the manifest (#1765)."""
+    from graphify.watch import check_update
+    from graphify.detect import save_manifest
+
+    (tmp_path / "existing.py").write_text("pass\n")
+    manifest_path = tmp_path / "graphify-out" / "manifest.json"
+    save_manifest({"code": [str(tmp_path / "existing.py")]}, str(manifest_path), root=tmp_path)
+
+    (tmp_path / "new_module.py").write_text("pass\n")
+
+    assert check_update(tmp_path) is True
+    out = capsys.readouterr().out
+    assert "1 new/changed" in out
+    assert "graphify --update" in out
+
+
+def test_check_update_reports_up_to_date_when_manifest_matches_corpus(tmp_path, capsys):
+    """No drift, no pending flag -> explicit up-to-date status, not silence."""
+    from graphify.watch import check_update
+    from graphify.detect import save_manifest
+
+    (tmp_path / "existing.py").write_text("pass\n")
+    manifest_path = tmp_path / "graphify-out" / "manifest.json"
+    save_manifest({"code": [str(tmp_path / "existing.py")]}, str(manifest_path), root=tmp_path)
+
+    assert check_update(tmp_path) is True
+    out = capsys.readouterr().out
+    assert "Up to date" in out
 
 
 def test_watch_raises_without_watchdog(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- `check_update()` only ever inspected `graphify-out/needs_update`, a flag written exclusively by the `graphify watch` daemon. Anyone not running that daemon got a silent `exit 0` from `graphify check-update` regardless of how far the corpus had drifted — including brand-new files that never had a manifest row to begin with.
- Wires `detect_incremental(kind="ast")` into `check_update`, using the same persisted `--exclude` patterns a real rebuild uses (`_read_build_excludes`), so it now reports actual new/changed and deleted file counts diffed against the manifest.
- Success is no longer silent: prints an explicit `Up to date` line, so "checked and clean" is now distinguishable from "couldn't check" (e.g. no manifest yet).

Fixes #1765.

## Test plan
- [x] Added `test_check_update_reports_new_file_absent_from_manifest` — reproduces the reported bug (a file created after the last extract, with no manifest row, is now detected)
- [x] Added `test_check_update_reports_up_to_date_when_manifest_matches_corpus` — confirms the new explicit up-to-date message
- [x] Updated stale docstring on `test_check_update_no_flag_returns_true` to match new behavior
- [x] `uv run pytest tests/test_watch.py -q -k check_update` — 5 passed
- [x] `uv run pytest tests/ -q` — full suite: 3266 passed (5 pre-existing failures unrelated to this change, missing optional `openai` dependency in this environment)