### PR TITLE
docs(exporters): add the porting playbook and status table

### DIFF
--- a/graphify/exporters/MIGRATION.md
+++ b/graphify/exporters/MIGRATION.md
@@ -1,0 +1,54 @@
+# Migrating an exporter out of export.py
+
+`graphify/export.py` holds several output-format exporters in one ~1,100-line
+file. They are being split into this package one format at a time, the same way
+`graphify/extractors/` is being split out of `extract.py`. This is the playbook
+for porting ONE exporter. It is written so an AI agent can execute it in a
+single session. (Motivation: the runaway-file-size guardrail discussed in
+issue #1213.)
+
+## Status
+
+| exporter | module | migrated |
+|---|---|---|
+| HTML viz (`to_html`) | `exporters/html.py` | yes |
+| GraphDB push (`push_to_falkordb`, `push_to_neo4j`) | `exporters/graphdb.py` | yes |
+| shared palette (`COMMUNITY_COLORS`) | `exporters/base.py` | yes |
+| `graph.json` (`to_json`) | — | no |
+| Cypher (`to_cypher`) | — | no |
+| Obsidian vault (`to_obsidian`) | — | no |
+| Canvas (`to_canvas`) | — | no |
+| GraphML (`to_graphml`) | — | no |
+| SVG (`to_svg`) | — | no |
+
+`callflow_html.py` is a separate concern (Mermaid architecture / call-flow
+HTML built from `graphify-out/` files, not from a graph object) and is out of
+scope for this split.
+
+## Invariants (non-negotiable)
+
+1. **Verbatim moves only.** No renames, no docstring edits, no reformatting,
+   no added annotations, no "improvements". Verify: save the block before
+   cutting and confirm the pasted block is byte-identical.
+2. **One exporter per PR.** Small diffs keep review trivial and avoid conflicts
+   with other in-flight ports.
+3. **Facade re-export is mandatory.** `export.py` must keep exporting every
+   moved name so existing imports (`from graphify.export import to_html`) keep
+   working — `from graphify.exporters.<mod> import <fn>  # noqa: E402,F401`.
+4. **No exporter imports another exporter.** Symbols shared by more than one
+   exporter go in `exporters/base.py`; each module imports from `base`, never
+   from a sibling, so the split cannot introduce a circular import. `export.py`
+   and the per-format modules both import from `base`.
+
+## Steps
+
+1. Pick one exporter function in `export.py` (e.g. `to_json`). Note its tests
+   (e.g. `tests/test_cli_export.py`, `tests/test_export.py`).
+2. Create `graphify/exporters/<format>.py` and move the function verbatim, plus
+   any helper used *only* by it. If a helper is shared, move it to
+   `exporters/base.py` first (its own small step).
+3. Re-export from `export.py`:
+   `from graphify.exporters.<format> import <fn>  # noqa: E402,F401`, and delete
+   the original definition.
+4. Run the exporter's existing tests. They must pass unchanged — the facade
+   keeps every call site working. Update the status table above.


### PR DESCRIPTION
## Summary

`graphify/exporters/` is being split out of `export.py` using the same facade pattern as `graphify/extractors/` (`base.py` for shared symbols, per-format modules moved verbatim, `export.py` re-exporting each moved name behind `# noqa: E402,F401`). Three pieces already live there — `to_html` → `exporters/html.py`, the FalkorDB/Neo4j push → `exporters/graphdb.py`, `COMMUNITY_COLORS` → `exporters/base.py` — but unlike `extractors/`, the package had no `MIGRATION.md`, so the pattern in use and the remaining work were undocumented.

This adds `graphify/exporters/MIGRATION.md`: the porting invariants (verbatim moves, one exporter per PR, mandatory facade re-export, no exporter-imports-exporter) and a status table.

Still in `export.py` (verified they are real definitions, not already-migrated re-exports): `to_json`, `to_cypher`, `to_obsidian`, `to_canvas`, `to_graphml`, `to_svg`. `callflow_html.py` is noted as a separate concern (Mermaid HTML built from `graphify-out/` files, not a graph object) and out of scope.

Docs-only; no code touched. Mirrors `graphify/extractors/MIGRATION.md` in structure so contributors porting either package follow the same steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)