### PR TITLE
fix: preserve exact identifiers in query expansion

### DIFF
--- a/graphify/skills/agents/references/query.md
+++ b/graphify/skills/agents/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/amp/references/query.md
+++ b/graphify/skills/amp/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/claude/references/query.md
+++ b/graphify/skills/claude/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/claw/references/query.md
+++ b/graphify/skills/claw/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/codex/references/query.md
+++ b/graphify/skills/codex/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/copilot/references/query.md
+++ b/graphify/skills/copilot/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/droid/references/query.md
+++ b/graphify/skills/droid/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/kilo/references/query.md
+++ b/graphify/skills/kilo/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/kiro/references/query.md
+++ b/graphify/skills/kiro/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/opencode/references/query.md
+++ b/graphify/skills/opencode/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/pi/references/query.md
+++ b/graphify/skills/pi/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/trae/references/query.md
+++ b/graphify/skills/trae/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/vscode/references/query.md
+++ b/graphify/skills/vscode/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/graphify/skills/windows/references/query.md
+++ b/graphify/skills/windows/references/query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tests/test_skillgen.py
+++ b/tests/test_skillgen.py
@@ -189,6 +189,23 @@ def test_query_heading_is_homed_in_core_stub_only():
     assert "## For /graphify path" not in core_headings
 
 
+def test_query_expansion_preserves_exact_identifiers_across_rendered_skills():
+    """Query guidance must retain user-supplied code anchors before expansion."""
+    platforms = gen.load_platforms()
+    query_bodies = [
+        art
+        for art in gen.render_all(platforms)
+        if "Constrained query expansion" in art.content
+    ]
+    assert query_bodies, "no rendered skill contains the query-expansion guidance"
+    for art in query_bodies:
+        assert "preserve exact identifier anchors" in art.content, art.path
+        assert "Do not lowercase or split them" in art.content, art.path
+        assert "12-token vocabulary-expansion limit" in art.content, art.path
+        assert "Exact identifiers preserved (N)" in art.content, art.path
+        assert "preserved exact identifiers first" in art.content, art.path
+
+
 def test_eight_references_render_for_claude():
     """claude renders exactly the eight on-demand fragments from the design."""
     _, refs = _claude_artifacts()

--- a/tools/skillgen/expected/graphify__skills__agents__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__agents__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__amp__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__amp__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__claude__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__claude__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__claw__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__claw__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__codex__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__codex__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__copilot__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__copilot__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__droid__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__droid__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__kilo__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__kilo__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__kiro__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__kiro__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__opencode__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__opencode__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__pi__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__pi__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__trae__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__trae__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__vscode__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__vscode__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/expected/graphify__skills__windows__references__query.md
+++ b/tools/skillgen/expected/graphify__skills__windows__references__query.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash

--- a/tools/skillgen/fragments/references/query/default.md
+++ b/tools/skillgen/fragments/references/query/default.md
@@ -45,22 +45,40 @@ print(f'vocab: {len(vocab)} tokens')
 "
 ```
 
-2. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
+2. Before expanding vocabulary, preserve exact identifier anchors from the original
+   question:
+   - Keep inline-code spans and identifier-shaped tokens verbatim when they contain an
+     internal case transition or an identifier separator such as `_`, `.`, `::`, or
+     `/` (for example, `CheckoutMatchingResult`, `process_request`, or
+     `pkg.module.Handler`).
+   - Preserve only identifiers that the user actually supplied. Never invent an exact
+     identifier from model memory.
+   - Keep their original spelling and order. Do not lowercase or split them, and do not
+     count them against the 12-token vocabulary-expansion limit.
+   - Deduplicate repeated exact identifiers while keeping their first occurrence.
+
+3. Read `graphify-out/.vocab.txt`. Then for the user's question, select **up to 12 tokens from this exact list** that semantically match the query intent. Hard constraints:
    - You MUST pick only tokens present in the vocabulary file. Do NOT invent tokens.
    - If a query concept has no plausible token in the vocab, skip it — do not substitute a near-synonym from training memory.
-   - If **no** vocab tokens match the query at all, output an empty list and tell the user the corpus has no relevant vocabulary for this question. Do not fabricate a search.
    - Translate cross-language: Russian "аутентификация" → look for `auth`, `credential`, `token`, `security` IFF present in vocab.
    - Morphology: "handlers" maps to `handler` IFF present; "todos" maps to `todo` IFF present.
 
-3. Print the selection explicitly to the user before running the query, so the expansion is auditable:
+4. Print both selections explicitly before running the query, so the expansion is
+   auditable:
 ```
+Exact identifiers preserved (N): [IdentifierOne, package.symbol]
 Query expanded to (from graph vocab, N tokens): [token1, token2, ...]
 ```
-If the list is empty, say so plainly and stop — do not proceed to traversal.
+An empty vocabulary-token list is valid when at least one exact identifier was
+preserved. If both lists are empty, say plainly that the corpus has no relevant
+vocabulary for this question and stop; do not fabricate a search.
 
 ### Step 1 — Traversal
 
-Build the **expanded query string** by joining the selected tokens with spaces. Use this string as `QUESTION` below — NOT the original user question. (The original question is preserved only for `save-result` at the end.)
+Build the **expanded query string** by joining the preserved exact identifiers first,
+followed by the selected vocabulary tokens. Use this string as `QUESTION` below, not
+the full original prose. The original question remains the source of the exact
+identifiers and is preserved for `save-result` at the end.
 
 Prefer the CLI when it is installed:
 ```bash


### PR DESCRIPTION
## Summary

- preserve user-supplied code identifiers before graph-vocabulary expansion
- keep exact anchors in their original spelling and order without consuming the 12-token expansion budget
- render the updated query guidance for every supported split-skill runtime
- add a generator-level regression test covering all rendered query skills

## Root cause

The query skill currently builds the traversal query exclusively from lowercase
tokens selected from the graph vocabulary. This improves recall for natural-language
questions, but it can discard a precise identifier that the user already supplied.

For example, an exact anchor such as `CheckoutMatchingResult` can become the separate
terms `checkout matching result`. On a large graph, those broader terms may seed
unrelated nodes while the exact symbol is no longer guaranteed to participate in the
query.

## Change

The query-expansion flow now:

1. captures inline-code and identifier-shaped spans from the original question
2. preserves those anchors verbatim, in order, with deduplication
3. selects up to 12 additional terms from the graph vocabulary
4. builds the query with exact anchors first, followed by expanded terms
5. reports both lists so the transformation remains auditable

Exact anchors are user-provided rather than model-invented. A query can also proceed
with exact anchors when no additional vocabulary token is appropriate.

This is intentionally independent from #2113: that PR bounds the query engine's seed
recovery, while this PR prevents the skill layer from dropping precise identifiers
before the engine sees the query.

## Scope

This changes skill guidance and generated skill artifacts only. It does not modify
query scoring, traversal behavior, or graph construction.

## Validation

- `uv run pytest -q tests/test_skillgen.py tests/test_install_references.py tests/test_install_roundtrip.py`: 124 passed, 1 skipped
- `uv run ruff check tests/test_skillgen.py`
- `uv run python -m tools.skillgen --check`
- `uv run python -m tools.skillgen --audit-coverage`
- `uv run python -m tools.skillgen --schema-singleton`
- `uv run python -m tools.skillgen --monolith-roundtrip`
- `uv run python -m tools.skillgen --always-on-roundtrip`
- `git diff --check`
- `uv run graphify update .`

Authored with Codex (GPT-5).
