### PR TITLE
perf(neo4j): fix O(N²) edge inserts via labeled MATCH + UNWIND batching

### DIFF
--- a/graphify/exporters/graphdb.py
+++ b/graphify/exporters/graphdb.py
@@ -1,9 +1,12 @@
 """graphdb — moved verbatim from graphify/export.py."""
 from __future__ import annotations
 
+from collections import defaultdict
 from graphify.analyze import _node_community_map
 import networkx as nx
 import re
+
+_BATCH_SIZE = 500
 
 
 def push_to_neo4j(
@@ -37,42 +40,90 @@ def push_to_neo4j(
         sanitized = re.sub(r"[^A-Za-z0-9_]", "", label)
         return sanitized if sanitized else "Entity"
 
+    # Group by label/rel-type: Cypher does not support parameterized labels,
+    # so UNWIND batches must be homogeneous to keep a fixed query shape.
+    # Build id->label map so edge MATCH can include the label and use the index.
+    id_to_label: dict[str, str] = {}
+    by_label: dict[str, list[dict]] = defaultdict(list)
+    for node_id, data in G.nodes(data=True):
+        props = {
+            k: v for k, v in data.items()
+            if isinstance(v, (str, int, float, bool)) and not k.startswith("_")
+        }
+        props["id"] = node_id
+        cid = node_community.get(node_id)
+        if cid is not None:
+            props["community"] = cid
+        lbl = _safe_label(data.get("file_type", "Entity").capitalize())
+        id_to_label[node_id] = lbl
+        by_label[lbl].append(props)
+
+    # Group edges by (src_label, tgt_label, rel) so the MATCH can use label
+    # indexes — a label-less MATCH (a {id: ...}) ignores all constraints and
+    # scans the full node store, making edge inserts O(N²).
+    by_rel: dict[tuple, list[dict]] = defaultdict(list)
+    for u, v, data in G.edges(data=True):
+        props = {
+            k: v for k, v in data.items()
+            if isinstance(v, (str, int, float, bool)) and not k.startswith("_")
+        }
+        src_lbl = id_to_label.get(u, "Entity")
+        tgt_lbl = id_to_label.get(v, "Entity")
+        rel = _safe_rel(data.get("relation", "RELATED_TO"))
+        by_rel[(src_lbl, tgt_lbl, rel)].append({"src": u, "tgt": v, "props": props})
+
+    total_nodes = sum(len(v) for v in by_label.values())
+    total_edges = sum(len(v) for v in by_rel.values())
+
+    import time as _time
+    _LOG_INTERVAL = 60  # seconds
+
+    def _log_progress(kind: str, done: int, total: int) -> None:
+        pct = int(done * 100 / total) if total else 100
+        print(f"[graphify] neo4j {kind}: {done}/{total} ({pct}%)", flush=True)
+
     driver = GraphDatabase.driver(uri, auth=(user, password))
     nodes_pushed = 0
     edges_pushed = 0
+    last_node_log = _time.monotonic()
+    last_edge_log = _time.monotonic()
 
     with driver.session() as session:
-        for node_id, data in G.nodes(data=True):
-            props = {
-                k: v for k, v in data.items()
-                if isinstance(v, (str, int, float, bool)) and not k.startswith("_")
-            }
-            props["id"] = node_id
-            cid = node_community.get(node_id)
-            if cid is not None:
-                props["community"] = cid
-            ftype = _safe_label(data.get("file_type", "Entity").capitalize())
-            session.run(
-                f"MERGE (n:{ftype} {{id: $id}}) SET n += $props",
-                id=node_id,
-                props=props,
-            )
-            nodes_pushed += 1
+        for label, rows in by_label.items():
+            for i in range(0, len(rows), _BATCH_SIZE):
+                batch = rows[i:i + _BATCH_SIZE]
+                session.execute_write(
+                    lambda tx, b=batch, lbl=label: tx.run(
+                        f"UNWIND $batch AS row MERGE (n:{lbl} {{id: row.id}}) SET n += row",
+                        batch=b,
+                    )
+                )
+                nodes_pushed += len(batch)
+                now = _time.monotonic()
+                if now - last_node_log >= _LOG_INTERVAL:
+                    _log_progress("nodes", nodes_pushed, total_nodes)
+                    last_node_log = now
 
-        for u, v, data in G.edges(data=True):
-            rel = _safe_rel(data.get("relation", "RELATED_TO"))
-            props = {
-                k: v for k, v in data.items()
-                if isinstance(v, (str, int, float, bool)) and not k.startswith("_")
-            }
-            session.run(
-                f"MATCH (a {{id: $src}}), (b {{id: $tgt}}) "
-                f"MERGE (a)-[r:{rel}]->(b) SET r += $props",
-                src=u,
-                tgt=v,
-                props=props,
-            )
-            edges_pushed += 1
+        _log_progress("nodes", nodes_pushed, total_nodes)
+
+        for (src_lbl, tgt_lbl, rel), rows in by_rel.items():
+            for i in range(0, len(rows), _BATCH_SIZE):
+                batch = rows[i:i + _BATCH_SIZE]
+                session.execute_write(
+                    lambda tx, b=batch, sl=src_lbl, tl=tgt_lbl, r=rel: tx.run(
+                        f"UNWIND $batch AS row "
+                        f"MATCH (a:{sl} {{id: row.src}}), (b:{tl} {{id: row.tgt}}) "
+                        f"MERGE (a)-[rr:{r}]->(b) SET rr += row.props",
+                        batch=b,
+                    )
+                )
+                edges_pushed += len(batch)
+                now = _time.monotonic()
+                if now - last_edge_log >= _LOG_INTERVAL:
+                    _log_progress("edges", edges_pushed, total_edges)
+                    last_edge_log = now
+
+        _log_progress("edges", edges_pushed, total_edges)
 
     driver.close()
     return {"nodes": nodes_pushed, "edges": edges_pushed}


### PR DESCRIPTION
## Problem

`push_to_neo4j` was catastrophically slow on large graphs (5+ hours for ~40k nodes/edges in production). Two compounding issues:

1. **Per-row round-trips**: each node/edge was a separate `session.run()` auto-commit transaction (~77k Bolt round-trips for a medium repo).

2. **Label-less edge MATCH** (the critical one): the edge query was:
   ```cypher
   MATCH (a {id: row.src}), (b {id: row.tgt})
   ```
   With no label, Neo4j ignores all uniqueness constraints and scans the **full node store** for every row — O(N²) regardless of indexes or UNWIND batching.

## Fix

1. Group nodes by label and edges by `(src_label, tgt_label, rel)`, send as UNWIND batches of 500 via `execute_write()`.
2. Include labels in the edge MATCH by building an `id→label` map during the node pass:
   ```cypher
   MATCH (a:Code {id: row.src}), (b:Document {id: row.tgt})
   ```
   This hits the per-label b-tree index (requires a uniqueness constraint on `id` per label, which callers should create before pushing).
3. Log progress every 60s so long pushes aren't silent.

## Benchmark

Ephemeral Neo4j 5, no pre-existing data:

| Strategy | 10k nodes / 20k edges |
|---|---|
| baseline (per-row session.run) | 88s |
| UNWIND + constraint, label-less MATCH | 71s (barely better) |
| UNWIND + constraint + **labeled MATCH** | **1.5s (50x faster)** |

Production: 212k nodes + 398k edges pushed in ~24s.

## Notes

- The label-less MATCH fix is the dominant improvement; UNWIND batching alone barely moves the needle because it just reduces transaction overhead while the per-row full-scan cost remains.
- Callers should `CREATE CONSTRAINT label_id_unique IF NOT EXISTS FOR (n:Label) REQUIRE n.id IS UNIQUE` for each label before pushing to get the full benefit.