### PR TITLE
fix(skill): per-type incremental kinds for the --update runbook (#2033)

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1706,6 +1706,13 @@ def detect_incremental(
         semantically.
     kind="ast": a file is "changed" when its ast_hash is missing or its
         content has changed. Use this for `graphify update`.
+    kind="auto": per-file-type — code files compare against ast_hash,
+        everything else (docs/papers/images/videos) against semantic_hash.
+        Use this for the skill's `--update` runbook (#2033): code never
+        receives semantic extraction, so its missing semantic_hash is not a
+        pending obligation and must not re-queue an AST-built corpus, while
+        docs downgraded by an AST-only rebuild still get their semantic
+        catch-up.
 
     Fast path: mtime unchanged + hash matches → unchanged (free, no disk IO
     beyond stat). Slow path: mtime bumped → compare MD5 against the relevant
@@ -1765,7 +1772,10 @@ def detect_incremental(
                 # Normalise legacy {mtime, hash} to new schema
                 if "hash" in stored and "ast_hash" not in stored:
                     stored = {"mtime": stored.get("mtime", 0), "ast_hash": stored["hash"], "semantic_hash": ""}
-                hash_key = "semantic_hash" if kind == "semantic" else "ast_hash"
+                if kind == "auto":
+                    hash_key = "ast_hash" if ftype == "code" else "semantic_hash"
+                else:
+                    hash_key = "semantic_hash" if kind == "semantic" else "ast_hash"
                 stored_hash = stored.get(hash_key, "")
                 # Missing semantic_hash means update ran but extract hasn't — always re-extract
                 if not stored_hash:

--- a/graphify/skill-aider.md
+++ b/graphify/skill-aider.md
@@ -748,7 +748,10 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto': ast_hash for code, semantic_hash for docs/papers/images. The
+# semantic default would report every code file of an AST-built corpus as
+# changed and re-extract the whole corpus (#2033).
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2))
 Path('.graphify_incremental.json').write_text(json.dumps(result))

--- a/graphify/skill-devin.md
+++ b/graphify/skill-devin.md
@@ -887,7 +887,10 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto': ast_hash for code, semantic_hash for docs/papers/images. The
+# semantic default would report every code file of an AST-built corpus as
+# changed and re-extract the whole corpus (#2033).
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result))

--- a/graphify/skills/agents/references/update.md
+++ b/graphify/skills/agents/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/amp/references/update.md
+++ b/graphify/skills/amp/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/claude/references/update.md
+++ b/graphify/skills/claude/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/claw/references/update.md
+++ b/graphify/skills/claw/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/codex/references/update.md
+++ b/graphify/skills/codex/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/copilot/references/update.md
+++ b/graphify/skills/copilot/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/droid/references/update.md
+++ b/graphify/skills/droid/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/kilo/references/update.md
+++ b/graphify/skills/kilo/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/kiro/references/update.md
+++ b/graphify/skills/kiro/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/opencode/references/update.md
+++ b/graphify/skills/opencode/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/pi/references/update.md
+++ b/graphify/skills/pi/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/trae/references/update.md
+++ b/graphify/skills/trae/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/vscode/references/update.md
+++ b/graphify/skills/vscode/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/graphify/skills/windows/references/update.md
+++ b/graphify/skills/windows/references/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1295,6 +1295,69 @@ def test_save_manifest_without_filter_unchanged_for_code(tmp_path):
     manifest = json.loads(Path(manifest_path).read_text())
     assert str(py) in manifest
     assert manifest[str(py)]["ast_hash"] != ""
+
+
+# Regression tests for #2033 - kind="auto" compares ast_hash for code and
+# semantic_hash for everything else, so the skill's --update runbook neither
+# re-extracts a whole AST-built corpus (code has no semantic_hash by design)
+# nor loses the semantic catch-up for docs downgraded by an AST-only rebuild.
+
+def test_detect_incremental_auto_code_with_ast_hash_only_is_unchanged(tmp_path):
+    """#2033: after an AST-only stamp (graphify update), an untouched code
+    file has ast_hash but no semantic_hash. kind="auto" must report it
+    unchanged — code never receives semantic extraction, so the missing
+    semantic_hash is not a pending obligation."""
+    py = tmp_path / "main.py"
+    py.write_text("print('hello')")
+    manifest_path = str(tmp_path / "graphify-out" / "manifest.json")
+    save_manifest({"code": [str(py)]}, manifest_path, root=tmp_path, kind="ast")
+
+    inc = detect_incremental(tmp_path, manifest_path, kind="auto")
+    assert inc["new_files"]["code"] == []
+    assert [Path(f).name for f in inc["unchanged_files"]["code"]] == ["main.py"]
+
+
+def test_detect_incremental_auto_doc_missing_semantic_hash_is_changed(tmp_path):
+    """#2033: an AST-only stamp clears/omits semantic_hash for a changed doc.
+    kind="auto" must still queue the doc for semantic re-extraction — that
+    catch-up is the whole point of semantic-hash bookkeeping (#2014)."""
+    doc = tmp_path / "notes.md"
+    doc.write_text("# Notes\n\nsome content")
+    manifest_path = str(tmp_path / "graphify-out" / "manifest.json")
+    save_manifest({"document": [str(doc)]}, manifest_path, root=tmp_path, kind="ast")
+
+    inc = detect_incremental(tmp_path, manifest_path, kind="auto")
+    assert [Path(f).name for f in inc["new_files"]["document"]] == ["notes.md"]
+
+
+def test_detect_incremental_auto_changed_code_is_changed(tmp_path):
+    """kind="auto" still reports a code file whose content changed since the
+    last ast stamp."""
+    py = tmp_path / "main.py"
+    py.write_text("print('hello')")
+    manifest_path = str(tmp_path / "graphify-out" / "manifest.json")
+    save_manifest({"code": [str(py)]}, manifest_path, root=tmp_path, kind="ast")
+
+    py.write_text("print('changed')")
+    os.utime(py, (os.path.getmtime(py) + 5, os.path.getmtime(py) + 5))
+
+    inc = detect_incremental(tmp_path, manifest_path, kind="auto")
+    assert [Path(f).name for f in inc["new_files"]["code"]] == ["main.py"]
+
+
+def test_detect_incremental_auto_doc_with_semantic_hash_is_unchanged(tmp_path):
+    """kind="auto" trusts a valid semantic_hash: an untouched doc stamped by
+    a real semantic pass is not re-queued."""
+    doc = tmp_path / "notes.md"
+    doc.write_text("# Notes\n\nsome content")
+    manifest_path = str(tmp_path / "graphify-out" / "manifest.json")
+    save_manifest({"document": [str(doc)]}, manifest_path, root=tmp_path, kind="both")
+
+    inc = detect_incremental(tmp_path, manifest_path, kind="auto")
+    assert inc["new_files"]["document"] == []
+    assert [Path(f).name for f in inc["unchanged_files"]["document"]] == ["notes.md"]
+
+
 # Regression tests for #945 - .gitignore fallback when no .graphifyignore exists
 
 def test_gitignore_fallback_when_no_graphifyignore(tmp_path):

--- a/tools/skillgen/expected/graphify__skill-aider.md
+++ b/tools/skillgen/expected/graphify__skill-aider.md
@@ -748,7 +748,10 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto': ast_hash for code, semantic_hash for docs/papers/images. The
+# semantic default would report every code file of an AST-built corpus as
+# changed and re-extract the whole corpus (#2033).
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2))
 Path('.graphify_incremental.json').write_text(json.dumps(result))

--- a/tools/skillgen/expected/graphify__skill-devin.md
+++ b/tools/skillgen/expected/graphify__skill-devin.md
@@ -887,7 +887,10 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto': ast_hash for code, semantic_hash for docs/papers/images. The
+# semantic default would report every code file of an AST-built corpus as
+# changed and re-extract the whole corpus (#2033).
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result))

--- a/tools/skillgen/expected/graphify__skills__agents__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__agents__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__amp__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__amp__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__claude__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claude__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__claw__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claw__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__codex__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__codex__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__copilot__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__copilot__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__droid__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__droid__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__kilo__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kilo__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__kiro__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kiro__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__opencode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__opencode__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__pi__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__pi__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__trae__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__trae__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__vscode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__vscode__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__windows__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__windows__references__update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/fragments/core/aider.md
+++ b/tools/skillgen/fragments/core/aider.md
@@ -748,7 +748,10 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto': ast_hash for code, semantic_hash for docs/papers/images. The
+# semantic default would report every code file of an AST-built corpus as
+# changed and re-extract the whole corpus (#2033).
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2))
 Path('.graphify_incremental.json').write_text(json.dumps(result))

--- a/tools/skillgen/fragments/core/devin.md
+++ b/tools/skillgen/fragments/core/devin.md
@@ -887,7 +887,10 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto': ast_hash for code, semantic_hash for docs/papers/images. The
+# semantic default would report every code file of an AST-built corpus as
+# changed and re-extract the whole corpus (#2033).
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result))

--- a/tools/skillgen/fragments/references/shared/update.md
+++ b/tools/skillgen/fragments/references/shared/update.md
@@ -12,7 +12,13 @@ import sys, json
 from graphify.detect import detect_incremental, save_manifest
 from pathlib import Path
 
-result = detect_incremental(Path('INPUT_PATH'))
+# kind='auto' compares code files against ast_hash and docs/papers/images
+# against semantic_hash. The default (kind='semantic') reports every code file
+# of an AST-built corpus as changed — code never gets a semantic_hash — turning
+# a 12-file delta into a full-corpus re-extraction (#2033); plain kind='ast'
+# would instead skip the semantic catch-up for docs an AST-only rebuild
+# downgraded (#2014). Per-type is the only mode that matches this pipeline.
+result = detect_incremental(Path('INPUT_PATH'), kind='auto')
 new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
@@ -142,7 +148,18 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # root= matches the build_merge call above so the manifest keys stay relative to
 # the scan root — portable across clones/machines, so --update keeps matching
 # cached files instead of missing every one after a move (#1417).
-save_manifest(incremental['files'], root='INPUT_PATH')
+# Two stamps, not one kind='both' pass (#2033): 'both' would forge a
+# semantic_hash for every file in the corpus, including docs this run never
+# semantically extracted, silently cancelling their future catch-up.
+# 1) kind='ast' over the full corpus: refreshes ast_hash; an untouched file
+#    keeps its semantic_hash, a changed one has it cleared.
+# 2) kind='semantic' over just the files the semantic pass covered this run —
+#    the changed docs/papers/images (and transcribed videos). On a code-only
+#    update that set is empty and the second stamp is skipped.
+save_manifest(incremental['files'], root='INPUT_PATH', kind='ast')
+sem_files = {t: incremental.get('new_files', {}).get(t, []) for t in ('document', 'paper', 'image', 'video')}
+if any(sem_files.values()):
+    save_manifest(sem_files, root='INPUT_PATH', kind='semantic')
 print('[graphify update] Manifest saved.')
 "
 ```

--- a/tools/skillgen/gen.py
+++ b/tools/skillgen/gen.py
@@ -918,6 +918,29 @@ def _is_semantic_cache_scope_fix_line(line: str) -> bool:
     ) or stripped.startswith("saved = save_semantic_cache(")
 
 
+def _is_incremental_kind_fix_line(line: str) -> bool:
+    """Whether a line is part of the incremental-detection kind fix (#2033).
+
+    The monolith --update flow called ``detect_incremental(...)`` with the
+    default ``kind="semantic"``, so on an AST-built corpus — where code files
+    never receive a semantic_hash — every file reported as changed and a
+    12-file delta became a full-corpus re-extraction. The call now passes
+    ``kind='auto'`` (ast_hash for code, semantic_hash for docs/papers/images).
+    Both the old bare call (removed) and the new call (added) match on the
+    ``detect_incremental(`` clause with an ``import`` guard for the ``from
+    graphify.detect import ...`` line; the three explanatory comment lines
+    match verbatim so any rewording still trips the round-trip.
+    """
+    stripped = line.strip()
+    if "detect_incremental(" in stripped and "import" not in stripped:
+        return True
+    return stripped in (
+        "# kind='auto': ast_hash for code, semantic_hash for docs/papers/images. The",
+        "# semantic default would report every code file of an AST-built corpus as",
+        "# changed and re-extract the whole corpus (#2033).",
+    )
+
+
 # Every line that may differ between a rendered monolith and its pristine v8
 # baseline. Each predicate documents one sanctioned change-class; a blank line is
 # allowed because the multi-line fix blocks insert spacing. Anything else failing
@@ -936,6 +959,7 @@ _SANCTIONED_MONOLITH_DIFFS = (
     _is_obsidian_usage_comment_line,
     _is_uv_from_interpreter_fix_line,
     _is_semantic_cache_scope_fix_line,
+    _is_incremental_kind_fix_line,
 )
 
 


### PR DESCRIPTION
Fixes #2033.

## Problem

Both calls in the `--update` runbook fall back to defaults that are wrong for this pipeline (verified on current `v8`, `edec9ea`):

1. **`detect_incremental()`** defaults to `kind="semantic"`, which treats a missing `semantic_hash` as "changed". Code files never receive semantic extraction (the skill sends only docs/papers/images to subagents), so on an AST-built corpus — e.g. one maintained by `graphify update`, `--watch`, or the git hook, which stamp `kind="ast"` — **every** code file reports as changed. That's the 629-reported vs 12-real blowup in the issue.
2. **`save_manifest()`** defaults to `kind="both"`, forging a `semantic_hash` for every corpus file — including docs that were never semantically extracted — so a later semantic pass considers them done and silently never runs.

## Why not a blanket `kind='ast'`

The issue suggests passing `kind='ast'` at detection. That fixes the code-file blowup but breaks the other direction: a doc downgraded by an AST-only rebuild (`kind="ast"` stamps clear its `semantic_hash` on content change — that's the documented catch-up signal, and the silent-downgrade scenario of #2014) would compare by its freshly-stamped `ast_hash` and report unchanged, so the runbook would never semantically re-extract it. Code and docs need different hash columns.

## Fix

- **`detect.py`**: `detect_incremental()` gains `kind="auto"` — code files compare against `ast_hash`, everything else against `semantic_hash`. One-line dispatch inside the existing per-type loop; `"semantic"`/`"ast"` behavior untouched.
- **Shared `references/update.md` fragment**: detection passes `kind='auto'`; the merge step replaces the single default-`both` stamp with two: `kind='ast'` over the corpus (preserves each untouched file's `semantic_hash`, clears it for changed files), then `kind='semantic'` over just the changed docs/papers/images/videos the semantic pass actually covered. On the runbook's code-only branch that set is empty, leaving exactly the `kind='ast'`-only stamp the issue asks for — one shared code path, no branch duplication.
- **`aider`/`devin` monoliths**: same `kind='auto'` detection fix (their legacy update flow never re-saves the manifest, so there's no stamping call to fix).
- **`tools/skillgen/gen.py`**: the monolith round-trip sanctions the new lines via `_is_incremental_kind_fix_line`, following the existing predicate convention; all artifacts and `expected/` regenerated (`--check`, `--audit-coverage`, `--schema-singleton`, `--monolith-roundtrip`, `--always-on-roundtrip` all pass).

## Verification

- 4 new regression tests in `tests/test_detect.py` (code-with-`ast_hash`-only unchanged; doc missing `semantic_hash` re-queued; changed code re-queued; doc with valid `semantic_hash` unchanged). The full 9-suite batch touching `detect_incremental`/skillgen matches the clean-`v8` baseline failure-for-failure (remaining failures are pre-existing environment gaps: missing `rapidfuzz`/tree-sitter).
- End-to-end against the **rendered** `graphify/skills/claude/references/update.md`: every embedded `python -c` snippet parses; on a 5-file AST-built corpus (3 code + 2 docs) the old detection reports all 5 files changed, the new one reports 0 code files and only the 2-doc semantic backlog; after the two-stamp save, changed code carries a fresh `ast_hash` with **no** forged `semantic_hash`, covered docs carry a real `semantic_hash`, and a follow-up detection reports zero changes.

## Residual (intentionally out of scope)

- A doc that is dispatched this run but whose chunk the LLM drops still gets stamped by the second call (it's in the changed set). That's strictly narrower than the current behavior (which stamps the entire corpus) and matching the CLI's dispatched-but-omitted tracking (#1948) would need per-chunk bookkeeping the runbook doesn't have.
- `graphify extract`'s own incremental path keeps `kind="semantic"` per the issue's scoping ("the full-pipeline path should keep `kind="semantic"`/`"both"`").
