### PR TITLE
chore(agents): refresh the dogfood AGENTS.md and pin it to the packaged block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,12 @@
 ## graphify
 
-This project has a graphify knowledge graph at graphify-out/.
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+When the user types `/graphify`, use the installed graphify skill or instructions before doing anything else.
 
 Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- Dirty graphify-out/ files are expected after hooks or incremental updates; dirty graph files are not a reason to skip graphify. Only skip graphify if the task is about stale or incorrect graph output, or the user explicitly says not to use it.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/tests/test_always_on_dogfood.py
+++ b/tests/test_always_on_dogfood.py
@@ -1,0 +1,28 @@
+"""The repo's own AGENTS.md must carry the current packaged graphify block.
+
+graphify install splices graphify/always_on/agents-md.md into a project's
+AGENTS.md. This repo dogfoods that block, but nothing kept the two in sync:
+the checked-in AGENTS.md had drifted to an older revision that still told
+agents to read GRAPH_REPORT.md first, while the packaged block installed for
+users had moved to query-first rules. This test runs the real splice against
+the repo's AGENTS.md and requires it to be a no-op, so editing the packaged
+block forces the dogfood copy to be refreshed in the same change.
+"""
+from pathlib import Path
+
+from graphify.install import _AGENTS_MD_MARKER, _always_on, _replace_or_append_section
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_repo_agents_md_matches_packaged_block() -> None:
+    agents_md = REPO_ROOT / "AGENTS.md"
+    content = agents_md.read_text(encoding="utf-8")
+    spliced = _replace_or_append_section(
+        content, _AGENTS_MD_MARKER, _always_on("agents-md")
+    )
+    assert content == spliced, (
+        "AGENTS.md has drifted from graphify/always_on/agents-md.md; refresh it "
+        "by applying _replace_or_append_section (or run graphify install against "
+        "this repo) so the dogfood copy matches what users get."
+    )


### PR DESCRIPTION
## Summary

The repo's own `AGENTS.md` carried an older revision of the always-on block than what `graphify install` writes for users from `graphify/always_on/agents-md.md`: it still told agents to read `GRAPH_REPORT.md` first and to navigate `wiki/` unconditionally, while the packaged block moved to query-first rules and the "if wiki exists" soft-guard. (The unconditional wiki wording is the same surface #2006 flags.)

Two changes:

1. **Refresh**: `AGENTS.md` is regenerated by applying the real splice (`_replace_or_append_section` + `_always_on("agents-md")`) — byte-for-byte what an install would produce.
2. **Pin**: a new test runs that same splice against the checked-in file and requires a no-op, so any future edit to the packaged block forces the dogfood copy along in the same PR. Verified it fails against the pre-refresh file and passes after.

No behavior change for users — the packaged block is untouched; only the repo's own copy catches up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)