### PR TITLE
feat(wiki): preserve hand-authored custom pages across export

### DIFF
--- a/graphify/wiki.py
+++ b/graphify/wiki.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections import Counter
 from pathlib import Path
 from urllib.parse import quote
+import json
 import networkx as nx
 
 from graphify.build import edge_data
@@ -166,6 +167,18 @@ def _god_node_article(G: nx.Graph, nid: str, labels: dict[int, str], node_commun
     return "\n".join(lines)
 
 
+def _custom_title(path: Path) -> str:
+    """Link title for a preserved custom page: its first markdown H1, else a
+    de-slugged filename."""
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("# "):
+                return line[2:].strip()
+    except Exception:
+        pass
+    return path.stem.replace("-", " ").replace("_", " ").title()
+
+
 def _index_md(
     communities: dict[int, list[str]],
     labels: dict[int, str],
@@ -173,6 +186,7 @@ def _index_md(
     total_nodes: int,
     total_edges: int,
     resolver: dict[str, str] | None = None,
+    custom_pages: list[tuple[str, str]] | None = None,
 ) -> str:
     resolver = resolver or {}
     lines: list[str] = [
@@ -198,6 +212,12 @@ def _index_md(
         lines += ["## God Nodes", "(most connected concepts — the load-bearing abstractions)", ""]
         for node in god_nodes_data:
             lines.append(f"- {_md_link(node['label'], resolver)} — {node['degree']} connections")
+        lines.append("")
+
+    if custom_pages:
+        lines += ["## Custom Pages", "(hand-authored — preserved across `graphify export wiki`)", ""]
+        for title, fname in custom_pages:
+            lines.append(f"- [{title}]({fname})")
         lines.append("")
 
     lines += [
@@ -257,14 +277,9 @@ def to_wiki(
             "Re-run `graphify extract .` to regenerate .graphify_analysis.json."
         )
 
-    # Clear stale .md files from previous runs to prevent orphan accumulation.
-    # Community labels are LLM-generated (per skill.md Step 5) and non-deterministic
-    # across runs — the same conceptual community may be named differently each time
-    # (e.g. "AutoAgent Skills" → "AutoAgent Methodology"), leaving the previous file
-    # as an orphan. Since to_wiki() owns wiki/ entirely (always writes the full set),
-    # it can safely clear .md files at the start of each call.
-    for old_article in out.glob("*.md"):
-        old_article.unlink()
+    # Orphan cleanup happens AFTER slug computation (see below), via a manifest of
+    # our own prior output — so hand-authored custom pages graphify never wrote are
+    # preserved across re-export instead of being deleted every run.
 
     labels = community_labels or {cid: f"Community {cid}" for cid in communities}
     cohesion = cohesion or {}
@@ -316,6 +331,34 @@ def to_wiki(
             god_articles.append((nid, slug))
             resolver.setdefault(node_data['label'], slug)
 
+    # Clean up only OUR OWN prior output; preserve hand-authored custom pages.
+    # to_wiki historically nuked every *.md, deleting user-added pages. Instead we
+    # track what we generate in a manifest and delete only orphaned past output
+    # (files we generated last run but not this run — e.g. renamed communities).
+    # Any file graphify never wrote (custom analysis pages) is left untouched.
+    generated = {f"{s}.md" for s in community_slugs.values()}
+    generated |= {f"{slug}.md" for _nid, slug in god_articles}
+    generated.add("index.md")
+    _manifest = out / ".graphify_wiki_files.json"
+    _prev: set[str] = set()
+    if _manifest.exists():
+        try:
+            _prev = set(json.loads(_manifest.read_text(encoding="utf-8")))
+        except Exception:
+            _prev = set()
+    # No manifest yet (first run after this feature landed): delete nothing so
+    # existing custom pages survive the migration. Orphans self-heal next run.
+    for _stale in _prev - generated:
+        _p = out / _stale
+        if _p.exists():
+            _p.unlink()
+    # Custom pages = whatever remains on disk that we neither generate nor tracked.
+    custom_pages: list[tuple[str, str]] = []
+    for _p in sorted(out.glob("*.md")):
+        if _p.name in generated:
+            continue
+        custom_pages.append((_custom_title(_p), _p.name))
+
     # Second pass: render and write each article with the full resolver in hand.
     for cid, nodes in communities.items():
         label = labels.get(cid, f"Community {cid}")
@@ -330,8 +373,11 @@ def to_wiki(
 
     # Index
     (out / "index.md").write_text(
-        _index_md(communities, labels, god_nodes_data, G.number_of_nodes(), G.number_of_edges(), resolver),
+        _index_md(communities, labels, god_nodes_data, G.number_of_nodes(), G.number_of_edges(), resolver, custom_pages),
         encoding="utf-8",
     )
+
+    # Record what we generated so the next run cleans up only its own orphans.
+    _manifest.write_text(json.dumps(sorted(generated)), encoding="utf-8")
 
     return count

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -389,3 +389,58 @@ def test_wiki_links_use_collision_suffixed_slug(tmp_path):
     assert "parser_2.md" in index_targets  # link points at the suffixed file...
     for t in index_targets:
         assert (tmp_path / t).exists(), t  # ...and every target is a real file
+
+
+# Custom-page preservation - to_wiki must not delete hand-authored pages it never
+# generated, and must surface them from the index so they stay reachable.
+
+def test_to_wiki_preserves_custom_pages(tmp_path):
+    """A hand-authored .md that to_wiki did not generate must survive re-export
+    (previously every *.md was deleted at the start of each run)."""
+    custom = tmp_path / "my-analysis.md"
+    custom.write_text("# My Analysis\n\nHand-written.\n", encoding="utf-8")
+    to_wiki(_make_graph(), COMMUNITIES, tmp_path, community_labels=LABELS)
+    assert custom.exists()
+    assert custom.read_text(encoding="utf-8").startswith("# My Analysis")
+
+
+def test_index_lists_custom_pages_by_h1(tmp_path):
+    """Preserved custom pages are linked from index.md under a Custom Pages
+    section, titled by their first markdown H1."""
+    (tmp_path / "my-analysis.md").write_text("# Deep Dive\n\nx\n", encoding="utf-8")
+    to_wiki(_make_graph(), COMMUNITIES, tmp_path, community_labels=LABELS)
+    index = (tmp_path / "index.md").read_text(encoding="utf-8")
+    assert "## Custom Pages" in index
+    assert "[Deep Dive](my-analysis.md)" in index
+
+
+def test_to_wiki_removes_only_its_own_orphans(tmp_path):
+    """Re-export after a community is relabeled deletes the old (orphaned)
+    generated article, but leaves a custom page untouched."""
+    (tmp_path / "keep-me.md").write_text("# Keep Me\n", encoding="utf-8")
+    to_wiki(_make_graph(), {0: ["n1", "n2"]}, tmp_path, community_labels={0: "Alpha"})
+    assert (tmp_path / "Alpha.md").exists()
+    # relabel the same community - Alpha.md is now an orphan of our own making
+    to_wiki(_make_graph(), {0: ["n1", "n2"]}, tmp_path, community_labels={0: "Beta"})
+    assert (tmp_path / "Beta.md").exists()
+    assert not (tmp_path / "Alpha.md").exists()   # our orphan cleaned up
+    assert (tmp_path / "keep-me.md").exists()      # custom page preserved
+
+
+def test_to_wiki_writes_manifest(tmp_path):
+    """to_wiki records the files it generated so the next run can scope cleanup."""
+    to_wiki(_make_graph(), COMMUNITIES, tmp_path, community_labels=LABELS, god_nodes_data=GOD_NODES)
+    manifest = tmp_path / ".graphify_wiki_files.json"
+    assert manifest.exists()
+    import json
+    names = set(json.loads(manifest.read_text(encoding="utf-8")))
+    assert "index.md" in names
+    assert "Parsing_Layer.md" in names
+
+
+def test_custom_page_without_h1_falls_back_to_filename(tmp_path):
+    """A custom page with no H1 is still linked, titled by a de-slugged filename."""
+    (tmp_path / "raw_notes.md").write_text("just text, no heading\n", encoding="utf-8")
+    to_wiki(_make_graph(), COMMUNITIES, tmp_path, community_labels=LABELS)
+    index = (tmp_path / "index.md").read_text(encoding="utf-8")
+    assert "[Raw Notes](raw_notes.md)" in index


### PR DESCRIPTION
## Problem

`graphify export wiki` deletes **every** `wiki/*.md` at the start of each run:

```python
for old_article in out.glob("*.md"):
    old_article.unlink()
```

This exists to clear orphaned community articles (LLM-generated labels are non-deterministic, so a renamed community would otherwise leave its old file behind). But it also deletes **any page a user added by hand** — custom analysis, notes, topology deep-dives — with no way to keep them. Re-running the export silently wipes them, and there's no opt-out.

## Fix

`to_wiki` now tracks the files it generates in a `.graphify_wiki_files.json` manifest and, on re-export, deletes **only its own prior output** (files it generated last run but not this run — e.g. renamed communities). Any file graphify never wrote is left untouched.

Preserved pages are also auto-listed in a **Custom Pages** section of `index.md`, titled by their first markdown `# H1` (falling back to a de-slugged filename), so they stay reachable from the agent entry point instead of becoming orphans.

**Migration safety:** the first run after upgrade has no manifest, so it deletes nothing — existing custom pages survive. Self-generated orphans are cleaned up from the next run onward.

## Behavior

- Community/god-node articles regenerate exactly as before (byte-identical on an unchanged graph).
- A hand-authored `my-analysis.md` now survives re-export and appears under `## Custom Pages` in the index.
- Renaming a community still removes its stale article (verified by test).

## Tests

Adds 5 tests to `tests/test_wiki.py`:
- `test_to_wiki_preserves_custom_pages`
- `test_index_lists_custom_pages_by_h1`
- `test_to_wiki_removes_only_its_own_orphans`
- `test_to_wiki_writes_manifest`
- `test_custom_page_without_h1_falls_back_to_filename`

`pytest tests/test_wiki.py` → **35 passed** (30 existing + 5 new).

## Notes

- `import json` moved to module level (was needed by the new manifest read/write).
- No public API change; `to_wiki`'s signature is unchanged. `_index_md` gains an optional `custom_pages` argument.
