### PR TITLE
fix: document the Codex PreToolUse hook as an intentional no-op

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ This writes a small config file that tells your assistant to consult the knowled
 
 **CodeBuddy** does the same two things as Claude Code: writes a `CODEBUDDY.md` section telling CodeBuddy to read `graphify-out/GRAPH_REPORT.md` before answering architecture questions, and installs `PreToolUse` hooks (`.codebuddy/settings.json`) that fire before Bash search commands and file reads, nudging toward `graphify query` instead.
 
-**Codex** writes to `AGENTS.md` and also installs a `PreToolUse` hook in `.codex/hooks.json` that fires before every Bash tool call, same always-on mechanism as Claude Code.
+**Codex** writes to `AGENTS.md`, which is what actually carries the always-on graph guidance on this platform. `graphify codex install` also registers a `PreToolUse` hook in `.codex/hooks.json` (`graphify hook-check`), but that entry is deliberately a **no-op**: Codex Desktop rejects `hookSpecificOutput.additionalContext` on `PreToolUse`, so emitting a nudge there would break Bash tool calls. Unlike Claude Code — where the hook (`graphify hook-guard`) does the nudging — on Codex the hook fires and intentionally does nothing, and `AGENTS.md` is the always-on mechanism.
 
 **Kilo Code** installs the Graphify skill to `~/.config/kilo/skills/graphify/SKILL.md` and a native `/graphify` command to `~/.config/kilo/command/graphify.md`. `graphify kilo install` also writes `AGENTS.md` plus a native `tool.execute.before` plugin (`.kilo/plugins/graphify.js` + `.kilo/kilo.json` or `.kilo/kilo.jsonc` registration) so Kilo gets the same always-on graph reminder behavior through native `.kilo` config.
 

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -1388,7 +1388,11 @@ def _install_codex_hook(project_dir: Path) -> None:
     existing["hooks"]["PreToolUse"] = [h for h in pre_tool if "graphify" not in str(h)]
     existing["hooks"]["PreToolUse"].extend(hook_entry["hooks"]["PreToolUse"])
     hooks_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
-    print(f"  .codex/hooks.json  ->  PreToolUse hook registered ({graphify_exe} hook-check)")
+    print(
+        f"  .codex/hooks.json  ->  PreToolUse hook registered ({graphify_exe} hook-check"
+        " - intentional no-op; Codex Desktop rejects additionalContext on PreToolUse,"
+        " so graph guidance comes from AGENTS.md)"
+    )
 def _uninstall_codex_hook(project_dir: Path) -> None:
     """Remove graphify PreToolUse hook from .codex/hooks.json."""
     hooks_path = project_dir / ".codex" / "hooks.json"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1116,3 +1116,59 @@ def test_hermes_skill_destination_posix_uses_home():
     with patch("graphify.__main__.platform.system", return_value="Linux"):
         dst = _platform_skill_destination("hermes", project=False)
     assert str(dst).endswith(".hermes/skills/graphify/SKILL.md"), dst
+
+
+def _cli_dispatched_commands() -> set[str]:
+    """Subcommand names the CLI actually dispatches.
+
+    `graphify`'s dispatcher is an `elif cmd == "..."` chain rather than a declarative
+    table, so the set is read back out of the source. Used to prove a hook command
+    written by an installer is not a stale/renamed subcommand (#2165).
+    """
+    import re
+    from graphify import cli
+
+    source = Path(cli.__file__).read_text(encoding="utf-8")
+    names = set(re.findall(r'cmd\s*==\s*"([a-z0-9][a-z0-9-]*)"', source))
+    names |= {
+        m
+        for group in re.findall(r'cmd\s+in\s+\(([^)]*)\)', source)
+        for m in re.findall(r'"([a-z0-9][a-z0-9-]*)"', group)
+    }
+    return names
+
+
+def test_codex_hook_command_is_a_real_cli_subcommand(tmp_path):
+    """#2165: the PreToolUse command in .codex/hooks.json must be a command the CLI
+    dispatches, so a renamed subcommand can never leave a permanently dead hook.
+
+    `hook-check` is intentionally a no-op on Codex (Codex Desktop rejects
+    additionalContext on PreToolUse), but it must still be a *recognized* command --
+    an unrecognized one exits non-zero and would break every Bash tool call.
+    """
+    import json
+
+    from graphify.install import _install_codex_hook
+
+    _install_codex_hook(tmp_path)
+    hooks = json.loads((tmp_path / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+
+    entries = [
+        h
+        for group in hooks["hooks"]["PreToolUse"]
+        for h in group["hooks"]
+        if "graphify" in h.get("command", "")
+    ]
+    assert entries, "codex install must register a graphify PreToolUse hook"
+
+    dispatched = _cli_dispatched_commands()
+    assert "hook-check" in dispatched, "sanity: parser must find known commands"
+
+    for entry in entries:
+        # command is "<abs exe path> <subcommand> [args...]"
+        parts = entry["command"].split()
+        subcommand = parts[1] if len(parts) > 1 else ""
+        assert subcommand in dispatched, (
+            f"codex hook registers {subcommand!r}, which the CLI does not dispatch "
+            f"(#2165). Known commands: {sorted(dispatched)}"
+        )


### PR DESCRIPTION
Fixes #2165

## What I found (the report's diagnosis is not quite right)

`hook-check` **is** a real command, and its no-op behavior is deliberate — not a stale
subcommand falling through. Verified against `v8` (0.9.26):

- `graphify/cli.py` dispatches it explicitly, with the reason inline:
  *"Codex Desktop rejects hookSpecificOutput.additionalContext on PreToolUse. Keep this as a
  cross-platform no-op so installed hooks never break Bash tool calls. Graph guidance reaches
  the agent via AGENTS.md / skill instead."*
- `graphify/__main__.py` lists `hook-check` in `_silent_cmds` ("runs on every editor tool use
  and must be silent"), and CHANGELOG has a past fix specifically for its silence.
- `__main__.py` also states the split directly: *"Claude Code accepts additionalContext on
  PreToolUse (Codex Desktop does not — that path stays a no-op via `hook-check`)."*

Two of the report's other points also don't reproduce on 0.9.26:

```console
$ graphify totally-bogus-subcommand
error: unknown command 'totally-bogus-subcommand'
Run 'graphify --help' for usage.
$ echo $?      # -> 1
```

So an unrecognized subcommand **already** exits non-zero; `hook-check` returning instantly
with exit 0 is it working as designed, not falling through. And because
`hook-check` never reads stdin, it can't hang the way `hook-guard` does — so the missing
`timeout` field isn't a hazard on this entry.

**I therefore did not repoint the Codex installer at `hook-guard`.** That's what the issue
suggests, but `hook-guard` emits `additionalContext`, which is exactly what Codex Desktop
rejects — it would reintroduce the #522-class breakage this no-op exists to avoid.

## The real problem: the docs and the installer over-promise

What legitimately misleads users (and produced this report) is that both the README and the
installer's own output describe the Codex hook as if it enforced graph usage:

- **README** claimed the Codex hook "fires before every Bash tool call, same always-on
  mechanism as Claude Code" — it is not the same mechanism; on Codex the hook is inert and
  `AGENTS.md` does the work. Now stated accurately, with the reason.
- **`_install_codex_hook`** printed `PreToolUse hook registered (... hook-check)` with no hint
  the entry is intentionally inert. It now says so.

## Plus the guard the issue implicitly asks for

New test `test_codex_hook_command_is_a_real_cli_subcommand` reads the command back out of the
generated `.codex/hooks.json` and asserts its subcommand is one the CLI actually dispatches.
If a hook command is ever renamed out from under an installer, the suite fails instead of
shipping a permanently dead hook.

Verified it actually catches that (temporarily pointed the installer at `hook-check-BOGUS`):

```
E   AssertionError: codex hook registers 'hook-check-BOGUS', which the CLI does not dispatch
    (#2165). Known commands: ['add', 'affected', ..., 'hook', 'hook-check', 'hook-guard', ...]
```

## Testing

```console
$ uv run pytest tests/test_install.py::test_codex_hook_command_is_a_real_cli_subcommand -q
1 passed, 1 warning in 0.46s

$ uv run pytest tests/test_install.py tests/test_install_references.py tests/test_install_roundtrip.py tests/test_hooks.py -q
12 failed, 207 passed, 1 skipped, 1 warning in 24.09s

$ uv run ruff check --config pyproject.toml graphify/install.py tests/test_install.py
All checks passed!

$ uv run python -m tools.skillgen --check
check OK: 134 artifact(s) match committed output and expected/.
```

Real installer output after the change:

```
  .codex/hooks.json  ->  PreToolUse hook registered (…/graphify.EXE hook-check - intentional
  no-op; Codex Desktop rejects additionalContext on PreToolUse, so graph guidance comes from
  AGENTS.md)
```

**On those 12 failures — they are pre-existing on Windows, not caused by this PR.** My
baseline `uv run pytest tests/ -q` on unmodified `v8` (66d8110) gives **45 failed, 3578
passed, 15 skipped**, of which exactly 12 are in these four files (`test_install.py` 2,
`test_install_references.py` 1, `test_install_roundtrip.py` 1, `test_hooks.py` 8) — the same
12, mostly `WinError 2/32` and POSIX path-separator assertions. I did not touch them, since
they're outside this issue's scope. I don't have a Linux/macOS box to confirm they're green
there, so please read that count in that light.
