### PR TITLE
test: read generated outputs as UTF-8 on Windows

### DIFF
--- a/tests/test_merge_chunks_validation.py
+++ b/tests/test_merge_chunks_validation.py
@@ -31,7 +31,7 @@ def test_merge_chunks_skips_chunk_with_path_escape_id(tmp_path, monkeypatch, cap
 
     _run_merge(monkeypatch, ["graphify", "merge-chunks", str(good), str(bad), "--out", str(out)])
 
-    merged = json.loads(out.read_text())
+    merged = json.loads(out.read_text(encoding="utf-8"))
     assert {n["id"] for n in merged["nodes"]} == {"pkg.mod.good"}
     captured = capsys.readouterr()
     assert "skipping invalid chunk" in captured.err
@@ -48,7 +48,7 @@ def test_merge_chunks_fails_closed_when_every_chunk_is_invalid(tmp_path, monkeyp
         _run_merge(monkeypatch, ["graphify", "merge-chunks", str(bad), "--out", str(out)])
 
     assert exc.value.code == 1
-    assert json.loads(out.read_text()) == {"previous": "semantic result"}
+    assert json.loads(out.read_text(encoding="utf-8")) == {"previous": "semantic result"}
     err = capsys.readouterr().err
     assert "skipping invalid chunk" in err
     assert "no valid chunks to merge" in err
@@ -62,7 +62,7 @@ def test_merge_chunks_accepts_valid_empty_chunk(tmp_path, monkeypatch):
 
     _run_merge(monkeypatch, ["graphify", "merge-chunks", str(empty), "--out", str(out)])
 
-    merged = json.loads(out.read_text())
+    merged = json.loads(out.read_text(encoding="utf-8"))
     assert merged["nodes"] == []
     assert merged["edges"] == []
 
@@ -87,7 +87,7 @@ def test_merge_chunks_fails_closed_on_unmatched_glob(tmp_path, monkeypatch, caps
         _run_merge(monkeypatch, ["graphify", "merge-chunks", unmatched, "--out", str(out)])
 
     assert exc.value.code == 1
-    assert json.loads(out.read_text()) == {"previous": True}
+    assert json.loads(out.read_text(encoding="utf-8")) == {"previous": True}
     err = capsys.readouterr().err
     assert "skipping invalid chunk" in err
     assert "no valid chunks to merge" in err
@@ -102,7 +102,7 @@ def test_merge_chunks_accepts_synonym_file_type(tmp_path, monkeypatch):
                "edges": [], "hyperedges": []})
     out = tmp_path / "merged.json"
     _run_merge(monkeypatch, ["graphify", "merge-chunks", str(c), "--out", str(out)])
-    merged = json.loads(out.read_text())
+    merged = json.loads(out.read_text(encoding="utf-8"))
     assert {n["id"] for n in merged["nodes"]} == {"pkg.readme", "pkg.tool"}
 
 
@@ -114,7 +114,7 @@ def test_merge_chunks_accepts_unicode_id(tmp_path, monkeypatch):
                "edges": [], "hyperedges": []})
     out = tmp_path / "merged.json"
     _run_merge(monkeypatch, ["graphify", "merge-chunks", str(c), "--out", str(out)])
-    merged = json.loads(out.read_text())
+    merged = json.loads(out.read_text(encoding="utf-8"))
     assert {n["id"] for n in merged["nodes"]} == {"mod_处理数据"}
 
 
@@ -144,7 +144,7 @@ def test_merge_chunks_merges_valid_chunks(tmp_path, monkeypatch):
 
     _run_merge(monkeypatch, ["graphify", "merge-chunks", str(c0), str(c1), "--out", str(out)])
 
-    merged = json.loads(out.read_text())
+    merged = json.loads(out.read_text(encoding="utf-8"))
     assert {n["id"] for n in merged["nodes"]} == {"a", "b"}
     assert merged["input_tokens"] == 17
     assert merged["output_tokens"] == 8

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -71,7 +71,7 @@ def run_pipeline(tmp_path: Path) -> dict:
     json_path = tmp_path / "graph.json"
     to_json(G, communities, str(json_path))
     assert json_path.exists()
-    data = json.loads(json_path.read_text())
+    data = json.loads(json_path.read_text(encoding="utf-8"))
     assert "nodes" in data and "links" in data
     assert all("community" in n for n in data["nodes"])
 
@@ -79,7 +79,7 @@ def run_pipeline(tmp_path: Path) -> dict:
     html_path = tmp_path / "graph.html"
     to_html(G, communities, str(html_path), community_labels=labels)
     assert html_path.exists()
-    html = html_path.read_text()
+    html = html_path.read_text(encoding="utf-8")
     assert "vis-network" in html
     assert "RAW_NODES" in html
 


### PR DESCRIPTION
## Summary

- read generated graph JSON and HTML using their actual UTF-8 encoding
- keep merge-chunks Unicode IDs intact under non-UTF-8 Windows locales
- avoid changing production output or global locale behavior

## Reproduction

On a Chinese Windows environment, the affected tests decoded UTF-8 output with the default GBK codec. Pipeline tests raised `UnicodeDecodeError`, and the merge-chunks Unicode ID assertion observed mojibake.

## Verification

- `pytest -q tests/test_merge_chunks_validation.py tests/test_pipeline.py` — 18 passed
- affected files plus optional-backend environment checks — 22 passed
- `ruff check tests/test_merge_chunks_validation.py tests/test_pipeline.py` — passed
- `git diff --check` — passed

The repository has additional pre-existing Windows-specific test failures outside these files; they are intentionally not included in this focused change.