### PR TITLE
fix(extract): rewrite alias re-export targets

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4583,10 +4583,10 @@ def extract(
                     break
             if canonical_nid is None:
                 continue
-            # Named alias imports can retain an absolute-prefixed target even
+            # Named alias imports/re-exports can retain an absolute-prefixed target
             # when the symbol node is already canonical. Record every old form
-            # so a redundant edge can be recognized without globally
-            # reinterpreting an id that another real node may own.
+            # so a redundant import edge or dangling re-export target can be fixed
+            # without globally reinterpreting an id that another real node may own.
             for old_pref, new_pref in entry:
                 if not canonical_nid.startswith(new_pref + "_"):
                     continue
@@ -4617,6 +4617,12 @@ def extract(
             owned_node_ids = {node.get("id") for node in all_nodes}
             deduped_edges: list[dict] = []
             for edge in all_edges:
+                if edge.get("relation") == "re_exports":
+                    candidates = edge_alias_candidates.get(edge.get("target", ""), set())
+                    if len(candidates) == 1 and edge.get("target") not in owned_node_ids:
+                        edge["target"] = next(iter(candidates))
+                    deduped_edges.append(edge)
+                    continue
                 candidates = (
                     edge_alias_candidates.get(edge.get("target", ""), set())
                     if edge.get("relation") == "imports"

--- a/tests/test_js_import_resolution.py
+++ b/tests/test_js_import_resolution.py
@@ -1271,6 +1271,106 @@ def test_alias_import_symbol_resolves_from_parent_working_directory(tmp_path, mo
     assert all(edge["source"] in node_ids and edge["target"] in node_ids for edge in named_imports)
 
 
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "export { formatDate } from '@/lib/utils'\n",
+        "export { formatDate as displayDate } from '@/lib/utils'\n",
+    ],
+)
+def test_alias_reexport_symbol_resolves_with_relative_input_paths(
+    tmp_path, monkeypatch, statement
+):
+    _write(
+        tmp_path / "tsconfig.json",
+        json.dumps({"compilerOptions": {"baseUrl": ".", "paths": {"@/*": ["src/*"]}}}),
+    )
+    _write(tmp_path / "src/lib/utils.ts", "export function formatDate() { return 'ok' }\n")
+    _write(tmp_path / "src/lib/index.ts", statement)
+
+    monkeypatch.chdir(tmp_path)
+    target = Path("src/lib/utils.ts")
+    barrel = Path("src/lib/index.ts")
+    result = extract([target, barrel], cache_root=Path("."))
+
+    node_ids = {node["id"] for node in result["nodes"]}
+    file_target = _file_node_id(target)
+    symbol_target = _make_id(_file_stem(target), "formatDate")
+    reexports = [
+        edge
+        for edge in result["edges"]
+        if edge["source"] == _file_node_id(barrel)
+        and edge["relation"] == "re_exports"
+    ]
+
+    assert sorted(edge["target"] for edge in reexports) == sorted(
+        [file_target, symbol_target]
+    )
+    assert all(edge["target"] in node_ids for edge in reexports)
+    absolute_prefix = _file_node_id(target.resolve())
+    assert all(not edge["target"].startswith(absolute_prefix + "_") for edge in reexports)
+
+
+def test_alias_reexport_symbol_resolves_from_parent_working_directory(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    _write(
+        project / "tsconfig.json",
+        json.dumps({"compilerOptions": {"baseUrl": ".", "paths": {"@/*": ["src/*"]}}}),
+    )
+    _write(project / "src/lib/utils.ts", "export function formatDate() { return 'ok' }\n")
+    _write(project / "src/lib/index.ts", "export { formatDate } from '@/lib/utils'\n")
+
+    monkeypatch.chdir(tmp_path)
+    target = Path("project/src/lib/utils.ts")
+    barrel = Path("project/src/lib/index.ts")
+    result = extract([target, barrel], cache_root=Path("project"))
+
+    node_ids = {node["id"] for node in result["nodes"]}
+    source = _file_node_id(Path("src/lib/index.ts"))
+    symbol_target = _make_id(_file_stem(Path("src/lib/utils.ts")), "formatDate")
+    symbol_reexports = [
+        edge
+        for edge in result["edges"]
+        if edge["source"] == source
+        and edge["relation"] == "re_exports"
+        and edge["target"] != _file_node_id(Path("src/lib/utils.ts"))
+    ]
+
+    assert [edge["target"] for edge in symbol_reexports] == [symbol_target]
+    assert all(edge["target"] in node_ids for edge in symbol_reexports)
+
+
+def test_alias_reexport_does_not_rewrite_an_owned_symbol_id(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    target = Path("src/lib/utils.ts")
+    absolute_prefix = _file_node_id(target.resolve())
+    mirror = Path(f"{absolute_prefix}.ts")
+    barrel = Path("src/lib/index.ts")
+
+    _write(
+        Path("tsconfig.json"),
+        json.dumps({"compilerOptions": {"baseUrl": ".", "paths": {"@/*": ["src/*"]}}}),
+    )
+    _write(target, "export function formatDate() { return 'target' }\n")
+    _write(mirror, "export function formatDate() { return 'mirror' }\n")
+    _write(barrel, "export { formatDate } from '@/lib/utils'\n")
+
+    result = extract([target, mirror, barrel], cache_root=Path("."))
+
+    node_ids = {node["id"] for node in result["nodes"]}
+    owned_target = _make_id(_file_stem(mirror), "formatDate")
+    symbol_reexports = [
+        edge
+        for edge in result["edges"]
+        if edge["source"] == _file_node_id(barrel)
+        and edge["relation"] == "re_exports"
+        and edge["target"] != _file_node_id(target)
+    ]
+
+    assert [edge["target"] for edge in symbol_reexports] == [owned_target]
+    assert owned_target in node_ids
+
+
 def test_alias_import_does_not_remap_an_owned_symbol_id(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     target = Path("src/lib/utils.ts")


### PR DESCRIPTION
## Summary

- rewrite uniquely identified dangling alias `re_exports` symbol targets to their canonical owned node
- preserve ambiguous or legitimately owned targets and leave existing import twin-deduplication unchanged

Fixes #1983

## Result

For the issue fixture, path-normalized `re_exports` targets now resolve as:

```text
("src_lib_utils_formatdate", true)
("src_lib_utils", true)
```

The symbol-level and file-level provenance edges both remain present.

## Testing

- `python -m pytest tests/test_js_import_resolution.py tests/test_import_extension_resolution.py tests/test_extract.py tests/test_extraction_spec_ids.py -q` (277 passed, 1 skipped)
- `python -m pytest tests/ -q --tb=short --ignore=tests/test_ollama_retry_cap.py` (3357 passed, 33 skipped; optional OpenAI SDK tests were unavailable locally)
- `python -m ruff check graphify/extract.py tests/test_js_import_resolution.py` (passed)
