### PR TITLE
Fix DreamMaker parent-relative #include paths (lstrip charset misuse)

### DIFF
--- a/graphify/extractors/dm.py
+++ b/graphify/extractors/dm.py
@@ -86,7 +86,7 @@ def extract_dm(path: Path) -> dict:
             file_node = node.child_by_field_name("file")
             raw = _read_include_path(file_node)
             if raw:
-                norm = raw.replace("\\", "/").lstrip("./")
+                norm = re.sub(r"^\./", "", raw.replace("\\", "/"))
                 resolved = (path.parent / norm).resolve()
                 edge: dict = {
                     "source": file_nid,


### PR DESCRIPTION
## Problem

`extract_dm` normalizes DreamMaker `#include` paths with `str.lstrip("./")`:

```python
norm = raw.replace("\\", "/").lstrip("./")
resolved = (path.parent / norm).resolve()
```

`str.lstrip` treats its argument as a **set of characters**, not a prefix. It's meant to drop a leading `./`, but it strips *every* leading `.` and `/`, which destroys parent-relative includes:

| raw | `lstrip("./")` | correct |
|---|---|---|
| `../shared/base.dm` | `shared/base.dm` ❌ | `../shared/base.dm` |
| `../../a.dm` | `a.dm` ❌ | `../../a.dm` |
| `.hidden/x.dm` | `hidden/x.dm` ❌ | `.hidden/x.dm` |

`(path.parent / norm).resolve()` then points at the wrong directory, `.exists()` returns False, and what should be an internal `imports_from` edge to the real included file becomes a bogus external `imports` edge to a phantom node — silently losing the cross-file link in the knowledge graph.

## Evidence (sibling proves intent)

The local-include resolver in `extractors/bash.py` does the same "resolve relative to the file's parent, emit `imports_from` if it exists on disk, else external `imports`" flow — but it resolves `(path.parent / raw)` from the **raw** path and never strips `..`. `dm.py` intends the identical resolution but corrupts the path first.

## Fix

Strip only a literal leading `./` (`re` is already imported), preserving `../`:

```python
norm = re.sub(r"^\./", "", raw.replace("\\", "/"))
```

## Reproduction

With a real `sub/child.dm` including `../shared/base.dm` (and `shared/base.dm` on disk):

| | edge |
|---|---|
| before | `imports` (external), target = phantom `shared/base.dm` ❌ |
| after | `imports_from` (internal), target = resolved `shared/base.dm` ✅ |

The `./`-prefix and no-prefix cases are unaffected.
