### PR TITLE
fix: suppress warnings for intentionally skipped files

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4529,7 +4529,11 @@ def extract(
     _empty_sources: list[str] = []
     for i, _p in enumerate(paths):
         _res = per_file[i] or {}
-        if _res.get("nodes") or _res.get("error"):
+        # Some extractors deliberately return no graph data for recognized input
+        # (for example, JSON records rather than a config/manifest).  Their
+        # explicit ``skipped`` marker distinguishes that expected outcome from
+        # the anomalous empty extraction this warning is meant to surface.
+        if _res.get("nodes") or _res.get("error") or _res.get("skipped"):
             continue
         if _get_extractor(_p) is not None:
             _empty_sources.append(str(_p))

--- a/tests/test_zero_node_no_cache.py
+++ b/tests/test_zero_node_no_cache.py
@@ -52,3 +52,15 @@ def test_no_warning_when_all_files_produce_nodes(tmp_path, capsys):
     ex.extract([f], cache_root=tmp_path / "out", parallel=False)
     err = capsys.readouterr().err
     assert "zero nodes" not in err
+
+
+def test_intentionally_skipped_data_json_does_not_warn(tmp_path, capsys):
+    """A recognized data document is empty by design, not an extractor failure."""
+    f = tmp_path / "records.json"
+    f.write_text('[{"id": 1, "name": "Ada"}]')
+
+    result = ex.extract([f], cache_root=tmp_path / "out", parallel=False)
+
+    assert result["nodes"] == []
+    err = capsys.readouterr().err
+    assert "zero nodes" not in err, err


### PR DESCRIPTION
Fixes #2107.

## Problem

The zero-node diagnostic treats every extractor result with no nodes as anomalous. Some extractors intentionally return an explicit `skipped` marker for recognized but non-graph input, such as data-only JSON documents, so those files currently produce a false warning that asks users to re-run and report them.

## Change

Exclude results carrying the extractor-level `skipped` marker from the anomalous zero-node warning. Actual empty extractor results remain uncached and still warn.

## Validation

- Added a regression using a top-level JSON records array
- Preserved the existing negative control for a genuinely anomalous empty Ruby extraction
- Python 3.10: `3609 passed, 3 skipped`
- Python 3.12: `3609 passed, 3 skipped`
- All five `tools.skillgen` integrity checks pass
- `ruff check graphify/extract.py tests/test_zero_node_no_cache.py` passes
- `graphify update .` completed: 11,961 nodes / 21,152 edges

This is intentionally scoped to the warning behavior; skipped data JSON remains absent from the graph by design.