### PR TITLE
fix(install): stop hardcoding the global skill path in the Antigravity workflow

### DIFF
--- a/graphify/install.py
+++ b/graphify/install.py
@@ -915,6 +915,9 @@ def vscode_uninstall(project_dir: Path | None = None) -> None:
         print(f"  {instructions}  ->  deleted (was empty after removal)")
 _ANTIGRAVITY_RULES_PATH = Path(".agents") / "rules" / "graphify.md"
 _ANTIGRAVITY_WORKFLOW_PATH = Path(".agents") / "workflows" / "graphify.md"
+# Names no SKILL.md location on purpose: this constant is shared by the global and
+# project-scoped installs, which put the skill in different places, so any hardcoded
+# path dangles for the other scope. Antigravity resolves the skill by frontmatter name.
 _ANTIGRAVITY_WORKFLOW = """\
 ---
 name: graphify
@@ -923,7 +926,7 @@ description: Turn any folder of files into a navigable knowledge graph
 
 # Workflow: graphify
 
-Follow the graphify skill installed at ~/.gemini/config/skills/graphify/SKILL.md to run the full pipeline.
+Follow the graphify skill to run the full pipeline.
 
 If no path argument is given, use `.` (current directory).
 """

--- a/tests/test_antigravity_install.py
+++ b/tests/test_antigravity_install.py
@@ -20,6 +20,37 @@ def test_antigravity_project_install_writes_rules_and_workflows(tmp_path):
     assert skill.read_text(encoding="utf-8").startswith("---\n")
 
 
+def test_antigravity_workflow_names_no_skill_path(tmp_path):
+    """The workflow must not hardcode a SKILL.md location.
+
+    One constant serves both scopes, which install the skill to different places,
+    so naming either path dangles for the other: a project-scoped install used to
+    point at ~/.gemini/config/skills/graphify/SKILL.md, which it never writes.
+    """
+    m._project_install("antigravity", tmp_path)
+    body = (tmp_path / ".agents" / "workflows" / "graphify.md").read_text(encoding="utf-8")
+    assert ".gemini" not in body, "workflow must not reference the global skill dir"
+    assert "SKILL.md" not in body, "workflow must not name a skill path in any scope"
+    assert "~" not in body, "workflow must not reference a home directory"
+    assert "graphify skill" in body, "workflow should still point at the skill by name"
+
+
+def test_antigravity_global_install_workflow_names_no_skill_path(tmp_path, monkeypatch):
+    """Global install shares the constant, so it must stay path-free too."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    m._antigravity_install(tmp_path)
+
+    # The skill really does land in the global dir the old text named ...
+    assert (
+        tmp_path / "home" / ".gemini" / "config" / "skills" / "graphify" / "SKILL.md"
+    ).exists()
+    # ... but the workflow still must not hardcode it.
+    body = (tmp_path / ".agents" / "workflows" / "graphify.md").read_text(encoding="utf-8")
+    assert ".gemini" not in body
+    assert "SKILL.md" not in body
+
+
 def test_antigravity_project_uninstall_clears_rules_and_workflows(tmp_path):
     m._project_install("antigravity", tmp_path)
     m._project_uninstall("antigravity", tmp_path)


### PR DESCRIPTION
Fixes #2319.

## Problem

`_ANTIGRAVITY_WORKFLOW` is one constant shared by both install scopes, but the two scopes write `SKILL.md` to different places:

| scope | skill destination |
| --- | --- |
| global — `antigravity install` | `~/.gemini/config/skills/graphify/SKILL.md` |
| project — `install --project --platform antigravity` | `.agents/skills/graphify/SKILL.md` |

The template named the global path unconditionally, so a project-scoped install emitted a workflow pointing at a file that scope never writes. On a machine with no prior global install the reference dangles outright; with one, it silently points at a different (possibly stale) copy of the skill than the one just installed.

## Reproduction

Both command forms from the issue, in a clean project with an empty `HOME`, before this change:

```
$ graphify install --project --platform antigravity
$ sed -n 8p .agents/workflows/graphify.md
Follow the graphify skill installed at ~/.gemini/config/skills/graphify/SKILL.md to run the full pipeline.

$ ls ~/.gemini/config/skills/graphify/SKILL.md
ls: No such file or directory          # dangling

$ find . -name SKILL.md
./.agents/skills/graphify/SKILL.md      # where it actually went
```

`graphify antigravity install --project` produces the identical result.

## Fix

Rather than interpolating the correct path per scope, the workflow now names no path at all:

```diff
-Follow the graphify skill installed at ~/.gemini/config/skills/graphify/SKILL.md to run the full pipeline.
+Follow the graphify skill to run the full pipeline.
```

This follows the convention the rest of the installer already uses. None of the six blocks in `always_on/` names a skill location — they describe behavior (`graphify query`, read `graphify-out/`) and are therefore correct in every scope. Kiro's steering file is the clearest example, and Antigravity's own `.agents/rules/graphify.md` already follows it. The workflow was the one generated artifact naming a `SKILL.md` path anywhere in `install.py`, and unlike the `always_on/` blocks it is an inline constant rather than a `tools/skillgen` artifact, so it never went through the drift guard that keeps the others path-free.

Naming the skill instead of its location resolves in both scopes: the installed `SKILL.md` declares `name: graphify` in its frontmatter, which is how Antigravity discovers it under `.agents/skills/` or `~/.gemini/config/skills/`. It also removes the interpolation, the `~`-contraction edge case, and a latent wrinkle in the idempotency check at `install.py:1013`, which would otherwise compare a project install's workflow against the global text and rewrite it every run.

Happy to switch to per-scope interpolation instead if you'd prefer the workflow keep an explicit path.

## Verification

After the change, both command forms emit a path-free workflow while the skill still lands in `.agents/skills/graphify/SKILL.md`. Global `antigravity install` is unchanged: the skill still installs to `~/.gemini/config/skills/graphify/SKILL.md`, only the workflow text differs.

## Tests

The existing tests asserted only that the workflow file exists, which is why this shipped. Added two that assert the generated workflow names no skill path — one per scope, since the constant is shared. Both fail on the parent commit and pass here.

`uv run pytest tests/ -q` after `uv sync --all-extras`: **3877 passed, 1 failed**. The one failure is `tests/test_labeling.py::test_label_communities_batches_when_over_batch_size`, which fails identically on the parent commit (3875 passed, same single failure). It is order-dependent — it asserts batch call ordering and fails 5/5 when run in isolation while passing when its module's earlier tests run first — so it looks pre-existing and unrelated to this change. Flagging it rather than touching it.

`ruff check` clean; `python -m tools.skillgen --check` reports all 134 artifacts matching.
