### PR TITLE
fix(extract): don't force-write a partial graph over a complete one

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -2762,7 +2762,10 @@ def dispatch_command(cmd: str) -> None:
             # across modes (#1317; node dedup also collapses shared Swift module
             # anchors emitted per importing file, #1327).
             from graphify.build import dedupe_edges as _dedupe_edges, dedupe_nodes as _dedupe_nodes
-            from graphify.export import backup_if_protected as _backup
+            from graphify.export import (
+                backup_if_protected as _backup,
+                existing_graph_node_count as _existing_graph_node_count,
+            )
             if (
                 incremental_mode
                 and not code_files
@@ -2808,6 +2811,24 @@ def dispatch_command(cmd: str) -> None:
                     _e["source_file"] = (
                         _node_sf.get(_e.get("source")) or _node_sf.get(_e.get("target")) or ""
                     )
+            # RT-parity for the raw path: an incomplete build must not force a
+            # partial graph over a larger complete one here either. The clustered
+            # path gets this from to_json's #479 guard; this path never calls
+            # to_json, so replicate the shrink check against the existing file and
+            # exit before the write/manifest unless --allow-partial is set.
+            if _extraction_incomplete and not cli_allow_partial:
+                _existing_n = _existing_graph_node_count(graph_json_path)
+                if _existing_n is not None and len(merged["nodes"]) < _existing_n:
+                    print(
+                        "[graphify extract] error: extraction was incomplete (an AST/"
+                        "semantic pass failed) and the resulting --no-cluster graph is "
+                        f"smaller than the existing {graph_json_path} "
+                        f"({len(merged['nodes'])} < {_existing_n} nodes). Refusing to "
+                        "overwrite a complete graph with a partial one. Re-run after "
+                        "fixing the failures, or pass --allow-partial to overwrite anyway.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
             _backup(graphify_out)
             graph_json_path.write_text(
                 json.dumps(merged, indent=2), encoding="utf-8"
@@ -2908,10 +2929,9 @@ def dispatch_command(cmd: str) -> None:
         # graph could silently overwrite a good complete one, so fall back to the
         # shrink guard (force=False) unless the user opts in with --allow-partial.
         #
-        # Scope: this guards the clustered write path only. The `--no-cluster`
-        # raw-dump path (above) writes graph.json directly and has never had a
-        # shrink guard, so an incomplete --no-cluster run can still overwrite a
-        # complete graph — a pre-existing gap this change does not close.
+        # Both write paths are guarded: the clustered path here via to_json's
+        # #479 check, and the `--no-cluster` raw-dump path above via the same
+        # shrink check against the existing file (existing_graph_node_count).
         #
         # Trade-off: this reuses to_json's coarse node-count guard, not the
         # source-aware _check_shrink that watch/update use. On an incremental run

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -2108,7 +2108,7 @@ def dispatch_command(cmd: str) -> None:
                 "Usage: graphify extract <path> [--backend gemini|kimi|claude|openai|deepseek|ollama] "
                 "[--model M] [--mode deep] [--out DIR] [--google-workspace] [--no-cluster] "
                 "[--max-workers N] [--token-budget N] [--max-concurrency N] "
-                "[--api-timeout S] [--postgres DSN] [--cargo] [--timing]",
+                "[--api-timeout S] [--postgres DSN] [--cargo] [--allow-partial] [--timing]",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -2129,6 +2129,7 @@ def dispatch_command(cmd: str) -> None:
         out_dir: Path | None = None
         cli_postgres_dsn: str | None = None
         cli_cargo: bool = False
+        cli_allow_partial: bool = False
         no_cluster = False
         dedup_llm = False
         google_workspace = False
@@ -2240,6 +2241,8 @@ def dispatch_command(cmd: str) -> None:
                 i += 1
             elif a == "--force":
                 force = True; i += 1
+            elif a == "--allow-partial":
+                cli_allow_partial = True; i += 1
             elif a == "--timing":
                 cli_timing = True; i += 1
             else:
@@ -2519,6 +2522,12 @@ def dispatch_command(cmd: str) -> None:
                     )
                     sys.exit(1)
 
+        # Track whether this run's extraction was incomplete (a whole extractor
+        # pass crashed, or some semantic chunks failed). A partial result must not
+        # be force-written over a good complete graph — the final write falls back
+        # to the #479 shrink guard unless --allow-partial is set.
+        _extraction_incomplete = False
+
         # AST extraction on code files. Empty code list (docs-only corpus) is
         # the issue #698 case — skip cleanly instead of crashing inside extract().
         ast_result: dict = {"nodes": [], "edges": [], "input_tokens": 0, "output_tokens": 0}
@@ -2536,6 +2545,7 @@ def dispatch_command(cmd: str) -> None:
             except Exception as exc:
                 print(f"[graphify extract] AST extraction failed: {exc}", file=sys.stderr)
                 ast_result = {"nodes": [], "edges": [], "input_tokens": 0, "output_tokens": 0}
+                _extraction_incomplete = True  # the whole AST pass was lost
         stages.mark("AST extract")
 
         # Semantic extraction on docs/papers/images. Check cache first.
@@ -2622,6 +2632,7 @@ def dispatch_command(cmd: str) -> None:
                         file=sys.stderr,
                     )
                     fresh = {"nodes": [], "edges": [], "hyperedges": [], "input_tokens": 0, "output_tokens": 0}
+                    _extraction_incomplete = True  # the semantic pass crashed
 
                 # on_chunk_done only fires after a chunk succeeds. If fresh
                 # semantic extraction was requested and no chunks completed,
@@ -2635,6 +2646,11 @@ def dispatch_command(cmd: str) -> None:
                         file=sys.stderr,
                     )
                     sys.exit(1)
+                # Some (but not all) chunks failed — the graph is missing nodes
+                # from the failed chunks, so it must not clobber a larger complete
+                # graph without an explicit --allow-partial override.
+                if _chunk_stats["total"] and _chunk_stats["succeeded"] < _chunk_stats["total"]:
+                    _extraction_incomplete = True
                 try:
                     _save_semantic_cache(
                         fresh.get("nodes", []),
@@ -2885,7 +2901,42 @@ def dispatch_command(cmd: str) -> None:
 
         from graphify.export import backup_if_protected as _backup
         _backup(graphify_out)
-        _to_json(G, communities, str(graph_json_path), force=True)
+        # force=True bypasses the #479 shrink guard entirely. A full build
+        # legitimately shrinks (fuzzy dedup collapse, deleted code) so it keeps
+        # force=True — EXCEPT when this run's extraction was incomplete (an
+        # extractor pass crashed or some semantic chunks failed). Then a partial
+        # graph could silently overwrite a good complete one, so fall back to the
+        # shrink guard (force=False) unless the user opts in with --allow-partial.
+        #
+        # Scope: this guards the clustered write path only. The `--no-cluster`
+        # raw-dump path (above) writes graph.json directly and has never had a
+        # shrink guard, so an incomplete --no-cluster run can still overwrite a
+        # complete graph — a pre-existing gap this change does not close.
+        #
+        # Trade-off: this reuses to_json's coarse node-count guard, not the
+        # source-aware _check_shrink that watch/update use. On an incremental run
+        # a legitimate deletion that coincides with an unrelated transient chunk
+        # failure can therefore be refused here — recoverable by re-running or
+        # passing --allow-partial (the good graph is preserved and the manifest
+        # is not stamped, so the retry re-extracts).
+        _force_write = cli_allow_partial or not _extraction_incomplete
+        _wrote = _to_json(G, communities, str(graph_json_path), force=_force_write)
+        if not _wrote:
+            # The shrink guard refused: this partial build is smaller than the
+            # existing graph. Exit before writing the manifest/marker below, which
+            # would otherwise stamp these files as done and make the next
+            # incremental run skip re-extracting them (poisoning the manifest
+            # against the graph we declined to write). Exit non-zero so a retry
+            # re-attempts.
+            print(
+                "[graphify extract] error: extraction was incomplete (an AST/semantic "
+                f"pass failed) and the resulting graph is smaller than the existing "
+                f"{graph_json_path}. Refusing to overwrite a complete graph with a "
+                "partial one. Re-run after fixing the failures, or pass --allow-partial "
+                "to overwrite anyway.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         stages.mark("export")
         if merged.get("output_tokens", 0) > 0:
             (graphify_out / ".graphify_semantic_marker").write_text(

--- a/graphify/export.py
+++ b/graphify/export.py
@@ -180,6 +180,38 @@ def _git_head() -> str | None:
         return None
 
 
+def existing_graph_node_count(path: "str | Path") -> int | None:
+    """Node count of an existing graph.json, or None when it can't be compared
+    (absent, empty, unreadable, malformed, or over the size cap).
+
+    The raw ``--no-cluster`` write path uses this to apply the same #479 shrink
+    guard that :func:`to_json` applies inline for the clustered path. None means
+    "can't verify — let the write proceed", matching how ``to_json`` treats an
+    empty/oversized/unreadable existing file.
+    """
+    p = Path(path)
+    if not p.exists():
+        return None
+    from graphify.security import check_graph_file_size_cap
+    try:
+        check_graph_file_size_cap(p)
+    except Exception:
+        # Oversized: reading it to compare would be the DoS the cap guards against.
+        return None
+    try:
+        raw = p.read_text(encoding="utf-8")
+    except Exception:
+        return None
+    if not raw.strip():
+        return None
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return None
+    nodes = data.get("nodes") if isinstance(data, dict) else None
+    return len(nodes) if isinstance(nodes, list) else None
+
+
 def to_json(G: nx.Graph, communities: dict[int, list[str]], output_path: str, *, force: bool = False, built_at_commit: str | None = None, community_labels: dict[int, str] | None = None) -> bool:
     # Safety check: refuse to silently shrink an existing graph (#479)
     existing_path = Path(output_path)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -775,3 +775,15 @@ def test_to_html_handles_null_source_file_and_label(tmp_path):
     out = tmp_path / "graph.html"
     to_html(G, {0: ["n1", "n2", "n3"]}, str(out))
     assert out.exists() and out.stat().st_size > 0
+
+
+def test_existing_graph_node_count(tmp_path):
+    from graphify.export import existing_graph_node_count
+    p = tmp_path / "graph.json"
+    assert existing_graph_node_count(p) is None            # absent
+    p.write_text("", encoding="utf-8")
+    assert existing_graph_node_count(p) is None            # empty
+    p.write_text("{not json", encoding="utf-8")
+    assert existing_graph_node_count(p) is None            # malformed
+    p.write_text('{"nodes": [{"id": "a"}, {"id": "b"}], "links": []}', encoding="utf-8")
+    assert existing_graph_node_count(p) == 2               # valid

--- a/tests/test_incomplete_build_guard.py
+++ b/tests/test_incomplete_build_guard.py
@@ -108,3 +108,62 @@ def test_complete_extraction_keeps_force_write(monkeypatch, tmp_path):
     mainmod.main()
 
     assert rec["called"] and rec["force"] is True
+
+
+def _seed_existing_graph(gout, n):
+    import json
+    gout.mkdir(parents=True, exist_ok=True)
+    (gout / "graph.json").write_text(
+        json.dumps({"nodes": [{"id": f"keep{i}", "label": f"k{i}"} for i in range(n)],
+                    "links": []}),
+        encoding="utf-8",
+    )
+
+
+def _arm_no_cluster(monkeypatch, tmp_path, *, extra_argv=()):
+    corpus = _make_docs_corpus(tmp_path)
+    out_dir = tmp_path / "out"
+    gout = out_dir / "graphify-out"
+    _seed_existing_graph(gout, 5)  # existing complete graph
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake-key")
+
+    def _stub_corpus(paths, **kwargs):
+        on_chunk = kwargs.get("on_chunk_done")
+        if on_chunk:
+            on_chunk(0, 3, {"nodes": [], "edges": [], "hyperedges": []})  # 1 of 3 -> partial
+        return {"nodes": [{"id": "s1", "source_file": str(corpus / "README.md"),
+                           "file_type": "document", "label": "Notes"}],
+                "edges": [], "hyperedges": [], "input_tokens": 1, "output_tokens": 1}
+
+    monkeypatch.setattr("graphify.llm.extract_corpus_parallel", _stub_corpus)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        mainmod.sys, "argv",
+        ["graphify", "extract", str(corpus), "--backend", "claude", "--no-cluster",
+         "--out", str(out_dir), *extra_argv],
+    )
+    return gout / "graph.json"
+
+
+def test_no_cluster_incomplete_build_refuses_to_shrink(tmp_path, monkeypatch, capsys):
+    import json
+    graph = _arm_no_cluster(monkeypatch, tmp_path)
+
+    with pytest.raises(SystemExit) as exc:
+        mainmod.main()
+
+    assert exc.value.code == 1
+    assert "Refusing to overwrite" in capsys.readouterr().err
+    # The existing 5-node graph is untouched — the partial 1-node graph was refused.
+    assert len(json.loads(graph.read_text())["nodes"]) == 5
+
+
+def test_no_cluster_allow_partial_overwrites(tmp_path, monkeypatch):
+    import json
+    graph = _arm_no_cluster(monkeypatch, tmp_path, extra_argv=["--allow-partial"])
+
+    with pytest.raises(SystemExit) as exc:
+        mainmod.main()
+
+    assert exc.value.code == 0  # the raw --no-cluster path exits 0 on success
+    assert len(json.loads(graph.read_text())["nodes"]) == 1

--- a/tests/test_incomplete_build_guard.py
+++ b/tests/test_incomplete_build_guard.py
@@ -1,0 +1,110 @@
+"""Tests for the incomplete-build shrink-guard on `graphify extract`.
+
+A full build writes the graph with `to_json(..., force=True)`, which bypasses the
+#479 shrink guard. When this run's extraction was incomplete (an AST pass crashed
+or some semantic chunks failed), forcing the write can silently overwrite a good
+complete graph with a smaller partial one. The build now drops back to the shrink
+guard (force=False) on an incomplete run — unless `--allow-partial` is passed —
+and exits non-zero (before writing the manifest) if the guard refuses.
+"""
+from __future__ import annotations
+
+import pytest
+
+import graphify.__main__ as mainmod
+
+
+def _make_docs_corpus(tmp_path):
+    # Docs-only corpus: no code files, so AST extraction is skipped and the only
+    # driver of incompleteness is the (stubbed) semantic chunk run.
+    (tmp_path / "README.md").write_text("# Notes\nThe entry point overview.\n")
+    (tmp_path / "GUIDE.md").write_text("# Guide\nHow to use the thing.\n")
+    return tmp_path
+
+
+def _seed_to_json_recorder(monkeypatch, *, returns=True):
+    """Patch export.to_json to record the ``force`` it was called with and return
+    a fixed bool (True = wrote, False = shrink guard refused)."""
+    rec = {"called": False, "force": None}
+
+    def _stub(G, communities, output_path, *, force=False, **kwargs):
+        rec["called"] = True
+        rec["force"] = force
+        return returns
+
+    monkeypatch.setattr("graphify.export.to_json", _stub)
+    return rec
+
+
+def _arm_extract(monkeypatch, tmp_path, *, chunk_total, chunk_succeeded, extra_argv=()):
+    corpus = _make_docs_corpus(tmp_path)
+    out_dir = tmp_path / "out"
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake-key")
+
+    def _stub_corpus(paths, **kwargs):
+        on_chunk = kwargs.get("on_chunk_done")
+        if on_chunk:
+            for i in range(chunk_succeeded):
+                on_chunk(i, chunk_total, {"nodes": [], "edges": [], "hyperedges": []})
+        return {
+            "nodes": [{"id": "s1", "source_file": str(corpus / "README.md"),
+                       "file_type": "document", "label": "Notes"}],
+            "edges": [], "hyperedges": [], "input_tokens": 10, "output_tokens": 5,
+        }
+
+    monkeypatch.setattr("graphify.llm.extract_corpus_parallel", _stub_corpus)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        mainmod.sys, "argv",
+        ["graphify", "extract", str(corpus), "--backend", "claude",
+         "--out", str(out_dir), *extra_argv],
+    )
+    return out_dir
+
+
+def test_partial_extraction_refuses_to_shrink_existing_graph(monkeypatch, tmp_path, capsys):
+    # 1 of 3 chunks succeeded -> incomplete; the shrink guard refuses (returns False).
+    rec = _seed_to_json_recorder(monkeypatch, returns=False)
+    out_dir = _arm_extract(monkeypatch, tmp_path, chunk_total=3, chunk_succeeded=1)
+
+    with pytest.raises(SystemExit) as exc:
+        mainmod.main()
+
+    assert exc.value.code == 1
+    assert rec["called"] and rec["force"] is False, "incomplete build must not force the write"
+    err = capsys.readouterr().err
+    assert "Refusing to overwrite" in err
+    # The manifest must not be stamped for a graph we declined to write.
+    assert not (out_dir / "graphify-out" / "manifest.json").exists()
+
+
+def test_partial_extraction_writes_when_not_shrinking(monkeypatch, tmp_path):
+    # Incomplete run, but the new graph is not smaller -> the guard permits the
+    # write. force is still False (guard active), and the CLI does not exit 1.
+    rec = _seed_to_json_recorder(monkeypatch, returns=True)
+    _arm_extract(monkeypatch, tmp_path, chunk_total=3, chunk_succeeded=1)
+
+    mainmod.main()  # no SystemExit
+
+    assert rec["called"] and rec["force"] is False
+
+
+def test_allow_partial_forces_write_despite_incomplete(monkeypatch, tmp_path):
+    rec = _seed_to_json_recorder(monkeypatch, returns=True)
+    _arm_extract(monkeypatch, tmp_path, chunk_total=3, chunk_succeeded=1,
+                 extra_argv=["--allow-partial"])
+
+    mainmod.main()
+
+    assert rec["called"] and rec["force"] is True, "--allow-partial must restore force=True"
+
+
+def test_complete_extraction_keeps_force_write(monkeypatch, tmp_path):
+    # All chunks succeeded -> a complete build legitimately keeps force=True so a
+    # genuine dedup/deletion shrink still overwrites.
+    rec = _seed_to_json_recorder(monkeypatch, returns=True)
+    _arm_extract(monkeypatch, tmp_path, chunk_total=1, chunk_succeeded=1)
+
+    mainmod.main()
+
+    assert rec["called"] and rec["force"] is True


### PR DESCRIPTION
### Problem
A full `graphify extract` writes the final graph with `to_json(..., force=True)`, which bypasses the `#479` shrink guard in its entirety (the guard is gated behind `if not force and existing_path.exists()`). Forcing is correct for a clean build that legitimately shrinks — fuzzy-dedup collapse, deleted code — but it means a build whose extraction was **incomplete** silently overwrites a good, larger graph with a smaller partial one. That happens when an AST extractor pass crashes (the `except` swallows it and continues) or when some, but not all, semantic chunks fail (only the *all*-failed case aborted before). A docs-heavy corpus with a few rate-limited chunks is exactly the case where a complete graph gets clobbered by a partial rebuild with no warning.

### Fix
The extract path now tracks a `_extraction_incomplete` flag, set when the AST pass raises, when the semantic pass raises, or when `succeeded < total` chunks completed. At the final write it computes `force = cli_allow_partial or not _extraction_incomplete`: a clean build still forces (legit shrinks proceed), but an incomplete build falls back to the shrink guard, so a smaller partial graph is **refused** rather than written. On refusal the command prints a clear error and exits non-zero *before* the manifest, marker, and analysis sidecars are written — so the manifest is never stamped for a graph we declined to write, and a later retry re-attempts cleanly. A new `--allow-partial` flag restores `force=True` for the cases where overwriting with a partial graph is intentional.

**Both write paths are guarded.** The clustered path gets this from `to_json`'s #479 check; the `--no-cluster` raw-dump path (which never calls `to_json`) gets the same check via a new `existing_graph_node_count` helper that reads the existing graph's node count under the same size cap and refuses an incomplete shrink before the raw write.

### Known limitation (documented in code)
The fallback reuses `to_json`'s coarse node-count guard rather than the source-aware `_check_shrink` that `watch`/`update` use. So on an incremental run, a legitimate deletion that coincides with an unrelated transient chunk failure can be refused — always recoverable by re-running or passing `--allow-partial` (the good graph is preserved and the manifest is not stamped).

### Tests
`tests/test_incomplete_build_guard.py`: clustered path — partial+shrink → refuse + exit 1 + no manifest, partial-but-not-shrinking → writes, `--allow-partial`, clean build keeps force; `--no-cluster` path — partial+shrink refused with the existing graph left intact, and `--allow-partial` overwrites; plus a unit test for `existing_graph_node_count`. Full test suite green (3290 passed).
