### PR TITLE
fix(io): write graph.json and manifest.json atomically

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -246,7 +246,8 @@ def _prune_graph_json_sources(graph_path: Path, stale_sources: list[str]) -> int
         data["hyperedges"] = kept_hyper
     from graphify.export import backup_if_protected as _backup
     _backup(graph_path.parent)
-    graph_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    from graphify.paths import write_json_atomic
+    write_json_atomic(graph_path, data, indent=2)
     return n_removed
 
 
@@ -1615,7 +1616,8 @@ def dispatch_command(cmd: str) -> None:
             out_data = _jg.node_link_data(merged, edges="links")
         except TypeError:
             out_data = _jg.node_link_data(merged)
-        Path(_current_path).write_text(json.dumps(out_data, indent=2), encoding="utf-8")
+        from graphify.paths import write_json_atomic
+        write_json_atomic(_current_path, out_data, indent=2)
         sys.exit(0)
 
     elif cmd == "merge-graphs":

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1597,8 +1597,10 @@ def save_manifest(
         # their absolute form so the manifest round-trips on the saving
         # machine even when not every entry can be portably encoded.
         manifest = {_to_relative_for_storage(k, root): v for k, v in manifest.items()}
-    Path(manifest_path).parent.mkdir(parents=True, exist_ok=True)
-    Path(manifest_path).write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    from graphify.paths import write_json_atomic
+    # Atomic write: a crash mid-write must not leave a truncated manifest that
+    # detect_incremental then fails to parse.
+    write_json_atomic(manifest_path, manifest, indent=2)
 
 
 def detect_incremental(

--- a/graphify/export.py
+++ b/graphify/export.py
@@ -266,8 +266,9 @@ def to_json(G: nx.Graph, communities: dict[int, list[str]], output_path: str, *,
     commit = built_at_commit if built_at_commit is not None else _git_head()
     if commit:
         data["built_at_commit"] = commit
-    with open(output_path, "w", encoding="utf-8") as f:  # nosec
-        json.dump(data, f, indent=2)
+    from graphify.paths import write_json_atomic
+    # Atomic write: a crash/ENOSPC mid-write must not truncate a good graph.json.
+    write_json_atomic(output_path, data, indent=2)
     return True
 
 

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -16,11 +16,80 @@ flow) and every reader honours it.
 
 from __future__ import annotations
 
+import json
 import os
 import re
+import stat
+import tempfile
 from pathlib import Path, PurePosixPath
 
 GRAPHIFY_OUT = os.environ.get("GRAPHIFY_OUT", "graphify-out")
+
+
+def _atomic_replace(path: "str | Path", write_fn) -> None:
+    """Atomically replace ``path`` with content written by ``write_fn(f)``.
+
+    Writes a temp file in the SAME directory, then ``os.replace``s it into place
+    (an atomic rename on one filesystem). A process kill (SIGKILL/Ctrl-C), OOM, or
+    ENOSPC mid-write leaves the previous file intact — the destination is
+    untouched until the rename. This is NOT a power-loss durability guarantee:
+    there is no fsync (matching the rest of the codebase), so an OS/hardware crash
+    right after the rename can still expose unflushed bytes on some filesystems.
+    The temp file is removed if the write fails.
+
+    A symlinked destination is resolved first so the write goes THROUGH the link
+    to its target (rather than replacing the link with a regular file), keeping
+    the shared-output/worktree symlink setups this module documents working.
+    """
+    # Resolve symlinks so the temp lands on the target's filesystem (same-fs
+    # atomic rename) and the replace writes through the link, not over it.
+    real = Path(os.path.realpath(str(path)))
+    real.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(real.parent), prefix=f".{real.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            write_fn(f)
+        # mkstemp creates the temp file 0600; match the destination's existing
+        # mode (or the umask default for a new file) so an atomic replace never
+        # silently tightens a previously group/world-readable output to
+        # owner-only. Best-effort — a chmod failure must not fail the write.
+        try:
+            mode = stat.S_IMODE(os.stat(real).st_mode)
+        except OSError:
+            umask = os.umask(0)
+            os.umask(umask)
+            mode = 0o666 & ~umask
+        try:
+            os.chmod(tmp, mode)
+        except OSError:
+            pass
+        try:
+            os.replace(tmp, str(real))
+        except PermissionError:
+            # Windows: os.replace fails (WinError 5/32) when the destination is
+            # briefly locked by another handle (antivirus, an open reader). Fall
+            # back to copy-then-delete, matching graphify.cache's atomic writer.
+            import shutil
+            shutil.copy2(tmp, str(real))
+            os.unlink(tmp)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def write_text_atomic(path: "str | Path", text: str) -> None:
+    """Atomically write ``text`` (UTF-8) to ``path``. See :func:`_atomic_replace`."""
+    _atomic_replace(path, lambda f: f.write(text))
+
+
+def write_json_atomic(path: "str | Path", obj, *, indent: "int | None" = None) -> None:
+    """Atomically write ``obj`` as JSON to ``path``, streaming the encode into the
+    temp file rather than materializing the whole string first (matters for very
+    large graphs). See :func:`_atomic_replace`."""
+    _atomic_replace(path, lambda f: json.dump(obj, f, indent=indent))
 
 # Directory segments that, when they appear as a whole path component, mark the
 # whole path as a test location. Matched against path *segments* (not raw

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -1,0 +1,101 @@
+"""Tests for atomic JSON writes (graph.json / manifest.json).
+
+A crash, kill, or disk-full mid-write must not leave a truncated/corrupt file
+that a later load chokes on. `write_text_atomic` writes a temp file in the same
+directory then `os.replace`s it into place; on failure the original is untouched.
+"""
+import json
+import os
+
+import pytest
+
+from graphify.paths import write_text_atomic
+
+
+def test_write_text_atomic_writes_and_leaves_no_tmp(tmp_path):
+    p = tmp_path / "out" / "graph.json"  # parent doesn't exist yet
+    write_text_atomic(p, '{"a": 1}')
+    assert json.loads(p.read_text()) == {"a": 1}
+    # No leftover temp file in the target directory.
+    assert [x.name for x in p.parent.iterdir()] == ["graph.json"]
+
+
+def test_write_text_atomic_preserves_existing_on_failure(tmp_path, monkeypatch):
+    p = tmp_path / "graph.json"
+    p.write_text("original", encoding="utf-8")
+
+    def boom(src, dst):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError):
+        write_text_atomic(p, "content-that-must-not-land")
+
+    # The original file is intact and the temp file was cleaned up.
+    assert p.read_text() == "original"
+    assert sorted(x.name for x in tmp_path.iterdir()) == ["graph.json"]
+
+
+def test_write_text_atomic_preserves_existing_mode(tmp_path):
+    # An atomic replace must not tighten a 0644 file to mkstemp's 0600 default.
+    p = tmp_path / "graph.json"
+    p.write_text("{}", encoding="utf-8")
+    os.chmod(p, 0o644)
+    write_text_atomic(p, '{"x": 1}')
+    assert (os.stat(p).st_mode & 0o777) == 0o644
+
+
+def test_write_text_atomic_new_file_respects_umask(tmp_path):
+    # A brand-new file must land at the umask default (e.g. 0644), NOT mkstemp's
+    # 0600 — otherwise every fresh graph.json would be owner-only.
+    p = tmp_path / "new.json"
+    write_text_atomic(p, "{}")
+    umask = os.umask(0)
+    os.umask(umask)
+    assert (os.stat(p).st_mode & 0o777) == (0o666 & ~umask)
+
+
+def test_write_text_atomic_writes_through_symlink(tmp_path):
+    # Shared-output setups symlink graph.json to shared storage; the atomic write
+    # must update the target and keep the link, not replace it with a real file.
+    target = tmp_path / "real.json"
+    target.write_text("old", encoding="utf-8")
+    link = tmp_path / "link.json"
+    link.symlink_to(target)
+    write_text_atomic(link, "new")
+    assert link.is_symlink()
+    assert target.read_text() == "new"
+
+
+def test_write_json_atomic_roundtrip(tmp_path):
+    from graphify.paths import write_json_atomic
+
+    p = tmp_path / "g.json"
+    write_json_atomic(p, {"nodes": [1, 2], "x": "é"}, indent=2)
+    assert json.loads(p.read_text()) == {"nodes": [1, 2], "x": "é"}
+    assert not any(name.name.endswith(".tmp") for name in tmp_path.iterdir())
+
+
+def test_to_json_writes_atomically_no_tmp_leftover(tmp_path):
+    import networkx as nx
+    from graphify.export import to_json
+
+    G = nx.Graph()
+    G.add_node("a", label="a", file_type="code")
+    G.add_node("b", label="b", file_type="code")
+    G.add_edge("a", "b")
+    out = tmp_path / "graph.json"
+    assert to_json(G, {}, str(out), force=True) is True
+    json.loads(out.read_text())  # valid JSON
+    assert not any(x.name.endswith(".tmp") for x in tmp_path.iterdir())
+
+
+def test_save_manifest_writes_atomically(tmp_path):
+    from graphify.detect import save_manifest
+
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+    mpath = tmp_path / "graphify-out" / "manifest.json"
+    save_manifest({"code": [str(tmp_path / "a.py")]}, manifest_path=str(mpath),
+                  kind="both", root=tmp_path)
+    assert json.loads(mpath.read_text())  # non-empty, valid JSON
+    assert not any(x.name.endswith(".tmp") for x in mpath.parent.iterdir())


### PR DESCRIPTION
### Problem
`graph.json` (the clustered `to_json` write, the `--no-cluster` raw dump, and the merge driver) and `manifest.json` (`save_manifest`) were all written with a direct `open()`/`write_text`. A crash, `SIGKILL`/Ctrl-C, OOM, or a disk-full condition partway through the write leaves a **truncated, unparseable file** in place of the previous good one — and the very next `graphify` invocation (or `detect_incremental` reading the manifest) then fails to load it. For the graph and the manifest, which gate every subsequent run, a partial write is a self-inflicted outage.

### Fix
Add `write_text_atomic` / `write_json_atomic` to `graphify.paths` and route the four writers through them. The helpers write to a temp file in the **same directory** and then `os.replace` it into place — an atomic rename on one filesystem, so the destination is never observed half-written and a failed write leaves the previous file untouched (the temp is cleaned up). Details that make it safe in the real environments graphify runs in:

- JSON is **streamed** into the temp via `json.dump` rather than materialized as one giant string first (matters for the very large graphs graphify can produce).
- The destination's existing file mode is **preserved** so an atomic replace never silently tightens a `0644` output to `mkstemp`'s `0600` (new files get the umask default).
- A **symlinked destination** is resolved first so the write goes *through* the link to its target rather than replacing the link with a regular file (the shared-output / worktree setups this module documents keep working).
- A Windows `os.replace` `PermissionError` (destination briefly locked by antivirus or an open reader) falls back to copy-then-delete — matching the atomic writer already in `graphify.cache`.

This is not a power-loss durability guarantee (there is no `fsync`, consistent with the rest of the codebase); it protects concurrent readers and the process-kill / ENOSPC cases, not an OS/hardware crash.

### Tests
`tests/test_atomic_writes.py`: write leaves no temp behind; a failed `os.replace` preserves the original and cleans the temp; existing mode preserved and new-file mode follows umask (not `0600`); symlink write-through; streaming `write_json_atomic` round-trip; and `to_json` / `save_manifest` leave no `.tmp` leftover. Full test suite green (3291 passed).
