### PR TITLE
fix: pin interpreters whose path contains a space

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -503,10 +503,17 @@ def _pinned_python() -> str:
     that is not a valid plain filesystem path character, preventing $(...),
     backtick, double-quote, semicolon, etc. from being injected into generated
     shell scripts or the merge-driver command line. The allowlist includes ':'
-    and '\\' so Windows paths (C:\\...) are accepted. An empty return means
-    callers must fall back to the `graphify` launcher on PATH — safe degradation.
+    and '\\' so Windows paths (C:\\...) are accepted, and a plain space so
+    Windows profile paths (C:\\Users\\First Last\\...) are too — a space cannot
+    start a substitution or a new command, and every consumer quotes the value:
+    the hook scripts embed it as '$_PINNED' (single-quoted, then referenced as
+    "$_PINNED") and _register_merge_driver double-quotes it (#2166). Before that
+    a space rejected the whole path, so hooks installed under any Windows user
+    whose profile name contains a space silently pinned nothing. An empty return
+    means callers must fall back to the `graphify` launcher on PATH — safe
+    degradation.
     """
-    if re.search(r"[^a-zA-Z0-9/_.@:\\-]", sys.executable):
+    if re.search(r"[^a-zA-Z0-9/_.@: \\-]", sys.executable):
         return ""
     return sys.executable
 
@@ -551,7 +558,12 @@ def _register_merge_driver(root: Path) -> str:
     import subprocess as _sp
     pinned = _pinned_python()
     if pinned:
-        driver = f"{pinned} -m graphify merge-driver %O %A %B"
+        # Double-quoted: the allowlist in _pinned_python() permits a space (Windows
+        # profile paths), and git runs this driver string through a shell, so an
+        # unquoted "C:\\Users\\First Last\\...\\python.exe" would split into two
+        # words and the driver would never run (#2166). The same allowlist keeps
+        # '$' and backticks out, so double quotes cannot introduce expansion.
+        driver = f'"{pinned}" -m graphify merge-driver %O %A %B'
     else:
         driver = "graphify merge-driver %O %A %B"
     try:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -676,3 +676,82 @@ def test_uninstall_removes_merge_driver_keeps_other_attrs(tmp_path):
     content = (repo / ".gitattributes").read_text(encoding="utf-8")
     assert "*.png binary" in content
     assert "merge=graphify" not in content
+
+
+@pytest.mark.parametrize("exe", [
+    r"C:\Users\First Last\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe",
+    r"C:\Program Files\Python312\python.exe",
+    "/home/first last/.local/share/uv/tools/graphifyy/bin/python",
+])
+def test_pinned_python_accepts_paths_containing_spaces(exe, monkeypatch):
+    """#2166: a space must not empty the pin.
+
+    The install-time allowlist had no space, so `sys.executable` under any Windows
+    profile whose name contains one (`C:\\Users\\First Last\\...`, or the very common
+    `C:\\Program Files\\...`) was rejected wholesale and the hook shipped `_PINNED=''`.
+    Every interpreter probe then failed and each commit no-op'd with the "could not
+    locate a Python" warning, so the graph never rebuilt.
+    """
+    import sys as _sys
+
+    from graphify.hooks import _pinned_python
+
+    monkeypatch.setattr(_sys, "executable", exe)
+    assert _pinned_python() == exe, "a path containing a space must still be pinned"
+
+
+@pytest.mark.parametrize("exe", [
+    r"C:\Users\evil\python.exe; rm -rf /",
+    "/tmp/py`id`",
+    "/tmp/py$(id)",
+    "/tmp/py$IFS",
+    r"C:\Users\ev'il\python.exe",
+    '/tmp/py"quote',
+])
+def test_pinned_python_still_rejects_shell_metacharacters(exe, monkeypatch):
+    """Widening the allowlist for spaces (#2166) must not admit anything that can
+    start a substitution, end the single-quoted assignment, or chain a command."""
+    import sys as _sys
+
+    from graphify.hooks import _pinned_python
+
+    monkeypatch.setattr(_sys, "executable", exe)
+    assert _pinned_python() == "", f"dangerous interpreter path accepted: {exe!r}"
+
+
+def test_merge_driver_quotes_interpreter_with_spaces(tmp_path, monkeypatch):
+    """#2166: git runs the merge driver through a shell, so a pinned path with a
+    space has to be quoted or the driver splits into two words and never runs."""
+    import subprocess
+    import sys as _sys
+
+    from graphify.hooks import install
+
+    exe = r"C:\Users\First Last\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe"
+    repo = _make_git_repo(tmp_path)
+    monkeypatch.setattr(_sys, "executable", exe)
+    install(repo)
+
+    driver = subprocess.run(
+        ["git", "-C", str(repo), "config", "--get", "merge.graphify.driver"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert driver.startswith(f'"{exe}"'), f"interpreter not quoted in merge driver: {driver!r}"
+    assert driver.endswith("-m graphify merge-driver %O %A %B")
+
+
+def test_install_pins_interpreter_path_with_spaces(tmp_path, monkeypatch):
+    """#2166 end to end: the emitted hooks must carry the real interpreter, not ''."""
+    import sys as _sys
+
+    from graphify.hooks import install
+
+    exe = r"C:\Users\First Last\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe"
+    repo = _make_git_repo(tmp_path)
+    monkeypatch.setattr(_sys, "executable", exe)
+    install(repo)
+
+    for name in ("post-commit", "post-checkout"):
+        script = (repo / ".git" / "hooks" / name).read_text()
+        assert f"_PINNED='{exe}'" in script, f"{name} did not pin the spaced interpreter"
+        assert "_PINNED=''" not in script, f"{name} pinned an empty interpreter (#2166)"


### PR DESCRIPTION
Fixes #2166

## Root cause (a bit narrower than the report)

The empty `_PINNED` comes from the install-time allowlist in `_pinned_python()`, not from the
uv-tool layout. It accepted `[a-zA-Z0-9/_.@:\-]` — no **space** — and rejects the path
wholesale on any non-matching character, so `sys.executable` under a profile whose name
contains a space records nothing.

Verified on Windows against `v8` (0.9.26), stubbing `sys.executable`:

```
PINNED   'C:\Users\devuser\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe'  -> pinned
EMPTY!!  'C:\Users\First Last\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe' -> ''
PINNED   '/home/u/.local/share/uv/tools/graphifyy/bin/python'                      -> pinned
EMPTY!!  'C:\Users\evil\py.exe; rm -rf /'                                          -> ''   (correct)
EMPTY!!  "C:\Users\ev'il\python.exe"                                               -> ''   (correct)
```

So a **space-free** Windows uv path pins fine — which is why this reads as uv-layout-specific.
What actually breaks it is a space anywhere in the interpreter path: `C:\Users\First Last\...`,
or the equally common `C:\Program Files\Python312\python.exe`. Once `_PINNED` is empty, probe 1
is skipped and (per the report's own table) probes 2–4 can't recover on a uv install, so every
commit warns and no-ops.

That also means the issue's other suggestion — writing `graphify-out/.graphify_python` at hook
install time — isn't needed to fix this; probe 1 works once it's actually populated. I left it
out to keep the change minimal.

## Fix

- **`_pinned_python()`: allow a plain space.** This is safe because every consumer already
  quotes the value — the hook embeds `_PINNED='<path>'` (single-quoted) and dereferences
  `"$_PINNED"`, so a space can neither split a word nor start a command. `$`, backtick, `;`,
  `'` and `"` remain rejected, so the injection guard is unchanged.
- **`_register_merge_driver()`: quote the interpreter.** It interpolated the path *unquoted*
  into `merge.graphify.driver`, which git runs through a shell — a spaced path would split into
  two words and the driver would never run. Now double-quoted, which is safe precisely because
  the allowlist keeps `$`/backticks out.

I deliberately did **not** convert the pinned path to forward slashes (the issue suggests
`sys.executable.replace("\\", "/")`). Probe 1 quotes `"$_PINNED"` so backslashes are fine there,
`#2126` already established that a pinned `C:\...` path is the expected shape, and rewriting it
would churn the existing `test_install_embeds_pinned_interpreter` assertion for no gain.

## Testing

New tests in `tests/test_hooks.py`:

```console
$ uv run pytest tests/test_hooks.py -q -k "pinned_python_accepts_paths_containing_spaces or pinned_python_still_rejects or merge_driver_quotes_interpreter or install_pins_interpreter_path_with_spaces"
11 passed, 67 deselected, 1 warning in 1.29s
```

Confirmed they actually catch the bug — same tests with `graphify/hooks.py` reverted to `v8`:

```
FAILED tests/test_hooks.py::test_pinned_python_accepts_paths_containing_spaces[C:\Users\First Last\...\python.exe]
FAILED tests/test_hooks.py::test_pinned_python_accepts_paths_containing_spaces[C:\Program Files\Python312\python.exe]
FAILED tests/test_hooks.py::test_pinned_python_accepts_paths_containing_spaces[/home/first last/...]
FAILED tests/test_hooks.py::test_merge_driver_quotes_interpreter_with_spaces - interpreter not quoted in merge driver: 'graphify merge-dri...'
FAILED tests/test_hooks.py::test_install_pins_interpreter_path_with_spaces - post-commit did not pin the spaced interpreter
5 failed, 73 deselected
```

Affected files plus both pre-commit gates:

```console
$ uv run pytest tests/test_hooks.py tests/test_hook_strict.py tests/test_install.py -q
11 failed, 172 passed, 1 warning in 19.40s

$ uv run ruff check --config pyproject.toml graphify/hooks.py tests/test_hooks.py
All checks passed!

$ uv run python -m tools.skillgen --check
check OK: 134 artifact(s) match committed output and expected/.
```

**Those 11 failures are pre-existing on Windows, not from this PR.** Baseline `uv run pytest
tests/ -q` on unmodified `v8` (66d8110) is **45 failed, 3578 passed, 15 skipped**, of which
exactly 11 live in these three files (`test_hooks.py` 8, `test_hook_strict.py` 1,
`test_install.py` 2) — the same 11, and most of the `test_hooks.py` ones are the
`bash`-dependent allowlist tests plus `WinError` cases. I have no Linux/macOS box to confirm
they're green there, so please read that number in that light.

