### PR TITLE
feat: extract n8n workflow exports into the graph

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -43,6 +43,10 @@ from graphify.extractors.elixir import extract_elixir  # noqa: F401
 from graphify.extractors.fortran import _cpp_preprocess, extract_fortran  # noqa: F401
 from graphify.extractors.go import extract_go  # noqa: F401
 from graphify.extractors.json_config import extract_json  # noqa: F401
+from graphify.extractors.n8n import (  # noqa: F401
+    extract_n8n_workflow,
+    is_n8n_workflow_path,
+)
 from graphify.extractors.markdown import extract_markdown  # noqa: F401
 from graphify.extractors.pascal_forms import extract_delphi_form, extract_lazarus_form  # noqa: F401
 from graphify.extractors.powershell import extract_powershell, extract_powershell_manifest  # noqa: F401
@@ -4061,6 +4065,12 @@ def _get_extractor(path: Path) -> Any | None:
     # (servers, commands, packages, env vars) instead of opaque JSON keys.
     if is_mcp_config_path(path):
         return extract_mcp_config
+    # n8n workflow exports are data-shaped JSON that extract_json skips (#1224),
+    # but their `nodes`/`connections` pair is the actual program. Routed by
+    # content sniff before generic .json dispatch so the steps and the control
+    # flow between them land in the graph instead of nothing.
+    if is_n8n_workflow_path(path):
+        return extract_n8n_workflow
     # Package manifests (apm.yml, pyproject.toml, go.mod, pom.xml) → a canonical
     # package node + depends_on edges, by filename before generic suffix dispatch
     # (#1377). apm.yml would otherwise be a .yml document handled by the LLM.

--- a/graphify/extractors/n8n.py
+++ b/graphify/extractors/n8n.py
@@ -1,0 +1,173 @@
+"""n8n workflow extractor.
+
+An n8n workflow is data-shaped JSON: ``extract_json`` deliberately skips it
+(#1224) because a generic key-walk of one turns into hundreds of orphan
+key-nodes. But the file *is* the program — its ``nodes`` array is the set of
+steps and ``connections`` is the control flow between them. Extracting those
+two structures gives the same signal an AST gives a source file, without any of
+the key-node noise, so n8n workflows are routed here by content sniff before
+generic ``.json`` dispatch.
+
+Sticky notes are canvas annotations rather than steps, so they become
+``document`` nodes: they carry the author's block structure ("Блок 1: …") and
+are worth keeping, but they never participate in control flow.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from graphify.extractors.base import _file_stem, _make_id
+
+# n8n exports are machine-generated and can be large; the router in a real
+# project runs past the 1 MiB ceiling extract_json uses for config files. The
+# parse here is a single json.loads plus two shallow walks, not a per-key AST
+# walk, so a higher ceiling is affordable.
+_MAX_BYTES = 8 * 1024 * 1024
+
+_STICKY_TYPE = "n8n-nodes-base.stickyNote"
+
+
+def is_n8n_workflow_path(path: Path) -> bool:
+    """Return True when ``path`` looks like an exported n8n workflow.
+
+    Sniffs bytes rather than trusting the filename: n8n exports carry no naming
+    convention. The ``n8n-nodes-base.`` marker appears in every export that has
+    at least one built-in node; the structural fallback catches workflows built
+    entirely from community nodes.
+    """
+    if path.suffix.lower() != ".json":
+        return False
+    try:
+        with path.open("rb") as fh:
+            head = fh.read(64 * 1024)
+    except OSError:
+        return False
+    if b'"n8n-nodes-base.' in head:
+        return True
+    return b'"connections"' in head and b'"typeVersion"' in head
+
+
+def _line_index(source: str) -> list[int]:
+    """Byte-free offset→line lookup table: newline positions in ``source``."""
+    offsets = []
+    pos = source.find("\n")
+    while pos != -1:
+        offsets.append(pos)
+        pos = source.find("\n", pos + 1)
+    return offsets
+
+
+def _line_of(offset: int, newlines: list[int]) -> int:
+    """1-based line number for a character offset."""
+    lo, hi = 0, len(newlines)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if newlines[mid] < offset:
+            lo = mid + 1
+        else:
+            hi = mid
+    return lo + 1
+
+
+def extract_n8n_workflow(path: Path) -> dict[str, Any]:
+    """Extract steps and control flow from an exported n8n workflow.
+
+    Behaviour matches the other extractors: ``{"nodes": [...], "edges": [...]}``
+    on success, or the same shape plus ``error``/``skipped`` when the file can't
+    be used.
+    """
+    try:
+        with path.open("rb") as fh:
+            raw = fh.read(_MAX_BYTES + 1)
+    except OSError as exc:
+        return {"nodes": [], "edges": [], "error": str(exc)}
+    if len(raw) > _MAX_BYTES:
+        return {"nodes": [], "edges": [], "error": "n8n workflow too large to index"}
+
+    try:
+        source = raw.decode("utf-8")
+        doc = json.loads(source)
+    except (UnicodeDecodeError, ValueError) as exc:
+        return {"nodes": [], "edges": [], "error": str(exc)}
+
+    if not isinstance(doc, dict) or not isinstance(doc.get("nodes"), list):
+        return {"nodes": [], "edges": [], "skipped": "not an n8n workflow export"}
+
+    stem = _file_stem(path)
+    str_path = str(path)
+    newlines = _line_index(source)
+
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen_ids: set[str] = set()
+    # n8n enforces unique node names within a workflow, and `connections` keys
+    # are those names — so name→id is the join between the two structures.
+    id_by_name: dict[str, str] = {}
+
+    def add_node(nid: str, label: str, line: int, file_type: str) -> None:
+        if nid and nid not in seen_ids:
+            seen_ids.add(nid)
+            nodes.append({"id": nid, "label": label, "file_type": file_type,
+                          "source_file": str_path, "source_location": f"L{line}"})
+
+    def add_edge(src: str, tgt: str, relation: str, line: int,
+                 context: str | None = None) -> None:
+        if not src or not tgt or src == tgt:
+            return
+        edge = {"source": src, "target": tgt, "relation": relation,
+                "confidence": "EXTRACTED", "source_file": str_path,
+                "source_location": f"L{line}", "weight": 1.0}
+        if context:
+            edge["context"] = context
+        edges.append(edge)
+
+    def line_of_name(name: str) -> int:
+        """Line where a node's own ``"name"`` key sits, or L1 if not found."""
+        needle = f'"name": {json.dumps(name, ensure_ascii=False)}'
+        offset = source.find(needle)
+        return _line_of(offset, newlines) if offset != -1 else 1
+
+    file_nid = _make_id(str(path))
+    workflow_label = doc.get("name") or path.name
+    add_node(file_nid, str(workflow_label), 1, "code")
+
+    for entry in doc["nodes"]:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        nid = _make_id(stem, name)
+        if not nid:
+            continue
+        node_type = entry.get("type") or ""
+        line = line_of_name(name)
+        is_sticky = node_type == _STICKY_TYPE
+        add_node(nid, name, line, "document" if is_sticky else "code")
+        add_edge(file_nid, nid, "contains", line)
+        if not is_sticky:
+            id_by_name[name] = nid
+
+    connections = doc.get("connections")
+    if isinstance(connections, dict):
+        for src_name, outputs in connections.items():
+            src_nid = id_by_name.get(src_name)
+            if not src_nid or not isinstance(outputs, dict):
+                continue
+            line = line_of_name(src_name)
+            for branches in outputs.values():
+                if not isinstance(branches, list):
+                    continue
+                for branch in branches:
+                    if not isinstance(branch, list):
+                        continue
+                    for conn in branch:
+                        if not isinstance(conn, dict):
+                            continue
+                        tgt_nid = id_by_name.get(conn.get("node"))
+                        if tgt_nid:
+                            add_edge(src_nid, tgt_nid, "calls", line, context="call")
+
+    return {"nodes": nodes, "edges": edges}

--- a/tests/test_n8n_extraction.py
+++ b/tests/test_n8n_extraction.py
@@ -1,0 +1,149 @@
+"""Tests for n8n workflow extraction.
+
+An exported n8n workflow is data-shaped JSON, so :func:`extract_json` skips it
+(#1224) and the file contributes nothing to the graph — even though its
+``nodes``/``connections`` pair is the program itself. :func:`extract_n8n_workflow`
+reads those two structures, and ``_get_extractor`` routes to it by content sniff
+before generic ``.json`` dispatch.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from graphify.extract import (
+    _get_extractor,
+    _make_id,
+    extract_json,
+    extract_n8n_workflow,
+    is_n8n_workflow_path,
+)
+
+WORKFLOW = {
+    "name": "Demo Router",
+    "nodes": [
+        {"id": "a1", "name": "Приём сообщения", "type": "n8n-nodes-base.telegramTrigger",
+         "typeVersion": 1, "position": [0, 0], "parameters": {}},
+        {"id": "a2", "name": "Это /start?", "type": "n8n-nodes-base.if",
+         "typeVersion": 2, "position": [10, 0], "parameters": {}},
+        {"id": "a3", "name": "Отправить приветствие", "type": "n8n-nodes-base.telegram",
+         "typeVersion": 1, "position": [20, 0], "parameters": {}},
+        {"id": "a4", "name": "Блок 1: приём", "type": "n8n-nodes-base.stickyNote",
+         "typeVersion": 1, "position": [0, 40], "parameters": {"content": "заметка"}},
+    ],
+    "connections": {
+        "Приём сообщения": {"main": [[{"node": "Это /start?", "type": "main", "index": 0}]]},
+        "Это /start?": {"main": [
+            [{"node": "Отправить приветствие", "type": "main", "index": 0}],
+            [],
+        ]},
+    },
+    "active": True,
+    "settings": {},
+}
+
+
+def _write_workflow(path: Path, doc: dict | None = None) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc if doc is not None else WORKFLOW,
+                               ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def _labels(result: dict) -> set[str]:
+    return {n["label"] for n in result["nodes"]}
+
+
+def _flow(result: dict) -> set[tuple[str, str]]:
+    by_id = {n["id"]: n["label"] for n in result["nodes"]}
+    return {
+        (by_id.get(e["source"], e["source"]), by_id.get(e["target"], e["target"]))
+        for e in result["edges"] if e["relation"] == "calls"
+    }
+
+
+def test_workflow_is_routed_to_the_n8n_extractor(tmp_path):
+    """Generic .json dispatch would skip it as data JSON and yield nothing."""
+    wf = _write_workflow(tmp_path / "router.json")
+    assert _get_extractor(wf) is extract_n8n_workflow
+    assert extract_json(wf)["nodes"] == []
+
+
+def test_non_workflow_json_is_left_to_json_config(tmp_path):
+    manifest = tmp_path / "package.json"
+    manifest.write_text(json.dumps({"name": "demo", "dependencies": {"left-pad": "^1"}}),
+                        encoding="utf-8")
+    assert not is_n8n_workflow_path(manifest)
+    assert _get_extractor(manifest) is extract_json
+
+
+def test_community_node_workflow_is_recognized_structurally(tmp_path):
+    """A workflow built only from community nodes carries no n8n-nodes-base marker."""
+    doc = json.loads(json.dumps(WORKFLOW))
+    for node in doc["nodes"]:
+        node["type"] = node["type"].replace("n8n-nodes-base.", "@acme/n8n-nodes-acme.")
+    assert is_n8n_workflow_path(_write_workflow(tmp_path / "community.json", doc))
+
+
+def test_steps_and_control_flow_become_nodes_and_edges(tmp_path):
+    result = extract_n8n_workflow(_write_workflow(tmp_path / "router.json"))
+
+    assert "Приём сообщения" in _labels(result)
+    assert _flow(result) == {
+        ("Приём сообщения", "Это /start?"),
+        ("Это /start?", "Отправить приветствие"),
+    }
+
+
+def test_every_step_is_contained_by_the_workflow_node(tmp_path):
+    wf = _write_workflow(tmp_path / "router.json")
+    result = extract_n8n_workflow(wf)
+
+    file_nid = _make_id(str(wf))
+    contained = {e["target"] for e in result["edges"]
+                 if e["relation"] == "contains" and e["source"] == file_nid}
+    assert len(contained) == len(WORKFLOW["nodes"])
+    assert {n["label"] for n in result["nodes"] if n["id"] == file_nid} == {"Demo Router"}
+
+
+def test_sticky_notes_are_documents_and_carry_no_control_flow(tmp_path):
+    result = extract_n8n_workflow(_write_workflow(tmp_path / "router.json"))
+
+    sticky = [n for n in result["nodes"] if n["label"] == "Блок 1: приём"]
+    assert [n["file_type"] for n in sticky] == ["document"]
+    sticky_id = sticky[0]["id"]
+    assert not [e for e in result["edges"]
+                if e["relation"] == "calls" and sticky_id in (e["source"], e["target"])]
+
+
+def test_cyrillic_step_names_survive_id_normalization(tmp_path):
+    """Cyrillic must not collapse to a single per-file id (#811)."""
+    result = extract_n8n_workflow(_write_workflow(tmp_path / "router.json"))
+    ids = [n["id"] for n in result["nodes"]]
+    assert len(ids) == len(set(ids))
+    assert all(_make_id("x", n["label"]) != "x" for n in result["nodes"][1:])
+
+
+def test_source_location_points_at_the_step_definition(tmp_path):
+    wf = _write_workflow(tmp_path / "router.json")
+    result = extract_n8n_workflow(wf)
+    lines = wf.read_text(encoding="utf-8").splitlines()
+
+    for node in result["nodes"]:
+        line_no = int(node["source_location"].lstrip("L"))
+        if line_no > 1:
+            assert node["label"] in lines[line_no - 1]
+
+
+def test_malformed_json_reports_an_error_instead_of_raising(tmp_path):
+    broken = tmp_path / "broken.json"
+    broken.write_text('{"nodes": [ "connections": "typeVersion"', encoding="utf-8")
+    result = extract_n8n_workflow(broken)
+    assert result["nodes"] == [] and result["error"]
+
+
+def test_json_without_a_nodes_array_is_skipped(tmp_path):
+    other = tmp_path / "other.json"
+    other.write_text(json.dumps({"connections": {}, "typeVersion": 1}), encoding="utf-8")
+    result = extract_n8n_workflow(other)
+    assert result["nodes"] == [] and result["skipped"]


### PR DESCRIPTION
## Problem

An exported n8n workflow contributes **zero nodes** to the graph.

`extract_json` deliberately skips data-shaped JSON (#1224) — a generic key-walk of one explodes into orphan key-nodes — and recognises config/manifest JSON by filename or a top-level key probe (`dependencies` / `extends` / `$ref` / `$schema` / `compilerOptions`). An n8n export matches none of those, so it falls through to the data-JSON skip.

That guard is right in general but wrong here: for an n8n project the workflow file *is* the program. Its `nodes` array is the set of steps and `connections` is the control flow between them. Skipping it means the graph indexes the helper modules a project bundles into its Code nodes while knowing nothing about the router, the branches, or the schedules that actually run them. The only signal is the `produced zero nodes` warning (#1666).

## Approach

`extract_n8n_workflow` reads exactly those two structures and nothing else, so the key-node noise #1224 guards against never appears. Routed by content sniff before generic `.json` dispatch, mirroring how MCP config files are routed in `_get_extractor`.

- **Steps** → one node each, `calls` edges between them from `connections`, plus `contains` from the workflow node.
- **Sticky notes** → `document` nodes. They carry the author's canvas block structure ("Блок 1: …") but never participate in control flow, so they are excluded from the name→id map the connection walk uses.
- **Sniff** — the `n8n-nodes-base.` marker, with a structural fallback (`connections` + `typeVersion`) for workflows built entirely from community nodes. Verified not to capture JSON Schema files or `package.json`.
- **Size ceiling** 8 MiB rather than the 1 MiB `extract_json` uses: this is a single `json.loads` plus two shallow walks, not a per-key AST walk, and real routers run past 1 MiB.

## Result

Measured on a 4-workflow project (516 KB router + 3 sub-workflows):

| | before | after |
|---|---|---|
| nodes from `workflows/*.json` | 0 | 223 |
| control-flow edges | 0 | 220 |

Branch structure becomes traceable — `graphify explain "Valid Apple Health Payload"` now returns the true branch and the false branch instead of `No node matching`.

## Tests

`tests/test_n8n_extraction.py` — 10 cases: routing (and that non-workflow JSON still reaches `extract_json`), the community-node fallback, control flow, containment, sticky-note handling, Cyrillic id survival (#811), `source_location` accuracy, and both failure paths.

`uv run pytest tests/ -q` after `uv sync --all-extras`: **3483 passed, 3 skipped**.

One judgment call worth flagging: the contributing notes say a new *language* extractor should add a fixture plus cases in `test_languages.py`. This is a file-format extractor rather than a language, so I followed the `test_astro_extraction.py` / `test_vue_extraction.py` precedent of a dedicated module with inline fixtures. Happy to move it if you would rather it went through `test_languages.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)