### PR TITLE
fix: recover every declared SQL routine from unparseable PL/pgSQL

### DIFF
--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -200,9 +200,16 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
             # several statements, so scan for every CREATE in it. We deliberately
             # do not scan the body for FROM/JOIN references: PL/pgSQL loop
             # variables and locals would produce junk reads_from targets.
+            #
+            # Each name part is either a bare identifier or a double-quoted
+            # (delimited) one, so schema-qualified generated DDL such as
+            # CREATE OR REPLACE FUNCTION "public"."fn"(...) is recovered too.
+            # A bare [\w$.]+ stops dead at the leading quote, which silently
+            # dropped every quoted PL/pgSQL routine (#2180).
             text = _read(node)
             for m in re.finditer(
-                r"CREATE\s+(?:OR\s+REPLACE\s+)?(?:FUNCTION|PROCEDURE)\s+([\w$.]+)",
+                r"CREATE\s+(?:OR\s+REPLACE\s+)?(?:FUNCTION|PROCEDURE)\s+"
+                r"((?:\"[^\"\n]+\"|[\w$]+)(?:\s*\.\s*(?:\"[^\"\n]+\"|[\w$]+))*)",
                 text, re.IGNORECASE,
             ):
                 name = m.group(1)
@@ -291,5 +298,26 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
             if (tbl_nid, ref_nid) not in emitted:
                 _add_edge(tbl_nid, ref_nid, "references", tbl_line)
                 emitted.add((tbl_nid, ref_nid))
+
+    # Global regex fallback for routines (#2180). PL/pgSQL bodies break the parse
+    # in more than one shape, and only the first was recovered before:
+    #   1. the whole CREATE lands in one ERROR node          -> handled in walk()
+    #   2. the statement is shredded into loose top-level tokens
+    #      (keyword_create/keyword_function/object_reference/... ) and the ERROR
+    #      node holds only the offending body line, e.g. `PERFORM x();` or
+    #      `x := 1;` -- so no CREATE text is inside any ERROR node at all
+    #   3. the name is a quoted identifier ("public"."fn"), which a bare
+    #      [\w$.]+ pattern cannot match
+    # Shapes 2 and 3 silently dropped the routine: no node, no warning, exit 0.
+    # Scanning the raw source catches all three, and _add_node dedupes by id so
+    # routines already recovered from the tree are not emitted twice.
+    for m in re.finditer(
+        r"CREATE\s+(?:OR\s+REPLACE\s+)?(?:FUNCTION|PROCEDURE)\s+"
+        r"((?:\"[^\"\n]+\"|[\w$]+)(?:\s*\.\s*(?:\"[^\"\n]+\"|[\w$]+))*)",
+        src_text, re.IGNORECASE,
+    ):
+        fn_name = m.group(1)
+        fn_line = src_text[: m.start()].count("\n") + 1
+        _add_node(_make_id(stem, fn_name), f"{fn_name}()", fn_line)
 
     return {"nodes": nodes, "edges": edges}

--- a/tests/fixtures/sample_plpgsql_quoted.sql
+++ b/tests/fixtures/sample_plpgsql_quoted.sql
@@ -1,0 +1,62 @@
+-- Generated-style PostgreSQL DDL (#2180): every identifier is double-quoted and
+-- each body uses a PL/pgSQL-only statement, so tree-sitter-sql parses these as
+-- ERROR nodes. Name recovery is the only path that can see them, and a bare
+-- [\w$.]+ name pattern stops at the leading quote -- which silently dropped
+-- every routine in files shaped like this.
+
+CREATE TABLE "public"."accounts" (
+    "id" INT PRIMARY KEY,
+    "name" TEXT
+);
+
+CREATE OR REPLACE FUNCTION "public"."raise_exception_fn"("p_id" "uuid") RETURNS "void"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+BEGIN
+  RAISE EXCEPTION 'insufficient_privilege' USING ERRCODE = '42501';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."raise_notice_fn"() RETURNS "void" LANGUAGE "plpgsql" AS $$
+BEGIN
+  RAISE NOTICE 'hi';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."perform_fn"() RETURNS "void" LANGUAGE "plpgsql" AS $$
+BEGIN
+  PERFORM "public"."raise_notice_fn"();
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."assign_fn"() RETURNS "void" LANGUAGE "plpgsql" AS $$
+DECLARE
+  "x" int;
+BEGIN
+  x := 1;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."if_then_fn"() RETURNS "void" LANGUAGE "plpgsql" AS $$
+BEGIN
+  IF true THEN RAISE EXCEPTION 'x'; END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."null_body_fn"() RETURNS "void" LANGUAGE "plpgsql" AS $$
+BEGIN
+  NULL;
+END;
+$$;
+
+CREATE PROCEDURE "public"."quoted_proc"() LANGUAGE "plpgsql" AS $$
+BEGIN
+  PERFORM 1;
+END;
+$$;
+
+CREATE TABLE "public"."audit_log" (
+    "id" INT PRIMARY KEY,
+    "account_id" INT REFERENCES "public"."accounts"
+);

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -542,3 +542,47 @@ def test_sql_plpgsql_clean_function_not_double_emitted():
     # And nothing else is duplicated either
     ids = [n["id"] for n in r["nodes"]]
     assert len(ids) == len(set(ids))
+
+def test_sql_quoted_plpgsql_routines_are_recovered():
+    """#2180: quoted identifiers must not defeat the ERROR-node name recovery.
+
+    Generated PostgreSQL DDL (Supabase-style dumps, for example) quotes every
+    identifier: CREATE OR REPLACE FUNCTION "public"."fn"(...). The recovery
+    pattern matched a bare [\\w$.]+, which stops at the leading quote, so every
+    routine whose body also failed to parse -- RAISE, PERFORM, :=, IF..THEN,
+    bare NULL; -- was dropped with no warning and exit code 0. The same body
+    with an *unquoted* name recovered fine, which is why the drop looked like it
+    depended only on the body statement.
+    """
+    r = _extract_sql_or_skip("sample_plpgsql_quoted.sql")
+    labels = [n["label"] for n in r["nodes"]]
+    for name in (
+        "raise_exception_fn",
+        "raise_notice_fn",
+        "perform_fn",
+        "assign_fn",
+        "if_then_fn",
+        "null_body_fn",
+        "quoted_proc",
+    ):
+        assert f'"public"."{name}"()' in labels, f"{name} dropped from a quoted-DDL file (#2180)"
+
+def test_sql_quoted_plpgsql_file_stays_clean():
+    """The #2180 recovery must not add junk, duplicates, or drop the tables."""
+    r = _extract_sql_or_skip("sample_plpgsql_quoted.sql")
+    labels = [n["label"] for n in r["nodes"]]
+    # Tables before and after the unparseable routines still extract.
+    assert any("accounts" in l for l in labels)
+    assert any("audit_log" in l for l in labels)
+    # No empty or ERROR labels leaked out of the recovery.
+    for l in labels:
+        assert l, "empty node label"
+        assert l != "ERROR"
+    # Nothing emitted twice (a routine must not come from both paths).
+    ids = [n["id"] for n in r["nodes"]]
+    assert len(ids) == len(set(ids)), "duplicate node ids"
+    assert len(labels) == len(set(labels)), f"duplicate labels: {labels}"
+    # Every recovered routine is reachable from the file node.
+    contains_targets = {e["target"] for e in r["edges"] if e["relation"] == "contains"}
+    fn_ids = {n["id"] for n in r["nodes"] if n["label"].endswith("()")}
+    assert fn_ids <= contains_targets


### PR DESCRIPTION
Fixes #2180

## Root cause: three parse shapes, only one was recovered

#1910 added ERROR-node name recovery, but PL/pgSQL breaks the parse in more than one
shape and the recovery only handled the first:

1. **The whole `CREATE` lands in one `ERROR` node** — recovered before this PR.
2. **The statement is shredded into loose top-level tokens.** For a body using `PERFORM`
   or `:=`, tree-sitter emits `keyword_create`, `keyword_or`, `keyword_replace`,
   `keyword_function`, `object_reference`, `function_arguments`, … `keyword_begin`, and then
   an `ERROR` node containing **only the offending body line**. Dumping the tree for the
   fixture in this PR:

   ```
   keyword_function     line  27  FUNCTION
   object_reference     line  27  "public"."perform_fn"
   ...
   keyword_begin        line  28  BEGIN
   ERROR                line  29  PERFORM "public"."raise_notice_fn"();
   ```

   No `ERROR` node contains any `CREATE` text, so scanning ERROR nodes finds nothing.
   **This is why `PERFORM` and `:=` still dropped after #1910.**
3. **The routine name is a quoted identifier.** The recovery matched a bare `[\w$.]+`,
   which stops dead at the leading quote, so `CREATE OR REPLACE FUNCTION "public"."fn"(...)`
   matched nothing at all. Generated dumps quote every identifier, so entire files
   recovered zero routines.

Confirmed shape 3 directly against `v8` with your repro — the same PL/pgSQL body recovers
under an *unquoted* name and drops under a quoted one:

```
20260101000001_dropped.sql:   1 node(s) -> ['20260101000001_dropped.sql']                      # dropped
20260101000002_extracted.sql: 2 node(s) -> [..., '"public"."probe_with_return"()']
20260101000003_unquoted.sql:  2 node(s) -> [..., 'public.probe_unquoted()']                    # recovered!
```

That's the missing piece in the issue's analysis: the body decides whether you hit the
error path at all, but the **quoting and the shredding shape** decide whether recovery can
see the routine. It also explains why the predicate wasn't clean at 186 functions —
unquoted or fully-parsed routines came through, quoted-and-shredded ones didn't.

## Fix

Option 1 from the issue, implemented the way this extractor already handles the same class
of problem. There's an existing *global regex fallback* after the tree walk for
`REFERENCES` edges ("catch any REFERENCES missed due to ERROR nodes in the parse tree"); I
mirrored it for routines: scan the raw source for every
`CREATE [OR REPLACE] FUNCTION|PROCEDURE`, with name parts accepting bare **or** double-quoted
identifiers, and emit any routine the tree walk missed. `_add_node` already dedupes by node
id, so routines recovered from the tree aren't emitted twice.

This is shape-agnostic — it fixes all three cases above, so a future grammar quirk can't
silently drop a declared routine again. After the fix your repro gives the expected 4 nodes
(2 file + 2 function).

I did **not** implement option 2 (the loud per-file "extracted N of M" warning). It's a good
idea, but a raw-text count can't tell a real declaration from `CREATE FUNCTION` inside a
comment or a string literal, so it would need its own care to avoid warning on every clean
file. Happy to add it as a follow-up if you want it — and with this fix the count should now
be N == M anyway.

## Testing

New fixture `tests/fixtures/sample_plpgsql_quoted.sql`: generated-style DDL where every
identifier is quoted and the bodies cover your matrix — `RAISE EXCEPTION`, `RAISE NOTICE`,
`PERFORM`, `:=`, `IF..THEN`, bare `NULL;`, plus a `CREATE PROCEDURE` — with tables before and
after.

```console
$ uv run pytest tests/test_multilang.py -q -k "quoted_plpgsql"
2 passed, 50 deselected, 1 warning in 0.38s

$ uv run pytest tests/test_multilang.py tests/test_languages.py tests/test_pg_introspect.py -q
391 passed, 1 warning in 2.08s
```

Confirmed the tests catch the bug — same tests with `graphify/extractors/sql.py` reverted to `v8`:

```
FAILED tests/test_multilang.py::test_sql_quoted_plpgsql_routines_are_recovered
  - AssertionError: perform_fn dropped from a quoted-DDL file (#2180)
```

Full suite (this touches an extractor, so I ran everything):

```console
$ uv run pytest tests/ -q
45 failed, 3580 passed, 15 skipped, 4 warnings in 407.51s
```

```console
$ uv run ruff check --config pyproject.toml graphify/extractors/sql.py tests/test_multilang.py
All checks passed!

$ uv run python -m tools.skillgen --check
check OK: 134 artifact(s) match committed output and expected/.
```

**Those 45 failures are pre-existing on Windows, not from this PR.** My baseline on
unmodified `v8` (66d8110) is **45 failed, 3578 passed, 15 skipped** — the same 45, and passed
moves 3578 -> 3580, exactly the two tests added here. The pre-existing ones are Windows-specific
(`WinError 2/32`, POSIX path-separator assertions, `bash`-dependent tests); none are in
`test_multilang.py`. I have no Linux/macOS box to confirm they're green there.

If you'd like, I'm happy to have the before/after count checked against your 186-function
schema — that's a better stress case than any fixture I can write.
