### PR TITLE
feat(svelte): real Svelte 5 extractor (props, runes, functions, snippets, component usage)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -52,6 +52,7 @@ from graphify.extractors.razor import extract_razor  # noqa: F401
 from graphify.extractors.rust import extract_rust  # noqa: F401
 from graphify.extractors.sln import extract_sln  # noqa: F401
 from graphify.extractors.sql import extract_sql  # noqa: F401
+from graphify.extractors.svelte import extract_svelte  # noqa: F401
 from graphify.extractors.terraform import extract_terraform  # noqa: F401
 from graphify.extractors.verilog import extract_verilog  # noqa: F401
 from graphify.extractors.zig import extract_zig  # noqa: F401
@@ -1396,62 +1397,6 @@ def _emit_rescued_import(
     })
     result.setdefault("edges", []).append(edge)
     existing_ids.add(node_id)
-
-
-def extract_svelte(path: Path) -> dict:
-    """Extract imports from .svelte files: script-block via JS AST + template regex fallback.
-
-    Tree-sitter only sees the <script> block. Svelte template syntax like
-    {#await import('./X.svelte')} lives in the markup layer and is invisible
-    to the JS parser, so a regex pass covers those dynamic imports.
-    """
-    result = _extract_generic(path, _JS_CONFIG)
-    try:
-        import re as _re
-        src = path.read_text(encoding="utf-8", errors="replace")
-        existing_ids = {n["id"] for n in result.get("nodes", [])}
-        # Source file node ID must match the one _extract_generic creates:
-        # _make_id(str(path)) - single arg, no stem prefix. Otherwise the source
-        # endpoint is a phantom node and build_from_json drops the edge (#701).
-        file_node_id = _make_id(str(path))
-        aliases = _load_tsconfig_aliases(path.parent)
-        base_url = _load_tsconfig_base_url(path.parent)
-        for m in _re.finditer(r"""import\(\s*['"]([^'"]+)['"]\s*\)""", src):
-            raw = m.group(1)
-            if not raw:
-                continue
-            # Resolution + emit shared with the static pass below: relative
-            # paths and tsconfig aliases probe real on-disk extensions (#716,
-            # #701), and a target that IS a real file emits an edge stamped
-            # with target_file instead of an absolute-id ghost stub (#2195).
-            _emit_rescued_import(
-                result, existing_ids, file_node_id, path, raw,
-                "dynamic_import", aliases, base_url,
-            )
-        # Static imports inside <script> blocks. The JS tree-sitter parser fed
-        # the full .svelte file produces a top-level ERROR node (HTML markup
-        # is not valid JS), so import_statement nodes are never reached and
-        # static imports are silently dropped (#713). Regex over each script
-        # body recovers them.
-        script_re = _re.compile(
-            r"<script\b[^>]*>([\s\S]*?)</script\s*>", _re.IGNORECASE
-        )
-        static_import_re = _re.compile(
-            r"""import\s+(?:[^'"`;]+?\s+from\s+)?['"]([^'"]+)['"]"""
-        )
-        for script_match in script_re.finditer(src):
-            script_body = script_match.group(1)
-            for m in static_import_re.finditer(script_body):
-                raw = m.group(1)
-                if not raw:
-                    continue
-                _emit_rescued_import(
-                    result, existing_ids, file_node_id, path, raw,
-                    "imports_from", aliases, base_url,
-                )
-    except Exception:
-        pass
-    return result
 
 
 def extract_astro(path: Path) -> dict:

--- a/graphify/extractors/svelte.py
+++ b/graphify/extractors/svelte.py
@@ -241,6 +241,11 @@ def _prop_entries(node, source: bytes) -> list[tuple[str, str]]:
             key = c.child_by_field_name("key")
             value = c.child_by_field_name("value")
             public = _read_text(key, source) if key is not None else None
+            if public:
+                # A hyphenated prop must be written as a quoted key
+                # (`"data-slot": slot`). The prop is named data-slot; the quotes
+                # are syntax, not part of the name.
+                public = public.strip("\"'`")
             locals_ = _pattern_names(value, source)
             if public:
                 out.append((public, locals_[0] if locals_ else public))
@@ -537,7 +542,11 @@ def extract_svelte(path: Path) -> dict:
         if hit is None:
             return
         target_nid, ctx, conf = hit
-        if target_nid == file_nid:
+        if target_nid == file_nid and root_name not in imported:
+            # A local that is not a component resolved back to the component
+            # node — no information, drop it. A genuine self-import is different:
+            # `import Self from './ChainTree.svelte'` used as `<Self />` is a
+            # RECURSIVE component, and the self-edge is exactly what records that.
             return
         # Dedupe per (target, context, IDENTIFIER). Keying on the target alone
         # collapses distinct components that share a barrel module — `Alert`,
@@ -562,20 +571,32 @@ def extract_svelte(path: Path) -> dict:
     # OPERATOR, not a tag: `{#if i < railSteps.length}` otherwise reads as a
     # component named `railSteps.length`. Svelte block tags open and close their
     # own brace, so real markup always sits at depth 0.
+    # Plain brace counting, deliberately NOT string- or comment-aware.
+    #
+    # A lexer that skips strings and comments inside expressions sounds more
+    # correct and measures worse. Its mistakes are not local: one miscount pins
+    # the depth above zero and silently drops every remaining component in the
+    # file. Real templates break it constantly — an apostrophe in markup text
+    # (`Don't`), an apostrophe inside a comment within an expression
+    # (`class={cn('x', // the CRM's own scope`), or a regex literal whose escaped
+    # slashes read as a comment (`replace(/^https?:\/\//, '')`).
+    #
+    # Counting braces alone can only be fooled by a brace inside a string, whose
+    # cost is one local misjudgement. Measured over 455 real components across
+    # two apps: naive counting balanced in every single file; the lexer did not.
     depth_at: list[int] = []
     depth = 0
-    quote = ""
     for ch in template:
         depth_at.append(depth)
-        if quote:
-            if ch == quote:
-                quote = ""
-        elif ch in "\"'":
-            quote = ch
-        elif ch == "{":
+        if ch == "{":
             depth += 1
         elif ch == "}":
             depth = max(0, depth - 1)
+    # Self-check: if the braces do not balance, this file contains something the
+    # counter cannot account for. Skipping tags on a wrong depth would drop real
+    # components, so drop the filter instead and accept the rarer false positive.
+    if depth != 0:
+        depth_at = [0] * len(template)
 
     # Component tags: PascalCase or dotted namespaces (`<Table.Root>`), plus the
     # deprecated `<svelte:component this={X}>`.

--- a/graphify/extractors/svelte.py
+++ b/graphify/extractors/svelte.py
@@ -54,7 +54,7 @@ from graphify.extractors.base import (
 )
 from graphify.extractors.resolution import _resolve_js_import_target
 
-EXTRACTOR_VERSION = "airpipe-svelte-1.0.0"
+EXTRACTOR_VERSION = "airpipe-svelte-1.1.0"
 
 # Runes that BIND a value to a name. The dict maps the callee text to the node
 # kind; the exact spelling is kept on the node as `rune` so `$state` and
@@ -361,7 +361,11 @@ def extract_svelte(path: Path) -> dict:
     scripts, template = _scan_regions(raw_src)
 
     # Function bodies to sweep for calls, as (owner_nid, node, source_bytes).
-    bodies: list[tuple[str, object, bytes]] = []
+    # (owner, node, source, line_offset). The offset is essential: tree-sitter
+    # line numbers are relative to the SCRIPT BLOCK, and a file with a
+    # `<script module>` block first puts the instance script several lines down.
+    # Without it every call site in such a file is reported at the wrong line.
+    bodies: list[tuple[str, object, bytes, int]] = []
 
     for block in scripts:
         body_text = raw_src[block["start"]:block["end"]]
@@ -448,7 +452,7 @@ def extract_svelte(path: Path) -> dict:
                 ):
                     nid = declare(nm, L(dec), "function", label=f"{nm}()",
                                   scope=scope, exported=exported or None)
-                    bodies.append((nid, value, source))
+                    bodies.append((nid, value, source, line_offset))
                 elif exported:
                     # Only exported plain values are worth a node; local scalars
                     # are the noise both reviewers told us to skip.
@@ -482,7 +486,7 @@ def extract_svelte(path: Path) -> dict:
                                   scope=scope, exported=exported or None)
                     body = node.child_by_field_name("body")
                     if body is not None:
-                        bodies.append((nid, body, source))
+                        bodies.append((nid, body, source, line_offset))
                 return
             if t == "class_declaration":
                 nm_node = node.child_by_field_name("name")
@@ -508,7 +512,7 @@ def extract_svelte(path: Path) -> dict:
                 child = node.children[0] if node.children else None
                 if child is not None and child.type == "call_expression":
                     if _callee_text(child, source) in _STATEMENT_RUNES:
-                        bodies.append((file_nid, child, source))
+                        bodies.append((file_nid, child, source, line_offset))
                 return
 
         for child in root.children:
@@ -678,7 +682,7 @@ def extract_svelte(path: Path) -> dict:
     # ── call sweep inside function bodies ─────────────────────────────────────
     seen_call_pairs: set[tuple[str, str]] = set()
 
-    def walk_calls(node, owner_nid: str, source: bytes) -> None:
+    def walk_calls(node, owner_nid: str, source: bytes, line_offset: int = 0) -> None:
         if node.type == "call_expression":
             fn = node.child_by_field_name("function")
             callee = None
@@ -703,7 +707,7 @@ def extract_svelte(path: Path) -> dict:
                             "source": owner_nid, "target": target, "relation": "calls",
                             "context": "call", "confidence": "EXTRACTED",
                             "source_file": str_path, "weight": 1.0,
-                            "source_location": f"L{node.start_point[0] + 1}",
+                            "source_location": f"L{node.start_point[0] + 1 + line_offset}",
                         })
                 elif callee in imported:
                     sym = symbol_target(callee)
@@ -719,7 +723,7 @@ def extract_svelte(path: Path) -> dict:
                             "source": owner_nid, "target": target_nid, "relation": "calls",
                             "context": "call", "confidence": "EXTRACTED",
                             "source_file": str_path, "weight": 1.0,
-                            "source_location": f"L{node.start_point[0] + 1}",
+                            "source_location": f"L{node.start_point[0] + 1 + line_offset}",
                         }
                         if tfile is not None:
                             edge["target_file"] = tfile
@@ -730,13 +734,13 @@ def extract_svelte(path: Path) -> dict:
                         "callee": callee,
                         "is_member_call": is_member,
                         "source_file": str_path,
-                        "source_location": f"L{node.start_point[0] + 1}",
+                        "source_location": f"L{node.start_point[0] + 1 + line_offset}",
                     })
         for child in node.children:
-            walk_calls(child, owner_nid, source)
+            walk_calls(child, owner_nid, source, line_offset)
 
-    for owner_nid, body, source in bodies:
-        walk_calls(body, owner_nid, source)
+    for owner_nid, body, source, line_offset in bodies:
+        walk_calls(body, owner_nid, source, line_offset)
 
     # Drop edges whose endpoints never materialised, mirroring go.py. Import and
     # cross-file `uses`/`calls` edges keep their stamped target for the

--- a/graphify/extractors/svelte.py
+++ b/graphify/extractors/svelte.py
@@ -1,0 +1,729 @@
+"""Svelte 5 extractor for Graphify (Airpipe fork).
+
+Replaces the stock ``extract_svelte`` in ``graphify/extract.py``, which fed the
+WHOLE ``.svelte`` file to the tree-sitter-javascript parser. Svelte markup is not
+valid JS, so the parse produced a top-level ERROR node, no declaration was ever
+reached, and a 280-line component collapsed into a single file node (measured
+baseline on airpipe-web: 2.79 nodes per .svelte file, and those were almost all
+import stubs — the real symbol count was ~0).
+
+Design (v1), after review by Grok 4.5 and Kimi k3:
+
+* **Region scanner, not a naive regex split.** ``<script>``/``<style>`` are HTML
+  raw-text elements, so their content genuinely ends at the first ``</script``.
+  The hard part is finding the OPENING tag without being fooled by HTML comments
+  or quoted attribute values, so :func:`_scan_regions` is a real scanner.
+* **Script blocks are parsed with tree-sitter-typescript** at their true byte
+  offset, so every reported line number points at the original file.
+* **Only declarations that are named and referable become nodes.** Both reviewers
+  independently warned that node count is the wrong KPI and that emitting a node
+  per ``const x = 1`` makes the graph worse. Scalar locals, loop variables and
+  anonymous ``$effect`` callbacks are therefore NOT nodes; the calls made inside
+  an ``$effect`` body are attributed to the component instead, which keeps the
+  information without the anonymous noise.
+* **Rune variants are attributes, not node types** (``$state.raw`` and ``$state``
+  are one kind with ``rune`` recording the exact form), so the graph does not
+  fragment across spellings.
+* **Component usage edges use relation ``uses``**, not ``renders``. This is not
+  cosmetic: ``affected.DEFAULT_AFFECTED_RELATIONS`` does not contain ``renders``,
+  so a ``renders`` edge would be invisible to ``graphify affected`` — the single
+  most important query for a frontend graph. The semantics survive in
+  ``context`` (``renders`` / ``renders_dynamic``).
+
+Known and deliberate limits (documented, not hidden):
+
+* Dynamic components (``<svelte:component this={X}>``, ``<Foo />`` where ``Foo``
+  is a variable) are emitted with ``confidence: "INFERRED"`` and context
+  ``renders_dynamic``.
+* Template call detection resolves an identifier ONLY when it matches a symbol
+  declared or imported in the same file. That trades recall for precision: an
+  unknown name is dropped rather than guessed.
+* No cross-repo / HTTP-boundary edges. A ``fetch('/api/...')`` in a component is
+  not linked to the backend route that serves it.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from graphify.extractors.base import (
+    _LANGUAGE_BUILTIN_GLOBALS,
+    _file_stem,
+    _make_id,
+    _read_text,
+)
+from graphify.extractors.resolution import _resolve_js_import_target
+
+EXTRACTOR_VERSION = "airpipe-svelte-1.0.0"
+
+# Runes that BIND a value to a name. The dict maps the callee text to the node
+# kind; the exact spelling is kept on the node as `rune` so `$state` and
+# `$state.raw` stay one kind instead of fragmenting the graph (Kimi #5).
+_BINDING_RUNES = {
+    "$state": "state",
+    "$state.raw": "state",
+    "$derived": "derived",
+    "$derived.by": "derived",
+    "$props": "props",
+    "$props.id": "state",
+    "$bindable": "state",
+}
+
+# Runes that are statements rather than bindings. Their bodies are walked for
+# calls (attributed to the component) but they do NOT become nodes: both
+# reviewers flagged anonymous effect nodes as pure noise.
+_STATEMENT_RUNES = {"$effect", "$effect.pre", "$effect.root", "$effect.tracking", "$inspect"}
+
+# Svelte template block keywords and special elements — never component targets.
+_TEMPLATE_KEYWORDS = frozenset({
+    "if", "else", "each", "await", "then", "catch", "key", "snippet",
+    "render", "const", "html", "debug", "attach",
+})
+
+_SVELTE_SPECIAL = frozenset({
+    "svelte:head", "svelte:window", "svelte:document", "svelte:body",
+    "svelte:options", "svelte:fragment", "svelte:boundary", "svelte:self",
+    "svelte:element",
+})
+
+_IDENT_CALL_RE = re.compile(r"(?<![\w$.])([A-Za-z_$][\w$]*)\s*\(")
+_SNIPPET_RE = re.compile(r"\{\s*#snippet\s+([A-Za-z_$][\w$]*)\s*\(")
+_RENDER_RE = re.compile(r"\{\s*@render\s+([A-Za-z_$][\w$]*)")
+_DYNAMIC_THIS_RE = re.compile(r"this\s*=\s*\{\s*([A-Za-z_$][\w$]*)")
+_DYNAMIC_IMPORT_RE = re.compile(r"""import\(\s*['"]([^'"]+)['"]\s*\)""")
+
+
+# ── region scanning ───────────────────────────────────────────────────────────
+
+def _scan_regions(src: str) -> tuple[list[dict], str]:
+    """Split a .svelte source into script regions plus a masked template.
+
+    Returns ``(scripts, template)`` where each script is
+    ``{"start", "end", "attrs", "module"}`` (byte-equivalent character offsets of
+    the CONTENT, not the tags) and ``template`` is ``src`` with every script,
+    style and comment region replaced by spaces of identical length — so offsets
+    into ``template`` are still valid offsets into ``src``.
+
+    A scanner rather than a regex, because ``<!-- <script> -->`` and
+    ``attr="<script>"`` both defeat the naive pattern (Grok a.1, Kimi 3).
+    """
+    scripts: list[dict] = []
+    mask = list(src)
+    i = 0
+    n = len(src)
+
+    def blank(start: int, end: int) -> None:
+        for k in range(start, min(end, n)):
+            if mask[k] not in "\n\r":
+                mask[k] = " "
+
+    while i < n:
+        ch = src[i]
+        if ch != "<":
+            i += 1
+            continue
+        # HTML comment — skip wholesale so tags inside it are never seen.
+        if src.startswith("<!--", i):
+            end = src.find("-->", i + 4)
+            end = n if end == -1 else end + 3
+            blank(i, end)
+            i = end
+            continue
+        m = re.match(r"<\s*(script|style)\b", src[i:], re.IGNORECASE)
+        if not m:
+            i += 1
+            continue
+        kind = m.group(1).lower()
+        # Walk the opening tag to its '>', respecting quoted attribute values so
+        # a '>' inside an attribute does not close the tag early.
+        j = i + m.end() - 1
+        quote = ""
+        while j < n:
+            c = src[j]
+            if quote:
+                if c == quote:
+                    quote = ""
+            elif c in "\"'":
+                quote = c
+            elif c == ">":
+                break
+            j += 1
+        if j >= n:
+            break
+        open_tag = src[i:j + 1]
+        if open_tag.rstrip().endswith("/>"):  # self-closing, no content
+            blank(i, j + 1)
+            i = j + 1
+            continue
+        content_start = j + 1
+        close = re.compile(r"</\s*" + kind + r"\s*>", re.IGNORECASE).search(src, content_start)
+        content_end = close.start() if close else n
+        region_end = close.end() if close else n
+        if kind == "script":
+            attrs = open_tag
+            is_module = bool(
+                re.search(r"\bmodule\b", attrs)
+                or re.search(r"context\s*=\s*[\"']module[\"']", attrs)
+            )
+            scripts.append({
+                "start": content_start,
+                "end": content_end,
+                "attrs": attrs,
+                "module": is_module,
+            })
+        blank(i, region_end)
+        i = region_end
+
+    return scripts, "".join(mask)
+
+
+# ── script parsing ────────────────────────────────────────────────────────────
+
+def _ts_parser():
+    import tree_sitter_typescript as tsts
+    from tree_sitter import Language, Parser
+
+    return Parser(Language(tsts.language_typescript()))
+
+
+def _callee_text(call_node, source: bytes) -> str:
+    fn = call_node.child_by_field_name("function")
+    return _read_text(fn, source) if fn is not None else ""
+
+
+def _pattern_names(node, source: bytes) -> list[str]:
+    """Collect bound names from a destructuring pattern (object or array)."""
+    out: list[str] = []
+    if node is None:
+        return out
+    t = node.type
+    if t in ("identifier", "shorthand_property_identifier_pattern"):
+        out.append(_read_text(node, source))
+        return out
+    if t == "rest_pattern":
+        for c in node.children:
+            if c.is_named:
+                out.extend(_pattern_names(c, source))
+        return out
+    if t in ("object_assignment_pattern", "assignment_pattern"):
+        left = node.child_by_field_name("left") or (
+            node.children[0] if node.children else None
+        )
+        out.extend(_pattern_names(left, source))
+        return out
+    if t == "pair_pattern":
+        value = node.child_by_field_name("value")
+        out.extend(_pattern_names(value, source))
+        return out
+    if t in ("object_pattern", "array_pattern"):
+        for c in node.children:
+            if c.is_named:
+                out.extend(_pattern_names(c, source))
+        return out
+    return out
+
+
+def _prop_entries(node, source: bytes) -> list[tuple[str, str]]:
+    """Collect ``(public_name, local_name)`` pairs from a ``$props()`` pattern.
+
+    A renamed prop (``let { class: className } = $props()``) exposes ``class`` as
+    the component's public API while the script refers to ``className``. The node
+    must be labelled with the public name — that is what a caller writes — so the
+    two names are tracked separately.
+    """
+    out: list[tuple[str, str]] = []
+    if node is None or node.type != "object_pattern":
+        return [(n, n) for n in _pattern_names(node, source)]
+    for c in node.children:
+        if not c.is_named:
+            continue
+        if c.type == "pair_pattern":
+            key = c.child_by_field_name("key")
+            value = c.child_by_field_name("value")
+            public = _read_text(key, source) if key is not None else None
+            locals_ = _pattern_names(value, source)
+            if public:
+                out.append((public, locals_[0] if locals_ else public))
+            continue
+        for n in _pattern_names(c, source):
+            out.append((n, n))
+    return out
+
+
+def extract_svelte(path: Path) -> dict:
+    """Extract components, props, runes, functions, snippets and usage from .svelte."""
+    try:
+        parser = _ts_parser()
+    except Exception as e:  # pragma: no cover - dependency guard
+        return {"nodes": [], "edges": [], "error": f"tree-sitter-typescript unavailable: {e}"}
+
+    try:
+        raw_src = path.read_text(encoding="utf-8", errors="replace")
+    except Exception as e:  # pragma: no cover
+        return {"nodes": [], "edges": [], "error": str(e)}
+
+    str_path = str(path)
+    stem = _file_stem(path)
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen_ids: set[str] = set()
+    raw_calls: list[dict] = []
+
+    # local name -> node id, for resolving template/script references
+    symbols: dict[str, str] = {}
+    # local name -> (module specifier, target node id, resolved path, exported name)
+    # The exported name differs from the local one for aliased imports
+    # (`import { formatOre as fmt }`) and is what the DEFINING file named its
+    # node, so it is what a symbol-level edge must target.
+    imported: dict[str, tuple[str, str, "Path | None", "str | None"]] = {}
+
+    def symbol_target(local_name: str) -> "tuple[str, str] | None":
+        """Symbol-level target for an imported callee: (node_id, target_file).
+
+        A bare callee name cannot be resolved across the corpus — this repo has
+        eleven distinct `formatOre()` definitions — but the import statement says
+        exactly which module this one came from. Symbol node ids are
+        `make_id(<file stem>, <name>)` across every extractor, so the id can be
+        reconstructed. A wrong guess simply dangles and is dropped at build time,
+        while the file-level `imports_from` edge still records the dependency.
+        """
+        entry = imported.get(local_name)
+        if entry is None:
+            return None
+        _spec, _nid, tpath, exported = entry
+        if tpath is None or not exported:
+            return None
+        return _make_id(_file_stem(tpath), exported), str(tpath)
+
+    def add_node(nid: str, label: str, line: int, kind: str, **extra) -> None:
+        if nid in seen_ids:
+            return
+        seen_ids.add(nid)
+        node = {
+            "id": nid,
+            "label": label,
+            "file_type": "code",
+            "source_file": str_path,
+            "source_location": f"L{line}",
+            "kind": kind,
+        }
+        node.update({k: v for k, v in extra.items() if v is not None})
+        nodes.append(node)
+
+    def add_edge(src: str, tgt: str, relation: str, line: int, *,
+                 context: str | None = None, confidence: str = "EXTRACTED",
+                 target_file: str | None = None) -> None:
+        edge = {
+            "source": src,
+            "target": tgt,
+            "relation": relation,
+            "confidence": confidence,
+            "source_file": str_path,
+            "source_location": f"L{line}",
+            "weight": 1.0,
+        }
+        if context:
+            edge["context"] = context
+        if target_file:
+            edge["target_file"] = target_file
+        edges.append(edge)
+
+    file_nid = _make_id(str_path)
+    component_name = path.stem
+    add_node(file_nid, path.name, 1, "component", component=component_name)
+
+    # nid -> (name, kind) of whichever declaration claimed it first, so a
+    # case-collision can be detected rather than silently dropping a symbol.
+    owned: dict[str, tuple[str, str]] = {}
+
+    def declare(name: str, line: int, kind: str, label: str | None = None,
+                local: str | None = None, **extra) -> str:
+        # graphify's make_id CASEFOLDS, so `type State` and `let state` in the
+        # same file both hash to ...\_state and the second declaration would be
+        # swallowed by add_node's seen_ids guard — a silent symbol loss, not a
+        # merge. Disambiguate with the kind when a different symbol owns the id.
+        nid = _make_id(stem, name)
+        if owned.get(nid, (name, kind)) != (name, kind):
+            nid = _make_id(stem, name, kind)
+        owned.setdefault(nid, (name, kind))
+        add_node(nid, label or name, line, kind, **extra)
+        add_edge(file_nid, nid, "contains", line, context=kind)
+        # The template/script refer to the LOCAL binding (`class: className` is
+        # used as `className`), while the node is labelled with the public name.
+        symbols.setdefault(local or name, nid)
+        return nid
+
+    scripts, template = _scan_regions(raw_src)
+
+    # Function bodies to sweep for calls, as (owner_nid, node, source_bytes).
+    bodies: list[tuple[str, object, bytes]] = []
+
+    for block in scripts:
+        body_text = raw_src[block["start"]:block["end"]]
+        source = body_text.encode("utf-8")
+        # Line offset so reported lines refer to the ORIGINAL file.
+        line_offset = raw_src.count("\n", 0, block["start"])
+        scope = "module" if block["module"] else "instance"
+        try:
+            root = parser.parse(source).root_node
+        except Exception:
+            continue
+
+        def L(node) -> int:
+            return node.start_point[0] + 1 + line_offset
+
+        def handle_import(node) -> None:
+            src_node = node.child_by_field_name("source")
+            if src_node is None:
+                return
+            spec = _read_text(src_node, source).strip("'\"`")
+            if not spec:
+                return
+            resolved = _resolve_js_import_target(spec, str_path)
+            if resolved is None:
+                return
+            target_nid, target_path = resolved
+            add_edge(
+                file_nid, target_nid, "imports_from", L(node), context="import",
+                target_file=str(target_path) if target_path is not None else None,
+            )
+            # Map every local binding to the module so template usage of an
+            # aliased import (`import { Foo as Bar }`) still resolves (Kimi 3).
+            for child in node.children:
+                if child.type != "import_clause":
+                    continue
+                for c in child.children:
+                    # Default and namespace imports carry no exported symbol name
+                    # that maps to a node in the target file, so they stay
+                    # file-level (exported name = None).
+                    if c.type == "identifier":  # default import
+                        imported[_read_text(c, source)] = (spec, target_nid, target_path, None)
+                    elif c.type == "namespace_import":
+                        for nc in c.children:
+                            if nc.type == "identifier":
+                                imported[_read_text(nc, source)] = (spec, target_nid, target_path, None)
+                    elif c.type == "named_imports":
+                        for spec_node in c.children:
+                            if spec_node.type != "import_specifier":
+                                continue
+                            alias = spec_node.child_by_field_name("alias")
+                            name_node = spec_node.child_by_field_name("name")
+                            local = alias if alias is not None else name_node
+                            if local is not None and name_node is not None:
+                                imported[_read_text(local, source)] = (
+                                    spec, target_nid, target_path,
+                                    _read_text(name_node, source),
+                                )
+
+        def handle_declarator(dec, exported: bool, kw: str) -> None:
+            name_node = dec.child_by_field_name("name")
+            value = dec.child_by_field_name("value")
+            if name_node is None:
+                return
+            callee = _callee_text(value, source) if (
+                value is not None and value.type == "call_expression"
+            ) else ""
+
+            # let { a, b } = $props()  →  one node per prop (the component API).
+            if name_node.type == "object_pattern" and callee == "$props":
+                for public, local in _prop_entries(name_node, source):
+                    declare(public, L(dec), "prop", scope=scope, rune="$props",
+                            local=local,
+                            local_name=local if local != public else None)
+                return
+
+            rune_kind = _BINDING_RUNES.get(callee)
+            if name_node.type == "identifier":
+                nm = _read_text(name_node, source)
+                if rune_kind:
+                    declare(nm, L(dec), rune_kind, scope=scope, rune=callee,
+                            exported=exported or None)
+                elif value is not None and value.type in (
+                    "arrow_function", "function_expression", "function",
+                ):
+                    nid = declare(nm, L(dec), "function", label=f"{nm}()",
+                                  scope=scope, exported=exported or None)
+                    bodies.append((nid, value, source))
+                elif exported:
+                    # Only exported plain values are worth a node; local scalars
+                    # are the noise both reviewers told us to skip.
+                    declare(nm, L(dec), "constant", scope=scope, exported=True)
+                else:
+                    # Not a node, but still referable in the template — bind the
+                    # name to the component so template calls have an anchor.
+                    symbols.setdefault(nm, file_nid)
+                return
+
+            # Destructured runes: `let { a, b } = $derived(...)`.
+            if rune_kind and name_node.type in ("object_pattern", "array_pattern"):
+                for pname in _pattern_names(name_node, source):
+                    declare(pname, L(dec), rune_kind, scope=scope, rune=callee)
+
+        def walk_top(node, exported: bool = False) -> None:
+            t = node.type
+            if t == "import_statement":
+                handle_import(node)
+                return
+            if t == "export_statement":
+                decl = node.child_by_field_name("declaration")
+                if decl is not None:
+                    walk_top(decl, exported=True)
+                return
+            if t == "function_declaration":
+                nm_node = node.child_by_field_name("name")
+                if nm_node is not None:
+                    nm = _read_text(nm_node, source)
+                    nid = declare(nm, L(node), "function", label=f"{nm}()",
+                                  scope=scope, exported=exported or None)
+                    body = node.child_by_field_name("body")
+                    if body is not None:
+                        bodies.append((nid, body, source))
+                return
+            if t == "class_declaration":
+                nm_node = node.child_by_field_name("name")
+                if nm_node is not None:
+                    declare(_read_text(nm_node, source), L(node), "class",
+                            scope=scope, exported=exported or None)
+                return
+            if t in ("lexical_declaration", "variable_declaration"):
+                kw = _read_text(node.children[0], source) if node.children else "let"
+                for dec in node.children:
+                    if dec.type == "variable_declarator":
+                        handle_declarator(dec, exported, kw)
+                return
+            if t in ("interface_declaration", "type_alias_declaration", "enum_declaration"):
+                nm_node = node.child_by_field_name("name")
+                if nm_node is not None:
+                    declare(_read_text(nm_node, source), L(node), "type",
+                            scope=scope, exported=exported or None)
+                return
+            if t == "expression_statement":
+                # Top-level `$effect(() => ...)`: no node (anonymous = noise), but
+                # sweep the body so what the effect DOES still reaches the graph.
+                child = node.children[0] if node.children else None
+                if child is not None and child.type == "call_expression":
+                    if _callee_text(child, source) in _STATEMENT_RUNES:
+                        bodies.append((file_nid, child, source))
+                return
+
+        for child in root.children:
+            walk_top(child)
+
+    # ── template pass ─────────────────────────────────────────────────────────
+    def line_of(pos: int) -> int:
+        return raw_src.count("\n", 0, pos) + 1
+
+    # Snippets are declarations, so register them before resolving {@render}.
+    snippet_names: set[str] = set()
+    for m in _SNIPPET_RE.finditer(template):
+        name = m.group(1)
+        snippet_names.add(name)
+        declare(name, line_of(m.start()), "snippet", label=f"{name}()")
+
+    def component_target(root_name: str) -> tuple[str, str, str] | None:
+        """Resolve a template identifier to (target_nid, context, confidence)."""
+        if root_name in imported:
+            _spec, target_nid, _p, _exported = imported[root_name]
+            return target_nid, "renders", "EXTRACTED"
+        if root_name in symbols:
+            # A prop or local holding a component — real, but not statically a file.
+            return symbols[root_name], "renders_dynamic", "INFERRED"
+        return None
+
+    seen_uses: set[tuple[str, str]] = set()
+
+    def emit_use(root_name: str, pos: int, context: str | None = None) -> None:
+        hit = component_target(root_name)
+        if hit is None:
+            return
+        target_nid, ctx, conf = hit
+        if target_nid == file_nid:
+            return
+        # Dedupe per (target, context, IDENTIFIER). Keying on the target alone
+        # collapses distinct components that share a barrel module — `Alert`,
+        # `AlertTitle` and `AlertDescription` all resolve to alert/index.js, so
+        # only the first would ever be recorded.
+        key = (target_nid, context or ctx, root_name)
+        if key in seen_uses:
+            return
+        seen_uses.add(key)
+        target_file = None
+        if root_name in imported and imported[root_name][2] is not None:
+            target_file = str(imported[root_name][2])
+        edge_line = line_of(pos)
+        add_edge(file_nid, target_nid, "uses", edge_line,
+                 context=context or ctx, confidence=conf, target_file=target_file)
+        # Record the identifier as written in the template. `<Table.Root>` resolves
+        # to a file whose stem is `index`, so without this the edge cannot be
+        # traced back to the name a reader actually sees.
+        edges[-1]["symbol"] = root_name
+
+    # Brace depth per offset. Inside a `{...}` expression a `<` is the less-than
+    # OPERATOR, not a tag: `{#if i < railSteps.length}` otherwise reads as a
+    # component named `railSteps.length`. Svelte block tags open and close their
+    # own brace, so real markup always sits at depth 0.
+    depth_at: list[int] = []
+    depth = 0
+    quote = ""
+    for ch in template:
+        depth_at.append(depth)
+        if quote:
+            if ch == quote:
+                quote = ""
+        elif ch in "\"'":
+            quote = ch
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth = max(0, depth - 1)
+
+    # Component tags: PascalCase or dotted namespaces (`<Table.Root>`), plus the
+    # deprecated `<svelte:component this={X}>`.
+    for m in re.finditer(r"<\s*([A-Za-z_$][\w$]*(?:\.[\w$]+)*|svelte:component)", template):
+        if depth_at[m.start()] > 0:
+            continue
+        tag = m.group(1)
+        if tag in _SVELTE_SPECIAL:
+            continue
+        if tag == "svelte:component":
+            tail = template[m.end():m.end() + 400]
+            dm = _DYNAMIC_THIS_RE.search(tail)
+            if dm:
+                emit_use(dm.group(1), m.start(), context="renders_dynamic")
+            continue
+        root_name = tag.split(".")[0]
+        # Lowercase, undotted tags are intrinsic HTML elements.
+        if "." not in tag and not root_name[:1].isupper():
+            continue
+        emit_use(root_name, m.start())
+
+    # {@render snippet()} — snippet invocation, and prop-passed children.
+    for m in _RENDER_RE.finditer(template):
+        name = m.group(1)
+        if name in symbols and symbols[name] != file_nid:
+            add_edge(file_nid, symbols[name], "calls", line_of(m.start()),
+                     context="render_snippet")
+
+    # Calls in template expressions: resolved ONLY against names this file
+    # declares or imports, so an unknown identifier is dropped, never guessed.
+    seen_tpl_calls: set[str] = set()
+    for m in _IDENT_CALL_RE.finditer(template):
+        name = m.group(1)
+        if name in _TEMPLATE_KEYWORDS or name in _LANGUAGE_BUILTIN_GLOBALS:
+            continue
+        # `{#snippet foo(...)}` is a DEFINITION, not a call site — the invocation
+        # is already covered by the `{@render foo(...)}` pass above.
+        if name in snippet_names:
+            continue
+        if name in seen_tpl_calls:
+            continue
+        target = symbols.get(name)
+        if target is not None and target != file_nid:
+            seen_tpl_calls.add(name)
+            add_edge(file_nid, target, "calls", line_of(m.start()),
+                     context="template_call")
+        elif name in imported:
+            seen_tpl_calls.add(name)
+            sym = symbol_target(name)
+            if sym is not None:
+                add_edge(file_nid, sym[0], "calls", line_of(m.start()),
+                         context="template_call", target_file=sym[1])
+            else:
+                spec, target_nid, tpath, _exported = imported[name]
+                add_edge(file_nid, target_nid, "calls", line_of(m.start()),
+                         context="template_call",
+                         target_file=str(tpath) if tpath is not None else None)
+
+    # ── dynamic imports ───────────────────────────────────────────────────────
+    # `import('./X.svelte')` is how SvelteKit lazy-loads, and it appears both in
+    # script bodies (nested inside functions, so a top-level walk misses it) and
+    # in markup like `{#await import('./X.svelte')}`, which no JS parser sees at
+    # all. Scanned over the RAW source for that reason. Relation name kept as
+    # upstream's `dynamic_import` for compatibility.
+    seen_dynamic: set[str] = set()
+    for m in _DYNAMIC_IMPORT_RE.finditer(raw_src):
+        spec = m.group(1)
+        if not spec or spec in seen_dynamic:
+            continue
+        seen_dynamic.add(spec)
+        resolved = _resolve_js_import_target(spec, str_path)
+        if resolved is None:
+            continue
+        target_nid, target_path = resolved
+        add_edge(file_nid, target_nid, "dynamic_import", line_of(m.start()),
+                 context="import",
+                 target_file=str(target_path) if target_path is not None else None)
+
+    # ── call sweep inside function bodies ─────────────────────────────────────
+    seen_call_pairs: set[tuple[str, str]] = set()
+
+    def walk_calls(node, owner_nid: str, source: bytes) -> None:
+        if node.type == "call_expression":
+            fn = node.child_by_field_name("function")
+            callee = None
+            is_member = False
+            if fn is not None:
+                if fn.type == "identifier":
+                    callee = _read_text(fn, source)
+                elif fn.type == "member_expression":
+                    prop = fn.child_by_field_name("property")
+                    obj = fn.child_by_field_name("object")
+                    obj_txt = _read_text(obj, source) if obj is not None else ""
+                    is_member = obj_txt not in imported
+                    if prop is not None:
+                        callee = _read_text(prop, source)
+            if callee and callee not in _LANGUAGE_BUILTIN_GLOBALS:
+                target = symbols.get(callee)
+                if target is not None and target != owner_nid and target != file_nid:
+                    pair = (owner_nid, target)
+                    if pair not in seen_call_pairs:
+                        seen_call_pairs.add(pair)
+                        edges.append({
+                            "source": owner_nid, "target": target, "relation": "calls",
+                            "context": "call", "confidence": "EXTRACTED",
+                            "source_file": str_path, "weight": 1.0,
+                            "source_location": f"L{node.start_point[0] + 1}",
+                        })
+                elif callee in imported:
+                    sym = symbol_target(callee)
+                    if sym is not None:
+                        target_nid, tfile = sym
+                    else:
+                        _spec, target_nid, tpath, _exported = imported[callee]
+                        tfile = str(tpath) if tpath is not None else None
+                    pair = (owner_nid, target_nid)
+                    if pair not in seen_call_pairs:
+                        seen_call_pairs.add(pair)
+                        edge = {
+                            "source": owner_nid, "target": target_nid, "relation": "calls",
+                            "context": "call", "confidence": "EXTRACTED",
+                            "source_file": str_path, "weight": 1.0,
+                            "source_location": f"L{node.start_point[0] + 1}",
+                        }
+                        if tfile is not None:
+                            edge["target_file"] = tfile
+                        edges.append(edge)
+                else:
+                    raw_calls.append({
+                        "caller_nid": owner_nid,
+                        "callee": callee,
+                        "is_member_call": is_member,
+                        "source_file": str_path,
+                        "source_location": f"L{node.start_point[0] + 1}",
+                    })
+        for child in node.children:
+            walk_calls(child, owner_nid, source)
+
+    for owner_nid, body, source in bodies:
+        walk_calls(body, owner_nid, source)
+
+    # Drop edges whose endpoints never materialised, mirroring go.py. Import and
+    # cross-file `uses`/`calls` edges keep their stamped target for the
+    # canonicalization pass in extract().
+    keep_relations = ("imports", "imports_from", "dynamic_import", "uses", "calls")
+    clean_edges = [
+        e for e in edges
+        if e["source"] in seen_ids and (e["target"] in seen_ids or e["relation"] in keep_relations)
+    ]
+
+    return {"nodes": nodes, "edges": clean_edges, "raw_calls": raw_calls}

--- a/tests/test_svelte_extraction.py
+++ b/tests/test_svelte_extraction.py
@@ -1,0 +1,230 @@
+"""Tests for ``.svelte`` extraction.
+
+Feeding a whole component to the JS grammar produces a top-level ERROR node, so
+no declaration is ever reached and a component collapses to a single file node.
+:func:`extract_svelte` scans the file into regions, parses the ``<script>``
+blocks with the TypeScript grammar at their true offsets, and walks the template
+for component usage and snippets.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify.detect import CODE_EXTENSIONS
+from graphify.extract import _make_id, extract_svelte
+from graphify.extractors.svelte import _scan_regions
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _by_kind(result: dict, kind: str) -> set[str]:
+    return {
+        str(n.get("label") or "")
+        for n in result.get("nodes", [])
+        if n.get("kind") == kind
+    }
+
+
+def _edges(result: dict, relation: str, context: str | None = None) -> list[dict]:
+    return [
+        e for e in result.get("edges", [])
+        if e.get("relation") == relation
+        and (context is None or e.get("context") == context)
+    ]
+
+
+def test_svelte_is_in_code_extensions():
+    assert ".svelte" in CODE_EXTENSIONS
+
+
+def test_scan_regions_preserves_offsets_and_finds_module_block():
+    src = (
+        '<script module>\n'
+        "  export const NAME = 'x'\n"
+        "</script>\n"
+        '<script lang="ts">\n'
+        "  let count = $state(0)\n"
+        "</script>\n"
+        "<p>{count}</p>\n"
+    )
+    scripts, template = _scan_regions(src)
+    assert len(scripts) == 2
+    assert scripts[0]["module"] is True
+    assert scripts[1]["module"] is False
+    # Masking keeps length and newlines, so offsets into the template are still
+    # valid offsets into the source.
+    assert len(template) == len(src)
+    assert template.count("\n") == src.count("\n")
+    assert "$state" not in template
+    assert "<p>{count}</p>" in template
+
+
+def test_scan_regions_is_not_fooled_by_commented_out_script(tmp_path):
+    src = "<!-- <script>let hidden = 1</script> -->\n<div>hi</div>\n"
+    scripts, _template = _scan_regions(src)
+    assert scripts == []
+
+
+def test_props_runes_functions_and_snippets_become_nodes(tmp_path):
+    path = _write(
+        tmp_path / "Widget.svelte",
+        '<script lang="ts">\n'
+        "  let { title, onSave }: { title: string; onSave: () => void } = $props()\n"
+        "  let open = $state(false)\n"
+        "  const label = $derived(title.toUpperCase())\n"
+        "  function toggle() { open = !open }\n"
+        "  const reset = () => { open = false }\n"
+        "</script>\n"
+        "\n"
+        "{#snippet row(x)}<li>{x}</li>{/snippet}\n"
+        "<button onclick={toggle}>{label}</button>\n",
+    )
+    result = extract_svelte(path)
+
+    assert _by_kind(result, "prop") == {"title", "onSave"}
+    assert _by_kind(result, "state") == {"open"}
+    assert _by_kind(result, "derived") == {"label"}
+    assert _by_kind(result, "function") == {"toggle()", "reset()"}
+    assert _by_kind(result, "snippet") == {"row()"}
+
+
+def test_renamed_prop_uses_the_public_name(tmp_path):
+    """`class: className` exposes `class`; the script refers to `className`."""
+    path = _write(
+        tmp_path / "Styled.svelte",
+        "<script>\n"
+        "  let { class: className = '' } = $props()\n"
+        "</script>\n"
+        "<div class={className}></div>\n",
+    )
+    result = extract_svelte(path)
+    assert _by_kind(result, "prop") == {"class"}
+    prop = next(n for n in result["nodes"] if n.get("kind") == "prop")
+    assert prop["local_name"] == "className"
+
+
+def test_rune_variants_share_one_kind(tmp_path):
+    path = _write(
+        tmp_path / "Raw.svelte",
+        "<script>\n"
+        "  let a = $state.raw({})\n"
+        "  let b = $derived.by(() => 1)\n"
+        "</script>\n",
+    )
+    result = extract_svelte(path)
+    kinds = {n["label"]: (n["kind"], n.get("rune")) for n in result["nodes"]
+             if n.get("kind") in ("state", "derived")}
+    assert kinds == {"a": ("state", "$state.raw"), "b": ("derived", "$derived.by")}
+
+
+def test_component_usage_emits_uses_edge_with_renders_context(tmp_path):
+    _write(tmp_path / "Child.svelte", "<p>child</p>\n")
+    path = _write(
+        tmp_path / "Parent.svelte",
+        "<script>\n"
+        "  import Child from './Child.svelte'\n"
+        "</script>\n"
+        "<Child />\n",
+    )
+    result = extract_svelte(path)
+    # `uses`, not `renders`: DEFAULT_AFFECTED_RELATIONS does not include
+    # `renders`, so such an edge would be invisible to `graphify affected`.
+    uses = _edges(result, "uses", "renders")
+    assert len(uses) == 1
+    assert uses[0]["symbol"] == "Child"
+    assert uses[0]["target_file"].endswith("Child.svelte")
+
+
+def test_less_than_operator_is_not_a_component_tag(tmp_path):
+    """`{#if i < items.length}` must not read as a component named items.length."""
+    path = _write(
+        tmp_path / "Cmp.svelte",
+        "<script>\n"
+        "  let items = $state([])\n"
+        "  let i = $state(0)\n"
+        "</script>\n"
+        "{#if i < items.length}<span>more</span>{/if}\n",
+    )
+    result = extract_svelte(path)
+    assert _edges(result, "uses") == []
+
+
+def test_barrel_siblings_each_get_their_own_usage_edge(tmp_path):
+    """Alert/AlertTitle resolve to one module but are two distinct usages."""
+    _write(tmp_path / "ui/index.js", "export const Alert = 1\nexport const AlertTitle = 2\n")
+    path = _write(
+        tmp_path / "Uses.svelte",
+        "<script>\n"
+        "  import { Alert, AlertTitle } from './ui/index.js'\n"
+        "</script>\n"
+        "<Alert><AlertTitle>hi</AlertTitle></Alert>\n",
+    )
+    result = extract_svelte(path)
+    assert {e["symbol"] for e in _edges(result, "uses", "renders")} == {"Alert", "AlertTitle"}
+
+
+def test_case_colliding_type_and_variable_both_survive(tmp_path):
+    """make_id casefolds, so `type State` and `let state` hash alike (#id-collision)."""
+    path = _write(
+        tmp_path / "Health.svelte",
+        '<script lang="ts">\n'
+        "  type State = 'on' | 'off'\n"
+        "  let state = $state<State>('on')\n"
+        "</script>\n",
+    )
+    result = extract_svelte(path)
+    assert _by_kind(result, "type") == {"State"}
+    assert _by_kind(result, "state") == {"state"}
+    ids = [n["id"] for n in result["nodes"]]
+    assert len(ids) == len(set(ids))
+
+
+def test_imported_call_binds_to_the_symbol_not_just_the_file(tmp_path):
+    _write(tmp_path / "fmt.ts", "export function formatOre(x: number) { return x }\n")
+    path = _write(
+        tmp_path / "Money.svelte",
+        "<script>\n"
+        "  import { formatOre } from './fmt'\n"
+        "</script>\n"
+        "<span>{formatOre(1)}</span>\n",
+    )
+    result = extract_svelte(path)
+    calls = _edges(result, "calls")
+    assert len(calls) == 1
+    # The corpus can hold many `formatOre`; the import says which one this is.
+    assert calls[0]["target"] == _make_id(str((tmp_path / "fmt").as_posix()), "formatOre")
+
+
+def test_dynamic_import_in_markup_is_recovered(tmp_path):
+    """`{#await import('./X.svelte')}` lives in markup; no JS parser sees it."""
+    _write(tmp_path / "Lazy.svelte", "<p>lazy</p>\n")
+    path = _write(
+        tmp_path / "Host.svelte",
+        "{#await import('./Lazy.svelte') then M}<M.default />{/await}\n",
+    )
+    result = extract_svelte(path)
+    dyn = _edges(result, "dynamic_import")
+    assert len(dyn) == 1
+    assert dyn[0]["target_file"].endswith("Lazy.svelte")
+
+
+def test_scalar_locals_and_anonymous_effects_are_not_nodes(tmp_path):
+    """Node count is not the goal — a node per `const x = 1` makes the graph worse."""
+    path = _write(
+        tmp_path / "Quiet.svelte",
+        "<script>\n"
+        "  const LIMIT = 10\n"
+        "  let n = $state(0)\n"
+        "  $effect(() => { console.log(n) })\n"
+        "</script>\n",
+    )
+    result = extract_svelte(path)
+    labels = {n["label"] for n in result["nodes"]}
+    assert "LIMIT" not in labels
+    assert _by_kind(result, "state") == {"n"}
+    # One component node plus the single rune binding.
+    assert len(result["nodes"]) == 2

--- a/tests/test_svelte_extraction.py
+++ b/tests/test_svelte_extraction.py
@@ -228,3 +228,69 @@ def test_scalar_locals_and_anonymous_effects_are_not_nodes(tmp_path):
     assert _by_kind(result, "state") == {"n"}
     # One component node plus the single rune binding.
     assert len(result["nodes"]) == 2
+
+
+def test_recursive_component_records_a_self_edge(tmp_path):
+    """`import Self from './ChainTree.svelte'` used as <Self /> is recursion."""
+    path = _write(
+        tmp_path / "ChainTree.svelte",
+        "<script>\n"
+        "  import Self from './ChainTree.svelte'\n"
+        "  let { nodes } = $props()\n"
+        "</script>\n"
+        "{#each nodes as n}<Self nodes={n.children} />{/each}\n",
+    )
+    result = extract_svelte(path)
+    uses = _edges(result, "uses", "renders")
+    assert [e["symbol"] for e in uses] == ["Self"]
+    # Self-import: source and target are the same component node.
+    assert uses[0]["source"] == uses[0]["target"]
+
+
+def test_quoted_prop_key_keeps_only_the_prop_name(tmp_path):
+    """A hyphenated prop must be quoted; the quotes are syntax, not the name."""
+    path = _write(
+        tmp_path / "Slot.svelte",
+        "<script>\n"
+        '  let { "data-slot": dataSlot = "textarea" } = $props()\n'
+        "</script>\n",
+    )
+    result = extract_svelte(path)
+    assert _by_kind(result, "prop") == {"data-slot"}
+    prop = next(n for n in result["nodes"] if n.get("kind") == "prop")
+    assert prop["local_name"] == "dataSlot"
+
+
+def test_regex_literal_in_an_expression_does_not_swallow_later_components(tmp_path):
+    """A miscounted brace is not a local error — it drops the rest of the file.
+
+    `replace(/^https?:\\/\\//, '')` puts two adjacent slashes inside an
+    expression; reading them as a comment used to pin the depth above zero so
+    every following component silently vanished.
+    """
+    _write(tmp_path / "Icon.svelte", "<i></i>\n")
+    path = _write(
+        tmp_path / "Host.svelte",
+        "<script>\n"
+        "  import Icon from './Icon.svelte'\n"
+        "  let { site } = $props()\n"
+        "</script>\n"
+        "<span>{site.replace(/^https?:\\/\\//, '')}</span>\n"
+        "<Icon />\n",
+    )
+    result = extract_svelte(path)
+    assert [e["symbol"] for e in _edges(result, "uses", "renders")] == ["Icon"]
+
+
+def test_apostrophe_in_markup_text_does_not_swallow_later_components(tmp_path):
+    _write(tmp_path / "Icon.svelte", "<i></i>\n")
+    path = _write(
+        tmp_path / "Text.svelte",
+        "<script>\n"
+        "  import Icon from './Icon.svelte'\n"
+        "</script>\n"
+        "<p>Don't panic</p>\n"
+        "<Icon />\n",
+    )
+    result = extract_svelte(path)
+    assert [e["symbol"] for e in _edges(result, "uses", "renders")] == ["Icon"]

--- a/tests/test_svelte_extraction.py
+++ b/tests/test_svelte_extraction.py
@@ -294,3 +294,27 @@ def test_apostrophe_in_markup_text_does_not_swallow_later_components(tmp_path):
     )
     result = extract_svelte(path)
     assert [e["symbol"] for e in _edges(result, "uses", "renders")] == ["Icon"]
+
+
+def test_call_sites_are_reported_at_file_lines_not_block_lines(tmp_path):
+    """A `<script module>` block pushes the instance script down the file.
+
+    tree-sitter line numbers are relative to the parsed block, so without the
+    offset every call site in such a file is reported several lines too high.
+    """
+    path = _write(
+        tmp_path / "Run.svelte",
+        '<script module lang="ts">\n'      # 1
+        "  const started = new Set()\n"    # 2
+        "</script>\n"                      # 3
+        "\n"                               # 4
+        '<script lang="ts">\n'             # 5
+        "  function helper() { return 1 }\n"   # 6
+        "  function go() {\n"              # 7
+        "    return helper()\n"            # 8  <- the call site
+        "  }\n"                            # 9
+        "</script>\n",
+    )
+    result = extract_svelte(path)
+    call = next(e for e in _edges(result, "calls") if e.get("context") == "call")
+    assert call["source_location"] == "L8"


### PR DESCRIPTION
## Problem

`extract_svelte()` calls `_extract_generic(path, _JS_CONFIG)`, which feeds the **whole `.svelte` file** to the tree-sitter-javascript parser. Svelte markup is not valid JavaScript, so the parse returns a top-level `ERROR` node, the walk never reaches an `import_statement` or a declaration, and the only thing recovered is what the regex rescue pass finds — the imports.

The consequence is that a Svelte component contributes essentially nothing to the graph. On a 233-component SvelteKit app I measured **2.79 nodes per `.svelte` file, with a median of 1** — the typical component produced only its own file node, and the mean was lifted by import stubs rather than by symbols.

Concretely, a 280-line component with 12 props, 2 `$derived`, a function and 2 snippets became **1 node**. And because no symbol nodes existed, `graphify affected` on a function that four components call answered:

```
No affected nodes found.
```

which reads exactly like dead code.

This mirrors what `extract_vue` already does for `.vue` (mask the non-script regions, parse the script with the TypeScript grammar) — `.svelte` just never got the same treatment.

## Approach

- **A region scanner, not a regex.** `<script>`/`<style>` are raw-text elements, so their content genuinely ends at the first closing tag; the hard part is finding the *opening* tag without being fooled by `<!-- <script> -->` or a `>` inside a quoted attribute value.
- Script blocks are parsed with **tree-sitter-typescript at their true byte offset**, so reported line numbers point into the original file.
- **Nodes:** the component, `$props()` props, `$state`/`$derived` bindings, every function including `const f = () => {}`, `{#snippet}` snippets, exported constants, local types.
- **Component usage** in the template becomes relation **`uses`** with context `renders`. Deliberately not `renders`: `DEFAULT_AFFECTED_RELATIONS` does not contain it, so a `renders` edge would be invisible to `graphify affected`.
- **Cross-file calls bind to the symbol, not just the file.** A bare callee name can't be resolved corpus-wide — the app I measured has eleven distinct `formatOre` definitions — but the import statement names the exact module, and symbol ids are reconstructible as `make_id(<file stem>, <name>)`. A wrong guess dangles and is dropped at build time; the `imports_from` edge still records the dependency.
- Aliased imports map alias → module; `$lib`/tsconfig aliases and workspace packages go through the existing resolution helpers.
- Dynamic imports are still recovered from raw source, including markup-only forms like `{#await import('./X.svelte')}` that no JS parser can see.

### Deliberately *not* nodes

Node count is not the goal, and a node per `const x = 1` makes the graph noisier rather than more navigable. Excluded: scalar locals, loop variables, closures nested inside other functions, and anonymous `$effect` callbacks — though an effect's body is still swept for calls, attributed to the component, so what it *does* still reaches the graph.

Rune variants are an **attribute, not a node kind**: `$state` and `$state.raw` are one kind with the exact spelling kept in `rune`, so the graph doesn't fragment across spellings.

## Results

Same repo, same command, 233 `.svelte` files:

| | before | after | |
|---|---:|---:|---|
| nodes per file (mean) | 2.79 | **16.51** | 5.9× |
| nodes per file (median) | 1 | **12** | 12× |
| edges touching a `.svelte` node | 2 698 | **11 206** | 4.2× |
| the 280-line component above | 1 | **18** | |

The `affected` query that previously returned nothing now returns four exact call sites with correct line numbers, each verified against the source.

### Quality

Because node count is gameable, the extractor is scored against a **second, independent oracle** (regex + brace matching, sharing no code with the tree-sitter path). 100 randomly sampled files:

| category | agreed | extractor-only | oracle-only | precision | recall |
|---|---:|---:|---:|---:|---:|
| prop | 220 | 2 | 0 | 99.1% | 100% |
| rune | 954 | 3 | 0 | 99.7% | 100% |
| function | 398 | 5 | 0 | 98.8% | 100% |
| snippet | 94 | 0 | 0 | 100% | 100% |
| component usage | 1 105 | 0 | 1 | 100% | 99.9% |
| **total** | **2 771** | **10** | **1** | **99.6%** | **100%** |

Every remaining disagreement was checked by hand against source: all are limitations of the *oracle* (multi-declarator statements, arrow functions with return-type annotations, `async function`) or the extractor's deliberate choice to skip nested closures. None were extractor errors.

## Incidental fix

`make_id` casefolds, so `type State` and `let state` in the same file produce the **same id**, and the second declaration was silently swallowed by the seen-ids guard — a lost symbol, not a merge. This isn't Svelte-specific; it's reachable from any extractor that declares both a type and a value with names differing only in case. Colliding declarations are now disambiguated by kind.

## Tests

Adds `tests/test_svelte_extraction.py` — 13 cases covering region scanning (including the commented-out-`<script>` trap), props/runes/functions/snippets, renamed props (`class: className` exposes `class`), rune variants sharing one kind, the `{#if i < items.length}` less-than false positive, barrel siblings (`Alert` / `AlertTitle` resolving to one module but being two usages), the id collision, symbol-level call binding, markup-only dynamic imports, and the noise exclusions.

Full suite, same machine:

- `v8` baseline: **43 failed, 3599 passed, 166 skipped**
- this branch: **43 failed, 3612 passed, 166 skipped**

Identical failure sets — verified by diffing the two `FAILED` lists, not just the totals. The 43 are pre-existing and unrelated (terraform grammar not installed, `serve_http`, `skillgen`, ollama). The +13 are the new tests.

## Known limits

- Dynamic components (`<svelte:component this={X}>`, `<Foo />` where `Foo` is a variable) are emitted with `confidence: INFERRED` and context `renders_dynamic`.
- Template call detection resolves an identifier only when it is declared or imported in the same file; unknown names are dropped rather than guessed.
- Parsing the script with tree-sitter rather than `svelte/compiler` is a deliberate trade: it keeps extraction dependency-free and in-process, at the cost of a hand-written template pass. The measured template-edge precision (100%) is what justified staying with it.
