### PR TITLE
fix(llm): keep label retries above token floor

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -2800,8 +2800,9 @@ def _label_batch_with_retry(
     # Budget generously: a 2-5 word name is ~10 tokens, but models (notably
     # gemini) often prepend a short preamble or reasoning that eats the
     # completion and truncates the JSON mid-object, which used to fail the whole
-    # batch (#1690). The old 64 + 24*n floor left no headroom.
-    max_tokens = _resolve_max_tokens(min(256 + 48 * len(batch_cids), 8192))
+    # batch (#1690). Keep at least 512 tokens as adaptive retries shrink the
+    # batch; otherwise the recovery path starves its own base case (#2086).
+    max_tokens = _resolve_max_tokens(max(512, min(256 + 48 * len(batch_cids), 8192)))
     call_kwargs: dict = {"backend": backend, "max_tokens": max_tokens}
     if model is not None:
         call_kwargs["model"] = model

--- a/tests/test_label_retry.py
+++ b/tests/test_label_retry.py
@@ -44,3 +44,28 @@ def test_label_batch_recovers_via_split_on_invalid_json(monkeypatch):
 
     assert result == {42: "Label 42", 99: "Label 99", 137: "Label 137", 201: "Label 201"}
     assert call_count["n"] >= 2
+
+
+def test_label_batch_retry_keeps_a_safe_output_token_floor(monkeypatch):
+    """Split retries must not starve small batches of output tokens (#2086)."""
+    token_budgets: list[int] = []
+    monkeypatch.delenv("GRAPHIFY_MAX_OUTPUT_TOKENS", raising=False)
+
+    def fake_call_llm(prompt: str, **kwargs) -> str:
+        token_budgets.append(kwargs["max_tokens"])
+        cids = [int(m) for m in re.findall(r"Community (\d+):", prompt)]
+        if len(cids) > 1:
+            return "not json"
+        return json.dumps({str(cids[0]): f"Label {cids[0]}"})
+
+    monkeypatch.setattr(llm_mod, "_call_llm", fake_call_llm)
+
+    result = llm_mod._label_batch_with_retry(
+        [1, 2],
+        ["Community 1: auth", "Community 2: billing"],
+        backend="gemini",
+        model=None,
+    )
+
+    assert result == {1: "Label 1", 2: "Label 2"}
+    assert token_budgets == [512, 512, 512]


### PR DESCRIPTION
Fixes #2086.

## Root cause

The adaptive community-label retry path reduces `max_tokens` as it bisects a failed batch. The earlier #1690 adjustment improved the formula from `64 + 24*n` to `256 + 48*n`, but a single-community retry on current `v8` still receives only 304 output tokens. That leaves the recovery base case with the smallest budget.

## Change

- Preserve the existing batch-size scaling and 8192-token cap.
- Enforce a 512-token minimum before passing the value through `_resolve_max_tokens()`.
- Keep `GRAPHIFY_MAX_OUTPUT_TOKENS` authoritative when users explicitly set it.
- Add a regression test that forces a two-community parse failure, follows both single-community retries, and asserts that every call receives the 512-token floor.

## Validation

- Regression test before fix: failed with budgets `[352, 304, 304]`.
- `python -m pytest tests/test_label_retry.py -q`: 2 passed.
- Full locked Python 3.12 suite: 3550 passed, 3 skipped.
- `ruff check graphify/llm.py tests/test_label_retry.py`: passed.
- All five `tools.skillgen` validation modes: passed.
- `graphify update .`: completed successfully.
- `git diff --check`: passed.
