### PR TITLE
fix(hooks): replace DETACHED_PROCESS with CREATE_NO_WINDOW on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 worked/**/*.html linguist-vendored=true
 graphify-out/**/*.html linguist-vendored=true
 *.html linguist-detectable=false
+graphify-out/graph.json merge=graphify

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,3 @@
 worked/**/*.html linguist-vendored=true
 graphify-out/**/*.html linguist-vendored=true
 *.html linguist-detectable=false
-graphify-out/graph.json merge=graphify

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -215,7 +215,7 @@ except Exception as exc:
 # requires Python, so we let Python do the detaching: a tiny outer process spawns
 # the real rebuild fully detached and returns immediately, so the hook never
 # blocks. POSIX uses start_new_session (the setsid equivalent); Windows uses
-# DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP, breaking away from any job object
+# CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP, breaking away from any job object
 # when allowed. This payload is carried inside a shell double-quoted -c argument,
 # so it deliberately uses only single-quoted Python strings (no ", $, ` or \\).
 _LAUNCHER_TEMPLATE = """\
@@ -232,7 +232,7 @@ except OSError:
 _kw = dict(stdout=_out, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, cwd=os.getcwd(), close_fds=True)
 _cmd = [sys.executable, '-c', _src]
 if os.name == 'nt':
-    _flags = 0x00000008 | 0x00000200  # DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+    _flags = 0x08000000 | 0x00000200  # CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
     try:
         subprocess.Popen(_cmd, creationflags=_flags | 0x01000000, **_kw)  # + CREATE_BREAKAWAY_FROM_JOB
     except OSError:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -248,10 +248,10 @@ def test_hooks_do_not_use_nohup(name, script):
 @pytest.mark.parametrize("name,script", _HOOK_SCRIPTS)
 def test_hooks_use_cross_platform_detach(name, script):
     """The replacement detaches via Python: start_new_session on POSIX and
-    DETACHED_PROCESS|CREATE_NEW_PROCESS_GROUP on Windows (#1161)."""
+    CREATE_NO_WINDOW|CREATE_NEW_PROCESS_GROUP on Windows (#1161)."""
     assert "subprocess.Popen" in script
     assert "start_new_session=True" in script, f"{name} missing POSIX detach"
-    assert "0x00000008" in script, f"{name} missing Windows DETACHED_PROCESS flag"
+    assert "0x08000000" in script, f"{name} missing Windows CREATE_NO_WINDOW flag"
     assert "0x00000200" in script, f"{name} missing CREATE_NEW_PROCESS_GROUP flag"
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -248,7 +248,7 @@ def test_hooks_do_not_use_nohup(name, script):
 @pytest.mark.parametrize("name,script", _HOOK_SCRIPTS)
 def test_hooks_use_cross_platform_detach(name, script):
     """The replacement detaches via Python: start_new_session on POSIX and
-    CREATE_NO_WINDOW|CREATE_NEW_PROCESS_GROUP on Windows (#1161)."""
+    CREATE_NO_WINDOW|CREATE_NEW_PROCESS_GROUP on Windows (#1161 / #2253)."""
     assert "subprocess.Popen" in script
     assert "start_new_session=True" in script, f"{name} missing POSIX detach"
     assert "0x08000000" in script, f"{name} missing Windows CREATE_NO_WINDOW flag"


### PR DESCRIPTION
## Summary

Fixes #2253.

On Windows, Graphify's Git hook launcher started the background rebuild using `DETACHED_PROCESS` together with `python.exe`. Since `python.exe` is a console-subsystem executable, this caused Windows to open a new console window during every background rebuild triggered by `post-commit` and `post-checkout` hooks.

This change replaces `DETACHED_PROCESS` with `CREATE_NO_WINDOW` while preserving the existing detached background execution behavior by keeping:

* `CREATE_NEW_PROCESS_GROUP`
* `CREATE_BREAKAWAY_FROM_JOB` (best-effort)

The POSIX launch path (`start_new_session=True`) is unchanged.

## Changes

* Replace the Windows `DETACHED_PROCESS` creation flag with `CREATE_NO_WINDOW` in the hook launcher.
* Update the launcher comment to reflect the new Windows creation flag.
* Update the corresponding regression test to verify the generated launcher contains `CREATE_NO_WINDOW`.

## Why this approach?

The hook launcher introduced in #1161 was designed to replace the previous `nohup`-based implementation with a cross-platform Python launcher. This change preserves those original design goals:

* Git commits return immediately.
* Background rebuilds continue independently.
* Cross-platform behavior remains unchanged.
* No dependency on shell-specific utilities.

`CREATE_NO_WINDOW` suppresses the unwanted console window while retaining the existing process-group behavior through `CREATE_NEW_PROCESS_GROUP` and the existing best-effort `CREATE_BREAKAWAY_FROM_JOB`.

## Validation

Tested on Windows by:

* Installing Git hooks with `graphify hook install`
* Performing Git commits
* Verifying no console window appears
* Verifying commits complete immediately
* Verifying the background rebuild still executes
* Verifying rebuild logs are still written
* Verifying `graph.json`, `graph.html`, and `GRAPH_REPORT.md` are regenerated

Also updated and ran the relevant hook regression test to validate the generated launcher uses the expected Windows creation flags.
