### PR TITLE
fix(hooks): accept Windows backslash paths in interpreter allowlist (#2126)

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -41,7 +41,7 @@ if [ -z "$GRAPHIFY_PYTHON" ]; then
     if [ -f "$_GFY_PYTHON_FILE" ]; then
         _FROM_FILE=$(cat "$_GFY_PYTHON_FILE" 2>/dev/null | tr -d '[:space:]')
         case "$_FROM_FILE" in
-            *[!a-zA-Z0-9/_.@:\\-]*) _FROM_FILE="" ;;  # allowlist (covers Windows paths)
+            *[!a-zA-Z0-9/_.@:\\\\-]*) _FROM_FILE="" ;;  # allowlist (covers Windows paths)
         esac
         if [ -n "$_FROM_FILE" ] && [ -x "$_FROM_FILE" ] && "$_FROM_FILE" -c "$_GFY_PROBE" 2>/dev/null; then
             GRAPHIFY_PYTHON="$_FROM_FILE"
@@ -79,7 +79,7 @@ if [ -z "$GRAPHIFY_PYTHON" ]; then
         # Allowlist: only keep characters valid in a filesystem path to prevent
         # injection if the shebang contains shell metacharacters.
         case "$GRAPHIFY_PYTHON" in
-            *[!a-zA-Z0-9/_.@-]*) GRAPHIFY_PYTHON="" ;;
+            *[!a-zA-Z0-9/_.@:\\\\-]*) GRAPHIFY_PYTHON="" ;;
         esac
         if [ -n "$GRAPHIFY_PYTHON" ] && ! "$GRAPHIFY_PYTHON" -c "$_GFY_PROBE" 2>/dev/null; then
             GRAPHIFY_PYTHON=""

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -425,6 +425,63 @@ def test_probe_prefers_sibling_python_exe_on_windows_layouts():
     assert "/python.exe" in _PYTHON_DETECT
 
 
+def _extract_case_pattern(marker: str) -> str:
+    """Pull the `*[!...]*` glob portion of a real case arm out of _PYTHON_DETECT
+    by a unique anchor, so tests run against the emitted text, not a copy."""
+    from graphify.hooks import _PYTHON_DETECT
+    for line in _PYTHON_DETECT.splitlines():
+        if marker in line:
+            return line.strip().split(")")[0]
+    raise AssertionError(f"case arm containing {marker!r} not found in _PYTHON_DETECT")
+
+
+def _shell_verdict(pattern: str, candidate: str) -> str:
+    result = subprocess.run(
+        ["bash", "-c", f'case "$1" in\n{pattern}) echo REJECTED ;;\n*) echo ACCEPTED ;;\nesac', "_", candidate],
+        capture_output=True, text=True,
+    )
+    return result.stdout.strip()
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash required to exercise emitted glob")
+@pytest.mark.parametrize("winpath", [
+    r"C:\Users\u\.venv\Scripts\python.exe",
+    r"C:\Python311\python.exe",
+])
+def test_file_path_allowlist_accepts_windows_backslash_path(winpath):
+    """#2126: the .graphify_python FILE allowlist must accept real Windows paths
+    at actual shell runtime. Old pattern rejected them due to bash bracket-escape."""
+    pattern = _extract_case_pattern('_FROM_FILE=""')
+    assert _shell_verdict(pattern, winpath) == "ACCEPTED", (
+        f"Windows path {winpath!r} rejected by file-path allowlist at shell runtime"
+    )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash required to exercise emitted glob")
+@pytest.mark.parametrize("shebang_path", [
+    r"C:\Users\u\.venv\Scripts\python.exe",
+])
+def test_shebang_allowlist_accepts_windows_backslash_path(shebang_path):
+    """#2126: the shebang-parsed launcher allowlist had no `:` or `\\` at all, so
+    any Windows-style shebang path was unconditionally emptied. Must ACCEPT now."""
+    pattern = _extract_case_pattern('GRAPHIFY_PYTHON="" ;;')
+    assert _shell_verdict(pattern, shebang_path) == "ACCEPTED", (
+        f"Windows shebang path {shebang_path!r} rejected by launcher allowlist"
+    )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash required to exercise emitted glob")
+@pytest.mark.parametrize("dangerous", ["foo;rm -rf /", "foo`id`", "foo$(id)", "foo$IFS"])
+def test_python_detect_allowlists_still_reject_shell_metacharacters(dangerous):
+    """Guard against a naive fix (backslash right before `]`) that forms a
+    `:`-to-`\\` range admitting `;`, backtick, `$`. Both allowlists must reject."""
+    for marker in ('_FROM_FILE=""', 'GRAPHIFY_PYTHON="" ;;'):
+        pattern = _extract_case_pattern(marker)
+        assert _shell_verdict(pattern, dangerous) == "REJECTED", (
+            f"{marker} allowlist wrongly accepted dangerous input {dangerous!r}"
+        )
+
+
 @pytest.mark.parametrize("name,script", _HOOK_SCRIPTS)
 def test_hooks_reuse_git_dir_from_env(name, script):
     """git exports GIT_DIR to hooks, so the rev-parse fallback should only run

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -440,6 +440,11 @@ def _shell_verdict(pattern: str, candidate: str) -> str:
         ["bash", "-c", f'case "$1" in\n{pattern}) echo REJECTED ;;\n*) echo ACCEPTED ;;\nesac', "_", candidate],
         capture_output=True, text=True,
     )
+    # Fail loudly on a malformed case snippet instead of returning "" and
+    # producing a confusing ACCEPTED/REJECTED mismatch downstream.
+    assert result.returncode == 0, (
+        f"bash exited {result.returncode} for pattern {pattern!r}: {result.stderr.strip()}"
+    )
     return result.stdout.strip()
 
 


### PR DESCRIPTION
Fixes #2126.

## Problem
The post-commit/post-checkout hook's Python-interpreter allowlist silently rejected valid Windows paths (e.g. `C:\Users\...\python.exe`) on Git-Bash, so the hook fell through to `[graphify hook] could not locate a Python...` on every commit and the background rebuild never ran.

Root cause is a regex-dialect mismatch. In `_PYTHON_DETECT` the emitted POSIX-shell glob was `[!a-zA-Z0-9/_.@:\-]`. bash (and dash) treat a lone `\` inside a bracket expression as an escape character that consumes itself, so `\` is never actually a set member and any backslash-containing path is rejected. The pattern looks correct in the Python `re` dialect used at install time, which is why it passed review.

## Fix
Both interpreter-detection allowlists now emit `[!a-zA-Z0-9/_.@:\\-]` (two literal backslashes, hyphen last):

- **`.graphify_python` file path** (the one the issue names): backslash was being escaped away.
- **shebang-parsed launcher path**: this class additionally had no `:` or `\` at all, so any Windows-style shebang path was unconditionally emptied. Brought in line with the file-path allowlist so there is a single pattern to audit.

The doubled-backslash form was verified against real bash 3.2 and dash: it accepts `C:\...\python.exe` and still rejects `;`, `` ` ``, `$`, `$(...)`. I deliberately avoided the "backslash immediately before `]`" ordering, which forms a `:`-to-`\` character range that silently admits shell metacharacters (command injection). The install-time `_pinned_python()` regex is a raw Python string with correct `re` escaping and is left untouched.

## Tests
Added shell-runtime tests to `tests/test_hooks.py` that extract the real emitted `case`/`esac` glob from `_PYTHON_DETECT` and execute it through `bash` (a source-string assertion would not have caught this shell-semantics bug, which is exactly the gap that let it ship):

- Windows backslash paths are ACCEPTED by both allowlists.
- Shell metacharacters (`;`, backtick, `$(...)`, `$IFS`) are REJECTED by both allowlists (regression guard against the injection-prone ordering).

These fail against the pre-fix patterns and pass after. They are guarded with `skipif(shutil.which("bash") is None)` so they skip cleanly where bash is unavailable.