### PR TITLE
Add repository knowledge graph documentation

### DIFF
--- a/docs/knowledge_graph/CODEBASE_OVERVIEW.md
+++ b/docs/knowledge_graph/CODEBASE_OVERVIEW.md
@@ -1,0 +1,237 @@
+# graphify — Codebase Overview
+
+*A developer's guide to what this codebase is, how it's organized, and how it runs. Companion doc: `TECHNICAL_REFERENCE.md` (module-by-module deep reference). Visual: `graph.html` (open in a browser — interactive module dependency graph).*
+
+*Grounded in commit `e32c9f4` (branch `v8`, v0.9.24). Every claim below cites a file, and file:line where practical. Anything not directly verifiable in this pass is marked **[UNVERIFIED]**.*
+
+---
+
+## 1. What this project is
+
+**graphify** turns a folder of code, docs, papers, images, or videos into a **queryable knowledge graph** — nodes are entities (functions, classes, files, concepts...), edges are typed relationships (`calls`, `imports`, `inherits`, `documents`, ...). Its purpose (`pyproject.toml:6`, `README.md:97-113`) is to give AI coding assistants a token-efficient substitute for reading a whole repo: instead of grepping and reading dozens of files, an agent queries a prebuilt graph (`graphify-out/graph.json`) via CLI (`graphify query "..."`) or an MCP server (`graphify-mcp`). `BENCHMARKS.md` claims up to 71.5x token reduction vs. naive full-corpus reading.
+
+It ships two ways:
+- **As a Python library/CLI** — `uv tool install graphifyy` or `pip install graphifyy` (distributed name has a double-y; import name and CLI command are `graphify` — see Troubleshooting note below).
+- **As an "agent skill"** — `graphify install` writes platform-specific instruction files and hooks into 20+ AI coding tools (Claude Code, Codex, Cursor, Aider, Copilot, Kiro, Devin, ...) so the graph is consulted automatically before those tools read raw files (`graphify/install.py`).
+
+This is a **meta/self-referential codebase**: it is itself a code-comprehension tool, and the project runs it on itself (`.github/workflows/release-graph.yml`, `worked/` example outputs, `AGENTS.md` instructing contributing agents to consult `graphify-out/GRAPH_REPORT.md`).
+
+## 2. Tech stack
+
+| Aspect | Detail | Evidence |
+|---|---|---|
+| Language | Python ≥3.10, ~52,000 LOC across `graphify/` (65 files) + `graphify/exporters/` (4) + `graphify/extractors/` (29) | `pyproject.toml:11`; `wc -l` |
+| Build backend | `setuptools>=68` | `pyproject.toml [build-system]` |
+| Package manager | `uv` (primary/recommended), `pip` also works; `uv.lock` committed | `README.md:153-163`, `.github/workflows/ci.yml` |
+| Core deps | `networkx` (graph data structure), `numpy`, `rapidfuzz` (fuzzy matching), ~28 `tree-sitter-<language>` grammar packages | `pyproject.toml:14-42` |
+| Optional extras | `mcp`, `neo4j`, `falkordb`, `pdf`, `watch`, `svg`, `leiden`, `office`, `google`, `postgres`, `video`, per-LLM-backend extras (`kimi`,`ollama`,`bedrock`,`anthropic`,`gemini`,`openai`), `chinese`, `sql`, `pascal`, `dm`, `terraform`, `all` | `pyproject.toml:52-77` |
+| Non-Python files elsewhere in the repo | **Test fixtures only** — `tests/fixtures/sample.<ext>` for ~30 languages (`.go`, `.rs`, `.cs`, `.swift`, `.pas`, `.sql`, `.xaml`...) exercise the language extractors; they are not application code | `tests/fixtures/` listing |
+
+## 3. Architecture at a glance
+
+A **staged pipeline library**, not a long-running service by default:
+
+```
+detect()  →  extract()  →  build()/build_from_json()  →  cluster()  →  analyze fns  →  generate() (report)  →  to_json()/to_html()/... (export)
+```
+
+Each stage is (mostly) a pure function passing plain dicts / `networkx.Graph` objects — `ARCHITECTURE.md`'s framing of "no shared state" is accurate at the data-flow level, though in practice `analyze.py` has no single `analyze()` function (it's several independent functions) and `export.py` has no single `export()` (one `to_*` function per output format), correcting `ARCHITECTURE.md`'s simplified module table. See §5 for verified signatures.
+
+On top of this pipeline sit three additional runtime modes:
+1. **CLI query mode** — one-shot commands (`query`, `path`, `explain`, `affected`, `god-nodes`) read `graphify-out/graph.json` and print results.
+2. **MCP server** (`graphify/serve.py`) — stdio or Streamable-HTTP server exposing the graph as tools to any MCP-capable AI client; also deployable as a Docker container (`Dockerfile`).
+3. **Watch mode** (`graphify/watch.py`) — a `watchdog`-based filesystem watcher that debounces changes and re-triggers an AST-only rebuild, or flags a "needs semantic update" state for doc/paper/image changes.
+
+### 3.1 The two plugin systems
+
+This codebase has two orthogonal, unusually broad plugin architectures worth understanding up front:
+
+**A. Language extraction plugins** (`graphify/extractors/` + dispatch in `graphify/extract.py`) — ~30 languages. Two coexisting extractor shapes:
+- **Bespoke extractors**: self-contained AST walkers, one file each (`extractors/go.py`, `extractors/rust.py`, `extractors/blade.py`, `extractors/zig.py`, `extractors/elixir.py`, `extractors/dart.py`, `extractors/powershell.py`, `extractors/fortran.py`, `extractors/sql.py`, `extractors/dm.py`, `extractors/bash.py`, `extractors/apex.py`, `extractors/terraform.py`, `extractors/sln.py`, `extractors/pascal_forms.py`, `extractors/json_config.py`).
+- **Config-driven extractors**: python, js/ts, java, c/cpp, ruby, csharp, kotlin, scala, php, lua, swift, groovy, vue, svelte, astro, xaml — these still live inside `extract.py` as `extract_<lang>` wrapper functions that call one shared generic tree-sitter walker, `_extract_generic()` in `graphify/extractors/engine.py:2157`, parameterized by a `LanguageConfig` dataclass (`extractors/models.py:14`).
+
+  An in-flight refactor (`graphify/extractors/MIGRATION.md`) is migrating bespoke extractors out of `extract.py` one language per PR; config-driven languages are pinned as a future batch move once the shared engine core itself relocates. **Import direction is enforced one-way** (`extractors/base.py:1`: *"DO NOT import from graphify.extract here — direction is extract.py → extractors/ only"*), and `extract.py` re-exports every relocated name (`extract.py:27-142`, all `# noqa: F401`) so external callers see no breakage — a facade pattern.
+
+  Real runtime dispatch is the `_DISPATCH` table (`extract.py:3926`, ~90 extensions → `extract_<lang>` functions), consumed by `_get_extractor()` (`extract.py:4135`). A second registry, `LANGUAGE_EXTRACTORS` in `extractors/__init__.py:36-64`, exists only to keep a test (`tests/test_extractors_registry.py`) honest that the facade re-exports match — **it is not the runtime dispatch path**.
+
+  Cross-file/cross-language call resolution runs as a deferred second pass: every extractor emits unresolved `raw_calls`; `extract()` aggregates them across the whole corpus and resolves globally after all files are parsed (`extract.py:4994-5118`), assigning `EXTRACTED` confidence when import evidence backs the match, `INFERRED` otherwise. Additional **per-language resolver plugins** register into `graphify/resolver_registry.py` (`LanguageResolver` dataclass, `register()`/`run_language_resolvers()`) — e.g. Ruby (`ruby_resolution.py`) and Pascal (`pascal_resolution.py`) member-call resolution.
+
+**B. AI-tool "install as skill" plugins** (`graphify/install.py`, 2204 lines) — one entry per AI coding tool, table-driven for the common case (`_PLATFORM_CONFIG` dict, `install.py:324-465`, ~19 platforms) plus hand-written functions for platforms needing non-generic mechanics: Claude Code gets a `CLAUDE.md` section + a PreToolUse hook in `.claude/settings.json` (`install.py:1640-1688`); Cursor gets `.cursor/rules/graphify.mdc` (`install.py:1042-1056`); OpenCode/Kilo get injected JS plugins intercepting `tool.execute.before` (`install.py:1290-1313`, `1205-1228`); Codex/Aider/others get an `AGENTS.md` section (`install.py:1406-1441`); Kiro gets a steering file (`install.py:877-902`); Antigravity gets `.agents/rules/` + `.agents/workflows/` (`install.py:919-981`). All told, 21+ platforms are supported (`README.md` command list confirms: claude, windows, codebuddy, codex, opencode, aider, amp, agents, claw, droid, trae, trae-cn, gemini, cursor, antigravity, hermes, kiro, pi, devin).
+
+  The actual instruction *text* installed for each platform is itself **generated at build time** by `tools/skillgen/` (fragments under `tools/skillgen/fragments/*.md` + `tools/skillgen/platforms.toml` → committed output at `graphify/skill*.md` and `graphify/skills/<platform>/references/*.md`). CI's `skillgen-check` job (`.github/workflows/ci.yml`) runs 5 drift-guards (`--check`, `--audit-coverage`, `--schema-singleton`, `--monolith-roundtrip`, `--always-on-roundtrip`) so hand-edits to generated files, or missed regenerations, fail the build.
+
+## 4. Domain model
+
+- **Node**: `{id, label, file_type, source_file, source_location}`. `file_type ∈ {code, document, paper, image, rationale, concept}`.
+- **Edge**: `{source, target, relation, confidence, source_file}`. `confidence ∈ {EXTRACTED, INFERRED, AMBIGUOUS}` — `EXTRACTED` is explicit in source (an import statement, a direct call), `INFERRED` is a reasonable deduction (call-graph second pass), `AMBIGUOUS` is uncertain and flagged in `GRAPH_REPORT.md` for human review.
+- Schema enforced (warn, not hard-fail) by `validate_extraction()` in `graphify/validate.py:10`, called from `build_from_json()` (`build.py:539`).
+- Stored as `graphify-out/graph.json` (NetworkX node-link JSON). Derived artifacts on demand: `GRAPH_REPORT.md`, an Obsidian-compatible wiki vault, `graph.html`, `graph.svg`, `graph.canvas`, `graph.graphml`, a Cypher script, a D3 collapsible tree view, a Mermaid call-flow HTML doc.
+
+## 5. The core pipeline — verified function signatures
+
+*Corrects `ARCHITECTURE.md`'s simplified module table where the real code differs.*
+
+| Stage | Function | File:line | I/O |
+|---|---|---|---|
+| File discovery (used by `extract` CLI command) | `detect(root, *, follow_symlinks=None, google_workspace=None, extra_excludes=None, cache_root=None, gitignore=True) -> dict` | `graphify/detect.py:1238` | root path → classified file lists (code/doc/paper/image), gitignore-filtered |
+| File discovery (standalone/watch/update) | `collect_files(target, *, follow_symlinks=False, root=None) -> list[Path]` | `graphify/extract.py:5248` | dir/file path → flat sorted list of extractable files |
+| AST extraction | `extract(paths, cache_root=None, *, root=None, parallel=True, max_workers=None) -> dict` | `graphify/extract.py:4381` | file paths → `{"nodes":[...], "edges":[...], "input_tokens":0, "output_tokens":0}` |
+| Semantic (LLM) extraction | `extract_corpus_parallel(...)` | `graphify/llm.py` | doc/paper/image paths → `{"nodes":[...], "edges":[...], "hyperedges":[...], tokens}` |
+| Build (merge extractions) | `build(extractions, *, directed=False, dedup=True, root=None) -> nx.Graph` | `graphify/build.py:938` | list of extraction dicts → graph |
+| Build (single dict) | `build_from_json(extraction, *, directed=False, root=None) -> nx.Graph` | `graphify/build.py:490` | one extraction dict → graph; runs schema validation internally |
+| Build (incremental) | `build_merge(...)` | `graphify/build.py:1038` | new extractions + existing `graph.json` → merged graph |
+| Cluster | `cluster(G, resolution=1.0, exclude_hubs_percentile=None) -> dict[int, list[str]]` | `graphify/cluster.py:134` | graph → `{community_id: [node_ids]}` (Leiden-based) |
+| Cluster scoring | `score_all(G, communities) -> dict[int, float]` | `graphify/cluster.py:268` | → per-community cohesion score |
+| Analyze — hubs | `god_nodes(G, top_n=10) -> list[dict]` | `graphify/analyze.py:101` | most-connected non-trivial nodes |
+| Analyze — anomalies | `surprising_connections(G, communities, ...) -> list[dict]` | `graphify/analyze.py:125` | cross-community/cross-file "surprising" edges |
+| Analyze — questions | `suggest_questions(...)` | `graphify/analyze.py:420` | suggested exploration questions for the report |
+| Analyze — diff / cycles | `graph_diff(...)` / `find_import_cycles(...)` | `analyze.py:548` / `analyze.py:632` | graph comparison / import-cycle detection |
+| Report | `generate(G, communities, cohesion_scores, community_labels, god_node_list, surprise_list, detection_result, token_cost, root, ...) -> str` | `graphify/report.py:71` | all analysis artifacts → Markdown text (written as `GRAPH_REPORT.md`) |
+| Export — JSON | `to_json(G, communities, output_path, *, force=False, ...) -> bool` | `graphify/export.py:232` | writes `graph.json`; **refuses to shrink** the graph unexpectedly (issue #479 anti-data-loss guard) unless `force=True` |
+| Export — HTML/Obsidian/Canvas/GraphML/SVG/Cypher | `to_html`, `to_obsidian`, `to_canvas`, `to_graphml`, `to_svg`, `to_cypher` | `graphify/export.py` (various) + `graphify/exporters/html.py` | one function per format, dispatched by `graphify export <format>` |
+| Export — live graph DB push | `push_to_neo4j`, `push_to_falkordb` | `graphify/exporters/graphdb.py:9,80` | parameterized Cypher via the `neo4j`/`falkordb` SDKs |
+
+## 6. CLI execution flow
+
+**Startup**: `graphify <args>` (console script) or `python -m graphify` → `graphify/__main__.py:main()` (line 460) → `_run_cli()` (line 483). This reconfigures stdout/stderr to UTF-8, checks installed-skill version staleness, handles `-v`/`--help`/bare invocation, then:
+1. Tries `dispatch_install_cli(cmd)` from `graphify/install.py:1929` — handles `install`/`uninstall`/all per-platform install commands. If matched, done.
+2. Otherwise calls `dispatch_command(cmd)` in `graphify/cli.py:626` — a single large `if/elif` chain (not a registry) over ~30 subcommands, each with function-local lazy imports to keep bare CLI startup fast.
+
+**Bare `graphify <path>` invocation** (no subcommand): `cli.py:3675` rewrites `sys.argv` to insert `"extract"` and re-enters `main()`. This is the "just run `graphify .`" convenience form.
+
+**Three materially different "run the pipeline" commands** — a subtlety worth knowing before assuming they're interchangeable:
+
+| Command | What it runs | Produces |
+|---|---|---|
+| `graphify extract <path>` (= bare `graphify <path>`) | detect → AST extract → semantic (LLM) extract for docs/papers/images not cache-hit → build → cluster → analyze → `to_json` | `graph.json` + `.graphify_analysis.json` **only** — deliberately stops before labeling/report so the agent-orchestrated skill.md flow can do LLM community-naming as its own step |
+| `graphify cluster-only <path>` / `graphify label <path>` | loads existing `graph.json` → re-cluster → label communities (hub-based or LLM) → analyze → `generate()` report → `to_json`+`to_html` | `GRAPH_REPORT.md` + refreshed `graph.json`/`graph.html` — the "missing back half" of `extract` |
+| `graphify update <path>` | delegates entirely to `graphify.watch._rebuild_code()`, which runs detect → AST extract (**no LLM step**) → build → cluster → analyze → report → export in one call | `graph.json` + `GRAPH_REPORT.md` + `graph.html` in one shot, code-only (no semantic re-extraction) |
+
+**Full CLI command table** (branch locations in `graphify/cli.py` unless noted):
+
+| Command | Purpose |
+|---|---|
+| `install` / `uninstall` / `<platform> install\|uninstall` | Install/remove the skill for one or all of 21+ AI tool platforms (`install.py`) |
+| `provider list\|show\|add\|remove` | Manage custom LLM providers in `~/.graphify/providers.json` |
+| `prs` | PR-related subcommands (`graphify/prs.py`) |
+| `hook install\|uninstall\|status` | Git post-commit/post-checkout hook management (`graphify/hooks.py`) |
+| `query "<question>"` | BFS/DFS scoped-subgraph text answer to a question |
+| `affected "<node>"` | Reverse traversal — what depends on this node |
+| `god-nodes` | List most-connected hub nodes |
+| `save-result` / `reflect` | Feedback-loop: save a Q&A result / summarize `memory/` into `LESSONS.md` |
+| `path "A" "B"` | Shortest path between two named nodes |
+| `explain "X"` | Plain-language explanation of a node + neighbors |
+| `diagnose multigraph` | Reports same-endpoint edge collapse risk |
+| `add <url>` | Fetch a URL into the corpus (`graphify/ingest.py`) |
+| `watch <path>` | Watch a folder, rebuild on change (`graphify/watch.py`) |
+| `cluster-only` / `label` | Re-cluster + (re)label + regenerate report on an existing graph |
+| `update <path>` | Full AST-only rebuild (no LLM) |
+| `hook-check` / `hook-guard` / `check-update` | Editor/agent integration guards |
+| `tree` | D3 collapsible-tree HTML view (`graphify/tree_html.py`) |
+| `merge-driver` | Git merge driver for `graph.json` conflicts |
+| `merge-graphs` | Merge two+ standalone `graph.json` files |
+| `clone <url>` | Clone a GitHub repo, print its path |
+| `export <format>` | html / callflow-html / obsidian / wiki / svg / graphml / neo4j / falkordb |
+| `benchmark` | Token-reduction measurement vs. naive full-corpus reading |
+| `global add\|remove\|list\|path` | Cross-project merged graph at `~/.graphify/global-graph.json` |
+| `extract <path>` | Headless full pipeline (see table above) |
+| `cache-check` / `merge-chunks` / `merge-semantic` | Internal commands supporting agent-orchestrated (skill.md) semantic extraction |
+
+## 7. Serving mode (MCP)
+
+`graphify-mcp` → `graphify/serve.py:_main` (line 1929). Builds one shared `mcp.server.Server("graphify")` (`_build_server`, `serve.py:1103`) reused by both transports:
+- **stdio** (default): `serve()` at `serve.py:1713`.
+- **Streamable HTTP** (MCP spec 2025-03-26): `serve_http()` at `serve.py:1871`, Starlette app (`_build_http_app`, `serve.py:1789`), optional API-key middleware (`_ApiKeyMiddleware`, `serve.py:1748`, pure-ASGI to avoid buffering SSE), DNS-rebinding protection. This is what the `Dockerfile` runs as a shared team service (`ENTRYPOINT ["python", "-m", "graphify.serve"]`, `EXPOSE 8080`).
+
+**Tools exposed** (`list_tools()`, `serve.py:1192`): `query_graph`, `get_node`, `get_neighbors`, `get_community`, `god_nodes`, `graph_stats`, `shortest_path`, `list_prs`, `get_pr_impact`, `triage_prs` — each accepts an optional `project_path` to multiplex several graphs from one server process, with an mtime/size-keyed graph cache (`_load_ctx`, `serve.py:1131`). `get_neighbors`/`get_community`/`query_graph` honor a `token_budget` (default 2000) with truncation announced at the **top** of the response, not just the bottom (`_cut_lines_to_budget`, `serve.py:925`).
+
+**Resources**: `graphify://report`, `graphify://stats`, `graphify://god-nodes`, `graphify://surprises`, `graphify://audit`, `graphify://questions` — always read the server's default graph, not a per-call `project_path`.
+
+Query scoring lives in `serve.py`, not `cli.py`: TF-IDF-like term scoring with a trigram inverted index (`_score_nodes`, `serve.py:351`), hub-degree throttling during BFS/DFS (p99 degree threshold) so traversal doesn't blow out through god-nodes, and edge-`context` filtering (call/import/field/parameter_type/...). `graphify query` (the CLI command) calls this same code (`_query_graph_text`).
+
+## 8. Watch mode & git hooks
+
+**`graphify watch <path>`** (`graphify/watch.py:watch`, line ~1396): uses `watchdog`, polling observer on macOS (FSEvents can miss rapid saves), native observer elsewhere. Debounces (default 3s), classifies the batch as code-only (→ AST-only `_rebuild_code()`) or containing docs/papers/images (→ writes a `graphify-out/needs_update` flag, no auto LLM call). Concurrency-safe via an advisory `fcntl.flock` per-repo rebuild lock, with a pending-changes queue so a concurrent hook's changes aren't dropped.
+
+**`graphify hook install`** (`graphify/hooks.py`): installs a **post-commit** hook that spawns a detached background incremental rebuild (changed files only, `SIGALRM` timeout, resource limits) and a **post-checkout** hook that does a full rebuild on branch switches; also registers a git **merge driver** for `graph.json` so concurrent branch edits to the graph union-merge instead of conflicting. Both skip during rebase/merge/cherry-pick and inside linked worktrees.
+
+## 9. Security model (`graphify/security.py`)
+
+| Function | Guards against |
+|---|---|
+| `validate_url()` (`security.py:103`) | Non-http(s) schemes, cloud-metadata hostnames, private/loopback/CGN/link-local IP ranges (post-DNS-resolution) |
+| `_SSRFGuardedHTTPConnection` (`security.py:180`) | DNS-rebind TOCTOU — resolves+validates once, connects to that literal IP |
+| `_NoFileRedirectHandler` (`security.py:231`) | Open-redirect SSRF — re-validates every redirect target |
+| `safe_fetch()` / `safe_fetch_text()` (`security.py:258,302`) | Unbounded downloads (50MB/10MB caps), non-2xx handling |
+| `validate_graph_path()` (`security.py:315`) | Path traversal outside `graphify-out/` |
+| `check_graph_file_size_cap()` (`security.py:357`) | Memory-exhaustion from a huge/crafted `graph.json` (default 512MiB cap) |
+| `sanitize_label()` / `sanitize_metadata()` (`security.py:394,416`) | Control chars, oversized strings, unescaped HTML in exported labels |
+| `_cypher_escape()`/`_cypher_label()` (`export.py:339`) | Cypher injection in the Neo4j/FalkorDB text export |
+| `_yaml_str()` (`export.py:116`) | YAML-frontmatter injection in Obsidian export |
+
+Full threat model and disclosure process: `SECURITY.md`.
+
+## 10. Folder structure
+
+```
+graphify/                  Application package (~52,000 LOC, 65 files)
+├── exporters/              4 files — output-format plugins (html.py, graphdb.py=neo4j+falkordb, base.py)
+├── extractors/              29 files — per-language extraction plugins + shared engine.py/resolution.py
+├── skills/                  GENERATED per-platform skill markdown (tracked; produced by tools/skillgen)
+└── always_on/                GENERATED always-on instruction snippets
+tests/                      159 test files (per-module / per-language / per-platform / per-regression)
+└── fixtures/                 ~70 sample source files + multi-file cross-reference fixtures
+tools/skillgen/              Build-time generator: fragments/*.md → graphify/skill*.md + skills/*/references/*.md
+docs/                        Hand-written docs (how-it-works.md, RFCs) + docs/translations/ (33+ README translations)
+scripts/                     One dev script (gen_demo_path.py)
+worked/                      Example graphify outputs run against OTHER repos (httpx, karpathy-repos, ...) — demo artifacts
+.github/workflows/           ci.yml, publish.yml, release-graph.yml
+```
+
+Package data note: `[tool.setuptools] packages = ["graphify", "graphify.extractors", "graphify.exporters"]` (`pyproject.toml`) — `graphify.skills`/`graphify.always_on` are **not** importable packages, they ship as static markdown via `[tool.setuptools.package-data]`.
+
+## 11. Environment variables
+
+Only needed for headless/CI extraction (`README.md:490-528` has the authoritative full table — summarized here):
+
+| Variable | Purpose |
+|---|---|
+| `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` / `ANTHROPIC_MODEL` | Claude backend config |
+| `GEMINI_API_KEY` / `GOOGLE_API_KEY` | Gemini backend |
+| `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL` | OpenAI-compatible backend (also local servers) |
+| `DEEPSEEK_API_KEY`, `MOONSHOT_API_KEY` | DeepSeek / Kimi backends |
+| `OLLAMA_BASE_URL` / `OLLAMA_MODEL` / `GRAPHIFY_OLLAMA_*` | Local Ollama inference |
+| `AZURE_OPENAI_*` | Azure OpenAI backend |
+| `AWS_*` | Bedrock (standard credential chain, no API key) |
+| `GRAPHIFY_MAX_WORKERS` | AST extraction parallelism |
+| `GRAPHIFY_MAX_OUTPUT_TOKENS`, `GRAPHIFY_API_TIMEOUT`, `GRAPHIFY_MAX_RETRIES` | LLM call tuning |
+| `GRAPHIFY_FORCE` | Force rebuild even if the graph would shrink |
+| `GRAPHIFY_QUERY_LOG_ENABLE` / `GRAPHIFY_QUERY_LOG` / `GRAPHIFY_QUERY_LOG_DISABLE` / `GRAPHIFY_QUERY_LOG_RESPONSES` | Opt-in local query logging (off by default, `~/.cache/graphify-queries.log`) |
+| `GRAPHIFY_MAX_GRAPH_BYTES` | Override the 512MiB graph.json size cap |
+| `GRAPHIFY_TRIAGE_BACKEND` / `GRAPHIFY_TRIAGE_MODEL` | `graphify prs --triage` backend override |
+
+**Nothing is required for local code-only use** — `graphify extract --code-only` runs fully offline via tree-sitter.
+
+## 12. Testing, CI/CD, and deployment
+
+- **Tests**: 159 files under `tests/`, organized per-module, per-language-extractor, per-platform-installer, and per-regression (`test_cross_extension_reexport_self_cycle.py`-style descriptive names, not issue numbers). Fixtures under `tests/fixtures/` (one sample file per language, plus multi-file cross-reference dirs like `crate_a/`+`crate_b/` for cross-crate Rust resolution). Run: `pytest tests/ -q`. `tests/conftest.py` mainly filters known third-party warnings.
+- **CI** (`.github/workflows/ci.yml`, triggers on push/PR to `v1`-`v8`/`main`):
+  - `skillgen-check` — validates generated skill files match `tools/skillgen/` fragments (5 sub-checks, full git history checkout required).
+  - `test` — Python 3.10 and 3.12 matrix, `uv sync --all-extras --frozen`, `pytest`, then an end-to-end smoke test (`graphify --help`, `graphify install`).
+  - `security-scan` — `bandit -r graphify -ll` + `pip-audit --strict`, currently `continue-on-error: true` (informational, not a merge gate).
+- **Pre-commit** (`.pre-commit-config.yaml`): `skillgen-check` (local) + `ruff`.
+- **Publish** (`.github/workflows/publish.yml`): on GitHub release published (or manual dispatch) — builds sdist+wheel via `uv build`, asserts `pyproject.toml` version matches the release tag, `twine check`, publishes to PyPI via OIDC trusted publishing (package name `graphifyy`).
+- **release-graph** (`.github/workflows/release-graph.yml`): builds graphify's **own** self-graph (AST-only), runs `cluster-only --no-label`, exports HTML, bundles `graph.json`+`graph.html`+`GRAPH_REPORT.md` into `graphify-self-graph.tar.gz`, attaches it to the GitHub release.
+- **Deployment**: `Dockerfile` packages the **MCP server as a shared HTTP service** (`python:3.12-slim`, `pip install ".[mcp]"`, non-root user, `ENTRYPOINT ["python", "-m", "graphify.serve"]`, `graph.json` mounted at runtime via `-v`, never baked into the image — issue #1143). `docs/docker-mcp-sqlite.md` is an unrelated third-party runbook (SQLite MCP server in Docker Desktop's MCP Toolkit), not documentation of graphify's own image.
+- **Lint/typecheck**: ruff (`pyproject.toml [tool.ruff]`, deliberately conservative rule set `["E9","F63","F7","F82"]` — syntax/undefined-name only, noted as provisional), pyright (`basic` mode).
+
+## 13. Recent project activity (from `CHANGELOG.md`, v0.9.17→0.9.24, 2026-07-16 to 2026-07-22)
+
+Very high release velocity (near-daily point releases), almost entirely community-reported bug-fix regressions. Recurring themes: graph correctness/determinism (edge direction, path ordering, ID collisions), incremental-update/cache correctness (manifest stamping, atomic writes, shrink guards), cross-language import/re-export resolution edge cases, MCP/CLI output truncation and token budgets, and install/hook robustness across platforms. One notable feature in this window: opt-in strict PreToolUse hook mode (v0.9.19).
+
+## 14. Known rough edges (flagged during this research pass — not fixed, just documented)
+
+- **`graphify/cli.py` is a high-fan-in hub** (imports ~27 of the ~48 top-level `graphify` modules; `dispatch_command` is a single ~3,000-line `if/elif` chain rather than a command registry). See `graph.html` — it's visibly the most-connected node. Not necessarily a problem (lazy per-branch imports keep startup light), but it is the natural "start here" and "biggest blast radius" file.
+- **`graphify/symbol_resolution.py`** (top-level, 554 lines — distinct from `graphify/extractors/resolution.py`, which *is* wired in) appears to be **dead code in production** — imported only by its own test (`tests/test_symbol_resolution.py`); `extract.py` never imports it. Likely a parked/in-progress replacement for logic still embedded ad hoc in `extract.py`, or orphaned. **[UNVERIFIED — could not confirm intent from changelog/issues.]**
+- `ARCHITECTURE.md`'s module table describes a tidier, more aspirational shape (`analyze()`, `render_report()`, `export()`) than the actual code (`analyze.py` has no unary `analyze()`; the report function is `generate()`; `export.py` has one `to_*` function per format). This overview and `TECHNICAL_REFERENCE.md` use the verified real names.
+- `graphify/extractors/csharp.py` is **not** the C# extractor (that's `extract_csharp()` in `extract.py` via the shared engine) — it currently only holds C#-specific cross-file *resolution* passes, a preview of where the extractor itself will land once config-driven languages migrate per `MIGRATION.md`.

--- a/docs/knowledge_graph/TECHNICAL_REFERENCE.md
+++ b/docs/knowledge_graph/TECHNICAL_REFERENCE.md
@@ -1,0 +1,169 @@
+# graphify — Technical Reference
+
+*Deep module-by-module reference for contributors. Companion doc: `CODEBASE_OVERVIEW.md` (architecture, pipeline, execution flow — read that first). Visual: `graph.html`.*
+
+*Grounded in commit `e32c9f4` (branch `v8`, v0.9.24), file:line cited throughout. Marked **[UNVERIFIED]** where a research pass could not confirm intent from code alone.*
+
+---
+
+## 1. Module-by-module map (`graphify/*.py`, 48 top-level modules)
+
+Grouped by subsystem. "Imports →" lists internal `graphify.*` dependencies (from static `from graphify.X import` grep — not exhaustive of function-local/lazy imports, notably `cli.py`'s, which are far broader — see §3).
+
+### Pipeline core
+| Module | Responsibility | Key symbols |
+|---|---|---|
+| `detect.py` (1871 lines) | Corpus file discovery/classification for the `extract` command; gitignore/`.graphifyignore` handling; `CODE_EXTENSIONS` set | `detect(root, ...)` L1238 |
+| `extract.py` (5320 lines) | AST extraction orchestrator: dispatch table, ~20 `extract_<lang>` wrapper functions for config-driven languages, cross-file call resolution, facade re-exports for migrated extractors | `extract()` L4381, `_DISPATCH` L3926, `_get_extractor()` L4135, `collect_files()` L5248 |
+| `build.py` (1293 lines) | Merges extraction dicts into a `networkx.Graph`; ID disambiguation, dedup, incremental merge, legacy-ID migration | `build()` L938, `build_from_json()` L490, `build_merge()` L1038, `dedupe_nodes/edges()` L295/314 |
+| `cluster.py` (320 lines) | Leiden community detection, cohesion scoring, community-ID stability across rebuilds | `cluster()` L134, `score_all()` L268, `label_communities_by_hub()` L86, `remap_communities_to_previous()` L272 |
+| `analyze.py` (741 lines) | Independent analysis functions — no single `analyze()` entry point | `god_nodes()` L101, `surprising_connections()` L125, `suggest_questions()` L420, `graph_diff()` L548, `find_import_cycles()` L632 |
+| `report.py` (short) | Renders `GRAPH_REPORT.md` text | `generate()` L71 |
+| `export.py` (1093 lines) | One `to_*`/`push_to_*` function per output format (see §4) — no unary `export()` | `to_json()` L232, `to_obsidian()` L454, `to_canvas()` L785, `to_graphml()` L963, `to_svg()` L1026, `to_cypher()` L384, `backup_if_protected()` L35 |
+| `validate.py` | Extraction-dict schema enforcement (warn, not hard-fail) | `validate_extraction()` L10, `assert_valid()` L90, `VALID_CONFIDENCES`/`VALID_FILE_TYPES`/`REQUIRED_*_FIELDS` L4-7 |
+
+### CLI / orchestration
+| Module | Responsibility | Key symbols |
+|---|---|---|
+| `__main__.py` (716 lines) | Process entry point, argv parsing, help text, version-staleness check, hands off to `install.py` then `cli.py` | `main()` L460, `_run_cli()` L483 |
+| `cli.py` (3685 lines) | The command dispatcher — one `if/elif` branch per subcommand (see `CODEBASE_OVERVIEW.md` §6 for the full table) | `dispatch_command()` L626, `_reenter_main()` L621 |
+
+### Serving / live modes
+| Module | Responsibility | Key symbols |
+|---|---|---|
+| `serve.py` (1999 lines) | MCP server (stdio + Streamable HTTP), query scoring/traversal engine, resources | `_build_server()` L1103, `serve()` L1713, `serve_http()` L1871, `_score_nodes()` L351, `_bfs()`/`_dfs()` L740/770ish, `_subgraph_to_text()` L796 |
+| `watch.py` (1496 lines) | Filesystem watcher (watchdog), debounce, incremental rebuild, per-repo lock | `watch()` ~L1396, `_rebuild_code()` L839, `_rebuild_lock()` L157 |
+| `hooks.py` (690 lines) | Git post-commit/post-checkout hook install, merge driver registration | `install()` L633, `_hooks_dir()` L399, `_register_merge_driver()` L525 |
+| `affected.py` | Reverse-dependency traversal ("what depends on X") | `resolve_seed()` L98, `affected_nodes()` L145 |
+| `querylog.py` | Opt-in JSONL query logging, never raises | `log_query()` L43 |
+
+### Ingestion
+| Module | Responsibility | Key symbols |
+|---|---|---|
+| `ingest.py` (353 lines) | URL → corpus markdown file (tweets, arxiv, webpages, PDFs, images); routes all network I/O through `security.safe_fetch*` | `ingest()` L218, `save_query_result()` L274 |
+| `mcp_ingest.py` (386 lines) | Extractor (not a fetcher) for `.mcp.json`/`claude_desktop_config.json` style files → graph nodes; explicitly never reads env-var **values**, only keys (secret avoidance) | `extract_mcp_config()` L86 |
+| `scip_ingest.py` (363 lines) | SCIP index ingestion | — |
+| `manifest_ingest.py` | Manifest-based ingestion helper | — |
+| `transcribe.py` (353 lines) | Local audio/video transcription (faster-whisper) | `download_audio()` referenced |
+| `google_workspace.py` | `.gdoc`/`.gsheet`/`.gslides` shortcut export via `gws` | — |
+
+### Install / distribution
+| Module | Responsibility | Key symbols |
+|---|---|---|
+| `install.py` (2204 lines) | The 20+-platform "install as skill" system — see `CODEBASE_OVERVIEW.md` §3.1 for the architecture; per-platform functions listed there | `install()` L589, `dispatch_install_cli()` L1929, `_PLATFORM_CONFIG` L324, `uninstall_all()` L1714 |
+
+### Utilities / infrastructure
+| Module | Responsibility | Key symbols |
+|---|---|---|
+| `paths.py` (304 lines) | `graphify-out/` path resolution, atomic writes, test-path classification, call-site disambiguation | `write_json_atomic()` L88, `_atomic_replace()` L29, `disambiguate_ambiguous_candidates()` L223 |
+| `ids.py` (50 lines) | **Single canonical** node-ID normalization (explicitly fixes recurring "ID drift" bugs across 3 producers: AST extractor, LLM extractor, graph builder — cites issues #811/#550/#1033/#1104) | `normalize_id()` L32, `make_id()` L43 |
+| `security.py` (460 lines) | SSRF/path-traversal/size-cap/sanitization — see `CODEBASE_OVERVIEW.md` §9 | (table there) |
+| `cache.py` (1040 lines) | Two-tier extraction cache: versioned AST cache (`cache/ast/v{n}/`), unversioned semantic/LLM cache with prompt-fingerprint invalidation | `file_hash()` ~L256, `check_semantic_cache()` L719, `save_semantic_cache()` L808, `prompt_fingerprint()` L89 |
+| `resolver_registry.py` (85 lines) | Plugin registry for per-language cross-file resolution passes | `LanguageResolver` L28, `register()` L48, `run_language_resolvers()` L59 |
+| `symbol_resolution.py` (554 lines) | Deterministic Python/Bash import-alias-guided call resolution — **[UNVERIFIED: appears unused in production]**, only referenced by `tests/test_symbol_resolution.py`, not imported by `extract.py` or any `extractors/*.py` | `build_python_symbol_index()`, `resolve_python_import_guided_calls()` L218, `resolve_cross_file_raw_calls()` L307, `resolve_bash_source_edges()` L404 |
+| `ruby_resolution.py` / `pascal_resolution.py` | Language-specific resolver-registry plugins (Ruby member calls, Pascal inherited-ancestor calls) | `resolve_ruby_member_calls()` L52, `resolve_pascal_inherited_calls()` L42 |
+| `global_graph.py` (184 lines) | Cross-repo merged graph at `~/.graphify/global-graph.json`; repo-tag ID prefixing, dedup of shared external-library nodes | `global_add()` L79, `global_remove()` L161, `global_list()` L178 |
+| `dedup.py` (669 lines) + `_minhash.py` | Near-duplicate node detection via MinHash | — |
+| `diagnostics.py` (406 lines) | `diagnose multigraph` — same-endpoint edge collapse risk reporting | — |
+| `reflect.py` (882 lines) | Aggregates `graphify-out/memory/*.md` outcomes into `LESSONS.md` | — |
+| `prs.py` (761 lines) | PR-related subcommands (list/impact/triage) | — |
+| `benchmark.py` | Token-reduction measurement — note: uses its **own simplified** BFS reimplementation, not `serve._bfs`/`_score_nodes`, so its numbers may not perfectly represent live query cost | `run_benchmark()` |
+| `llm.py` (2994 lines) | LLM backend abstraction (Claude/OpenAI/Gemini/Ollama/Azure/Bedrock/Kimi/DeepSeek), semantic extraction orchestration, community labeling | `extract_corpus_parallel()`, `generate_community_labels()` |
+| `cache_check` support: `manifest.py`, `file_slice.py`, `semantic_cleanup.py`, `multigraph_compat.py`, `cargo_introspect.py`, `pg_introspect.py` | Supporting utilities for manifest tracking, LLM context slicing, semantic-result cleanup, multigraph→simple-graph compatibility shims, Cargo/Postgres schema introspection | — |
+| `callflow_html.py` (2022 lines) | Mermaid-based architecture/call-flow HTML doc generator | `write_callflow_html()` L1579, `generate_overview_graph()` L1075 |
+| `tree_html.py` (585 lines) | D3 v7 collapsible filesystem-tree HTML view | `write_tree_html()` L565, `build_tree()` L68 |
+| `wiki.py` (337 lines) | Obsidian-independent Wikipedia-style markdown wiki (one article per community + per god-node) | `to_wiki()` L211 |
+
+## 2. Extractors subsystem (`graphify/extractors/`, 29 files)
+
+| File | Role |
+|---|---|
+| `engine.py` (4581 lines) | Shared generic tree-sitter walker `_extract_generic()` (L2157) used by all config-driven languages; two-visitor-pass design (definitions pass, then a deferred calls pass) |
+| `base.py` | Shared helpers: `_make_id`, `_file_stem`, `_read_text`, `_LANGUAGE_BUILTIN_GLOBALS` (builtin-noise blocklist to prevent god-nodes, #726); enforces the one-way import boundary from `extract.py` |
+| `models.py` | `LanguageConfig` dataclass (L14) — the "strategy" object injected into `_extract_generic`; `_SymbolResolutionFacts` and fact dataclasses (L57-119) |
+| `resolution.py` (2617 lines) | **The wired-in** symbol resolution subsystem: JS/TS module-path resolution (tsconfig aliases, workspace packages), Python relative-import resolution, Java/PHP/Pascal/C# type-reference arbitration. Entry point `_augment_symbol_resolution_edges()` L1757, called once from `extract.py:4572` |
+| `__init__.py` | `LANGUAGE_EXTRACTORS` registry (L36-64) — test-only, confirms facade re-export identity; **not the runtime dispatch path** |
+| `go.py`, `rust.py`, `blade.py`, `zig.py`, `elixir.py`, `dart.py`, `powershell.py`, `fortran.py`, `sql.py`, `dm.py`, `bash.py`, `apex.py`, `terraform.py`, `sln.py`, `pascal_forms.py`, `json_config.py`, `pascal.py`, `objc.py`, `razor.py`, `julia.py`, `verilog.py`, `markdown.py` | Bespoke, self-contained per-language extractors (own `walk()`/`walk_calls()` AST traversal) |
+| `csharp.py` | **Not** the C# extractor — only cross-file C# resolution passes (`_build_csharp_type_def_index` L19, `_resolve_cross_file_csharp_imports` L77, `_resolve_csharp_type_references` L152); C# extraction itself is `extract_csharp()` in `extract.py` via the shared engine |
+
+**Extractor pattern example (bespoke, `go.py`)**: `extract_go(path)` (L53) walks the file once collecting declarations (`walk()`, L177-326: functions, receiver-typed methods, struct/interface embedding, imports), then a second pass (`walk_calls()`, L339-384) resolves call expressions against the file's own `label_to_nid` map, falling back to a `raw_calls` list for cross-file/global resolution. `rust.py` mirrors this exactly (walk L163-335, walk_calls L348-398).
+
+**Config-driven pattern example**: `extract_python()` (`extract.py:1136`) is a thin wrapper: `_extract_generic(path, _PYTHON_CONFIG)`. Same shape for Java (`extract.py:1592`→`_JAVA_CONFIG`), C# (`extract.py:1728`→`_CSHARP_CONFIG`), etc. — one `LanguageConfig` instance per language (e.g. `_PYTHON_CONFIG` L686, `_JS_CONFIG` L700, `_JAVA_CONFIG` L754, `_CSHARP_CONFIG` L832).
+
+**Adding a new language** — verified playbook (supersedes `ARCHITECTURE.md`'s simplified 5-step version; see `graphify/extractors/MIGRATION.md` for the authoritative in-flight refactor status):
+1. Write a bespoke `extract_<lang>(path) -> dict` in a new `graphify/extractors/<lang>.py` (self-contained walker), OR add a `LanguageConfig` + thin wrapper in `extract.py` if the language fits the generic engine.
+2. Register the suffix in `_DISPATCH` (`extract.py:3926`).
+3. Add the suffix to `CODE_EXTENSIONS` (`detect.py:31`) and `_WATCHED_EXTENSIONS` (`watch.py:264`, derived from `CODE_EXTENSIONS | DOC_EXTENSIONS | ...`).
+4. Add the `tree-sitter-<lang>` dependency to `pyproject.toml` (core or an optional extra, per `_EXTRA_FOR_EXTENSION` in `extract.py`).
+5. Add a fixture under `tests/fixtures/sample.<ext>` and tests in the relevant `tests/test_<lang>*.py`.
+6. If cross-file resolution is needed, register a `LanguageResolver` via `resolver_registry.register()` (see `ruby_resolution.py`/`pascal_resolution.py` for the pattern).
+
+## 3. Exporters subsystem (`graphify/exporters/`, 4 files)
+
+| File | Role |
+|---|---|
+| `base.py` | `COMMUNITY_COLORS` palette only — split out to avoid a circular import between `export.py` and format modules |
+| `html.py` (560 lines) | `to_html()` (L325) — interactive vis.js graph; auto-falls back to a community-aggregated meta-graph above a node-count limit |
+| `graphdb.py` (173 lines) | Both Neo4j **and** FalkorDB: `push_to_neo4j()` (L9, `neo4j` driver, parameterized Cypher) and `push_to_falkordb()` (L80, `falkordb` SDK, near-identical MERGE queries, differs only in connection setup) |
+
+**Full export format inventory** (each is an independent `to_*`/`push_to_*` function in `export.py`, dispatched by `graphify export <subcmd>` in `cli.py:2054`, not a single `export()` call):
+
+| Format | Function | Notable behavior |
+|---|---|---|
+| `graph.json` | `to_json()` | Shrink-guard refuses to overwrite with fewer nodes unless forced (#479); atomic write |
+| `graph.html` | `to_html()` | vis.js; community-aggregated fallback above a size threshold |
+| Obsidian vault | `to_obsidian()` | One `.md`/node + YAML frontmatter + `[[wikilinks]]`, one file per community, tracks graphify-owned files via a manifest so user notes are never clobbered |
+| `graph.canvas` | `to_canvas()` | Obsidian Canvas JSON, communities as grid-laid-out groups, top-200 edges by weight |
+| `graph.graphml` | `to_graphml()` | Gephi/yEd compatible |
+| `graph.svg` | `to_svg()` | matplotlib spring-layout static image, community-colored |
+| `cypher.txt` | `to_cypher()` | OpenCypher `MERGE` script with dedicated injection-safe escaping |
+| Live Neo4j/FalkorDB | `push_to_neo4j()`/`push_to_falkordb()` | Direct DB push via SDK, parameterized queries |
+| Mermaid call-flow HTML | `write_callflow_html()` (`callflow_html.py`) | Section-based Mermaid flowcharts + prose, bilingual EN/中文 |
+| D3 tree view | `write_tree_html()` (`tree_html.py`) | Collapsible filesystem-rooted tree, `graphify tree` command (not under `export`) |
+| Wiki | `to_wiki()` (`wiki.py`) | Wikipedia-style markdown, community + god-node articles |
+
+## 4. Design patterns catalog (with evidence)
+
+| Pattern | Where | Evidence |
+|---|---|---|
+| **Pipeline/stage pattern with instrumentation** | `cli.py`'s `extract`/`cluster-only` paths thread a `_StageTimer` through each phase | `cli.py:2645`, `.mark("detect")` etc. |
+| **Strategy pattern** | `LanguageConfig` injected into the single `_extract_generic()` algorithm; per-language hooks are callables in the config | `extractors/models.py:14-54` |
+| **Visitor / two-pass AST walker** | Every extractor: pass 1 collects definitions, pass 2 (deferred) resolves calls against the file's own symbol map, falling back to `raw_calls` for cross-file resolution | `go.py:177-384`, `rust.py:163-398` |
+| **Registry pattern** | `resolver_registry.py` (`_REGISTRY` list + `register()`/`run_language_resolvers()`); also the test-only `LANGUAGE_EXTRACTORS` in `extractors/__init__.py` | `resolver_registry.py:45-59` |
+| **Facade pattern** | `extract.py` re-exports every symbol relocated into `extractors/*` so external callers (`__main__.py`, `watch.py`, tests) are unaffected by the in-flight migration | `extract.py:27-142`, all `# noqa: F401` |
+| **Deferred/two-pass resolution at corpus scope** | Every file emits unresolved `raw_calls`; `extract()` aggregates and resolves them globally once all files are parsed | `extract.py:4561-5118` |
+| **Table-driven plugin dispatch** | `install.py`'s `_PLATFORM_CONFIG` covers ~19 of 21+ AI-tool platforms through one generic path; only platforms needing non-generic mechanics (native hooks, JS plugins) get bespoke functions | `install.py:324-465` + per-platform functions |
+| **Single source of truth for a cross-cutting concern** | `graphify/ids.py` centralizes ID normalization specifically because it drifted across 3 independent producers in the past | `ids.py:1-23` docstring |
+| **Split pipeline halves for two different callers** | `extract` (CLI/headless) stops before labeling; `cluster-only`/`label` is the shared "back half" also reachable standalone, so the LLM-orchestrated skill.md flow and the plain CLI flow share code without duplicating it | `cli.py:3482-3489` vs `cli.py:1438-1761` |
+| **Confidence-scored edges as first-class schema** | `EXTRACTED`/`INFERRED`/`AMBIGUOUS` let deterministic AST edges and LLM-inferred edges coexist safely; surfaced as a percentage breakdown in the report | `validate.py:5`, `report.py:93-97` |
+| **Build-time codegen with drift guards** | `tools/skillgen/` renders 20+ generated skill files from shared fragments; CI fails the build on any hand-edit or missed regeneration | `tools/skillgen/gen.py`, `.github/workflows/ci.yml` skillgen-check job |
+| **Anti-data-loss shrink guards** | Both `to_json()` and the incremental `build_merge()` refuse to silently produce a smaller graph than the last good one (issue #479) | `export.py:233-287` |
+
+## 5. Glossary
+
+| Term | Meaning |
+|---|---|
+| **Node** | A graph entity: function, class, file, concept, community, etc. Schema: `{id, label, file_type, source_file, source_location}`. |
+| **Edge** | A typed relationship between two nodes. Schema: `{source, target, relation, confidence, source_file}`. |
+| **EXTRACTED / INFERRED / AMBIGUOUS** | Confidence tiers for an edge — explicit-in-source, deduced, or uncertain-flag-for-review, respectively. |
+| **God node** | A node with unusually high degree (connectivity) — surfaced by `graphify god-nodes` / `analyze.god_nodes()` as an architectural hub, not necessarily a code smell. |
+| **Community** | A cluster of related nodes from Leiden community detection (`cluster.py`); roughly maps to a subsystem/module. |
+| **Cohesion score** | Per-community metric (`score_all()`) of how internally connected vs. externally connected a community's nodes are. |
+| **`graphify-out/`** | The default output directory for `graph.json`, `GRAPH_REPORT.md`, caches, wiki, and other generated artifacts. |
+| **Raw call** | An unresolved call-site reference emitted by a single-file extraction pass, resolved globally in a later corpus-wide pass. |
+| **Skill** | The bundle of instructions (`SKILL.md` + optional `references/`) that teaches an AI coding tool to use graphify's graph instead of raw file reads. |
+| **Always-on block** | A short instruction snippet injected into a tool's always-loaded context file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, ...) rather than a lazily-loaded skill file. |
+| **Bespoke extractor** | A hand-written, self-contained per-language AST walker (as opposed to a config-driven one riding the shared engine). |
+| **Config-driven extractor** | A language handled by the shared `_extract_generic()` engine, parameterized by a `LanguageConfig`. |
+| **Shrink guard** | A write-time check that refuses to persist a graph with unexpectedly fewer nodes than the previous version, to prevent silent data loss from a bad partial rebuild. |
+| **Hyperedge** | A relationship spanning more than two nodes, emitted by semantic (LLM) extraction; normalized during `build()` (`build.py:85`, `_normalize_hyperedge_members`). |
+| **Global graph** | A separate, cross-repo merged graph at `~/.graphify/global-graph.json`, built by tagging each project's node IDs with a repo prefix. |
+
+## 6. Uncertainties flagged during this research pass
+
+These are explicitly **not fixed** — they're documented so a developer doesn't waste time rediscovering them:
+
+1. `graphify/symbol_resolution.py` (top-level module) appears unused by the production pipeline — only its own test imports it. Whether it's a planned replacement for logic still ad hoc in `extract.py`, or dead/orphaned code, could not be determined from the code alone. **[UNVERIFIED]**
+2. `graphify/benchmark.py`'s token-reduction measurement reimplements a simplified BFS independent of the real `serve._bfs`/`_score_nodes` query path (no hub throttling, no IDF/trigram scoring, no stopword filtering) — so `BENCHMARKS.md`/README numbers sourced from it may not represent live query cost exactly. **[UNVERIFIED — not confirmed whether this divergence is intentional/acceptable to maintainers.]**
+3. The precise `cli.py` subcommand wiring to `ingest.ingest()` (likely `add`) and to `mcp_ingest.extract_mcp_config()` (likely inside `detect()`/`extract()`'s corpus-type routing) was not traced to an exact line in this pass.
+4. `ARCHITECTURE.md` (root-level doc) describes a slightly idealized/older module shape in places (unary `analyze()`/`export()`, `render_report()` instead of `generate()`) — this reference document reflects the verified current code; treat `ARCHITECTURE.md` as directional, not literal, until it's updated.

--- a/docs/knowledge_graph/graph.html
+++ b/docs/knowledge_graph/graph.html
@@ -1,0 +1,718 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>graphify — module map</title>
+<style>
+  :root {
+    --bg: #f4f2ec;
+    --bg-elev: #ffffff;
+    --ink: #1a1c1a;
+    --ink-dim: #5c6259;
+    --border: #d9d5c9;
+    --border-soft: #e7e3d7;
+    --accent: #c47f2b;
+    --accent-ink: #3a2a12;
+    --edge: #b9b4a4;
+    --edge-dim: #ded9cb;
+    --shadow: 0 8px 24px rgba(30, 28, 20, 0.10);
+
+    --c-pipeline: #2f8f7c;
+    --c-cli: #c47f2b;
+    --c-serving: #3f6fb0;
+    --c-ingestion: #8a5bb0;
+    --c-install: #b3405a;
+    --c-io: #5c8a3a;
+    --c-utils: #767a70;
+
+    --font-mono: ui-monospace, "SF Mono", "Cascadia Code", "JetBrains Mono", Consolas, Menlo, monospace;
+    --font-sans: -apple-system, "Segoe UI", system-ui, "Helvetica Neue", sans-serif;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #12140f;
+      --bg-elev: #1a1d16;
+      --ink: #ece8dc;
+      --ink-dim: #a5a794;
+      --border: #34372c;
+      --border-soft: #262920;
+      --accent: #e3a24d;
+      --accent-ink: #2b1c08;
+      --edge: #4a4c3f;
+      --edge-dim: #2b2d24;
+      --shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+
+      --c-pipeline: #4db89f;
+      --c-cli: #e3a24d;
+      --c-serving: #7ea3e0;
+      --c-ingestion: #b78ee0;
+      --c-install: #e07189;
+      --c-io: #8fc466;
+      --c-utils: #9a9d8f;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #12140f; --bg-elev: #1a1d16; --ink: #ece8dc; --ink-dim: #a5a794;
+    --border: #34372c; --border-soft: #262920; --accent: #e3a24d; --accent-ink: #2b1c08;
+    --edge: #4a4c3f; --edge-dim: #2b2d24; --shadow: 0 8px 28px rgba(0,0,0,0.45);
+    --c-pipeline: #4db89f; --c-cli: #e3a24d; --c-serving: #7ea3e0; --c-ingestion: #b78ee0;
+    --c-install: #e07189; --c-io: #8fc466; --c-utils: #9a9d8f;
+  }
+  :root[data-theme="light"] {
+    --bg: #f4f2ec; --bg-elev: #ffffff; --ink: #1a1c1a; --ink-dim: #5c6259;
+    --border: #d9d5c9; --border-soft: #e7e3d7; --accent: #c47f2b; --accent-ink: #3a2a12;
+    --edge: #b9b4a4; --edge-dim: #ded9cb; --shadow: 0 8px 24px rgba(30,28,20,0.10);
+    --c-pipeline: #2f8f7c; --c-cli: #c47f2b; --c-serving: #3f6fb0; --c-ingestion: #8a5bb0;
+    --c-install: #b3405a; --c-io: #5c8a3a; --c-utils: #767a70;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--font-sans);
+    overflow: hidden;
+  }
+
+  .app { display: grid; grid-template-rows: auto 1fr; height: 100vh; }
+
+  header {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-elev);
+    z-index: 5;
+  }
+  .brand { display: flex; align-items: baseline; gap: 10px; white-space: nowrap; }
+  .brand .mark {
+    font-family: var(--font-mono);
+    font-weight: 700;
+    font-size: 15px;
+    letter-spacing: 0.02em;
+    padding: 2px 7px;
+    border-radius: 4px;
+    background: var(--accent);
+    color: var(--accent-ink);
+  }
+  .brand h1 { font-size: 15px; font-weight: 600; margin: 0; color: var(--ink); }
+  .brand .sub { font-size: 12px; color: var(--ink-dim); }
+
+  .stats {
+    display: flex; gap: 16px; font-family: var(--font-mono); font-size: 12px; color: var(--ink-dim);
+    font-variant-numeric: tabular-nums;
+  }
+  .stats b { color: var(--ink); font-weight: 600; }
+
+  .search-wrap { flex: 1; max-width: 340px; margin-left: auto; position: relative; }
+  #search {
+    width: 100%;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    padding: 7px 10px 7px 30px;
+    color: var(--ink);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    outline: none;
+  }
+  #search:focus { border-color: var(--accent); }
+  .search-wrap svg { position: absolute; left: 9px; top: 50%; transform: translateY(-50%); opacity: 0.5; }
+
+  .hint {
+    font-size: 11.5px; color: var(--ink-dim); white-space: nowrap;
+  }
+  .hint kbd {
+    font-family: var(--font-mono); background: var(--bg); border: 1px solid var(--border);
+    border-radius: 3px; padding: 1px 5px; font-size: 10.5px;
+  }
+
+  main { position: relative; overflow: hidden; }
+  canvas { display: block; width: 100%; height: 100%; cursor: grab; }
+  canvas.dragging { cursor: grabbing; }
+
+  .legend {
+    position: absolute; left: 16px; bottom: 16px;
+    background: var(--bg-elev); border: 1px solid var(--border); border-radius: 10px;
+    padding: 12px 14px; box-shadow: var(--shadow); font-size: 12px; min-width: 168px;
+  }
+  .legend h2 {
+    font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--ink-dim);
+    margin: 0 0 8px 0; font-weight: 600;
+  }
+  .legend-row {
+    display: flex; align-items: center; gap: 8px; padding: 3px 4px; border-radius: 5px; cursor: pointer;
+    user-select: none;
+  }
+  .legend-row:hover { background: var(--border-soft); }
+  .legend-row.off { opacity: 0.35; }
+  .legend-dot { width: 9px; height: 9px; border-radius: 50%; flex: none; }
+  .legend-label { color: var(--ink); }
+  .legend-count { margin-left: auto; color: var(--ink-dim); font-family: var(--font-mono); font-size: 11px; }
+
+  .panel {
+    position: absolute; right: 16px; top: 16px; bottom: 16px; width: 320px;
+    background: var(--bg-elev); border: 1px solid var(--border); border-radius: 10px;
+    box-shadow: var(--shadow); display: flex; flex-direction: column; overflow: hidden;
+    transform: translateX(0); transition: transform 0.18s ease;
+  }
+  .panel.hidden { transform: translateX(calc(100% + 24px)); }
+  .panel-head {
+    padding: 14px 16px 12px 16px; border-bottom: 1px solid var(--border-soft);
+  }
+  .panel-eyebrow {
+    font-size: 10px; text-transform: uppercase; letter-spacing: 0.09em; font-weight: 600;
+  }
+  .panel-title { font-family: var(--font-mono); font-size: 16px; font-weight: 700; margin: 4px 0 2px 0; word-break: break-word; }
+  .panel-file { font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-dim); }
+  .panel-body { padding: 14px 16px; overflow-y: auto; flex: 1; }
+  .panel-body p { font-size: 13px; line-height: 1.55; color: var(--ink); margin: 0 0 14px 0; }
+  .panel-section-label {
+    font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--ink-dim);
+    font-weight: 600; margin-bottom: 6px;
+  }
+  .neighbor-group { margin-bottom: 12px; }
+  .neighbor-list { display: flex; flex-direction: column; gap: 3px; }
+  .neighbor-btn {
+    display: flex; align-items: center; gap: 7px; text-align: left; background: none; border: none;
+    color: var(--ink); font-family: var(--font-mono); font-size: 12px; padding: 4px 6px; border-radius: 5px;
+    cursor: pointer; width: 100%;
+  }
+  .neighbor-btn:hover { background: var(--border-soft); }
+  .neighbor-btn .legend-dot { width: 7px; height: 7px; }
+  .panel-close {
+    background: none; border: none; color: var(--ink-dim); cursor: pointer; font-size: 18px;
+    position: absolute; right: 10px; top: 10px; line-height: 1; padding: 4px;
+  }
+  .panel-close:hover { color: var(--ink); }
+  .panel-empty {
+    padding: 20px 16px; color: var(--ink-dim); font-size: 13px; line-height: 1.6;
+  }
+
+  .theme-toggle {
+    background: var(--bg); border: 1px solid var(--border); border-radius: 7px;
+    padding: 6px 10px; color: var(--ink-dim); font-size: 12px; cursor: pointer; font-family: var(--font-sans);
+  }
+  .theme-toggle:hover { color: var(--ink); border-color: var(--ink-dim); }
+
+  ::-webkit-scrollbar { width: 9px; }
+  ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 5px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .panel { transition: none; }
+  }
+</style>
+</head>
+<body>
+<div class="app">
+  <header>
+    <div class="brand">
+      <span class="mark">graphify</span>
+      <h1>module map</h1>
+      <span class="sub">graphify/*.py internal import graph</span>
+    </div>
+    <div class="stats">
+      <span><b id="stat-nodes">0</b> modules</span>
+      <span><b id="stat-edges">0</b> imports</span>
+      <span><b id="stat-hub">—</b> most-connected</span>
+    </div>
+    <div class="search-wrap">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.6" y2="16.6"/></svg>
+      <input id="search" type="text" placeholder="Find a module…" autocomplete="off" />
+    </div>
+    <button class="theme-toggle" id="theme-toggle" type="button">Theme</button>
+  </header>
+  <main>
+    <canvas id="graph"></canvas>
+    <div class="legend" id="legend">
+      <h2>Subsystem</h2>
+      <div id="legend-rows"></div>
+      <div class="hint" style="margin-top:9px;">Drag to pan · scroll to zoom<br />Click a module for detail</div>
+    </div>
+    <aside class="panel hidden" id="panel">
+      <button class="panel-close" id="panel-close" aria-label="Close">×</button>
+      <div class="panel-head">
+        <div class="panel-eyebrow" id="panel-eyebrow" style="color:var(--accent);">Subsystem</div>
+        <div class="panel-title" id="panel-title">—</div>
+        <div class="panel-file" id="panel-file">—</div>
+      </div>
+      <div class="panel-body" id="panel-body"></div>
+    </aside>
+  </main>
+</div>
+
+<script>
+/* ---------------------------------------------------------------------
+   Data: graphify/*.py internal import graph.
+   Hand-verified from static grep of `from graphify.X import` across the
+   package plus five research passes over the source (see
+   CODEBASE_OVERVIEW.md / TECHNICAL_REFERENCE.md for full citations).
+   Edge = "A imports from B". Node size ~ total degree (fan-in + fan-out).
+--------------------------------------------------------------------- */
+
+const CATEGORIES = {
+  pipeline:  { label: "Pipeline core",        color: "var(--c-pipeline)" },
+  cli:       { label: "CLI / orchestration",  color: "var(--c-cli)" },
+  serving:   { label: "Serving & live modes", color: "var(--c-serving)" },
+  ingestion: { label: "Ingestion",            color: "var(--c-ingestion)" },
+  install:   { label: "Install / skill dist.",color: "var(--c-install)" },
+  io:        { label: "Extractors & exporters", color: "var(--c-io)" },
+  utils:     { label: "Utilities",            color: "var(--c-utils)" },
+};
+
+const NODES = [
+  { id: "detect", cat: "pipeline", file: "graphify/detect.py", loc: 1871, desc: "Corpus file discovery/classification for the `extract` command. Owns CODE_EXTENSIONS and gitignore/.graphifyignore handling." },
+  { id: "extract", cat: "pipeline", file: "graphify/extract.py", loc: 5320, desc: "AST extraction orchestrator: the _DISPATCH table, ~20 config-driven extract_<lang> wrappers, and the corpus-wide deferred call-resolution pass." },
+  { id: "build", cat: "pipeline", file: "graphify/build.py", loc: 1293, desc: "Merges extraction dicts into a networkx.Graph. ID disambiguation, dedup, incremental merge (build_merge), legacy-ID migration." },
+  { id: "cluster", cat: "pipeline", file: "graphify/cluster.py", loc: 320, desc: "Leiden community detection, cohesion scoring, and stable community-ID remapping across rebuilds." },
+  { id: "analyze", cat: "pipeline", file: "graphify/analyze.py", loc: 741, desc: "Independent analysis functions: god_nodes, surprising_connections, suggest_questions, graph_diff, find_import_cycles. No single analyze() entry point." },
+  { id: "report", cat: "pipeline", file: "graphify/report.py", loc: 110, desc: "Renders GRAPH_REPORT.md text from graph + all analysis artifacts via generate()." },
+  { id: "export", cat: "pipeline", file: "graphify/export.py", loc: 1093, desc: "One to_*/push_to_* function per output format (json, obsidian, canvas, graphml, svg, cypher). No unary export()." },
+  { id: "validate", cat: "pipeline", file: "graphify/validate.py", loc: 96, desc: "Extraction-dict schema enforcement — warns, doesn't hard-fail. Called from build_from_json()." },
+
+  { id: "__main__", cat: "cli", file: "graphify/__main__.py", loc: 716, desc: "Process entry point: argv parsing, help text, skill version-staleness check, hands off to install.py then cli.py." },
+  { id: "cli", cat: "cli", file: "graphify/cli.py", loc: 3685, desc: "The command dispatcher — one long if/elif chain over ~30 subcommands with per-branch lazy imports. Highest fan-out module in the codebase." },
+
+  { id: "serve", cat: "serving", file: "graphify/serve.py", loc: 1999, desc: "MCP server (stdio + Streamable HTTP), the query scoring/BFS-DFS traversal engine, and MCP resources. Powers both `graphify query` and graphify-mcp." },
+  { id: "watch", cat: "serving", file: "graphify/watch.py", loc: 1496, desc: "watchdog-based filesystem watcher: debounce, incremental AST-only rebuild, per-repo advisory lock." },
+  { id: "hooks", cat: "serving", file: "graphify/hooks.py", loc: 690, desc: "Git post-commit / post-checkout hook install, plus a registered git merge driver for graph.json." },
+  { id: "affected", cat: "serving", file: "graphify/affected.py", loc: 220, desc: "Reverse-dependency traversal — resolves a seed node then walks in-edges to answer \"what depends on X\"." },
+  { id: "querylog", cat: "serving", file: "graphify/querylog.py", loc: 80, desc: "Opt-in, append-only JSONL query logger. Disabled by default; wrapped so it can never raise." },
+
+  { id: "ingest", cat: "ingestion", file: "graphify/ingest.py", loc: 353, desc: "URL → corpus markdown file (tweets, arxiv, webpages, PDFs, images). All network I/O routed through security.safe_fetch*." },
+  { id: "mcp_ingest", cat: "ingestion", file: "graphify/mcp_ingest.py", loc: 386, desc: "Extractor (not a fetcher) for .mcp.json-style files → graph nodes. Never reads env-var values, only keys." },
+  { id: "scip_ingest", cat: "ingestion", file: "graphify/scip_ingest.py", loc: 363, desc: "SCIP (Source Code Intelligence Protocol) index ingestion." },
+  { id: "manifest_ingest", cat: "ingestion", file: "graphify/manifest_ingest.py", loc: 90, desc: "Manifest-based ingestion helper." },
+  { id: "transcribe", cat: "ingestion", file: "graphify/transcribe.py", loc: 353, desc: "Local audio/video transcription via faster-whisper — nothing leaves the machine." },
+  { id: "google_workspace", cat: "ingestion", file: "graphify/google_workspace.py", loc: 140, desc: ".gdoc / .gsheet / .gslides shortcut export via the gws helper before extraction." },
+
+  { id: "install", cat: "install", file: "graphify/install.py", loc: 2204, desc: "The 20+-platform \"install as skill\" system. Table-driven for most platforms (_PLATFORM_CONFIG), bespoke functions for Claude Code, Cursor, OpenCode, Kilo, Kiro, Antigravity, Devin, CodeBuddy, Amp." },
+
+  { id: "extractors_engine", cat: "io", file: "graphify/extractors/engine.py", loc: 4581, desc: "Shared generic tree-sitter walker _extract_generic(), used by every config-driven language extractor. No classes — free functions parameterized by LanguageConfig." },
+  { id: "extractors_base", cat: "io", file: "graphify/extractors/base.py", loc: 90, desc: "Shared extractor helpers (_make_id, _file_stem, _read_text, builtin-noise blocklist). Enforces the one-way import boundary from extract.py." },
+  { id: "extractors_resolution", cat: "io", file: "graphify/extractors/resolution.py", loc: 2617, desc: "The wired-in symbol resolution subsystem: JS/TS module paths, Python relative imports, Java/PHP/Pascal/C# type-reference arbitration." },
+  { id: "extractors_models", cat: "io", file: "graphify/extractors/models.py", loc: 120, desc: "LanguageConfig dataclass — the strategy object injected into _extract_generic — plus symbol-resolution fact dataclasses." },
+  { id: "extractors_langs", cat: "io", file: "graphify/extractors/{go,rust,blade,zig,elixir,dart,...}.py", loc: null, desc: "25 bespoke, self-contained per-language AST walkers (own two-pass walk()/walk_calls()), covering languages not yet riding the shared engine." },
+  { id: "exporters_html", cat: "io", file: "graphify/exporters/html.py", loc: 560, desc: "to_html() — the interactive vis.js graph.html, with a community-aggregated fallback above a node-count limit." },
+  { id: "exporters_graphdb", cat: "io", file: "graphify/exporters/graphdb.py", loc: 173, desc: "push_to_neo4j() and push_to_falkordb() — near-identical parameterized-Cypher live DB pushes." },
+  { id: "exporters_base", cat: "io", file: "graphify/exporters/base.py", loc: 14, desc: "COMMUNITY_COLORS palette only — split out purely to avoid a circular import." },
+  { id: "callflow_html", cat: "io", file: "graphify/callflow_html.py", loc: 2022, desc: "Mermaid-based architecture / call-flow HTML doc generator, bilingual EN/中文." },
+  { id: "tree_html", cat: "io", file: "graphify/tree_html.py", loc: 585, desc: "D3 v7 collapsible filesystem-tree HTML view. Reachable via `graphify tree`, not `export`." },
+  { id: "wiki", cat: "io", file: "graphify/wiki.py", loc: 337, desc: "Wikipedia-style markdown wiki: one article per community, one per god-node, cross-linked." },
+
+  { id: "paths", cat: "utils", file: "graphify/paths.py", loc: 304, desc: "graphify-out/ path resolution, atomic writes, test-path classification, call-site disambiguation. The most widely-imported utility module." },
+  { id: "ids", cat: "utils", file: "graphify/ids.py", loc: 50, desc: "Single canonical node-ID normalization — normalize_id()/make_id() — written to stop ID drift across independent producers (#811, #550, #1033, #1104)." },
+  { id: "security", cat: "utils", file: "graphify/security.py", loc: 460, desc: "SSRF guards, path-traversal checks, size caps, label/metadata sanitization. Every external input passes through here first." },
+  { id: "cache", cat: "utils", file: "graphify/cache.py", loc: 1040, desc: "Two-tier extraction cache: versioned AST cache, unversioned semantic/LLM cache with prompt-fingerprint invalidation." },
+  { id: "resolver_registry", cat: "utils", file: "graphify/resolver_registry.py", loc: 85, desc: "Plugin registry for per-language cross-file resolution passes (LanguageResolver, register(), run_language_resolvers())." },
+  { id: "symbol_resolution", cat: "utils", file: "graphify/symbol_resolution.py", loc: 554, desc: "Deterministic Python/Bash import-alias-guided call resolution. Flagged: appears unused in production — only its own test imports it." },
+  { id: "ruby_resolution", cat: "utils", file: "graphify/ruby_resolution.py", loc: 90, desc: "Ruby cross-file member-call resolver, registered as a LanguageResolver plugin." },
+  { id: "pascal_resolution", cat: "utils", file: "graphify/pascal_resolution.py", loc: 60, desc: "Pascal/Delphi cross-file resolver for calls to inherited ancestor methods in a different file." },
+  { id: "global_graph", cat: "utils", file: "graphify/global_graph.py", loc: 184, desc: "Cross-repo merged graph at ~/.graphify/global-graph.json — repo-tag ID prefixing, shared-library dedup." },
+  { id: "dedup", cat: "utils", file: "graphify/dedup.py", loc: 669, desc: "Near-duplicate node detection via MinHash." },
+  { id: "_minhash", cat: "utils", file: "graphify/_minhash.py", loc: 60, desc: "MinHash signature primitives used by dedup.py." },
+  { id: "diagnostics", cat: "utils", file: "graphify/diagnostics.py", loc: 406, desc: "`diagnose multigraph` — same-endpoint edge collapse risk reporting." },
+  { id: "reflect", cat: "utils", file: "graphify/reflect.py", loc: 882, desc: "Aggregates graphify-out/memory/*.md outcomes into a deterministic LESSONS.md." },
+  { id: "prs", cat: "utils", file: "graphify/prs.py", loc: 761, desc: "PR-related subcommands: list/impact/triage." },
+  { id: "benchmark", cat: "utils", file: "graphify/benchmark.py", loc: 160, desc: "Token-reduction measurement vs. naive full-corpus reading. Uses its own simplified BFS, not serve.py's real query path." },
+  { id: "llm", cat: "utils", file: "graphify/llm.py", loc: 2994, desc: "LLM backend abstraction (Claude/OpenAI/Gemini/Ollama/Azure/Bedrock/Kimi/DeepSeek), semantic extraction, community labeling." },
+  { id: "manifest", cat: "utils", file: "graphify/manifest.py", loc: 70, desc: "Tracks which files have been stamped/processed across incremental runs." },
+  { id: "file_slice", cat: "utils", file: "graphify/file_slice.py", loc: 90, desc: "LLM context slicing for large files during semantic extraction." },
+  { id: "semantic_cleanup", cat: "utils", file: "graphify/semantic_cleanup.py", loc: 336, desc: "Post-processes LLM-produced semantic nodes/edges before merge." },
+  { id: "multigraph_compat", cat: "utils", file: "graphify/multigraph_compat.py", loc: 60, desc: "Multigraph → simple-graph compatibility shim." },
+  { id: "cargo_introspect", cat: "utils", file: "graphify/cargo_introspect.py", loc: 90, desc: "Extracts crate→crate dependencies from Cargo.toml (`--cargo` flag)." },
+  { id: "pg_introspect", cat: "utils", file: "graphify/pg_introspect.py", loc: 90, desc: "Extracts schema from a live PostgreSQL database (`--postgres` flag)." },
+];
+
+const EDGES = [
+  ["__main__","cli"], ["__main__","install"], ["__main__","paths"],
+  ["cli","paths"], ["cli","affected"], ["cli","analyze"], ["cli","benchmark"], ["cli","build"],
+  ["cli","cache"], ["cli","callflow_html"], ["cli","cargo_introspect"], ["cli","cluster"],
+  ["cli","detect"], ["cli","diagnostics"], ["cli","export"], ["cli","extract"], ["cli","global_graph"],
+  ["cli","hooks"], ["cli","ingest"], ["cli","llm"], ["cli","pg_introspect"], ["cli","prs"],
+  ["cli","reflect"], ["cli","report"], ["cli","security"], ["cli","semantic_cleanup"], ["cli","serve"],
+  ["cli","tree_html"], ["cli","watch"], ["cli","wiki"], ["cli","install"],
+  ["analyze","build"], ["analyze","detect"],
+  ["benchmark","build"], ["benchmark","paths"], ["benchmark","serve"],
+  ["cache","paths"],
+  ["callflow_html","paths"],
+  ["dedup","_minhash"],
+  ["detect","google_workspace"], ["detect","paths"],
+  ["export","analyze"], ["export","build"], ["export","exporters_base"], ["export","exporters_graphdb"],
+  ["export","exporters_html"], ["export","security"],
+  ["extract","extractors_engine"], ["extract","extractors_base"], ["extract","extractors_resolution"],
+  ["extract","extractors_models"], ["extract","extractors_langs"], ["extract","paths"], ["extract","security"],
+  ["extract","resolver_registry"], ["extract","ruby_resolution"], ["extract","pascal_resolution"],
+  ["global_graph","build"],
+  ["hooks","watch"],
+  ["ingest","security"],
+  ["install","paths"],
+  ["llm","file_slice"],
+  ["manifest","detect"],
+  ["manifest_ingest","ids"],
+  ["mcp_ingest","extractors_base"], ["mcp_ingest","ids"], ["mcp_ingest","security"],
+  ["pg_introspect","extract"],
+  ["prs","paths"],
+  ["reflect","ingest"], ["reflect","paths"],
+  ["scip_ingest","security"],
+  ["security","paths"],
+  ["serve","build"], ["serve","paths"], ["serve","security"],
+  ["symbol_resolution","extractors_base"], ["symbol_resolution","ids"], ["symbol_resolution","paths"], ["symbol_resolution","security"],
+  ["transcribe","paths"],
+  ["watch","detect"], ["watch","paths"], ["watch","extract"], ["watch","build"], ["watch","cluster"],
+  ["watch","analyze"], ["watch","report"], ["watch","export"],
+  ["wiki","build"],
+  ["build","validate"],
+  ["extractors_engine","extractors_models"], ["extractors_resolution","extractors_models"],
+  ["extractors_base","ids"],
+];
+
+/* ---------------------------------------------------------------------
+   Force-directed layout (self-contained, no dependencies)
+--------------------------------------------------------------------- */
+
+const byId = new Map(NODES.map(n => [n.id, n]));
+const degree = new Map(NODES.map(n => [n.id, 0]));
+EDGES.forEach(([a, b]) => {
+  degree.set(a, (degree.get(a) || 0) + 1);
+  degree.set(b, (degree.get(b) || 0) + 1);
+});
+const neighbors = new Map(NODES.map(n => [n.id, new Set()]));
+EDGES.forEach(([a, b]) => { neighbors.get(a).add(b); neighbors.get(b).add(a); });
+
+const canvas = document.getElementById("graph");
+const ctx = canvas.getContext("2d");
+let W = 0, H = 0, DPR = Math.min(window.devicePixelRatio || 1, 2);
+
+function resize() {
+  const rect = canvas.parentElement.getBoundingClientRect();
+  W = rect.width; H = rect.height;
+  canvas.width = W * DPR; canvas.height = H * DPR;
+  canvas.style.width = W + "px"; canvas.style.height = H + "px";
+  ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+}
+window.addEventListener("resize", resize);
+
+// seed positions on a circle by category cluster
+const catList = Object.keys(CATEGORIES);
+NODES.forEach((n, i) => {
+  const catIdx = catList.indexOf(n.cat);
+  const catAngle = (catIdx / catList.length) * Math.PI * 2;
+  const withinCat = NODES.filter(m => m.cat === n.cat);
+  const idxInCat = withinCat.indexOf(n);
+  const r = 90 + (idxInCat / Math.max(1, withinCat.length)) * 140;
+  n.x = Math.cos(catAngle) * r + (Math.random() - 0.5) * 40;
+  n.y = Math.sin(catAngle) * r + (Math.random() - 0.5) * 40;
+  n.vx = 0; n.vy = 0;
+  n.r = 5 + Math.min(16, Math.sqrt(degree.get(n.id) || 1) * 3.4);
+});
+
+let camX = 0, camY = 0, zoom = 1;
+let dragNode = null, dragCam = false, lastMouse = null, moved = false;
+let selected = null, hovered = null, categoryOff = new Set();
+let query = "";
+
+function simulateStep() {
+  const REPULSE = 2600, SPRING = 0.02, SPRING_LEN = 95, CENTER = 0.0026, DAMP = 0.86;
+  for (let i = 0; i < NODES.length; i++) {
+    const a = NODES[i];
+    let fx = -a.x * CENTER, fy = -a.y * CENTER;
+    for (let j = 0; j < NODES.length; j++) {
+      if (i === j) continue;
+      const b = NODES[j];
+      let dx = a.x - b.x, dy = a.y - b.y;
+      let d2 = dx * dx + dy * dy + 0.01;
+      let d = Math.sqrt(d2);
+      const f = REPULSE / d2;
+      fx += (dx / d) * f; fy += (dy / d) * f;
+    }
+    a.fx = fx; a.fy = fy;
+  }
+  EDGES.forEach(([id1, id2]) => {
+    const a = byId.get(id1), b = byId.get(id2);
+    let dx = b.x - a.x, dy = b.y - a.y;
+    let d = Math.sqrt(dx * dx + dy * dy) || 0.01;
+    const f = (d - SPRING_LEN) * SPRING;
+    const fx = (dx / d) * f, fy = (dy / d) * f;
+    a.fx += fx; a.fy += fy;
+    b.fx -= fx; b.fy -= fy;
+  });
+  NODES.forEach(n => {
+    if (n === dragNode) return;
+    n.vx = (n.vx + n.fx) * DAMP;
+    n.vy = (n.vy + n.fy) * DAMP;
+    n.x += n.vx * 0.16;
+    n.y += n.vy * 0.16;
+  });
+}
+
+let settleFrames = 0;
+const MAX_SETTLE = 260;
+
+function worldToScreen(x, y) {
+  return [W / 2 + camX + x * zoom, H / 2 + camY + y * zoom];
+}
+function screenToWorld(sx, sy) {
+  return [(sx - W / 2 - camX) / zoom, (sy - H / 2 - camY) / zoom];
+}
+
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+function nodeVisible(n) {
+  if (categoryOff.has(n.cat)) return false;
+  if (!query) return true;
+  return n.id.toLowerCase().includes(query) || (n.file || "").toLowerCase().includes(query);
+}
+
+function draw() {
+  ctx.clearRect(0, 0, W, H);
+  const bg = cssVar("--bg");
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, W, H);
+
+  const edgeColor = cssVar("--edge");
+  const edgeDim = cssVar("--edge-dim");
+  const accent = cssVar("--accent");
+  const inkDim = cssVar("--ink-dim");
+  const ink = cssVar("--ink");
+  const bgElev = cssVar("--bg-elev");
+
+  const activeSet = selected ? new Set([selected.id, ...neighbors.get(selected.id)]) : null;
+  const hoverSet = hovered ? new Set([hovered.id, ...neighbors.get(hovered.id)]) : null;
+
+  // edges
+  EDGES.forEach(([id1, id2]) => {
+    const a = byId.get(id1), b = byId.get(id2);
+    if (!nodeVisible(a) || !nodeVisible(b)) return;
+    const [ax, ay] = worldToScreen(a.x, a.y);
+    const [bx, by] = worldToScreen(b.x, b.y);
+    let isActive = activeSet && activeSet.has(id1) && activeSet.has(id2);
+    let isHover = hoverSet && hoverSet.has(id1) && hoverSet.has(id2);
+    ctx.strokeStyle = isActive || isHover ? accent : (activeSet ? edgeDim : edgeColor);
+    ctx.lineWidth = isActive || isHover ? 1.6 : 0.9;
+    ctx.globalAlpha = activeSet && !isActive ? 0.28 : 0.85;
+    ctx.beginPath();
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(bx, by);
+    ctx.stroke();
+
+    // arrowhead
+    const angle = Math.atan2(by - ay, bx - ax);
+    const bn = b.r * zoom + 3;
+    const tipx = bx - Math.cos(angle) * bn, tipy = by - Math.sin(angle) * bn;
+    ctx.beginPath();
+    ctx.moveTo(tipx, tipy);
+    ctx.lineTo(tipx - 6 * Math.cos(angle - 0.4), tipy - 6 * Math.sin(angle - 0.4));
+    ctx.lineTo(tipx - 6 * Math.cos(angle + 0.4), tipy - 6 * Math.sin(angle + 0.4));
+    ctx.closePath();
+    ctx.fillStyle = ctx.strokeStyle;
+    ctx.fill();
+  });
+  ctx.globalAlpha = 1;
+
+  // nodes
+  NODES.forEach(n => {
+    if (!nodeVisible(n)) return;
+    const [x, y] = worldToScreen(n.x, n.y);
+    const r = n.r * zoom;
+    const isSel = selected === n;
+    const isHov = hovered === n;
+    const dim = activeSet && !activeSet.has(n.id);
+    ctx.globalAlpha = dim ? 0.25 : 1;
+
+    ctx.beginPath();
+    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.fillStyle = cssVar("--c-" + n.cat);
+    ctx.fill();
+    if (isSel || isHov) {
+      ctx.lineWidth = 2.4;
+      ctx.strokeStyle = accent;
+      ctx.stroke();
+    } else {
+      ctx.lineWidth = 1;
+      ctx.strokeStyle = bg;
+      ctx.stroke();
+    }
+
+    if (zoom > 0.55 || isSel || isHov) {
+      ctx.globalAlpha = dim ? 0.4 : 1;
+      ctx.font = (isSel || isHov ? "600 " : "500 ") + Math.max(10, Math.min(12.5, 11 * zoom)) + "px " + cssVar("--font-mono");
+      ctx.fillStyle = ink;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "top";
+      ctx.fillText(n.id, x, y + r + 4);
+    }
+    ctx.globalAlpha = 1;
+  });
+
+  if (settleFrames < MAX_SETTLE) {
+    simulateStep();
+    settleFrames++;
+  }
+  requestAnimationFrame(draw);
+}
+
+/* ---------------------------------------------------------------------
+   Interaction
+--------------------------------------------------------------------- */
+
+function nodeAt(sx, sy) {
+  let best = null, bestD = Infinity;
+  for (const n of NODES) {
+    if (!nodeVisible(n)) continue;
+    const [x, y] = worldToScreen(n.x, n.y);
+    const d = Math.hypot(x - sx, y - sy);
+    if (d < Math.max(9, n.r * zoom) + 3 && d < bestD) { best = n; bestD = d; }
+  }
+  return best;
+}
+
+canvas.addEventListener("mousedown", e => {
+  const rect = canvas.getBoundingClientRect();
+  const sx = e.clientX - rect.left, sy = e.clientY - rect.top;
+  const n = nodeAt(sx, sy);
+  moved = false;
+  if (n) { dragNode = n; n.vx = 0; n.vy = 0; }
+  else { dragCam = true; canvas.classList.add("dragging"); }
+  lastMouse = [e.clientX, e.clientY];
+});
+window.addEventListener("mousemove", e => {
+  if (!lastMouse) {
+    const rect = canvas.getBoundingClientRect();
+    const sx = e.clientX - rect.left, sy = e.clientY - rect.top;
+    const n = nodeAt(sx, sy);
+    if (n !== hovered) { hovered = n; canvas.style.cursor = n ? "pointer" : "grab"; }
+    return;
+  }
+  const dx = e.clientX - lastMouse[0], dy = e.clientY - lastMouse[1];
+  if (Math.abs(dx) + Math.abs(dy) > 2) moved = true;
+  if (dragNode) {
+    const [wx, wy] = screenToWorld(e.clientX - canvas.getBoundingClientRect().left, e.clientY - canvas.getBoundingClientRect().top);
+    dragNode.x = wx; dragNode.y = wy;
+    settleFrames = Math.min(settleFrames, MAX_SETTLE - 40);
+  } else if (dragCam) {
+    camX += dx; camY += dy;
+  }
+  lastMouse = [e.clientX, e.clientY];
+});
+window.addEventListener("mouseup", e => {
+  if (dragNode && !moved) selectNode(dragNode);
+  else if (dragCam && !moved) {
+    const rect = canvas.getBoundingClientRect();
+    const n = nodeAt(e.clientX - rect.left, e.clientY - rect.top);
+    if (n) selectNode(n); else deselect();
+  }
+  dragNode = null; dragCam = false; lastMouse = null;
+  canvas.classList.remove("dragging");
+});
+canvas.addEventListener("wheel", e => {
+  e.preventDefault();
+  const rect = canvas.getBoundingClientRect();
+  const sx = e.clientX - rect.left, sy = e.clientY - rect.top;
+  const [wx, wy] = screenToWorld(sx, sy);
+  const factor = Math.exp(-e.deltaY * 0.0011);
+  zoom = Math.max(0.25, Math.min(3.2, zoom * factor));
+  camX = sx - W / 2 - wx * zoom;
+  camY = sy - H / 2 - wy * zoom;
+}, { passive: false });
+
+/* ---------------------------------------------------------------------
+   Panel + legend
+--------------------------------------------------------------------- */
+
+const panel = document.getElementById("panel");
+const panelTitle = document.getElementById("panel-title");
+const panelFile = document.getElementById("panel-file");
+const panelEyebrow = document.getElementById("panel-eyebrow");
+const panelBody = document.getElementById("panel-body");
+
+function dot(cat) {
+  return `<span class="legend-dot" style="background:var(--c-${cat})"></span>`;
+}
+
+function selectNode(n) {
+  selected = n;
+  panel.classList.remove("hidden");
+  panelEyebrow.textContent = CATEGORIES[n.cat].label;
+  panelEyebrow.style.color = `var(--c-${n.cat})`;
+  panelTitle.textContent = n.id;
+  panelFile.textContent = n.file + (n.loc ? `  ·  ${n.loc} lines` : "");
+  const deg = degree.get(n.id) || 0;
+  const inNbrs = EDGES.filter(([a, b]) => b === n.id).map(([a]) => a);
+  const outNbrs = EDGES.filter(([a, b]) => a === n.id).map(([, b]) => b);
+  panelBody.innerHTML = `
+    <p>${n.desc}</p>
+    <div class="panel-section-label">Degree: ${deg} connection${deg === 1 ? "" : "s"}</div>
+    ${outNbrs.length ? `<div class="neighbor-group">
+      <div class="panel-section-label">Imports (${outNbrs.length})</div>
+      <div class="neighbor-list">${outNbrs.map(id => `<button class="neighbor-btn" data-id="${id}">${dot(byId.get(id).cat)}${id}</button>`).join("")}</div>
+    </div>` : ""}
+    ${inNbrs.length ? `<div class="neighbor-group">
+      <div class="panel-section-label">Imported by (${inNbrs.length})</div>
+      <div class="neighbor-list">${inNbrs.map(id => `<button class="neighbor-btn" data-id="${id}">${dot(byId.get(id).cat)}${id}</button>`).join("")}</div>
+    </div>` : ""}
+  `;
+  panelBody.querySelectorAll(".neighbor-btn").forEach(btn => {
+    btn.addEventListener("click", () => selectNode(byId.get(btn.dataset.id)));
+  });
+}
+function deselect() {
+  selected = null;
+  panel.classList.add("hidden");
+}
+document.getElementById("panel-close").addEventListener("click", deselect);
+
+const legendRows = document.getElementById("legend-rows");
+Object.entries(CATEGORIES).forEach(([key, meta]) => {
+  const count = NODES.filter(n => n.cat === key).length;
+  const row = document.createElement("div");
+  row.className = "legend-row";
+  row.dataset.cat = key;
+  row.innerHTML = `<span class="legend-dot" style="background:var(--c-${key})"></span><span class="legend-label">${meta.label}</span><span class="legend-count">${count}</span>`;
+  row.addEventListener("click", () => {
+    if (categoryOff.has(key)) categoryOff.delete(key); else categoryOff.add(key);
+    row.classList.toggle("off", categoryOff.has(key));
+  });
+  legendRows.appendChild(row);
+});
+
+document.getElementById("search").addEventListener("input", e => {
+  query = e.target.value.trim().toLowerCase();
+});
+
+/* ---------------------------------------------------------------------
+   Theme toggle
+--------------------------------------------------------------------- */
+const root = document.documentElement;
+const themeBtn = document.getElementById("theme-toggle");
+function currentTheme() {
+  return root.getAttribute("data-theme") ||
+    (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+}
+themeBtn.addEventListener("click", () => {
+  root.setAttribute("data-theme", currentTheme() === "dark" ? "light" : "dark");
+});
+
+/* ---------------------------------------------------------------------
+   Stats + boot
+--------------------------------------------------------------------- */
+document.getElementById("stat-nodes").textContent = NODES.length;
+document.getElementById("stat-edges").textContent = EDGES.length;
+const hub = [...degree.entries()].sort((a, b) => b[1] - a[1])[0];
+document.getElementById("stat-hub").textContent = hub[0] + " (" + hub[1] + ")";
+
+resize();
+requestAnimationFrame(draw);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

This PR adds comprehensive repository knowledge graph documentation generated by reverse engineering the Graphify codebase.

### Added

- CODEBASE_OVERVIEW.md
- TECHNICAL_REFERENCE.md
- graph.html (interactive dependency graph)

### Highlights

- High-level architecture overview
- Module dependency mapping
- Internal import relationships
- Technical reference for repository structure
- Interactive visualization of module relationships

### Notes

- No application source code was modified.
- This PR only adds documentation and visualization artifacts under `docs/knowledge_graph/`.