### PR TITLE
fix(watch): bring the incremental rebuild in line with cluster-only (stale labels, deleted viz)

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1240,6 +1240,7 @@ def _rebuild_code(
         gods = god_nodes(G)
         surprises = surprising_connections(G, communities)
         labels_file = out / ".graphify_labels.json"
+        sig_file = out / (".graphify_labels.json" + ".sig")
         try:
             raw = json.loads(labels_file.read_text(encoding="utf-8")) if labels_file.exists() else {}
             # Skip persisted "Community N" placeholders so the hub-fill below
@@ -1251,12 +1252,50 @@ def _rebuild_code(
         except Exception:
             raw = {}
             labels = {}
+        # A saved label belongs to a cid, but re-clustering reassigns cids: after a
+        # rebuild that adds nodes, cid 30 can cover a completely different community
+        # and its old name is then simply wrong. Validate every reused label against
+        # the membership signature saved beside the labels — the same guard the
+        # cluster-only path applies — and drop any whose community changed so the
+        # hub-fill below renames it, deterministically and correct-by-construction.
+        # Without this, an incremental `graphify update` launders stale names into
+        # labels.json as though they were current (#label-stale).
+        from graphify.cluster import community_member_sigs
+        cur_sigs = community_member_sigs(communities)
+        saved_sigs: dict[int, str] = {}
+        if sig_file.exists():
+            try:
+                saved_sigs = {
+                    int(k): v for k, v in
+                    json.loads(sig_file.read_text(encoding="utf-8")).items()
+                    if isinstance(v, str)
+                }
+            except Exception:
+                saved_sigs = {}
+        if saved_sigs:
+            # Precise: the signature tells us exactly which communities changed.
+            stale = {cid for cid in labels if saved_sigs.get(cid) != cur_sigs.get(cid)}
+        else:
+            # No sidecar (labels predate it). A differing community COUNT means the
+            # labels describe a different clustering, so no cid's label is trustworthy;
+            # an equal count is the best available "unchanged" signal.
+            stale = set(labels) if len(raw) != len(communities) else set()
+        for cid in stale:
+            del labels[cid]
         missing = {cid: members for cid, members in communities.items() if cid not in labels}
         if missing:
             # Deterministic hub name (highest-degree member) beats a bare "Community N"
             # placeholder for any community without a saved label.
             from graphify.cluster import label_communities_by_hub
             labels.update(label_communities_by_hub(G, missing))
+        if stale:
+            print(
+                f"[graphify watch] community set changed since labeling "
+                f"({len(raw)} saved labels, {len(communities)} communities now; "
+                f"renamed {len(stale)} community(ies) by their hub). "
+                f"Run `graphify label` to refresh names with the LLM.",
+                file=sys.stderr,
+            )
         questions = suggest_questions(G, communities, labels)
         from graphify.report import load_learning_for_report as _llfr
         report = generate(G, communities, cohesion, labels, gods, surprises, detection,
@@ -1301,6 +1340,12 @@ def _rebuild_code(
             graph_tmp.replace(existing_graph)
             report_path.write_text(report, encoding="utf-8")
             labels_file.write_text(labels_json, encoding="utf-8")
+            # Keep the membership signatures in step with the labels we just wrote.
+            # Skipping this was the other half of the stale-label bug: labels.json
+            # advanced every rebuild while the sidecar kept describing an older
+            # clustering, so the guard above had nothing accurate to check against.
+            sig_file.write_text(
+                json.dumps({str(k): v for k, v in cur_sigs.items()}), encoding="utf-8")
 
         (out / ".graphify_root").write_text(str(watch_path), encoding="utf-8")
 

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1359,18 +1359,40 @@ def _rebuild_code(
         except Exception:
             pass
 
-        # to_html raises ValueError for graphs > MAX_NODES_FOR_VIZ (5000).
+        # to_html raises ValueError for graphs > the viz node limit.
         # Wrap so core outputs (graph.json + GRAPH_REPORT.md) always land.
         html_written = False
         if not no_change:
+            html_target = out / "graph.html"
             try:
-                to_html(G, communities, str(out / "graph.html"), community_labels=labels or None)
+                to_html(G, communities, str(html_target), community_labels=labels or None)
                 html_written = True
             except ValueError as viz_err:
-                print(f"[graphify watch] Skipped graph.html: {viz_err}")
-                stale = out / "graph.html"
-                if stale.exists():
-                    stale.unlink()
+                # Over the cap. Deleting was defensible on its own — a kept
+                # graph.html would describe an older, smaller graph — but it
+                # leaves a project that crossed the threshold with no
+                # visualization at all, and the file is gone before the user
+                # sees the message. The export path (#1019) already re-renders
+                # the community-aggregation view in exactly this case, so do
+                # the same here: current AND present beats current OR present.
+                from graphify.exporters.html import _viz_node_limit
+                if html_target.exists():
+                    html_target.unlink()
+                limit = _viz_node_limit()
+                if limit <= 0:
+                    # GRAPHIFY_VIZ_NODE_LIMIT=0 means "no HTML viz" (CI runners),
+                    # so honour it rather than aggregating around it.
+                    print(f"[graphify watch] Skipped graph.html: {viz_err}")
+                else:
+                    try:
+                        to_html(G, communities, str(html_target),
+                                community_labels=labels or None, node_limit=limit)
+                        # The aggregator declines to write a single-community
+                        # graph, so trust the file rather than the call.
+                        html_written = html_target.exists()
+                    except Exception as fallback_err:
+                        print(f"[graphify watch] Skipped graph.html: {viz_err} "
+                              f"(aggregated view also failed: {fallback_err})")
 
         # Regenerate callflow HTML if the user previously generated one —
         # opt-in by existence so users who never ran callflow-html aren't affected.

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -267,6 +267,59 @@ def test_rebuild_code_drops_labels_whose_community_changed(tmp_path):
             )
 
 
+def test_rebuild_code_keeps_a_visualization_when_over_the_viz_cap(tmp_path, monkeypatch):
+    """Crossing the viz node limit must not leave the project with no graph.html.
+    _rebuild_code used to unlink the existing file and write nothing, so a repo
+    that grew past the cap silently lost its visualization — and the file was
+    already gone by the time the user read the message. The export path falls
+    back to the community-aggregation view in exactly this case; the incremental
+    path should too, so the artifact stays both current and present."""
+    import json
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    # Several *disconnected* clusters: the aggregator declines to render a
+    # single-community meta-graph, so a ring of mutually-importing modules
+    # would collapse to one community and exercise the wrong path.
+    for g in range(4):
+        for i in range(3):
+            other = (i + 1) % 3
+            (corpus / f"g{g}_m{i}.py").write_text(
+                f"import g{g}_m{other}\n\n"
+                + "".join(f"def g{g}_f{i}_{j}():\n    return {j}\n\n" for j in range(4)),
+                encoding="utf-8",
+            )
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+    html = corpus / "graphify-out" / "graph.html"
+    assert html.exists(), "expected a normal (under-cap) rebuild to write graph.html"
+    before = html.read_text(encoding="utf-8")
+
+    # Drop the cap below the graph's size but above its community count — the
+    # real shape of this bug. (A cap under the community count would make the
+    # aggregated meta-graph breach it too, which is a different situation.)
+    graph = json.loads((corpus / "graphify-out" / "graph.json").read_text(encoding="utf-8"))
+    communities = {n.get("community") for n in graph["nodes"] if n.get("community") is not None}
+    cap = (len(communities) + len(graph["nodes"])) // 2
+    assert len(communities) < cap < len(graph["nodes"]), "test corpus cannot exercise the cap"
+    monkeypatch.setenv("GRAPHIFY_VIZ_NODE_LIMIT", str(cap))
+    (corpus / "g9_extra.py").write_text("def extra():\n    return 1\n", encoding="utf-8")
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+
+    assert html.exists(), (
+        "graph.html was deleted when the graph exceeded the viz cap — the "
+        "incremental rebuild must fall back to the aggregated view like export does"
+    )
+    after = html.read_text(encoding="utf-8")
+    assert after != before, "graph.html must be re-rendered, not left stale"
+
+    # And the documented kill switch still means "no viz", not "aggregate".
+    monkeypatch.setenv("GRAPHIFY_VIZ_NODE_LIMIT", "0")
+    (corpus / "g9_extra2.py").write_text("def extra2():\n    return 2\n", encoding="utf-8")
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+    assert not html.exists(), "GRAPHIFY_VIZ_NODE_LIMIT=0 must disable the HTML viz outright"
+
+
 def test_update_rebuilds_with_nested_star_gitignore(tmp_path):
     """#1880: `graphify update` must not emit 0 nodes (and then refuse to
     overwrite) just because the source tree has a nested `.gitignore` with a

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -188,6 +188,85 @@ def test_rebuild_code_writes_community_name(tmp_path):
     )
 
 
+def test_rebuild_code_drops_labels_whose_community_changed(tmp_path):
+    """An incremental rebuild must not reuse a saved label for a community whose
+    membership changed. Labels are keyed by cid, but re-clustering reassigns cids,
+    so after new files land cid N can cover a different community and its old name
+    is then simply wrong. cluster-only guards this with the `.sig` membership
+    fingerprints; _rebuild_code ignored them and hub-filled only *missing* labels,
+    so stale names survived and were written back to labels.json as if current."""
+    import json
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "a.py").write_text(
+        "def alpha():\n    return beta()\n\ndef beta():\n    return 1\n", encoding="utf-8"
+    )
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+
+    out = corpus / "graphify-out"
+    labels_file = out / ".graphify_labels.json"
+    sig_file = out / ".graphify_labels.json.sig"
+    assert sig_file.exists(), "rebuild must persist membership signatures beside labels"
+
+    # Stand in for an LLM naming pass: give every community a distinctive name,
+    # leaving the signatures untouched so they still describe THIS clustering.
+    labels = json.loads(labels_file.read_text(encoding="utf-8"))
+    assert labels, "expected the first rebuild to write community labels"
+    labels_file.write_text(
+        json.dumps({cid: f"Named-{cid}" for cid in labels}), encoding="utf-8"
+    )
+
+    # Grow the corpus so clustering changes, then rebuild incrementally.
+    for name in ("b.py", "c.py", "d.py"):
+        (corpus / name).write_text(
+            f"def {name[0]}_one():\n    return {name[0]}_two()\n\n"
+            f"def {name[0]}_two():\n    return 2\n",
+            encoding="utf-8",
+        )
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+
+    graph = json.loads((out / "graph.json").read_text(encoding="utf-8"))
+    after = json.loads(labels_file.read_text(encoding="utf-8"))
+    sigs = json.loads(sig_file.read_text(encoding="utf-8"))
+
+    communities = {}
+    for node in graph["nodes"]:
+        cid = node.get("community")
+        if cid is not None:
+            communities.setdefault(str(cid), []).append(node["id"])
+
+    from graphify.cluster import community_member_sigs
+    expected = {
+        str(cid): sig
+        for cid, sig in community_member_sigs(
+            {int(c): m for c, m in communities.items()}
+        ).items()
+    }
+    assert sigs == expected, (
+        "signatures must be rewritten in step with the labels; a drifting sidecar "
+        "leaves the staleness guard nothing accurate to check against"
+    )
+
+    # Any surviving "Named-N" must sit on a community that genuinely did not change.
+    for cid, name in after.items():
+        if name.startswith("Named-"):
+            assert cid in communities, f"label kept for vanished community {cid}"
+            assert sigs[cid] == expected[cid], (
+                f"community {cid} kept the stale label {name!r} after its "
+                f"membership changed"
+            )
+
+    for node in graph["nodes"]:
+        cid = node.get("community")
+        if cid is not None and node.get("community_name", "").startswith("Named-"):
+            assert sigs[str(cid)] == expected[str(cid)], (
+                f"node {node['id']} carries stale community_name "
+                f"{node['community_name']!r}"
+            )
+
+
 def test_update_rebuilds_with_nested_star_gitignore(tmp_path):
     """#1880: `graphify update` must not emit 0 nodes (and then refuse to
     overwrite) just because the source tree has a nested `.gitignore` with a


### PR DESCRIPTION
Two places where `_rebuild_code` (the `graphify update` / watch path) diverges from what `cluster-only` and `export` already do carefully. Both are silent — nothing fails, the outputs are just wrong or missing.

---

## 1. Stale community labels

Labels are persisted keyed by community id, but re-clustering reassigns those ids. After a rebuild that adds nodes, cid 30 can cover a completely different community, and its saved name is then simply wrong.

`cluster-only` guards this: it validates each reused label against the `.graphify_labels.json.sig` membership fingerprints and re-hubs any community whose membership changed. That is exactly the case `community_member_sigs()` documents:

> A cid whose members no longer hash the same is a different community — reusing its old (LLM) label there is the "stale label after re-scoping" bug this guards against.

`_rebuild_code` skipped the check entirely — it reused every label whose cid was present and hub-filled only the **missing** ones, so stale names survived, then wrote them back to `labels.json` as though current. It also never refreshed the `.sig` sidecar, so signatures kept describing an older clustering and drifted out of step with the labels beside them, leaving the `cluster-only` guard nothing accurate to check against.

**Impact.** Found while adding a language extractor. Extraction grew the graph by ~3.5k nodes, re-clustering 463 → 515 communities and mislabeling **162 of them**: a `domain.audit` namespace reading `"BOB-34 — ACH / bank payments"`, a `domain.auth` namespace reading `"…document-sensitivity.up.sql"`. Node and edge data stayed correct — only the names lied, in `GRAPH_REPORT.md` and in query output where labels are the orientation cue. The sidecar had drifted to 300 entries against 515 live communities.

**Fix.** Apply the same signature check, write the sidecar in step with the labels, and print the same "run `graphify label`" notice `cluster-only` emits. Falls back to `cluster-only`'s community-count heuristic when no sidecar exists.

## 2. A graph that outgrows the viz cap loses `graph.html` entirely

Over `MAX_NODES_FOR_VIZ`, `_rebuild_code` unlinked the existing `graph.html` and wrote nothing. The delete on its own is defensible — a kept file would describe an older, smaller graph — but it is gone before the user reads the message, and every later rebuild removes it again, so a project that crosses the threshold just loses its visualization with no way to keep one.

`export html` already solved this (#1019): over the cap it re-renders the community-aggregation view rather than going without. This does the same, so the artifact is current **and** present rather than current **or** present.

`GRAPHIFY_VIZ_NODE_LIMIT=0` still means "no HTML viz" (CI runners) rather than "aggregate", and if the aggregated render also fails, the old skip-and-remove behaviour stands.

---

## Tests

- `test_rebuild_code_drops_labels_whose_community_changed` — labels a corpus, grows it so clustering shifts, rebuilds, and asserts no surviving label sits on a changed community, plus that the sidecar is rewritten in step.
- `test_rebuild_code_keeps_a_visualization_when_over_the_viz_cap` — drops the cap below the graph size but above its community count (the real shape of this bug), asserts `graph.html` survives and is re-rendered, and that `GRAPHIFY_VIZ_NODE_LIMIT=0` still disables it outright.

Both confirmed to **fail on the unfixed file** before the change. Full suite on this branch: 3764 passed (3 unrelated `test_ollama.py` backend-detection failures reproduce on a clean checkout — they trip on a `GEMINI_API_KEY` in the environment).