### PR TITLE
fix(markdown): recognize ~~~ fenced code blocks, not just backticks

### DIFF
--- a/graphify/extractors/markdown.py
+++ b/graphify/extractors/markdown.py
@@ -133,7 +133,7 @@ def extract_markdown(path: Path) -> dict:
         # Skip over fenced code blocks so their contents are not parsed as
         # headings, but do not emit nodes/edges for them (#1077).
         stripped = line_text.strip()
-        if stripped.startswith("```"):
+        if stripped.startswith(("```", "~~~")):
             in_code_block = not in_code_block
             continue
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -2239,6 +2239,22 @@ def test_markdown_fenced_heading_not_parsed():
     assert not any("Not A Heading" in l for l in labels), \
         f"fenced '## Not A Heading' was incorrectly parsed as a node: {labels}"
 
+
+def test_markdown_tilde_fenced_heading_not_parsed(tmp_path):
+    path = tmp_path / "tilde-fenced-heading.md"
+    path.write_text(
+        "# Real Heading\n\n"
+        "~~~python\n"
+        "# Not A Heading\n"
+        "~~~\n"
+    )
+
+    r = extract_markdown(path)
+    labels = _labels(r)
+
+    assert any("Real Heading" in label for label in labels)
+    assert not any("Not A Heading" in label for label in labels)
+
 def test_markdown_no_dangling_edges():
     r = extract_markdown(FIXTURES / "deploy_guide.md")
     node_ids = {n["id"] for n in r["nodes"]}
@@ -2288,6 +2304,21 @@ def test_markdown_link_skips_external_and_images(tmp_path):
     for e in refs:
         assert "example.com" not in e["target"]
         assert "logo" not in e["target"]
+
+
+def test_markdown_tilde_fenced_link_not_parsed(tmp_path):
+    path = tmp_path / "tilde-fenced-link.md"
+    path.write_text(
+        "# Real Heading\n\n"
+        "~~~markdown\n"
+        "[Not A Reference](./hidden.md)\n"
+        "~~~\n"
+    )
+
+    r = extract_markdown(path)
+    refs = [e for e in r["edges"] if e["relation"] == "references"]
+
+    assert not refs
 
 
 def test_markdown_link_edges_resolve_to_real_nodes(tmp_path):


### PR DESCRIPTION
## Summary
Found via code review, not tied to an existing issue.

- The markdown extractor's fence-toggle check only matched lines starting with ` ``` `, so a `~~~`-fenced block (CommonMark's other valid fence syntax) fell through as regular prose.
- Any `# ...`-shaped line inside a `~~~` block became a spurious heading node, and any markdown link inside it became a spurious document-reference edge.
- Extended the existing simple toggle (no fence-char/length tracking — matches the existing implementation's level of rigor, not full CommonMark fence-matching) to also recognize `~~~`.

## Test plan
- [x] Added `test_markdown_tilde_fenced_heading_not_parsed` and `test_markdown_tilde_fenced_link_not_parsed` in `tests/test_languages.py`, mirroring the existing backtick-fence regression tests
- [x] `uv run pytest tests/test_languages.py -q -k markdown` — 12 passed
- [x] `uv run pytest tests/ -q` — full suite: 3414 passed (4 pre-existing failures unrelated to this change, missing optional `openai` dependency in this environment)