### PR TITLE
fix(dedup): preserve a same-ID loser's disjoint attributes instead of dropping them (#2091)

### DIFF
--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -326,14 +326,22 @@ def deduplicate_entities(
             continue
         incumbent = seen_ids.get(nid)
         if incumbent is None:
-            seen_ids[nid] = node
+            seen_ids[nid] = dict(node)
         elif _collision_rank(node) < _collision_rank(incumbent):
             # Smallest-ranked node wins; the min over a total order is independent
             # of the order nodes arrive in, so the survivor no longer depends on
-            # chunk ordering (#1851).
-            seen_ids[nid] = node
+            # chunk ordering (#1851). The survivor's values win on conflicting keys,
+            # but the loser's disjoint attributes (an AST node's canonical label and
+            # source_location colliding with a semantic node's summary/confidence)
+            # are gap-filled rather than discarded (#2091).
+            merged = dict(node)
+            for k, v in incumbent.items():
+                merged.setdefault(k, v)
+            seen_ids[nid] = merged
             dropped[nid].append(incumbent)
         else:
+            for k, v in node.items():
+                incumbent.setdefault(k, v)
             dropped[nid].append(node)
 
     for nid, losers in dropped.items():

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -513,6 +513,30 @@ def test_same_file_relabel_is_noted(capsys):
     assert "WARNING" not in captured.err
 
 
+def test_same_id_merge_preserves_losers_disjoint_attributes():
+    """#2091: when two same-ID nodes collide, the survivor keeps its own values on
+    conflicting keys but gap-fills attributes only the loser carried. The AST node
+    wins the canonical label while the semantic node's summary/confidence_score —
+    which the user paid API credits for — must survive rather than be discarded."""
+    ast_node = {"id": "src_auth_login", "label": "login", "file_type": "code",
+                "source_file": "src/auth.py", "source_location": "L42"}
+    semantic_node = {"id": "src_auth_login", "label": "User login handler",
+                     "file_type": "code", "source_file": "src/auth.py",
+                     "summary": "Authenticates a user.", "confidence_score": 0.9}
+
+    result_nodes, _ = deduplicate_entities(
+        [ast_node, semantic_node], [], communities={})
+
+    assert len(result_nodes) == 1
+    survivor = result_nodes[0]
+    # Survivor wins conflicting keys (shorter, more canonical label).
+    assert survivor["label"] == "login"
+    assert survivor.get("source_location") == "L42"
+    # ...but the loser's disjoint attributes are gap-filled, not dropped.
+    assert survivor.get("summary") == "Authenticates a user."
+    assert survivor.get("confidence_score") == 0.9
+
+
 def test_collision_survivor_is_order_independent():
     """#1851: definer + same-file relabel + cross-file reference. Across every
     insertion order the SAME node (source_file AND label) must survive — the


### PR DESCRIPTION
## Summary

`build()`'s docstring promises a key-wise union for same-ID nodes, but on the default extract path `deduplicate_entities()` runs first and collapses a same-ID collision by keeping one whole dict and discarding the other. Any attribute the loser carried and the survivor did not — `summary`, `confidence_score` — is gone before NetworkX ever performs the union.

This is exactly the AST↔semantic reconciliation the pipeline exists for: `_semantic_id_remap` forces the AST node and the LLM node onto the same ID so they merge, and the merge then throws away the LLM's contribution the user paid API credits for. The loss is silent — the only output is a `note:` about the *label*, which never mentions that `summary`/`confidence_score` were dropped. `dedup=True` is hard-coded on the CLI path, so this is every `graphify extract` run with a semantic pass.

## Fix

`graphify/dedup.py` — the survivor still wins conflicting keys (so `_collision_rank` ordering and the collision reporting that reads the survivor's own `label`/`source_file` are unchanged), but the loser's *disjoint* keys are now gap-filled via `setdefault` rather than discarded. Storing `dict(node)` for each survivor also stops the caller's input node dicts from being mutated in place.

## Reproduction (from the issue), after the fix

```
dedup=False label='User login handler'   summary='Authenticates a user.' score=0.9
dedup=True  label='login'                summary='Authenticates a user.' score=0.9
```

`dedup=True` now yields at least the attribute set `dedup=False` yields, with the survivor's values winning on genuine conflicts (`label='login'`). Previously `dedup=True` returned `summary=None score=None`.

## Test

`tests/test_dedup.py::test_same_id_merge_preserves_losers_disjoint_attributes` — a same-ID AST/semantic pair with disjoint attributes; asserts the survivor keeps its own `label`/`source_location` on conflicts **and** gap-fills the loser's `summary`/`confidence_score`. Written test-first (failed on `None`, passes after the fix). Full `tests/test_dedup.py` suite green (45 passed); `test_build.py`, `test_semantic_id_remap_root.py`, and `test_export.py` unaffected.

Closes #2091