### PR TITLE
fix(build): preserve leaked biomedical category instead of discarding it

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -30,7 +30,7 @@ from pathlib import Path
 import networkx as nx
 from .ids import make_id, normalize_id as _normalize_id
 from .paths import default_graph_json as _default_graph_json
-from .validate import validate_extraction
+from .validate import validate_extraction, VALID_FILE_TYPES
 
 
 # Language interop families, keyed by extension, for the cross-language phantom-edge
@@ -70,6 +70,20 @@ _FILE_TYPE_SYNONYMS = {
     "data_source": "concept",
     "gotcha": "concept",
     "framework": "concept",
+}
+
+# Biomedical entity categories that semantic subagents are told to record in a
+# node's `entry_type` (see the biomedical extraction rules in the /graphify
+# skill). Models sometimes leak the category into `file_type` instead, where it
+# is not a valid file_type. Unlike the generic synonyms above — which collapse
+# unknown types to `concept` and discard the original token — these categories
+# carry real information, so we preserve them in `entry_type` rather than lose
+# them. `technology` is intentionally also present in _FILE_TYPE_SYNONYMS (it is
+# ambiguous with the code-corpus sense), so it is only recovered as biomedical
+# when the node already shows a biomedical signal (an existing `entry_type`).
+_BIOMEDICAL_CATEGORIES = {
+    "drug", "gene", "disease", "protein", "technology",
+    "peptide", "institution", "company",
 }
 
 
@@ -428,8 +442,19 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
         if node.get("file_type") in (None, ""):
             node["file_type"] = "concept"
         ft = node.get("file_type", "")
-        if ft and ft not in {"code", "document", "paper", "image", "rationale", "concept"}:
-            node["file_type"] = _FILE_TYPE_SYNONYMS.get(ft, "concept")
+        if ft and ft not in VALID_FILE_TYPES:
+            # A leaked biomedical entity category (drug/gene/disease/...) carries
+            # real information, so preserve it in entry_type instead of
+            # collapsing it to `concept` and discarding it. `technology` is
+            # ambiguous with the code-corpus synonym, so only treat it as
+            # biomedical when the node already carries a biomedical signal.
+            if ft in _BIOMEDICAL_CATEGORIES and (
+                node.get("entry_type") or ft not in _FILE_TYPE_SYNONYMS
+            ):
+                node.setdefault("entry_type", ft)
+                node["file_type"] = "document"
+            else:
+                node["file_type"] = _FILE_TYPE_SYNONYMS.get(ft, "concept")
 
     # Canonicalize hyperedge member lists (#1561): producers sometimes key the
     # member list `members`/`node_ids` instead of `nodes`. Fold aliases onto

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -994,3 +994,55 @@ def test_build_from_json_prunes_dangling_hyperedge_members(capsys):
     assert set(hes) == {"he_partial"}, "an all-dangling hyperedge must be dropped"
     assert hes["he_partial"]["nodes"] == ["alpha", "beta"]
     assert "he_all_ghost" in capsys.readouterr().err
+
+
+def test_leaked_biomedical_category_recovered_into_entry_type():
+    # #(new): biomedical semantic subagents are told to put the entity category
+    # (drug/gene/disease/...) in `entry_type`, but models sometimes also write
+    # it to `file_type`, which is not a valid file_type. Recover the category
+    # into entry_type and coerce file_type to a valid `document` — without
+    # emitting an invalid-file_type warning and without discarding the category.
+    ext = {
+        "nodes": [
+            # peptide is biomedical-exclusive: recovered even without entry_type
+            {"id": "phlip", "label": "pHLIP", "file_type": "peptide",
+             "source_file": "patents/records/x.md"},
+            # entry_type already correct; must not be overwritten
+            {"id": "mitocatch", "label": "MitoCatch", "file_type": "technology",
+             "entry_type": "technology", "source_file": "patents/records/y.md"},
+        ],
+        "edges": [],
+    }
+    G = build_from_json(ext)
+    assert G.nodes["phlip"]["file_type"] == "document"
+    assert G.nodes["phlip"]["entry_type"] == "peptide"
+    assert G.nodes["mitocatch"]["file_type"] == "document"
+    assert G.nodes["mitocatch"]["entry_type"] == "technology"
+
+
+def test_ambiguous_technology_without_signal_stays_code_synonym():
+    # `technology` is ambiguous with the code-corpus synonym (-> concept). With
+    # no biomedical signal (no entry_type), preserve the existing behavior so
+    # non-biomedical corpora are unaffected.
+    ext = {
+        "nodes": [
+            {"id": "n1", "label": "Some Tech", "file_type": "technology",
+             "source_file": "docs/a.md"},
+        ],
+        "edges": [],
+    }
+    G = build_from_json(ext)
+    assert G.nodes["n1"]["file_type"] == "concept"
+    assert "entry_type" not in G.nodes["n1"]
+
+
+def test_unknown_invalid_file_type_still_falls_back_to_concept():
+    ext = {
+        "nodes": [
+            {"id": "n1", "label": "Junk", "file_type": "gizmo",
+             "source_file": "docs/a.md"},
+        ],
+        "edges": [],
+    }
+    G = build_from_json(ext)
+    assert G.nodes["n1"]["file_type"] == "concept"


### PR DESCRIPTION
# fix(build): preserve leaked biomedical category instead of discarding it

## Problem

Biomedical semantic subagents are instructed (in the `/graphify` extraction
rules) to record a node's entity **category** — `drug` / `gene` / `disease` /
`protein` / `technology` / `peptide` / `institution` / `company` — in the
node's **`entry_type`** attribute. `file_type` is a separate axis with a small
closed set of valid values (`code`, `document`, `paper`, `image`, `rationale`,
`concept`).

In practice, models frequently **also** write the category into `file_type`,
e.g. a patent-record node comes out as `file_type: "technology"`. That is not a
valid file_type. The current canonicalizer in `build_from_json` handles this by
collapsing any unknown file_type to `concept` through `_FILE_TYPE_SYNONYMS`:

```python
if ft and ft not in {"code", "document", "paper", "image", "rationale", "concept"}:
    node["file_type"] = _FILE_TYPE_SYNONYMS.get(ft, "concept")
```

This silences the invalid-file_type validator warning, but it has two downsides
for biomedical corpora:

1. **The category is silently discarded.** `technology` → `concept`; `peptide`,
   `drug`, `gene`, etc. aren't in the synonym map at all and also fall to
   `concept`. The information the model extracted is lost.
2. **The node is mislabeled** as a generic `concept` document rather than the
   `document` (patent/paper record) it actually is.

Real-world example (patent records): nodes like `mitocatch`, `phlip`,
`bispecific-nanobody`, `erythrocyte-mito-capsule` came through with the category
duplicated into `file_type` — and in the observed data these nodes already
carried the **correct** `entry_type`, so the category was recoverable but was
being thrown away.

## Fix

When a node's `file_type` is a leaked biomedical category, recover it into
`entry_type` (without overwriting an existing one) and coerce `file_type` to
`document`:

```python
if ft and ft not in VALID_FILE_TYPES:
    if ft in _BIOMEDICAL_CATEGORIES and (
        node.get("entry_type") or ft not in _FILE_TYPE_SYNONYMS
    ):
        node.setdefault("entry_type", ft)
        node["file_type"] = "document"
    else:
        node["file_type"] = _FILE_TYPE_SYNONYMS.get(ft, "concept")
```

### Ambiguity handling for `technology`

`technology` is intentionally *also* a code-corpus synonym (→ `concept`), so it
is ambiguous. To avoid changing behavior for non-biomedical corpora, a bare
`technology` file_type with **no** biomedical signal keeps the existing
`concept` mapping; it is only recovered as biomedical when the node already
shows a biomedical signal (an existing `entry_type`). The condition
`ft not in _FILE_TYPE_SYNONYMS` means the biomedical-exclusive categories
(`peptide`, `drug`, `gene`, `disease`, `protein`, `institution`, `company`) are
always recovered, since none of them appear in the synonym map.

## Behavior matrix

| input `file_type` | input `entry_type` | result `file_type` | result `entry_type` |
|---|---|---|---|
| `peptide` | — | `document` | `peptide` |
| `technology` | `technology` | `document` | `technology` |
| `technology` | — | `concept` (unchanged) | — |
| `gizmo` (junk) | — | `concept` (unchanged) | — |
| `paper` (valid) | — | `paper` (unchanged) | — |

No invalid-file_type validator warning is emitted in any case.

## Tests

Adds three tests to `tests/test_build.py`:

- `test_leaked_biomedical_category_recovered_into_entry_type`
- `test_ambiguous_technology_without_signal_stays_code_synonym`
- `test_unknown_invalid_file_type_still_falls_back_to_concept`

All existing `test_build.py` tests continue to pass.

## Scope

Both `build_from_json` and the multi-extraction `build()` (which delegates to
`build_from_json`) are covered by the single change. No public API changes.
