### PR TITLE
fix: honor target filesystem filename limits

### DIFF
--- a/graphify/export.py
+++ b/graphify/export.py
@@ -13,6 +13,7 @@ from datetime import date
 from pathlib import Path
 import networkx as nx
 from networkx.readwrite import json_graph
+from graphify.paths import cap_filename_stem, filename_stem_limit
 from graphify.security import sanitize_label
 from graphify.analyze import _node_community_map
 from graphify.build import edge_data
@@ -413,20 +414,14 @@ generate_html = to_html
 
 
 def _cap_filename(s: str, limit: int = 200) -> str:
-    """Cap a filename stem to ``limit`` UTF-8 bytes so it stays under the 255-byte
-    filesystem limit even after the ``.md`` extension and dedup suffix are added
-    (#1094). The cap is on BYTES, not chars, because a label of multibyte
-    characters (CJK, accented) can exceed 255 bytes well under 255 chars. When
-    truncation happens, an 8-char hash of the full label is appended so two
-    distinct labels sharing a long prefix produce distinct, deterministic
-    filenames instead of colliding."""
-    b = s.encode("utf-8")
-    if len(b) <= limit:
-        return s
-    digest = hashlib.sha1(s.encode("utf-8")).hexdigest()[:8]  # nosec - not security
-    keep = limit - 9  # "_" + 8 hex chars
-    truncated = b[:keep].decode("utf-8", "ignore")  # "ignore" drops a split trailing char
-    return f"{truncated}_{digest}"
+    """Cap a filename stem to ``limit`` UTF-8 bytes (#1094).
+
+    Callers derive ``limit`` from the target filesystem and reserve the extension
+    and dedup suffix. The cap is on bytes, not characters, so multibyte labels
+    remain within that budget. Truncated names retain a deterministic digest to
+    keep distinct long labels from colliding.
+    """
+    return cap_filename_stem(s, limit)
 
 
 def _dedup_node_filenames(G: nx.Graph, safe_name) -> dict[str, str]:
@@ -468,6 +463,8 @@ def to_obsidian(
     """
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
+    node_name_limit = filename_stem_limit(out)
+    community_label_limit = filename_stem_limit(out, fixed_prefix="_COMMUNITY_")
 
     # #1506: when the export target is an existing Obsidian vault (a user pointed
     # --obsidian-dir at one), we must not clobber the user's own notes or their
@@ -497,7 +494,7 @@ def to_obsidian(
 
     # Map node_id → safe filename so wikilinks stay consistent.
     # Deduplicate: if two nodes produce the same filename, append a numeric suffix.
-    def safe_name(label: str) -> str:
+    def safe_name(label: str, *, limit: int = node_name_limit) -> str:
         cleaned = re.sub(r'[\\/*?:"<>|#^[\]]', "", label.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")).strip()
         # Strip trailing .md/.mdx/.markdown so "CLAUDE.md" doesn't become "CLAUDE.md.md"
         cleaned = re.sub(r"\.(md|mdx|qmd|markdown)$", "", cleaned, flags=re.IGNORECASE)
@@ -508,7 +505,7 @@ def to_obsidian(
         # emit a "@.md"-style filename. (#1409)
         if not re.search(r"\w", cleaned, flags=re.UNICODE):
             return "unnamed"
-        return _cap_filename(cleaned)
+        return _cap_filename(cleaned, limit)
 
     node_filename = _dedup_node_filenames(G, safe_name)
 
@@ -625,7 +622,7 @@ def to_obsidian(
     community_filename: dict = {}
     used_community: set[str] = set()
     for cid in communities:
-        base = f"_COMMUNITY_{safe_name(_community_name(cid))}"
+        base = f"_COMMUNITY_{safe_name(_community_name(cid), limit=community_label_limit)}"
         candidate = base
         n = 1
         while candidate.lower() in used_community:
@@ -700,7 +697,7 @@ def to_obsidian(
         if cross:
             lines.append("## Connections to other communities")
             for other_cid, edge_count in sorted(cross.items(), key=lambda x: -x[1]):
-                other_fname = community_filename.get(other_cid) or f"_COMMUNITY_{safe_name(_community_name(other_cid))}"
+                other_fname = community_filename.get(other_cid) or f"_COMMUNITY_{safe_name(_community_name(other_cid), limit=community_label_limit)}"
                 lines.append(f"- {edge_count} edge{'s' if edge_count != 1 else ''} to [[{other_fname}]]")
             lines.append("")
 
@@ -797,6 +794,7 @@ def to_canvas(
     """
     # Obsidian canvas color codes (cycle through for communities)
     CANVAS_COLORS = ["1", "2", "3", "4", "5", "6"]  # red, orange, yellow, green, cyan, purple
+    node_name_limit = filename_stem_limit(Path(output_path).parent)
 
     def safe_name(label: str) -> str:
         cleaned = re.sub(r'[\\/*?:"<>|#^[\]]', "", label.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")).strip()
@@ -808,7 +806,7 @@ def to_canvas(
         # emit a "@.md"-style filename. (#1409)
         if not re.search(r"\w", cleaned, flags=re.UNICODE):
             return "unnamed"
-        return _cap_filename(cleaned)
+        return _cap_filename(cleaned, node_name_limit)
 
     # Build node_filenames if not provided (same dedup logic as to_obsidian)
     if node_filenames is None:

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -17,6 +17,7 @@ flow) and every reader honours it.
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import re
 import stat
@@ -24,6 +25,49 @@ import tempfile
 from pathlib import Path, PurePosixPath
 
 GRAPHIFY_OUT = os.environ.get("GRAPHIFY_OUT", "graphify-out")
+
+
+def cap_filename_stem(value: str, limit: int = 200) -> str:
+    """Cap a filename stem to ``limit`` UTF-8 bytes without losing uniqueness.
+
+    Truncated values retain an eight-character digest of the full input.  The
+    limit is byte-based because filesystem ``NAME_MAX`` applies to encoded path
+    components, not Python character counts.
+    """
+    encoded = value.encode("utf-8")
+    if len(encoded) <= limit:
+        return value
+    digest = hashlib.sha1(encoded).hexdigest()[:8]  # nosec - identity, not security
+    if limit <= len(digest):
+        return digest[:max(1, limit)]
+    keep = limit - len(digest) - 1
+    prefix = encoded[:keep].decode("utf-8", "ignore")
+    return f"{prefix}_{digest}"
+
+
+def filename_stem_limit(
+    directory: "str | Path",
+    *,
+    fixed_prefix: str = "",
+    extension: str = ".md",
+    preferred: int = 200,
+    fallback_name_max: int = 255,
+) -> int:
+    """Return a conservative stem-byte budget for ``directory``'s filesystem.
+
+    ``PC_NAME_MAX`` can be lower than 255 on encrypted filesystems such as
+    eCryptfs.  Reserve space for a fixed generated prefix, the extension, and a
+    practical ten-byte collision suffix (``_`` plus nine digits).  The existing
+    200-byte cap remains unchanged on conventional filesystems.
+    """
+    try:
+        name_max = int(os.pathconf(str(directory), "PC_NAME_MAX"))
+        if name_max <= 0:
+            name_max = fallback_name_max
+    except (AttributeError, OSError, TypeError, ValueError):
+        name_max = fallback_name_max
+    reserved = len(fixed_prefix.encode("utf-8")) + len(extension.encode("utf-8")) + 10
+    return max(9, min(preferred, name_max - reserved))
 
 
 def _atomic_replace(path: "str | Path", write_fn) -> None:

--- a/graphify/wiki.py
+++ b/graphify/wiki.py
@@ -7,21 +7,22 @@ from urllib.parse import quote
 import networkx as nx
 
 from graphify.build import edge_data
+from graphify.paths import cap_filename_stem, filename_stem_limit
 
 
-def _safe_filename(name: str) -> str:
+def _safe_filename(name: str, limit: int = 200) -> str:
     """Make a label safe for use as a filename across platforms.
 
     Substitutes characters that Windows reserves in filenames
     (< > : " / \\ | ? *) and strips trailing dots/spaces, also reserved.
-    Falls back to 'unnamed' for empty results and caps length at 200
-    chars to stay well under common filesystem limits.
+    Falls back to 'unnamed' for empty results and caps the UTF-8 byte length to
+    the target filesystem's available stem budget.
     """
     import re
     s = name.replace("/", "-").replace(" ", "_").replace(":", "-")
     s = re.sub(r'[<>:"/\\|?*]', '_', s)
     s = s.strip('. ')
-    return s[:200] if s else 'unnamed'
+    return cap_filename_stem(s or 'unnamed', limit)
 
 
 def _md_link(label: str, resolver: dict[str, str]) -> str:
@@ -227,6 +228,7 @@ def to_wiki(
     """
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
+    stem_limit = filename_stem_limit(out)
 
     if not communities:
         raise ValueError(
@@ -304,7 +306,7 @@ def to_wiki(
     community_slugs: dict[int, str] = {}
     for cid in communities:
         label = labels.get(cid, f"Community {cid}")
-        slug = _unique_slug(_safe_filename(label))
+        slug = _unique_slug(_safe_filename(label, stem_limit))
         community_slugs[cid] = slug
         resolver.setdefault(label, slug)
 
@@ -312,7 +314,7 @@ def to_wiki(
     for node_data in god_nodes_data:
         nid = node_data.get("id")
         if nid and nid in G:
-            slug = _unique_slug(_safe_filename(node_data['label']))
+            slug = _unique_slug(_safe_filename(node_data['label'], stem_limit))
             god_articles.append((nid, slug))
             resolver.setdefault(node_data['label'], slug)
 

--- a/tests/test_obsidian_filename_cap.py
+++ b/tests/test_obsidian_filename_cap.py
@@ -1,6 +1,9 @@
 """Regression tests for issue #1094: to_obsidian / to_canvas must cap filenames
 to stay under the 255-byte filesystem limit, instead of crashing with
 OSError ENAMETOOLONG on long node labels."""
+import json
+import os
+
 import networkx as nx
 
 from graphify.export import to_obsidian, to_canvas
@@ -63,7 +66,6 @@ def test_obsidian_wikilink_resolves_after_truncation(tmp_path):
 
 
 def test_canvas_long_label_file_ref_capped(tmp_path):
-    import json
     G, comms = _graph(["c" * 300, "ok"])
     out = tmp_path / "graph.canvas"
     to_canvas(G, comms, str(out))
@@ -71,3 +73,35 @@ def test_canvas_long_label_file_ref_capped(tmp_path):
     for node in data.get("nodes", []):
         if node.get("type") == "file":
             assert len(node["file"].encode("utf-8")) <= 255, node["file"]
+
+
+def test_obsidian_respects_target_filesystem_name_max(tmp_path, monkeypatch):
+    """#2109: eCryptfs can report NAME_MAX=143 rather than the usual 255."""
+    monkeypatch.setattr(os, "pathconf", lambda _path, _name: 143)
+    G, _ = _graph(["n" * 170, "n" * 170])
+    comms = {0: ["n0"], 1: ["n1"]}
+
+    to_obsidian(
+        G,
+        comms,
+        str(tmp_path),
+        community_labels={0: "c" * 170, 1: "c" * 170},
+    )
+
+    names = [p.name for p in tmp_path.glob("*.md")]
+    assert max(len(name.encode("utf-8")) for name in names) <= 143
+    assert len({name.lower() for name in names}) == len(names)
+
+
+def test_canvas_respects_target_filesystem_name_max(tmp_path, monkeypatch):
+    monkeypatch.setattr(os, "pathconf", lambda _path, _name: 143)
+    G, comms = _graph(["n" * 170, "n" * 170])
+    out = tmp_path / "graph.canvas"
+
+    to_canvas(G, comms, str(out))
+
+    data = json.loads(out.read_text())
+    file_refs = [n["file"] for n in data.get("nodes", []) if n.get("type") == "file"]
+    assert file_refs
+    assert max(len(name.encode("utf-8")) for name in file_refs) <= 143
+    assert len({name.lower() for name in file_refs}) == len(file_refs)

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -1,4 +1,5 @@
 """Tests for graphify.wiki — Wikipedia-style article generation."""
+import os
 import re
 import urllib.parse
 import pytest
@@ -62,6 +63,29 @@ def test_to_wiki_god_node_article_created(tmp_path):
     G = _make_graph()
     to_wiki(G, COMMUNITIES, tmp_path, community_labels=LABELS, god_nodes_data=GOD_NODES)
     assert (tmp_path / "parse.md").exists()
+
+
+def test_to_wiki_respects_target_filesystem_name_max(tmp_path, monkeypatch):
+    """#2109: article filenames honor a lower runtime NAME_MAX such as eCryptfs."""
+    monkeypatch.setattr(os, "pathconf", lambda _path, _name: 143)
+    long_community = "c" * 170
+    long_god = "g" * 170
+    gods = [{"id": "n1", "label": long_god, "degree": 2}]
+
+    to_wiki(
+        _make_graph(),
+        COMMUNITIES,
+        tmp_path,
+        community_labels={0: long_community, 1: "Rendering Layer"},
+        god_nodes_data=gods,
+    )
+
+    article_names = [p.name for p in tmp_path.glob("*.md")]
+    assert article_names
+    assert max(len(name.encode("utf-8")) for name in article_names) <= 143
+    for article in tmp_path.glob("*.md"):
+        for _, target in _inline_links(article.read_text()):
+            assert (tmp_path / target).exists(), (article.name, target)
 
 
 def test_index_links_all_communities(tmp_path):


### PR DESCRIPTION
Fixes #2109.

## Problem

Export filename capping assumes the conventional 255-byte `NAME_MAX`. On eCryptfs and other filesystems with a lower runtime limit (143 bytes in the report), valid 155–200 byte labels can still fail with `ENAMETOOLONG`. The wiki exporter also caps characters rather than UTF-8 bytes.

## Change

- Query `PC_NAME_MAX` once for each export target, with a portable 255-byte fallback
- Derive a conservative UTF-8 stem budget that reserves `.md`, generated prefixes, and collision suffixes
- Share deterministic byte-aware truncation across Obsidian, Canvas, and wiki exports
- Preserve the existing 200-byte behavior on conventional filesystems

## Regression coverage

The new tests simulate `NAME_MAX=143`. Before the fix, generated components measured 184 bytes for Obsidian and 173 bytes for Canvas/wiki. They now verify:

- every generated component is at most 143 bytes
- duplicate long labels remain case-insensitively unique
- truncated wiki links still resolve to files on disk

## Validation

- Python 3.10: `3611 passed, 3 skipped`
- Python 3.12: `3611 passed, 3 skipped`
- Focused export/wiki suite: `88 passed`
- All five `tools.skillgen` integrity checks pass
- Ruff passes on all changed files
- `graphify update .` completed: 11,968 nodes / 21,176 edges

The reporter offered to verify on real eCryptfs hardware; the regression uses a controlled `pathconf` result because the local filesystem reports the conventional limit.