### PR TITLE
fix(serve): reorder except clauses so the corrupted-graph message is reachable

### DIFF
--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -55,11 +55,11 @@ def _load_graph(graph_path: str) -> nx.Graph:
         except Exception:
             G.graph["_learning_overlay"] = {}
         return G
-    except (ValueError, FileNotFoundError) as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        sys.exit(1)
     except json.JSONDecodeError as exc:
         print(f"error: graph.json is corrupted ({exc}). Re-run /graphify to rebuild.", file=sys.stderr)
+        sys.exit(1)
+    except (ValueError, FileNotFoundError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -612,6 +612,19 @@ def test_load_graph_corrupted_json_prints_recovery_message(tmp_path, capsys):
     assert "Re-run /graphify to rebuild" in err
 
 
+def test_load_graph_generic_value_error_message_unchanged(tmp_path, capsys):
+    """A non-decode ValueError (e.g. a non-.json path) must still print the
+    generic error, not the corrupted-graph hint — pins the except-clause
+    order from #2005 so a future refactor can't collapse them back."""
+    p = tmp_path / "graph.txt"
+    p.write_text("not a graph")
+    with pytest.raises(SystemExit):
+        _load_graph(str(p))
+    err = capsys.readouterr().err
+    assert "must be a .json file" in err
+    assert "corrupted" not in err
+
+
 def test_load_graph_rejects_oversized_file(monkeypatch, tmp_path, capsys):
     # #F4: oversized graph.json must fail fast (SystemExit) with a clear error.
     G = _make_graph()

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -599,6 +599,19 @@ def test_load_graph_missing_file(tmp_path):
         _load_graph(str(graphify_dir / "nonexistent.json"))
 
 
+def test_load_graph_corrupted_json_prints_recovery_message(tmp_path, capsys):
+    """json.JSONDecodeError is a ValueError subclass, so its except clause
+    must be checked before the bare (ValueError, FileNotFoundError) clause,
+    or the corrupted-graph recovery hint is unreachable (#2005)."""
+    p = tmp_path / "graph.json"
+    p.write_text("{not valid json")
+    with pytest.raises(SystemExit):
+        _load_graph(str(p))
+    err = capsys.readouterr().err
+    assert "graph.json is corrupted" in err
+    assert "Re-run /graphify to rebuild" in err
+
+
 def test_load_graph_rejects_oversized_file(monkeypatch, tmp_path, capsys):
     # #F4: oversized graph.json must fail fast (SystemExit) with a clear error.
     G = _make_graph()


### PR DESCRIPTION
## Summary
- `json.JSONDecodeError` subclasses `ValueError`, so `_load_graph()`'s `except (ValueError, FileNotFoundError)` clause always matched first — the `except json.JSONDecodeError` clause with the "graph.json is corrupted (...). Re-run /graphify to rebuild." recovery message was unreachable dead code.
- Users hitting a truncated/corrupted `graph.json` got the bare underlying `json.JSONDecodeError` message instead, contradicting what `SECURITY.md` documents for this exact threat.
- Moved the `json.JSONDecodeError` clause first so it actually catches. Audited the rest of `serve.py`'s exception handlers for the same narrower-after-broader ordering bug — found no other instance.

Fixes #2005.

## Test plan
- [x] Added `test_load_graph_corrupted_json_prints_recovery_message` — writes invalid JSON, asserts the recovery message (not the bare decode error) is printed
- [x] `uv run pytest tests/test_serve.py -q -k load_graph` — 6 passed
- [x] `uv run pytest tests/ -q` — full suite: 3412 passed (5 pre-existing failures unrelated to this change, missing optional `openai` dependency in this environment)