### PR TITLE
docs: replace .claudeignore troubleshooting tip with permissions.deny

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,12 +597,12 @@ graphify install  # overwrites the skill file
 ```
 
 **Claude Code prompt cache invalidated after every `graphify extract`**
-Graphify writes output files (`graph.json`, `graphify-out/`) into the workspace. If those paths aren't ignored, every write invalidates Claude Code's prompt cache, forcing a full re-upload at cache-write rates on the next turn. Add them to `.claudeignore`:
-```text
-# .claudeignore
-graph.json
-graphify-out/
+Graphify writes output files (`graph.json`, `graphify-out/`) into the workspace. If those paths aren't ignored, every write invalidates Claude Code's prompt cache, forcing a full re-upload at cache-write rates on the next turn. Claude Code has no `.claudeignore` support — deny read access to those paths instead:
+```json
+// .claude/settings.json
+{ "permissions": { "deny": ["Read(./graphify-out/**)", "Read(./graph.json)"] } }
 ```
+Note this gates *access*, not just cache behavior — it also blocks workflows that read `graphify-out/` back (e.g. using the generated wiki for navigation). If you rely on those, skip this and accept the cache cost instead.
 
 ---
 


### PR DESCRIPTION
## Summary
- Claude Code never shipped `.claudeignore` support: the original feature request (anthropics/claude-code#579) was closed pointing users at `permissions.deny` rules instead, and a long tail of reports confirms the file silently does nothing (anthropics/claude-code#36163, #16704, #46699, #56997, #65812).
- The README's "prompt cache invalidated" troubleshooting entry told users to create a `.claudeignore` — a no-op that leaves the actual symptom unresolved.
- Replaced with the supported `.claude/settings.json` `permissions.deny` equivalent, plus a one-line caveat that deny rules gate *access* (not just prompt-cache behavior), which conflicts with workflows that read `graphify-out/` back for navigation — as suggested in the issue.

Fixes #1843.

## Test plan
- Docs-only change, no runtime behavior affected. Verified no other file in the repo references `.claudeignore` (`grep -rl claudeignore . --include="*.md"` → only this README section).