### PR TITLE
fix(hooks): strip interpreter flags from launcher shebang

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -76,6 +76,12 @@ if [ -z "$GRAPHIFY_PYTHON" ]; then
             */env\\ *) GRAPHIFY_PYTHON="${_SHEBANG#*/env }" ;;
             *)         GRAPHIFY_PYTHON="$_SHEBANG" ;;
         esac
+        # Drop interpreter flags: pipx writes shebangs like
+        # `#!/path/to/venv/bin/python -E`, and uv/venv launchers may add -s/-I.
+        # The flag makes the value fail the path allowlist below, which silently
+        # blanks a perfectly good interpreter and lets the last-resort probe pick
+        # an unrelated system python that may hold a stale graphify.
+        GRAPHIFY_PYTHON="${GRAPHIFY_PYTHON%% *}"
         # Allowlist: only keep characters valid in a filesystem path to prevent
         # injection if the shebang contains shell metacharacters.
         case "$GRAPHIFY_PYTHON" in

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -2,6 +2,7 @@
 import os
 import shutil
 import subprocess
+import sys
 from types import SimpleNamespace
 from pathlib import Path
 import pytest
@@ -589,3 +590,53 @@ def test_uninstall_removes_merge_driver_keeps_other_attrs(tmp_path):
     content = (repo / ".gitattributes").read_text(encoding="utf-8")
     assert "*.png binary" in content
     assert "merge=graphify" not in content
+
+
+def _run_python_detect(tmp_path: Path, launcher_shebang: str) -> str:
+    """Run the _PYTHON_DETECT snippet against a fake launcher and report its pick.
+
+    Isolates probe 3 (shebang parsing): the pinned-python placeholder is blanked
+    and the working directory holds no graphify-out/.graphify_python, so the only
+    interpreter the snippet can find is the one named by the fake launcher.
+    """
+    from graphify.hooks import _PYTHON_DETECT
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    launcher = bindir / "graphify"
+    launcher.write_text(launcher_shebang + '\nexit 0\n', encoding="utf-8", newline="\n")
+    launcher.chmod(0o755)
+
+    script = _PYTHON_DETECT.replace("__PINNED_PYTHON__", "")
+    script += 'printf "%s" "$GRAPHIFY_PYTHON"\n'
+    script_path = tmp_path / "detect.sh"
+    script_path.write_text(script, encoding="utf-8", newline="\n")
+
+    # The snippet shells out to head/tr/sed, so the standard bin dirs stay on
+    # PATH; only the graphify launcher is replaced by the fake one.
+    env = dict(os.environ, PATH=os.pathsep.join([str(bindir), "/usr/bin", "/bin"]))
+    res = subprocess.run(
+        ["/bin/sh", str(script_path)],
+        cwd=str(tmp_path), env=env, capture_output=True, text=True,
+    )
+    return res.stdout.strip()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX shebang probe")
+def test_shebang_probe_strips_interpreter_flags(tmp_path):
+    """pipx writes `#!/path/to/venv/bin/python -E`.
+
+    The flag must be dropped before the path allowlist runs. Keeping it makes the
+    allowlist reject the whole value (space is not a path character), blanking a
+    working interpreter and letting the last-resort probe fall through to an
+    unrelated system python that may carry a stale graphify.
+    """
+    picked = _run_python_detect(tmp_path, f"#!{sys.executable} -E")
+    assert picked == sys.executable
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX shebang probe")
+def test_shebang_probe_accepts_plain_interpreter(tmp_path):
+    """A flagless shebang must keep working exactly as before."""
+    picked = _run_python_detect(tmp_path, f"#!{sys.executable}")
+    assert picked == sys.executable


### PR DESCRIPTION
## Problem

The post-commit hook's third interpreter probe parses the `graphify` launcher's shebang. pipx writes launchers with an interpreter flag:

```
#!/Users/me/.local/pipx/venvs/graphifyy/bin/python -E
```

The probe keeps the whole string, including ` -E`. The path allowlist immediately below rejects it because of the space, `GRAPHIFY_PYTHON` is blanked, and the last-resort probe falls through to `python3` on PATH — which is a different environment that may hold an older graphify.

The failure is silent and the symptom is misleading. On my machine the fallback interpreter had a stale graphify, so every commit rebuilt a smaller graph and tripped the shrink guard:

```
[graphify] WARNING: new graph has 10195 nodes but existing graph.json has 10216.
Refusing to overwrite — you may be missing chunk files from a previous session.
```

The guard was doing its job; nothing was wrong with the graph. It took a while to trace the warning back to interpreter selection rather than graph corruption, and the tempting "fix" (`--force`) would have been the wrong move.

The pinned-interpreter probe and `graphify-out/.graphify_python` usually prevent this, so the shebang path is only reached when both miss — a stale pinned path after a reinstall, or a repo whose `graphify-out/` has not been written yet. When it is reached, it currently fails for the most common isolated install layout.

## Fix

Keep the first whitespace-delimited token before the allowlist check:

```sh
GRAPHIFY_PYTHON="${GRAPHIFY_PYTHON%% *}"
```

Shebangs without flags are unaffected — the parameter expansion is a no-op when there is no space. This also covers `-s` / `-I`, which uv and some venv launchers emit.

## Tests

Two tests in `tests/test_hooks.py`, both driving the generated snippet with a fake pipx-style launcher rather than asserting on the template text:

- `test_shebang_probe_strips_interpreter_flags` — flagged shebang resolves to the venv interpreter. Fails on `v8` without this patch.
- `test_shebang_probe_accepts_plain_interpreter` — unflagged shebang keeps working.

`tests/test_hooks.py` passes in full (60 passed). The 4 pre-existing failures in `tests/test_ollama_retry_cap.py` are unrelated (missing `openai` from the `ollama` extra) and reproduce on a clean `v8`.

## Notes

This is deliberately a minimal fix to the existing probe. I noticed #1619 argues for dropping shebang parsing in the skill templates in favour of probing uv/pipx directories; if you want the hook to move the same way, this patch is easy to drop in favour of that. It touches only `graphify/hooks.py` and does not overlap with #1962, which is confined to `skill-*.md`.
