### PR TITLE
fix: skip the process pool when only one worker is available

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4320,6 +4320,15 @@ def _extract_parallel(
         max_workers = min(max_workers, 61)
     max_workers = max(max_workers, 1)
 
+    # A one-worker pool buys no parallelism: it still pays process spawn plus an
+    # IPC round trip per file, and it is the one residual case where the parent's
+    # rebuild watchdog (os._exit) can orphan a worker that is mid-task. The
+    # Windows post-commit hook exports GRAPHIFY_MAX_WORKERS=1, so this is the
+    # default there. Hand the work back so the caller extracts sequentially in
+    # this process instead (#2173).
+    if max_workers == 1:
+        return False
+
     # root anchors hash keys / node ids / XAML boundary; cache_location is where
     # the cache dir is written (defaults to root when not decoupled) (#1774).
     root_str = str(root)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1488,6 +1488,63 @@ def test_extract_parallel_returns_false_on_broken_pool(tmp_path, monkeypatch, ca
     assert "__main__" in out, "warning must hint at the Windows __main__ guard idiom"
 
 
+def test_extract_parallel_skips_pool_when_max_workers_is_one(tmp_path, monkeypatch):
+    """#2173: a resolved worker count of 1 must not spawn a ProcessPoolExecutor.
+
+    The Windows post-commit hook exports GRAPHIFY_MAX_WORKERS=1, so before this the
+    rebuild spawned a one-worker pool for >= _PARALLEL_THRESHOLD files: no
+    parallelism, one process spawn plus an IPC round trip per file, and the only
+    window where the parent's rebuild watchdog (os._exit) can orphan a worker
+    mid-task. _extract_parallel must decline (return False) so the caller extracts
+    sequentially in-process.
+    """
+    import concurrent.futures
+    from graphify import extract as extract_mod
+
+    spawned = {"count": 0}
+
+    def fake_pool(*args, **kwargs):
+        spawned["count"] += 1
+        raise AssertionError("ProcessPoolExecutor must not be constructed for 1 worker")
+
+    monkeypatch.setattr(concurrent.futures, "ProcessPoolExecutor", fake_pool)
+    monkeypatch.setenv("GRAPHIFY_MAX_WORKERS", "1")
+
+    uncached = [(i, FIXTURES / "sample.py") for i in range(25)]  # >= _PARALLEL_THRESHOLD
+    per_file: list = [None] * len(uncached)
+
+    ok = extract_mod._extract_parallel(uncached, per_file, tmp_path, None, len(uncached))
+    assert ok is False, "must hand the work back for sequential extraction"
+    assert spawned["count"] == 0, "no pool may be spawned when max_workers resolves to 1"
+
+
+def test_extract_parallel_still_spawns_pool_for_multiple_workers(tmp_path, monkeypatch):
+    """Guard the #2173 skip: >1 worker must still take the pool path."""
+    import concurrent.futures
+    from graphify import extract as extract_mod
+
+    spawned = {"count": 0}
+
+    class FakePool:
+        def __init__(self, *a, **kw):
+            spawned["count"] += 1
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def submit(self, *a, **kw):
+            raise concurrent.futures.process.BrokenProcessPool("stop here")
+
+    monkeypatch.setattr(concurrent.futures, "ProcessPoolExecutor", FakePool)
+    monkeypatch.setenv("GRAPHIFY_MAX_WORKERS", "4")
+
+    uncached = [(i, FIXTURES / "sample.py") for i in range(25)]
+    per_file: list = [None] * len(uncached)
+
+    extract_mod._extract_parallel(uncached, per_file, tmp_path, None, len(uncached))
+    assert spawned["count"] == 1, "multi-worker runs must still use the pool"
+
+
 # ---------------------------------------------------------------------------
 # Bash extractor tests (#866)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses item 2 of #2173.

## Item 2: skip the pool when `max_workers` resolves to 1

`_extract_parallel` spawned a `ProcessPoolExecutor` whenever there were
`>= _PARALLEL_THRESHOLD` (20) uncached files, regardless of the resolved worker count.
With one worker that buys no parallelism — it still pays a process spawn plus an IPC round
trip per file, and it's the one residual case where the parent's rebuild watchdog
(`os._exit`) can orphan a worker mid-task.

Since the Windows post-commit hook exports `GRAPHIFY_MAX_WORKERS=1`, this was the default
there for any rebuild touching 20+ uncached files.

The gate goes in after the env override and the win32/floor clamps, so it sees the *resolved*
count, and it returns `False` — reusing the existing contract, since the caller already falls
back to `_extract_sequential` in-process when `_extract_parallel` returns `False`:

```python
ran_parallel = False
if parallel and len(uncached_work) >= _PARALLEL_THRESHOLD:
    ran_parallel = _extract_parallel(...)
if not ran_parallel:
    _extract_sequential(...)
```

## Item 1 (`graphify watch` timeout): needs a decision first, so it's not here

The issue says watch's timeout "is guarded on `signal.SIGALRM` and is therefore a no-op on
Windows", and asks for the same `else: threading.Timer -> os._exit` fallback. Checking `v8`,
that premise doesn't hold: **`graphify/watch.py` contains no `SIGALRM`, no `signal.alarm`, and
no `threading.Timer` at all** — `watch()` calls `_rebuild_code(watch_path)` straight from its
debounce loop. There is no `else` branch to add, on Windows or anywhere; the timeout is absent
on every platform.

So implementing it means *introducing* a rebuild watchdog to watch, not fixing a
platform-conditional one. That's a behaviour change I didn't want to make unilaterally: unlike
the post-commit hook (short-lived, one rebuild), `watch` is a long-running foreground process,
and an `os._exit(1)` watchdog would kill the user's watcher on a slow-but-healthy rebuild of a
large repo. Reasonable options — abort the rebuild and keep watching, use a longer/separate
timeout for watch, or make it opt-in — are all product calls.

Happy to send that as a follow-up in whichever shape you prefer; just say which semantics you
want for a watch rebuild that exceeds the timeout.

## Testing

```console
$ uv run pytest tests/test_extract.py -q -k "skips_pool_when_max_workers_is_one or still_spawns_pool_for_multiple_workers"
2 passed, 149 deselected, 1 warning in 0.95s
```

Confirmed the new test catches the bug — same test with `graphify/extract.py` reverted to `v8`:

```
FAILED tests/test_extract.py::test_extract_parallel_skips_pool_when_max_workers_is_one
  - AssertionError: ProcessPoolExecutor must not be constructed for 1 worker
```

Full suite (this change touches the extraction core, so I ran everything rather than a subset):

```console
$ uv run pytest tests/ -q
45 failed, 3591 passed, 15 skipped, 4 warnings in 413.39s
```

```console
$ uv run ruff check --config pyproject.toml graphify/extract.py tests/test_extract.py
All checks passed!

$ uv run python -m tools.skillgen --check
check OK: 134 artifact(s) match committed output and expected/.
```

**Those 45 failures are pre-existing on Windows, not from this PR.** My baseline on unmodified
`v8` (66d8110) is **45 failed, 3578 passed, 15 skipped** — the same 45, and the passed count
only moves up. (My local tree also carried the two new tests from my #2166 branch during that
run, which is why passed goes 3578 -> 3591 rather than +2.) The pre-existing failures are
Windows-specific: `WinError 2/32`, POSIX path-separator assertions, and `bash`-dependent tests.
I have no Linux/macOS box to confirm they're green there, so please read that number in that
light.
