### PR TITLE
docs: fix incorrect clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,7 +811,7 @@ Built for people and teams whose work lives across hundreds of conversations and
 The project uses [uv](https://docs.astral.sh/uv/) for dev workflow. Install it once, then:
 
 ```bash
-git clone https://github.com/safishamsi/graphify.git
+git clone https://github.com/Graphify-Labs/graphify.git
 cd graphify
 git checkout v8                        # active development branch
 


### PR DESCRIPTION
## Summary
- The "Contributing" section of the README instructs new contributors to run `git clone https://github.com/safishamsi/graphify.git`, which is not this project's repository.
- Every badge and image link elsewhere in the same README already points to `Graphify-Labs/graphify`, confirming the correct URL.
- This fixes the clone command to match, so new contributors don't end up cloning the wrong repo.

## Test plan
- Doc-only change, no code affected.
- Visually confirmed the corrected URL matches `git remote -v` for this repository and the other GitHub links already in README.md.