### PR TITLE
fix(transcribe): normalize www.-prefixed URLs before validation

### DIFF
--- a/graphify/transcribe.py
+++ b/graphify/transcribe.py
@@ -47,6 +47,13 @@ def is_url(path: str) -> bool:
     return any(path.startswith(p) for p in URL_PREFIXES)
 
 
+def _normalize_url(url: str) -> str:
+    """Add an HTTPS scheme to URLs that start with ``www.``."""
+    if url.startswith('www.'):
+        return f'https://{url}'
+    return url
+
+
 def download_audio(url: str, output_dir: Path) -> Path:
     """Download audio-only stream from a URL using yt-dlp.
 
@@ -54,6 +61,7 @@ def download_audio(url: str, output_dir: Path) -> Path:
     Uses cached file if already downloaded.
     """
     from graphify.security import validate_url
+    url = _normalize_url(url)
     validate_url(url)  # blocks private IPs, bad schemes before yt-dlp runs
     yt_dlp = _get_yt_dlp()
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -9,7 +9,9 @@ import pytest
 
 from graphify.transcribe import (
     VIDEO_EXTENSIONS,
+    _normalize_url,
     build_whisper_prompt,
+    is_url,
     transcribe,
     transcribe_all,
 )
@@ -25,6 +27,33 @@ def test_video_extensions_set():
     assert ".wav" in VIDEO_EXTENSIONS
     assert ".mov" in VIDEO_EXTENSIONS
     assert ".py" not in VIDEO_EXTENSIONS
+
+
+# ---------------------------------------------------------------------------
+# URL handling
+# ---------------------------------------------------------------------------
+
+def test_normalize_url_adds_https_to_www_url():
+    assert _normalize_url("www.youtube.com/watch?v=xyz") == "https://www.youtube.com/watch?v=xyz"
+
+
+@pytest.mark.parametrize("url", [
+    "https://www.youtube.com/watch?v=xyz",
+    "http://www.youtube.com/watch?v=xyz",
+    "videos/lecture.mp4",
+])
+def test_normalize_url_preserves_other_inputs(url):
+    assert _normalize_url(url) == url
+
+
+@pytest.mark.parametrize("value, expected", [
+    ("www.youtube.com/watch?v=xyz", True),
+    ("http://youtube.com/watch?v=xyz", True),
+    ("https://youtube.com/watch?v=xyz", True),
+    ("videos/lecture.mp4", False),
+])
+def test_is_url_preserves_prefix_detection(value, expected):
+    assert is_url(value) is expected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Found via code review, not tied to an existing issue.

- `is_url()` classifies a scheme-less `"www.youtube.com/watch?v=..."` input as a URL (`www.` is in `URL_PREFIXES`), but `download_audio()` passed that raw string straight to `security.validate_url()`, which rejects anything without an `http`/`https` scheme.
- `transcribe_all()` only logs the resulting `ValueError` as `warning: could not transcribe ...` and silently drops the file — so any `www.`-form URL input failed unconditionally, with no clear signal why.
- Adds `_normalize_url()`: prepends `https://` to `www.`-prefixed input before it reaches `validate_url()`/yt-dlp. Already-scheme'd URLs and plain file paths pass through unchanged.

## Test plan
- [x] Added tests in `tests/test_transcribe.py`: `www.` input gets `https://` prepended; already-scheme'd URLs and file paths are untouched; `is_url()`'s existing detection behavior is unchanged
- [x] `uv run pytest tests/test_transcribe.py -q` — 19 passed
- [x] `uv run pytest tests/ -q` — full suite: 3419 passed (5 pre-existing failures unrelated to this change, missing optional `openai` dependency in this environment)