### PR TITLE
fix(kotlin): emit references edges for primary-constructor class_parameters

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2559,6 +2559,39 @@ def _extract_generic(
                                             add_edge(class_nid, target, "references", line,
                                                      context="generic_arg")
 
+            # Kotlin-specific: primary_constructor class_parameters carry
+            # constructor-injected fields (`private val x: Foo` - the idiomatic
+            # Hilt/DI pattern). Mirrors the Scala class_parameters handling
+            # below; without this, every constructor-injected dependency was
+            # invisible to the graph (only body-level property_declaration
+            # vals were captured, and only delegation_specifiers for supertypes).
+            if config.ts_module == "tree_sitter_kotlin":
+                for child in node.children:
+                    if child.type != "primary_constructor":
+                        continue
+                    for pc in child.children:
+                        if pc.type != "class_parameters":
+                            continue
+                        for cp in pc.children:
+                            if cp.type != "class_parameter":
+                                continue
+                            type_node = next(
+                                (t for t in cp.children
+                                 if t.type in ("user_type", "nullable_type", "type_reference")),
+                                None,
+                            )
+                            if type_node is None:
+                                continue
+                            cp_line = cp.start_point[0] + 1
+                            refs: list[tuple[str, str]] = []
+                            _kotlin_collect_type_refs(type_node, source, False, refs)
+                            for ref_name, role in refs:
+                                ctx = "generic_arg" if role == "generic_arg" else "field"
+                                target_nid = ensure_named_node(ref_name, cp_line)
+                                if target_nid != class_nid:
+                                    add_edge(class_nid, target_nid, "references",
+                                             cp_line, context=ctx)
+
             # Ruby: `class Dog < Animal` puts the base class in the `superclass`
             # field (a `<` token followed by a constant or scope_resolution).
             # There was no Ruby branch, so every Ruby inherits edge was dropped.

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -711,6 +711,20 @@ def test_kotlin_user_types_still_emit_references():
     assert ("run", "DataProcessor") in _edge_labels(r, "references", "parameter_type")
 
 
+def test_kotlin_primary_constructor_val_emits_references():
+    # `class HttpClient(private val config: Config)` - a constructor-injected
+    # field declared directly in the primary constructor's class_parameters,
+    # as opposed to a body-level `val`/`var` (property_declaration, already
+    # covered by test_kotlin_user_types_still_emit_references above). This is
+    # the idiomatic Kotlin/Hilt DI pattern (`@Inject constructor(private val
+    # x: Foo)`) and was previously dropped entirely: the Kotlin branch only
+    # walked delegation_specifiers (supertypes) and property_declaration
+    # (body vals), never primary_constructor/class_parameters, so every
+    # constructor-injected dependency was invisible to the graph.
+    r = extract_kotlin(FIXTURES / "sample.kt")
+    assert ("HttpClient", "Config") in _edge_labels(r, "references", "field")
+
+
 # ── Scala ─────────────────────────────────────────────────────────────────────
 
 def test_scala_no_error():


### PR DESCRIPTION
## Title
Kotlin extractor drops constructor-injected fields (`primary_constructor`/`class_parameters` never walked)

## Summary
`extract_kotlin` never emits `references` edges for dependencies declared in a
class's **primary constructor** (`class Foo(private val x: Bar)`) — the
idiomatic Kotlin/Hilt/Dagger DI pattern. Only two Kotlin-specific code paths
exist in `graphify/extractors/engine.py`:

1. `delegation_specifiers` → `inherits`/`implements` edges for supertypes.
2. `property_declaration` → `references` edges for **body-level** `val`/`var`.

Neither walks `primary_constructor → class_parameters → class_parameter`, so
every constructor-injected field is invisible to the graph. Scala already has
the equivalent handling for its structurally identical `class_parameters` node
(same file, ~30 lines below the Kotlin block) — Kotlin never got the same
treatment.

## Reproduction
Using the project's own fixture, `tests/fixtures/sample.kt`:

```kotlin
class HttpClient(private val config: Config) {
    ...
}
```

```python
from graphify.extract import extract_kotlin
r = extract_kotlin(Path("tests/fixtures/sample.kt"))
refs = [(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "references"]
assert ("HttpClient", "Config") in refs  # currently FAILS
```

No edge from `HttpClient` to `Config` is ever emitted, despite `Config` being
a required, explicit, statically-typed constructor dependency. Existing tests
(`test_kotlin_parameter_return_generic_and_field_contexts`,
`test_kotlin_user_types_still_emit_references`) already assert `references`
edges for a **body-level** `val` on `DataProcessor`, so the gap was masked —
nobody had asserted the primary-constructor case.

## Why this matters (real-world impact)
Found while running `/graphify` on a ~600-file, multi-module Kotlin/Android
app that uses constructor-injection (Hilt) everywhere — the standard pattern
for every ViewModel and Repository. Before the fix:

- A `MealDraftStore` class injected into **5 production ViewModels** via
  `private val mealDraftStore: MealDraftStore` showed **zero** incoming edges
  from any of them in the graph — only from test classes that instantiate it
  directly (`MealDraftStore()` in a test's `.setUp()`, captured via the
  `calls` path, which *is* handled).
- A `FirestoreSyncService` injected into 3 repositories was equally invisible.
- Applying the fix and re-running extraction (AST-only, no LLM cost) on the
  same corpus: **+292 edges** (5,452 → 5,744), and the top god-nodes' degree
  jumped accordingly (`GlucoseSettingsRepository` 58→68, `HistoryViewModel`
  41→53, `Food` 63→72) — all constructor-injection edges that were silently
  dropped before.

For any Kotlin codebase using DI via primary-constructor (which is close to
all idiomatic modern Kotlin), this means the dependency graph systematically
undercounts how classes actually depend on each other, skewing god-node
rankings, community detection, and "who uses X" queries.

## Fix
Mirror the existing Scala `class_parameters` handling
(`graphify/extractors/engine.py`, Scala block a few lines below the Kotlin
`delegation_specifiers` block) for Kotlin's `primary_constructor →
class_parameters → class_parameter` nodes. Patch attached (`kotlin-primary-
constructor-fix.diff`, applies cleanly to `v8` HEAD as of `abff1b1`):

- `graphify/extractors/engine.py`: +33 lines, new Kotlin-specific block
  right after the existing `delegation_specifiers` block.
- `tests/test_languages.py`: +14 lines, one new regression test
  (`test_kotlin_primary_constructor_val_emits_references`) using the
  existing `sample.kt` fixture — no fixture changes needed, the reproducing
  case (`HttpClient(private val config: Config)`) was already there.

Verified:
- `pytest tests/test_languages.py` — 318 passed, 13 skipped (unrelated
  optional deps), **0 failures**, including the 13 Kotlin tests (12 existing
  + 1 new).
- `pytest tests/test_extract.py tests/test_multilang.py
  tests/test_cross_language_call_resolution.py` — 174 passed, 12 skipped,
  0 failures.
- Manually confirmed on the real-world corpus described above that the fix
  produces exactly the expected new edges (constructor-injected ViewModels →
  their injected repositories/stores) and nothing spurious.

## Scope note
This fixes constructor-parameter type references only. It does **not**
address a related but separate gap: `when (result) { is Result.Success ->
... }` pattern-matching inside function bodies also isn't walked for type
references anywhere in the extractor (any language) — that's a broader,
more expensive change (walking arbitrary expression bodies) and out of scope
here.
