### PR TITLE
fix(skill): recover Windows interpreter without parsing launcher

### DIFF
--- a/graphify/skill-agents.md
+++ b/graphify/skill-agents.md
@@ -652,7 +652,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -661,7 +661,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -675,7 +675,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -685,7 +685,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-agents.md
+++ b/graphify/skill-agents.md
@@ -648,15 +648,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill-amp.md
+++ b/graphify/skill-amp.md
@@ -652,7 +652,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -661,7 +661,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -675,7 +675,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -685,7 +685,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-amp.md
+++ b/graphify/skill-amp.md
@@ -648,15 +648,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill-claw.md
+++ b/graphify/skill-claw.md
@@ -655,7 +655,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -664,7 +664,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -678,7 +678,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -688,7 +688,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-claw.md
+++ b/graphify/skill-claw.md
@@ -651,15 +651,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -652,7 +652,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -661,7 +661,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -675,7 +675,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -685,7 +685,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -648,15 +648,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill-copilot.md
+++ b/graphify/skill-copilot.md
@@ -655,7 +655,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -664,7 +664,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -678,7 +678,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -688,7 +688,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-copilot.md
+++ b/graphify/skill-copilot.md
@@ -651,15 +651,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill-droid.md
+++ b/graphify/skill-droid.md
@@ -652,7 +652,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -661,7 +661,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -675,7 +675,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -685,7 +685,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-droid.md
+++ b/graphify/skill-droid.md
@@ -648,15 +648,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill-kilo.md
+++ b/graphify/skill-kilo.md
@@ -655,7 +655,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -664,7 +664,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -678,7 +678,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -688,7 +688,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-kilo.md
+++ b/graphify/skill-kilo.md
@@ -651,15 +651,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill-kiro.md
+++ b/graphify/skill-kiro.md
@@ -655,7 +655,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -664,7 +664,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -678,7 +678,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -688,7 +688,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-kiro.md
+++ b/graphify/skill-kiro.md
@@ -651,15 +651,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -647,7 +647,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -656,7 +656,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -670,7 +670,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -680,7 +680,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -643,15 +643,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill-pi.md
+++ b/graphify/skill-pi.md
@@ -655,7 +655,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -664,7 +664,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -678,7 +678,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -688,7 +688,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-pi.md
+++ b/graphify/skill-pi.md
@@ -651,15 +651,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill-trae.md
+++ b/graphify/skill-trae.md
@@ -653,7 +653,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -662,7 +662,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -676,7 +676,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -686,7 +686,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-trae.md
+++ b/graphify/skill-trae.md
@@ -649,15 +649,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill-vscode.md
+++ b/graphify/skill-vscode.md
@@ -651,7 +651,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -660,7 +660,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -674,7 +674,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -684,7 +684,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-vscode.md
+++ b/graphify/skill-vscode.md
@@ -647,15 +647,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill-windows.md
+++ b/graphify/skill-windows.md
@@ -677,7 +677,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -686,7 +686,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -700,7 +700,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -710,7 +710,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill-windows.md
+++ b/graphify/skill-windows.md
@@ -673,15 +673,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -655,7 +655,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -664,7 +664,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -678,7 +678,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -688,7 +688,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -651,15 +651,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tests/test_skillgen.py
+++ b/tests/test_skillgen.py
@@ -303,8 +303,15 @@ def test_windows_frontmatter_name_and_shell_and_extra():
     assert core.index("## Troubleshooting") < core.index("## Honesty Rules")
 
 
-def test_windows_interpreter_guard_recovers_uv_tool_python(tmp_path):
-    """#1619 A1: recovery must probe uv's Python, not parse graphify.exe."""
+@pytest.mark.parametrize(
+    ("manager", "manager_args"),
+    (
+        ("uv", "tool dir"),
+        ("pipx", "environment --value PIPX_LOCAL_VENVS"),
+    ),
+)
+def test_windows_interpreter_guard_recovers_tool_python(tmp_path, manager, manager_args):
+    """#1619 A1: recovery must probe uv/pipx Python, not graphify.exe."""
     bash = shutil.which("bash")
     if bash is None:
         pytest.skip("bash is required to exercise the generated recovery guard")
@@ -314,41 +321,97 @@ def test_windows_interpreter_guard_recovers_uv_tool_python(tmp_path):
     fence_start = section.index("```bash\n") + len("```bash\n")
     guard = section[fence_start:section.index("\n```", fence_start)]
 
+    distribution_probe = (
+        "from importlib.metadata import version; version('graphifyy'); import graphify"
+    )
     assert 'head -1 "$GRAPHIFY_BIN"' not in guard
     for command in ("uv tool dir", "pipx environment --value PIPX_LOCAL_VENVS"):
         assert command in guard
     for suffix in ("graphifyy/Scripts/python.exe", "graphifyy/bin/python"):
         assert suffix in guard
-    assert '"$_PY" -c "import graphify"' in guard
+    assert guard.count(f'"$_PY" -I -c "{distribution_probe}"') == 4
 
-    tool_dir = tmp_path / "uv-tools"
+    tool_dir = tmp_path / f"{manager}-tools"
     python_exe = tool_dir / "graphifyy" / "Scripts" / "python.exe"
     python_exe.parent.mkdir(parents=True)
     python_exe.write_text(
         "#!/bin/sh\n"
-        "[ \"$1\" = -c ] && [ \"$2\" = \"import graphify\" ]\n",
+        f'[ "$1" = -I ] && [ "$2" = -c ] && [ "$3" = "{distribution_probe}" ]\n',
         encoding="utf-8",
     )
     python_exe.chmod(0o755)
 
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
-    uv = fake_bin / "uv"
-    uv.write_text(
-        f"#!/bin/sh\nprintf '%s\\n' '{tool_dir}'\n",
+    manager_bin = fake_bin / manager
+    manager_bin.write_text(
+        "#!/bin/sh\n"
+        f'[ "$*" = "{manager_args}" ] || exit 1\n'
+        f"printf '%s\\n' '{tool_dir}'\n",
         encoding="utf-8",
     )
-    uv.chmod(0o755)
+    manager_bin.chmod(0o755)
     graphify_exe = fake_bin / "graphify"
     graphify_exe.write_bytes(b"MZ\x90\x00not-a-script")
     graphify_exe.chmod(0o755)
 
     env = os.environ.copy()
-    env["PATH"] = os.pathsep.join((str(fake_bin), env.get("PATH", "")))
+    env["PATH"] = os.pathsep.join((str(fake_bin), "/usr/bin", "/bin"))
     subprocess.run([bash, "-c", guard], cwd=tmp_path, env=env, check=True)
 
     saved = (tmp_path / "graphify-out" / ".graphify_python").read_text(encoding="utf-8")
     assert saved == str(python_exe)
+
+
+@pytest.mark.parametrize(
+    "candidate_state", ("shadow_module", "metadata_only", "combined_shadow")
+)
+def test_interpreter_guard_rejects_incomplete_cwd_install(tmp_path, candidate_state):
+    """Cwd artifacts must not validate an unrelated or broken Python."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to exercise the generated recovery guard")
+
+    core, _ = _platform_artifacts("windows")
+    section = core[core.index("## Interpreter guard for subcommands"):]
+    fence_start = section.index("```bash\n") + len("```bash\n")
+    guard = section[fence_start:section.index("\n```", fence_start)]
+
+    if candidate_state in ("shadow_module", "combined_shadow"):
+        (tmp_path / "graphify.py").write_text(
+            "# shadows an installed package\n", encoding="utf-8"
+        )
+    if candidate_state in ("metadata_only", "combined_shadow"):
+        dist_info = tmp_path / "graphifyy-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: graphifyy\nVersion: 1.0\n",
+            encoding="utf-8",
+        )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    python_wrapper = "#!/bin/sh\nexec \"$REAL_PYTHON\" -S \"$@\"\n"
+    for name in ("python3", "python"):
+        candidate = fake_bin / name
+        candidate.write_text(python_wrapper, encoding="utf-8")
+        candidate.chmod(0o755)
+    for name in ("uv", "pipx"):
+        unavailable = fake_bin / name
+        unavailable.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        unavailable.chmod(0o755)
+    graphify_exe = fake_bin / "graphify"
+    graphify_exe.write_bytes(b"MZ\x90\x00not-a-script")
+    graphify_exe.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = os.pathsep.join((str(fake_bin), "/usr/bin", "/bin"))
+    env["REAL_PYTHON"] = sys.executable
+    env.pop("PYTHONPATH", None)
+    result = subprocess.run([bash, "-c", guard], cwd=tmp_path, env=env, check=False)
+
+    assert result.returncode != 0
+    assert not (tmp_path / "graphify-out" / ".graphify_python").exists()
 
 
 def test_posix_interpreter_guard_preserves_shebang_install(tmp_path):
@@ -366,7 +429,9 @@ def test_posix_interpreter_guard_preserves_shebang_install(tmp_path):
     python_exe.parent.mkdir(parents=True)
     python_exe.write_text(
         "#!/bin/sh\n"
-        "[ \"$1\" = -c ] && [ \"$2\" = \"import graphify\" ]\n",
+        "[ \"$1\" = -I ] && [ \"$2\" = -c ] && "
+        "[ \"$3\" = \"from importlib.metadata import version; "
+        "version('graphifyy'); import graphify\" ]\n",
         encoding="utf-8",
     )
     python_exe.chmod(0o755)

--- a/tests/test_skillgen.py
+++ b/tests/test_skillgen.py
@@ -8,6 +8,9 @@ lives only in the references, and no reference duplicates core content.
 """
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -298,6 +301,88 @@ def test_windows_frontmatter_name_and_shell_and_extra():
     # The troubleshooting section sits before Honesty Rules, single separator.
     assert "\n4. **Skip graspologic**" in core
     assert core.index("## Troubleshooting") < core.index("## Honesty Rules")
+
+
+def test_windows_interpreter_guard_recovers_uv_tool_python(tmp_path):
+    """#1619 A1: recovery must probe uv's Python, not parse graphify.exe."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to exercise the generated recovery guard")
+
+    core, _ = _platform_artifacts("windows")
+    section = core[core.index("## Interpreter guard for subcommands"):]
+    fence_start = section.index("```bash\n") + len("```bash\n")
+    guard = section[fence_start:section.index("\n```", fence_start)]
+
+    assert 'head -1 "$GRAPHIFY_BIN"' not in guard
+    for command in ("uv tool dir", "pipx environment --value PIPX_LOCAL_VENVS"):
+        assert command in guard
+    for suffix in ("graphifyy/Scripts/python.exe", "graphifyy/bin/python"):
+        assert suffix in guard
+    assert '"$_PY" -c "import graphify"' in guard
+
+    tool_dir = tmp_path / "uv-tools"
+    python_exe = tool_dir / "graphifyy" / "Scripts" / "python.exe"
+    python_exe.parent.mkdir(parents=True)
+    python_exe.write_text(
+        "#!/bin/sh\n"
+        "[ \"$1\" = -c ] && [ \"$2\" = \"import graphify\" ]\n",
+        encoding="utf-8",
+    )
+    python_exe.chmod(0o755)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    uv = fake_bin / "uv"
+    uv.write_text(
+        f"#!/bin/sh\nprintf '%s\\n' '{tool_dir}'\n",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+    graphify_exe = fake_bin / "graphify"
+    graphify_exe.write_bytes(b"MZ\x90\x00not-a-script")
+    graphify_exe.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = os.pathsep.join((str(fake_bin), env.get("PATH", "")))
+    subprocess.run([bash, "-c", guard], cwd=tmp_path, env=env, check=True)
+
+    saved = (tmp_path / "graphify-out" / ".graphify_python").read_text(encoding="utf-8")
+    assert saved == str(python_exe)
+
+
+def test_posix_interpreter_guard_preserves_shebang_install(tmp_path):
+    """The shared #1619 guard must retain ordinary POSIX venv recovery."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to exercise the generated recovery guard")
+
+    core, _ = _platform_artifacts("claude")
+    section = core[core.index("## Interpreter guard for subcommands"):]
+    fence_start = section.index("```bash\n") + len("```bash\n")
+    guard = section[fence_start:section.index("\n```", fence_start)]
+
+    python_exe = tmp_path / "venv" / "bin" / "python"
+    python_exe.parent.mkdir(parents=True)
+    python_exe.write_text(
+        "#!/bin/sh\n"
+        "[ \"$1\" = -c ] && [ \"$2\" = \"import graphify\" ]\n",
+        encoding="utf-8",
+    )
+    python_exe.chmod(0o755)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    graphify = fake_bin / "graphify"
+    graphify.write_text(f"#!{python_exe}\n", encoding="utf-8")
+    graphify.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = os.pathsep.join((str(fake_bin), "/usr/bin", "/bin"))
+    subprocess.run([bash, "-c", guard], cwd=tmp_path, env=env, check=True)
+
+    saved = (tmp_path / "graphify-out" / ".graphify_python").read_text(encoding="utf-8")
+    assert saved == str(python_exe)
 
 
 def test_codex_dispatch_is_agenttask_and_collects_in_memory():

--- a/tools/skillgen/expected/graphify__skill-agents.md
+++ b/tools/skillgen/expected/graphify__skill-agents.md
@@ -652,7 +652,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -661,7 +661,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -675,7 +675,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -685,7 +685,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-agents.md
+++ b/tools/skillgen/expected/graphify__skill-agents.md
@@ -648,15 +648,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill-amp.md
+++ b/tools/skillgen/expected/graphify__skill-amp.md
@@ -652,7 +652,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -661,7 +661,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -675,7 +675,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -685,7 +685,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-amp.md
+++ b/tools/skillgen/expected/graphify__skill-amp.md
@@ -648,15 +648,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill-claw.md
+++ b/tools/skillgen/expected/graphify__skill-claw.md
@@ -655,7 +655,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -664,7 +664,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -678,7 +678,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -688,7 +688,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-claw.md
+++ b/tools/skillgen/expected/graphify__skill-claw.md
@@ -651,15 +651,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill-codex.md
+++ b/tools/skillgen/expected/graphify__skill-codex.md
@@ -652,7 +652,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -661,7 +661,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -675,7 +675,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -685,7 +685,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-codex.md
+++ b/tools/skillgen/expected/graphify__skill-codex.md
@@ -648,15 +648,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill-copilot.md
+++ b/tools/skillgen/expected/graphify__skill-copilot.md
@@ -655,7 +655,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -664,7 +664,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -678,7 +678,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -688,7 +688,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-copilot.md
+++ b/tools/skillgen/expected/graphify__skill-copilot.md
@@ -651,15 +651,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill-droid.md
+++ b/tools/skillgen/expected/graphify__skill-droid.md
@@ -652,7 +652,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -661,7 +661,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -675,7 +675,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -685,7 +685,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-droid.md
+++ b/tools/skillgen/expected/graphify__skill-droid.md
@@ -648,15 +648,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill-kilo.md
+++ b/tools/skillgen/expected/graphify__skill-kilo.md
@@ -655,7 +655,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -664,7 +664,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -678,7 +678,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -688,7 +688,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-kilo.md
+++ b/tools/skillgen/expected/graphify__skill-kilo.md
@@ -651,15 +651,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill-kiro.md
+++ b/tools/skillgen/expected/graphify__skill-kiro.md
@@ -655,7 +655,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -664,7 +664,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -678,7 +678,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -688,7 +688,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-kiro.md
+++ b/tools/skillgen/expected/graphify__skill-kiro.md
@@ -651,15 +651,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill-opencode.md
+++ b/tools/skillgen/expected/graphify__skill-opencode.md
@@ -647,7 +647,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -656,7 +656,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -670,7 +670,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -680,7 +680,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-opencode.md
+++ b/tools/skillgen/expected/graphify__skill-opencode.md
@@ -643,15 +643,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill-pi.md
+++ b/tools/skillgen/expected/graphify__skill-pi.md
@@ -655,7 +655,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -664,7 +664,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -678,7 +678,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -688,7 +688,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-pi.md
+++ b/tools/skillgen/expected/graphify__skill-pi.md
@@ -651,15 +651,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill-trae.md
+++ b/tools/skillgen/expected/graphify__skill-trae.md
@@ -653,7 +653,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -662,7 +662,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -676,7 +676,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -686,7 +686,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-trae.md
+++ b/tools/skillgen/expected/graphify__skill-trae.md
@@ -649,15 +649,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill-vscode.md
+++ b/tools/skillgen/expected/graphify__skill-vscode.md
@@ -651,7 +651,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -660,7 +660,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -674,7 +674,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -684,7 +684,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-vscode.md
+++ b/tools/skillgen/expected/graphify__skill-vscode.md
@@ -647,15 +647,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill-windows.md
+++ b/tools/skillgen/expected/graphify__skill-windows.md
@@ -677,7 +677,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -686,7 +686,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -700,7 +700,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -710,7 +710,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill-windows.md
+++ b/tools/skillgen/expected/graphify__skill-windows.md
@@ -673,15 +673,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/expected/graphify__skill.md
+++ b/tools/skillgen/expected/graphify__skill.md
@@ -655,7 +655,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -664,7 +664,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -678,7 +678,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -688,7 +688,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi

--- a/tools/skillgen/expected/graphify__skill.md
+++ b/tools/skillgen/expected/graphify__skill.md
@@ -651,15 +651,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/fragments/core/core.md
+++ b/tools/skillgen/fragments/core/core.md
@@ -586,15 +586,53 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 ```bash
 if [ ! -f graphify-out/.graphify_python ]; then
-    GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-    if [ -n "$GRAPHIFY_BIN" ]; then
-        PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-        case "$PYTHON" in *[!a-zA-Z0-9/_.@-]*) PYTHON="python3" ;; esac
-    else
-        PYTHON="python3"
-    fi
+    find_graphify_python() {
+        if command -v uv >/dev/null 2>&1; then
+            _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        if command -v pipx >/dev/null 2>&1; then
+            _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
+            for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
+                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                    printf '%s\n' "$_PY"
+                    return 0
+                fi
+            done
+        fi
+        _GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+        if [ -f "$_GRAPHIFY_BIN" ] && IFS= read -r _SHEBANG < "$_GRAPHIFY_BIN"; then
+            case "$_SHEBANG" in
+                '#!'*)
+                    _PY=${_SHEBANG#\#!}
+                    case "$_PY" in
+                        *[!a-zA-Z0-9/_.@-]*) ;;
+                        *)
+                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                                printf '%s\n' "$_PY"
+                                return 0
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+        for _PY in python3 python; do
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+                "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
+                return 0
+            fi
+        done
+        return 1
+    }
+    PYTHON=$(find_graphify_python) || exit 1
     mkdir -p graphify-out
-    "$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w', encoding='utf-8').write(sys.executable)"
+    printf '%s' "$PYTHON" > graphify-out/.graphify_python
 fi
 ```
 

--- a/tools/skillgen/fragments/core/core.md
+++ b/tools/skillgen/fragments/core/core.md
@@ -590,7 +590,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v uv >/dev/null 2>&1; then
             _TOOL_DIR=$(uv tool dir 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_TOOL_DIR/graphifyy/Scripts/python.exe" "$_TOOL_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -599,7 +599,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
         if command -v pipx >/dev/null 2>&1; then
             _VENV_DIR=$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null | tr -d '\r' | tr '\\' '/')
             for _PY in "$_VENV_DIR/graphifyy/Scripts/python.exe" "$_VENV_DIR/graphifyy/bin/python"; do
-                if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                     printf '%s\n' "$_PY"
                     return 0
                 fi
@@ -613,7 +613,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
                     case "$_PY" in
                         *[!a-zA-Z0-9/_.@-]*) ;;
                         *)
-                            if [ -x "$_PY" ] && "$_PY" -c "import graphify" 2>/dev/null; then
+                            if [ -x "$_PY" ] && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                                 printf '%s\n' "$_PY"
                                 return 0
                             fi
@@ -623,7 +623,7 @@ if [ ! -f graphify-out/.graphify_python ]; then
             esac
         fi
         for _PY in python3 python; do
-            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -c "import graphify" 2>/dev/null; then
+            if command -v "$_PY" >/dev/null 2>&1 && "$_PY" -I -c "from importlib.metadata import version; version('graphifyy'); import graphify" 2>/dev/null; then
                 "$_PY" -c "import sys; print(sys.executable.replace(chr(92), '/'))" | tr -d '\r'
                 return 0
             fi


### PR DESCRIPTION
## Summary

- Recover a missing `.graphify_python` from validated uv and pipx tool environments before considering console-script shebang and system-Python fallbacks.
- Validate candidates in isolated mode and require both an installed `graphifyy` distribution and an importable `graphify` module, rejecting project-local metadata/module shadows and incomplete environments.
- Regenerate the skill artifacts and cover both tool managers, an MZ-prefixed Windows launcher, combined CWD shadowing, and the existing POSIX shebang path.

Addresses A1 in #1619.

## Result

Path-sanitized results from the Windows regression harness:

```text
uv -> <tmp>/uv-tools/graphifyy/Scripts/python.exe
pipx -> <tmp>/pipx-tools/graphifyy/Scripts/python.exe
cwd module or metadata shadow -> rejected
combined cwd module + metadata shadow -> rejected
```

## Testing

- `uv run --frozen pytest tests/test_skillgen.py -q --tb=short` (65 passed)
- `uv run --frozen pytest tests/ -q --tb=short` (3641 passed, 3 skipped)
- `uv run --frozen python -m tools.skillgen --check`, `--audit-coverage`, `--schema-singleton`, `--monolith-roundtrip`, and `--always-on-roundtrip` (passed; 134 generated artifacts match)
- `uv run --frozen ruff check tests/test_skillgen.py` (passed)
