### PR TITLE
docs(agent): optimize agent prompt template and fix non-existent wiki reference

### DIFF
--- a/graphify/always_on/agents-md.md
+++ b/graphify/always_on/agents-md.md
@@ -1,12 +1,15 @@
 ## graphify
 
-This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+This project has a knowledge graph at `graphify-out/` with project structure, symbol relationships, community analysis, and cross-file dependencies.
 
-When the user types `/graphify`, use the installed graphify skill or instructions before doing anything else.
+When the user types `/graphify`, use the installed Graphify skill or instructions before doing anything else.
 
 Rules:
-- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
-- Dirty graphify-out/ files are expected after hooks or incremental updates; dirty graph files are not a reason to skip graphify. Only skip graphify if the task is about stale or incorrect graph output, or the user explicitly says not to use it.
-- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
-- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
-- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+- For codebase questions, first run `graphify query "<question>"` when `graphify-out/graph.json` exists. Only fall back to source search if Graphify cannot answer or the requested information is outside the indexed graph.
+- Prefer Graphify over full-project searches whenever possible. Use source code browsing only to inspect implementation details after Graphify has identified the relevant files or symbols.
+- Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than `GRAPH_REPORT.md` or raw grep output.
+- Dirty `graphify-out/` files are expected after hooks or incremental updates; dirty graph files are not a reason to skip Graphify. Only skip Graphify if the task is about stale or incorrect graph output, or the user explicitly says not to use it.
+- Read `graphify-out/GRAPH_REPORT.md` for broad architecture review or when `graphify query`, `graphify path`, or `graphify explain` do not surface enough context.
+- Use `graphify-out/graph.html` only when an interactive visualization is explicitly needed; do not rely on it for automated reasoning.
+- If `graphify-out/graph.json` does not exist, assume the knowledge graph has not been generated yet. Inspect the source normally or ask the user to run `graphify update .`.
+- After modifying code that changes project structure, symbols, modules, or relationships, run `graphify update .` to keep the graph current (AST-only, no API cost). Minor changes such as comments, formatting, or documentation generally do not require updating the graph.


### PR DESCRIPTION
### Description
This PR refines and optimizes the system prompt template for AI coding agents (`agents.md`). The current implementation assumes a `graphify-out/wiki/index.md` directory for broad navigation, which is not generated by default in the current output structure. 

This update aligns the agent's behavior with the actual files generated (`graph.json`, `GRAPH_REPORT.md`, and `graph.html`) and provides clearer operational heuristics for the agent.

### Key Changes
* **Removed Stale Reference:** Eliminated the fallback rule for `graphify-out/wiki/index.md` since it doesn't exist by default.
* **Optimized Fallback & Search Logic:** Explicitly instructed the agent to prioritize Graphify queries (`query`, `path`, `explain`) over full-project text searches, falling back to source code browsing only when fine-grained implementation details are needed.
* **Architecture Review Guidance:** Redirected the agent to leverage `GRAPH_REPORT.md` effectively when broader context is missing.
* **Added Visual Graph Heuristics:** Defined the use case for `graphify-out/graph.html` (interactive visualization only, not for automated reasoning).
* **Missing Index Handling:** Added a rule telling the agent what to do if `graph.json` does not exist yet (inspect source normally or prompt the user to run update).
* **Smart Update Hook:** Specified that `graphify update .` is only necessary for functional structural changes (symbols, modules), saving resources on minor format/comment updates.

### Impact
These updates prevent AI agents (like OpenCode, Cline, or Roo Code) from wasting tokens and context windows looking for non-existent directories, resulting in faster and more accurate codebase analysis.