### PR TITLE
skill: mandatory-ID gate for re-extracted docs on --update

### DIFF
--- a/graphify/skill-agents.md
+++ b/graphify/skill-agents.md
@@ -675,6 +675,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill-amp.md
+++ b/graphify/skill-amp.md
@@ -675,6 +675,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill-claw.md
+++ b/graphify/skill-claw.md
@@ -678,6 +678,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -675,6 +675,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill-copilot.md
+++ b/graphify/skill-copilot.md
@@ -678,6 +678,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill-droid.md
+++ b/graphify/skill-droid.md
@@ -675,6 +675,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill-kilo.md
+++ b/graphify/skill-kilo.md
@@ -678,6 +678,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill-kiro.md
+++ b/graphify/skill-kiro.md
@@ -678,6 +678,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -670,6 +670,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill-pi.md
+++ b/graphify/skill-pi.md
@@ -678,6 +678,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill-trae.md
+++ b/graphify/skill-trae.md
@@ -676,6 +676,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill-vscode.md
+++ b/graphify/skill-vscode.md
@@ -674,6 +674,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill-windows.md
+++ b/graphify/skill-windows.md
@@ -707,6 +707,8 @@ if (-not (Test-Path graphify-out\.graphify_python)) {
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -678,6 +678,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/graphify/skills/agents/references/update.md
+++ b/graphify/skills/agents/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/amp/references/update.md
+++ b/graphify/skills/amp/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/claude/references/update.md
+++ b/graphify/skills/claude/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/claw/references/update.md
+++ b/graphify/skills/claw/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/codex/references/update.md
+++ b/graphify/skills/codex/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/copilot/references/update.md
+++ b/graphify/skills/copilot/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/droid/references/update.md
+++ b/graphify/skills/droid/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/kilo/references/update.md
+++ b/graphify/skills/kilo/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/kiro/references/update.md
+++ b/graphify/skills/kiro/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/opencode/references/update.md
+++ b/graphify/skills/opencode/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/pi/references/update.md
+++ b/graphify/skills/pi/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/trae/references/update.md
+++ b/graphify/skills/trae/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/vscode/references/update.md
+++ b/graphify/skills/vscode/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/graphify/skills/windows/references/update.md
+++ b/graphify/skills/windows/references/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skill-agents.md
+++ b/tools/skillgen/expected/graphify__skill-agents.md
@@ -675,6 +675,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill-amp.md
+++ b/tools/skillgen/expected/graphify__skill-amp.md
@@ -675,6 +675,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill-claw.md
+++ b/tools/skillgen/expected/graphify__skill-claw.md
@@ -678,6 +678,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill-codex.md
+++ b/tools/skillgen/expected/graphify__skill-codex.md
@@ -675,6 +675,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill-copilot.md
+++ b/tools/skillgen/expected/graphify__skill-copilot.md
@@ -678,6 +678,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill-droid.md
+++ b/tools/skillgen/expected/graphify__skill-droid.md
@@ -675,6 +675,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill-kilo.md
+++ b/tools/skillgen/expected/graphify__skill-kilo.md
@@ -678,6 +678,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill-kiro.md
+++ b/tools/skillgen/expected/graphify__skill-kiro.md
@@ -678,6 +678,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill-opencode.md
+++ b/tools/skillgen/expected/graphify__skill-opencode.md
@@ -670,6 +670,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill-pi.md
+++ b/tools/skillgen/expected/graphify__skill-pi.md
@@ -678,6 +678,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill-trae.md
+++ b/tools/skillgen/expected/graphify__skill-trae.md
@@ -676,6 +676,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill-vscode.md
+++ b/tools/skillgen/expected/graphify__skill-vscode.md
@@ -674,6 +674,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill-windows.md
+++ b/tools/skillgen/expected/graphify__skill-windows.md
@@ -707,6 +707,8 @@ if (-not (Test-Path graphify-out\.graphify_python)) {
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skill.md
+++ b/tools/skillgen/expected/graphify__skill.md
@@ -678,6 +678,8 @@ fi
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/expected/graphify__skills__agents__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__agents__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__amp__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__amp__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__claude__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claude__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__claw__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claw__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__codex__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__codex__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__copilot__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__copilot__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__droid__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__droid__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__kilo__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kilo__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__kiro__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kiro__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__opencode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__opencode__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__pi__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__pi__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__trae__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__trae__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__vscode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__vscode__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/expected/graphify__skills__windows__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__windows__references__update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 

--- a/tools/skillgen/fragments/core/core.md
+++ b/tools/skillgen/fragments/core/core.md
@@ -601,6 +601,8 @@ Before running any subcommand below (`--update`, `--cluster-only`, `query`, `pat
 
 Both are non-default subcommands. `--update` re-extracts only new or changed files; `--cluster-only` reruns clustering on the existing graph. See `references/update.md` for both flows.
 
+> **Re-extracting an already-graphed doc requires the mandatory-ID gate** (`references/update.md` → "REQUIRED: mandatory-ID gate for re-extracted docs"): snapshot that file's existing node IDs, pass them to the subagent as must-include, and refuse the merge if the node count drops below 90% of baseline or any ID is missing. Semantic re-extraction is non-deterministic and drops whole sections without it.
+
 ---
 
 ## For /graphify query

--- a/tools/skillgen/fragments/references/shared/update.md
+++ b/tools/skillgen/fragments/references/shared/update.md
@@ -65,6 +65,126 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
+### REQUIRED: mandatory-ID gate for re-extracted docs
+
+Semantic re-extraction of an already-graphed doc is non-deterministic: the same file can
+yield 75 nodes on one run and 49 on the next, dropping whole sections with no error. The
+loss lands in `build_merge` and only surfaces later as a question the graph can no longer
+answer. Apply this gate to **every changed doc/paper that already has nodes in
+`graph.json`**. Do not skip it for a small edit — a one-line change re-extracts the whole
+file.
+
+**1 — Snapshot the file's existing node IDs before extracting.** First clear any
+snapshots left behind by an earlier run — **once**, before the first target of this run:
+
+```bash
+rm -f graphify-out/.graphify_must_*.json graphify-out/.graphify_must_ids_*.txt
+```
+
+Then run the snapshot **once per changed doc**. The state files are keyed by target: a
+single fixed path would let the second doc's snapshot overwrite the first's, leaving that
+file silently ungated while the gate still printed PASS.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, re
+from pathlib import Path
+TARGET = 'DOC_PATH'   # substitute: the changed doc, VERBATIM as it appears in source_file
+g = json.loads(Path('graphify-out/graph.json').read_text(encoding='utf-8'))
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+t = norm(TARGET)
+# Match source_file EXACTLY. endswith() is not anchored to a path boundary, so a bare
+# name silently adopts every same-named file deeper in the tree ('README.md' is a
+# suffix of 'workers/README.md'), inflating the baseline with IDs the subagent cannot
+# emit and failing the gate on a perfect extraction.
+exact = [n for n in g['nodes'] if norm(n.get('source_file','')) == t]
+other = sorted({norm(n.get('source_file','')) for n in g['nodes']
+                if norm(n.get('source_file','')).endswith(t) and norm(n.get('source_file','')) != t})
+if not exact and other:
+    print('AMBIGUOUS TARGET - no source_file equals %r. Candidates:' % TARGET)
+    for c in other: print('   ', c)
+    print('Re-run with one of these verbatim; do not suffix-match.')
+    raise SystemExit(1)
+if other:
+    print('NOTE: %d other file(s) end with %r - matched exactly, not by suffix.' % (len(other), TARGET))
+ids = sorted(n['id'] for n in exact)
+SLUG = re.sub(r'[^A-Za-z0-9]+', '_', TARGET).strip('_')
+Path('graphify-out/.graphify_must_ids_%s.txt' % SLUG).write_text('\n'.join(ids), encoding='utf-8')
+Path('graphify-out/.graphify_must_%s.json' % SLUG).write_text(
+    json.dumps({'target': TARGET, 'ids': ids}, ensure_ascii=False), encoding='utf-8')
+print(f'baseline: {len(ids)} existing node(s) for {TARGET}')
+"
+```
+
+A count of 0 means the file is new — skip the gate and extract normally.
+
+**2 — Pass the IDs to the subagent as mandatory.** Append to the prompt from
+`references/extraction-spec.md`:
+
+- the baseline count as an explicit target ("the prior build extracted N nodes from this
+  file; land at approximately N — under 90% of N means you under-extracted, go back and
+  cover the sections you skimmed"),
+- the full ID list verbatim, labelled **MANDATORY — every one of these existed in the
+  prior graph and MUST appear in your output, reusing the ID verbatim**,
+- an instruction to verify every mandatory ID is present *before* writing CHUNK_PATH.
+
+Reusing the IDs also suppresses gratuitous ID churn on re-extraction, which orphans saved
+queries and inflates the merge diff for no semantic gain.
+
+**3 — Hard-gate the merge.** After the chunks land and before `build_merge`, require of
+**every** snapshotted target: node count ≥ 90% of baseline, and zero mandatory IDs missing.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json, glob
+from pathlib import Path
+# Read EVERY chunk, not just _01. Step 3B splits a delta into chunks of 20-25 files (and
+# each image gets its own), so a changed doc can land in any chunk; reading only _01
+# reports a perfect extraction as a total loss. Then gate every snapshot, so a multi-doc
+# update cannot leave one of its docs unchecked.
+chunks = sorted(glob.glob('graphify-out/.graphify_chunk_*.json'))
+snaps = sorted(glob.glob('graphify-out/.graphify_must_*.json'))
+if not chunks:
+    print('GATE: FAIL - no chunk files on disk'); raise SystemExit(1)
+nodes = []
+for c in chunks:
+    nodes += json.loads(Path(c).read_text(encoding='utf-8')).get('nodes', [])
+ids = {n['id'] for n in nodes}
+def norm(p): return str(p).replace(chr(92), '/')   # chr(92) = backslash, unquotable here
+bases = [json.loads(Path(s).read_text(encoding='utf-8')) for s in snaps]
+targets = [norm(b['target']) for b in bases]
+def owner(sf):
+    # Chunk source_file is the FILE_LIST path (absolute), so anchor on a path boundary --
+    # and when two targets both match, the LONGEST wins, or every 'workers/README.md' node
+    # would also be counted against the root 'README.md'.
+    sf = norm(sf)
+    cand = [x for x in targets if sf == x or sf.endswith('/' + x)]
+    return max(cand, key=len) if cand else None
+allok = True
+for base in bases:
+    t, must = norm(base['target']), base['ids']
+    own = [n for n in nodes if owner(n.get('source_file','')) == t]
+    missing = [m for m in must if m not in ids]
+    shrunk = len(own) < 0.9 * len(must)
+    ok = not (shrunk or missing)
+    allok = allok and ok
+    print('%s: nodes=%d baseline=%d missing=%d -> %s'
+          % (base['target'], len(own), len(must), len(missing), 'PASS' if ok else 'FAIL'))
+    if shrunk: print('  SHRINK: node count below 90% of baseline')
+    if missing: print('  MISSING:', ' '.join(missing[:20]))
+print('GATE:', 'PASS' if allok else 'FAIL')
+"
+```
+
+On **FAIL**, do not merge: re-dispatch the extraction with the same mandatory list and a
+sharper completeness instruction naming the missing IDs. Two consecutive failures — stop
+and report to the user rather than merging a regressed graph.
+
+**The `to_json` shrink guard (#479) stays authoritative.** It is the backstop, not a
+nuisance. Never pass `force=True` to clear it until you have diffed the old and new node
+sets and can name why each removed node is legitimately gone (file deleted, section
+removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a
+legitimate shrink; a missing section is not.
 
 If no new files exist (only deletions), create an empty extraction so the merge step can prune:
 


### PR DESCRIPTION
## Problem

Semantic re-extraction of a doc that already has nodes in `graph.json` is non-deterministic. Running `--update` twice on the same large project `CLAUDE.md` — changed by one line between runs — returned **75 nodes on one run and 49 on the next**, silently dropping an entire documented section.

Nothing errored. The loss went straight into `build_merge` and would only have surfaced much later as a question the graph could no longer answer. It was caught solely because the `to_json` shrink guard (#479) refused the write.

The failure mode is quiet by construction: the extraction "succeeds", the chunk is valid JSON, and the merge is happy. Only a node-count comparison against the prior build reveals it.

## Fix

Adds a required three-step gate to the `--update` flow, applied to any changed doc/paper that already has nodes in the graph:

1. **Snapshot** that file's existing node IDs from `graph.json` before extracting.
2. **Pass them to the subagent as mandatory must-include IDs**, with the baseline node count as an explicit target ("the prior build extracted N nodes; land at ~N — under 90% means you under-extracted").
3. **Hard-gate the merge** — refuse unless node count ≥ 90% of baseline *and* zero mandatory IDs are missing. On failure, re-dispatch naming the missing IDs; two consecutive failures stop and report rather than merging a regression.

It also restates that the shrink guard is the authoritative backstop: never `force=True` past it without diffing the old and new node sets and being able to name why each removed node is legitimately gone (file deleted, section removed, ID renamed with a verified replacement). ID churn on a re-extracted file is a legitimate shrink; a missing section is not.

Reusing the prior IDs has a second benefit beyond completeness: it suppresses gratuitous ID churn on re-extraction (`claude_weather_proxy_worker` → `claude_workers_weather_proxy`), which orphans saved queries and inflates the merge diff for no semantic gain.

## Relationship to #3203 / 0.9.53

0.9.53 ships a per-source, count-level guard on the `graphify extract` path. `build_merge` now flags any re-extracted source whose semantic node count strictly drops, and the extract CLI arms the shrink guard on that flag: the write is refused and the file's manifest stamp is withheld, so the file re-dispatches on the next run. I re-ran my #3203 repro against 0.9.53 and it does exactly that ([verification comment](https://github.com/Graphify-Labs/graphify/issues/3203#issuecomment-5479876567)).

So what this gate still covers is the residual, and there are two parts to it:

**1. The default skill `--update` path.** Only `graphify extract` acts on the new flag (`_handle_unverified_semantic_shrink` in `cli.py`). The skill's `--update` flow calls `build_merge` directly (`tools/skillgen/fragments/references/shared/update.md`) and never reads the flag. That call also passes no `dedup`, so #2497's identity diff is skipped on this path too (it is gated `if had_graph and not dedup:` in `build.py`). On a skill `--update`, an under-extracted doc is at best caught afterwards, by the whole-graph `to_json` count check (#479). That check can tell you something shrank, but not what, and it can't see the loss at all when growth elsewhere in the same run offsets it.

**2. The count-neutral identity shape.** When a re-extract returns the same number of nodes for a file under new IDs, a per-source count check passes it by construction. Upstream's own `test_build_merge_equal_count_different_ids_not_flagged` marks that shape as by design. On 0.9.53 it still writes: exit 0, 22 → 22 nodes, and the same 9 edges dropped as in the original repro. The mandatory-ID gate compares identity rather than count, so on the skill path that shape gets re-dispatched instead of merged.

In short, 0.9.53 guards strict shrinks on `graphify extract`. This gate covers the skill `--update` path, where that guard doesn't arm, and the count-neutral shape, which no count check can see.

## Evidence

- The 75 → 49 collapse above, caught only by the shrink guard.
- After adopting the gate: **three consecutive regression-free doc updates** on the same project.
- First run with the gate codified: **111/111 mandatory IDs present, node count held exactly**, merge clean, health check clean.
- A second, worse collapse (−26 nodes, dropping an entire documented API-contract section) was caught by the gate before merge and fixed by re-dispatching with the ID list — the graph never regressed.

## Scope

Markdown only — no code or CLI changes.

- Hand-edited: `tools/skillgen/fragments/references/shared/update.md` (the gate) and `tools/skillgen/fragments/core/core.md` (a pointer from the `--update` section).
- Everything else in the diff is regenerated via `python -m tools.skillgen` + `--bless`.

All five skillgen guards pass locally: `--check`, `--audit-coverage`, `--schema-singleton`, `--monolith-roundtrip`, `--always-on-roundtrip`.

## Note on CI

`tests/test_labeling.py::test_label_communities_batches_when_over_batch_size` may show red. It is **pre-existing and unrelated to this PR** — re-confirmed on an unmodified `v8` checkout at 50556ba, where it reproduces with:

```
pytest tests/test_skillgen.py tests/test_labeling.py
```

Cause: `label_communities` runs batches in a thread pool (`graphify/llm.py`, `workers = max(1, min(max_concurrency, n_batches))`), and for `backend="gemini"` concurrency stays > 1. The test appends to `calls` from inside the worker, so it records *completion* order but asserts *dispatch* order (`[100, 100, 50]`); under a different thread schedule it observes `[100, 50, 100]`. It passes when its file runs alone, which is why it usually goes unnoticed.

Happy to split that into its own issue/PR if useful — I left it untouched here to keep this diff to instructions only.


