### PR TITLE
fix(detect): gate coverage/ pruning on report artefacts (#2339)

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -795,7 +795,9 @@ _SKIP_DIRS = {
     ".tox", ".nox", ".eggs", "*.egg-info",  # nox is tox's successor, same .nox/ venv shape (#1804)
     "graphify-out", GRAPHIFY_OUT_NAME,  # never treat own output as source input (#524); honour GRAPHIFY_OUT (#1423)
     # Coverage/test-artefact dirs — generated, never architecturally meaningful
-    "coverage", "lcov-report",              # Vitest/Istanbul/nyc HTML reports (#870)
+    "lcov-report",                          # Vitest/Istanbul/nyc HTML reports (#870);
+                                            # bare "coverage" is gated on report
+                                            # artefacts below (#2339)
     "visual-tests", "visual-test",          # Playwright/visual-regression bundles (#869)
     "__snapshots__",                        # Jest/Vitest snapshot dir (unambiguous)
     "storybook-static",                     # Storybook production build output
@@ -823,6 +825,39 @@ _SKIP_FILES = {
 # silently dropped legitimate source from the graph (#1666). "__snapshots__" stays
 # unconditionally pruned above; only the ambiguous bare name is gated here.
 _JS_SNAPSHOT_TEST_ROOTS = frozenset({"__tests__", "__test__"})
+
+# Files a coverage tool writes into its own output dir. Any one of them is proof
+# the directory is generated: lcov (lcov.info), nyc/Istanbul (coverage-final.json,
+# clover.xml, the lcov-report/ subtree), coverage.py (coverage.xml, .coverage),
+# JaCoCo/Cobertura (jacoco.xml, cobertura-coverage.xml).
+_COVERAGE_ARTIFACT_FILES = frozenset({
+    "lcov.info", "coverage-final.json", "coverage-summary.json",
+    "clover.xml", "coverage.xml", "cobertura-coverage.xml", "jacoco.xml",
+    ".coverage", "index.html",
+})
+_COVERAGE_ARTIFACT_DIRS = frozenset({"lcov-report", "html-report"})
+
+
+def _has_coverage_artifacts(d: "Path") -> bool:
+    """True only when *d* holds files a coverage tool actually generated.
+
+    ``coverage`` is a legitimate package name (a Python package, a Go/Rust module,
+    a domain namespace), so pruning it by name alone silently drops real source —
+    an entire 5-module package in #2339, with its dependents left in the graph so
+    queries still returned plausible neighbours. Prune it only on real evidence,
+    mirroring the ``snapshots``/``env`` gating (#1666/#2058): a coverage report
+    file, or an Istanbul/lcov HTML report subtree.
+    """
+    try:
+        for name in _COVERAGE_ARTIFACT_FILES:
+            if (d / name).is_file():
+                return True
+        for name in _COVERAGE_ARTIFACT_DIRS:
+            if (d / name).is_dir():
+                return True
+    except OSError:
+        pass
+    return False
 
 
 def _has_venv_markers(d: "Path") -> bool:
@@ -858,6 +893,12 @@ def _is_noise_dir(part: str, parent: "Path | None" = None) -> bool:
         if parent is None:
             return False  # cannot verify; keep a possibly-real code dir
         return _has_venv_markers(parent / part)
+    if part == "coverage":
+        # Ambiguous: a generated report dir OR a real package named coverage.
+        # Prune only on actual coverage-artefact evidence (#2339).
+        if parent is None:
+            return False  # cannot verify; keep a possibly-real code dir
+        return _has_coverage_artifacts(parent / part)
     if part == "snapshots":
         # Prune only when it looks like an actual JS/Vitest snapshot dir.
         if parent is None:

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -686,6 +686,85 @@ def test_detect_skips_coverage_dir(tmp_path):
     assert any("main.py" in f for f in all_files)
 
 
+def test_detect_skips_coverage_dir_by_lcov_info(tmp_path):
+    """A coverage/ dir is still pruned on any single artefact file — an lcov.info
+    with no lcov-report/ subtree is enough evidence (#870, #2339)."""
+    cov = tmp_path / "coverage"
+    cov.mkdir()
+    (cov / "lcov.info").write_text("TN:\nSF:src/app.ts\nend_of_record\n")
+    (cov / "prettify.js").write_text("var PR_SHOULD_USE_CONTINUATION=true;")
+    (tmp_path / "main.py").write_text("def hello(): pass")
+    result = detect(tmp_path)
+    all_files = [f for files in result["files"].values() for f in files]
+    assert not any(f.startswith(str(cov)) for f in all_files)
+    assert any("main.py" in f for f in all_files)
+
+
+def test_detect_keeps_coverage_code_namespace(tmp_path):
+    """#2339: a coverage/ dir holding real modules and no coverage artefacts is a
+    legitimate package name, not a generated report, and must NOT be pruned.
+
+    Pruning it by name dropped an entire production package while leaving its
+    dependents in the graph, so queries kept returning plausible neighbours and
+    nothing in the report or skipped lists showed the loss."""
+    pkg = tmp_path / "auditor_toolkit" / "assurance" / "coverage"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("from .impact import Impact\n")
+    (pkg / "impact.py").write_text("class Impact:\n    def score(self): return 1\n")
+    (pkg / "inventory.py").write_text("def inventory():\n    return []\n")
+    (tmp_path / "app.py").write_text("from auditor_toolkit.assurance import coverage\n")
+    result = detect(tmp_path)
+    all_files = [f for files in result["files"].values() for f in files]
+    assert any("impact.py" in f for f in all_files)
+    assert any("inventory.py" in f for f in all_files)
+    assert any(f.endswith("coverage" + os.sep + "__init__.py") for f in all_files)
+
+
+def test_collect_files_keeps_coverage_code_namespace(tmp_path):
+    """#2339 as reported: collect_files returned [] for a real coverage package,
+    both when it is the walk target and when it is reached through the repo root.
+    A genuine report dir alongside it must still be skipped."""
+    from graphify.extract import collect_files
+
+    pkg = tmp_path / "auditor_toolkit" / "assurance" / "coverage"
+    pkg.mkdir(parents=True)
+    for name in ("__init__.py", "impact.py", "mapping.py"):
+        (pkg / name).write_text("def f(): pass\n")
+
+    report = tmp_path / "webapp" / "coverage"
+    report.mkdir(parents=True)
+    (report / "index.html").write_text("<html>coverage</html>")
+    (report / "base.css").write_text("body{}")
+    (report / "prettify.js").write_text("var PR=1;")
+
+    assert sorted(p.name for p in collect_files(pkg)) == [
+        "__init__.py", "impact.py", "mapping.py",
+    ]
+    walked = {str(p.relative_to(tmp_path)) for p in collect_files(tmp_path)}
+    assert any(p.endswith("impact.py") for p in walked)
+    assert not any("webapp" in p for p in walked), (
+        "a generated Istanbul report dir must still be pruned (#870)"
+    )
+
+
+def test_is_noise_dir_coverage_is_evidence_gated(tmp_path):
+    """The gate itself: name alone is not enough, and an unverifiable call
+    (no parent) keeps a possibly-real code dir — same contract as env/snapshots."""
+    src = tmp_path / "coverage"
+    src.mkdir()
+    (src / "__init__.py").write_text("")
+    assert detect_mod._is_noise_dir("coverage", tmp_path) is False
+
+    generated = tmp_path / "report" / "coverage"
+    generated.mkdir(parents=True)
+    (generated / "coverage-final.json").write_text("{}")
+    assert detect_mod._is_noise_dir("coverage", tmp_path / "report") is True
+
+    assert detect_mod._is_noise_dir("coverage") is False
+    # lcov-report stays unconditional — no package is ever named that.
+    assert detect_mod._is_noise_dir("lcov-report") is True
+
+
 def test_detect_skips_visual_tests_dir(tmp_path):
     """visual-tests/ bundles and snapshots are noise — must be excluded (#869)."""
     vt = tmp_path / "visual-tests"


### PR DESCRIPTION
Fixes #2339.

## Problem

`"coverage"` is an unconditional entry in `detect.py::_SKIP_DIRS`, and `_is_noise_dir`
matches directory names at any depth. In a repo where `coverage` is a legitimate package
name, the whole package is dropped from the graph — no warning, no `skipped_sensitive`
entry, nothing in the report.

The failure is quiet in the worst way: the package's *dependents* are still there, so
queries return plausible neighbours while the package itself simply doesn't exist as
nodes. The reporter only found it by diffing `git ls-files` against the distinct
`source_file` values in `graph.json`.

## Same bug class as #1666 and #2058

The comment on the entry is `# Vitest/Istanbul/nyc HTML reports (#870)` — a JS-ecosystem
artefact directory — but the pruning is unconditional and language-agnostic.

`detect.py` has already been fixed twice for exactly this shape:

- **#1666** — a bare `snapshots` dir is a Jest artefact *only* when it holds `.snap`
  files or sits under a JS test root; elsewhere it's a real code namespace.
- **#2058** — `env`/`.env`/`*_env` is pruned only on real virtualenv evidence
  (`pyvenv.cfg`, `bin/activate`, `lib/python*`, `conda-meta/`).

`coverage` hadn't been given the same treatment. This PR applies the existing pattern
rather than inventing a new mechanism.

## Fix

- `coverage` moves out of the unconditional `_SKIP_DIRS` set into an evidence-gated
  branch in `_is_noise_dir`, backed by a new `_has_coverage_artifacts()` helper written
  to match `_has_venv_markers()` (same `OSError` guard, same "cannot verify → keep a
  possibly-real code dir" contract when no parent is passed).
- Evidence is a file a coverage tool actually writes: `lcov.info`, `coverage-final.json`,
  `coverage-summary.json`, `clover.xml`, `coverage.xml`, `cobertura-coverage.xml`,
  `jacoco.xml`, `.coverage`, `index.html` — or an `lcov-report/` / `html-report/`
  subtree. That covers lcov, nyc/Istanbul, coverage.py, JaCoCo and Cobertura.
- **`lcov-report` stays unconditional.** It has no false-positive class — no package is
  ever named that — so gating it would only add filesystem probes for no benefit. Only
  the ambiguous bare name is gated, mirroring how `__snapshots__` stayed unconditional
  in #1666 while `snapshots` was gated.

## Reproduction

The reporter's repro, before and after (`auditor_toolkit/assurance/coverage/` holding
`__init__.py`, `impact.py`, `inventory.py`, `mapping.py`, `summary.py`, with a genuine
Istanbul report at `webapp/coverage/` in the same tree):

```
# before
direct target : []
via repo walk : []

# after
direct target : ['__init__.py', 'impact.py', 'inventory.py', 'mapping.py', 'summary.py']
via repo walk : ['auditor_toolkit/assurance/coverage/__init__.py', ... 'summary.py']
```

The generated `webapp/coverage/` report is still pruned in the "after" walk — its
`prettify.js` never enters the corpus — so #870 is not regressed.

## Tests

`tests/test_detect.py`, following the `test_detect_keeps_snapshots_code_namespace`
precedent. Three of them fail on clean `v8`:

- `test_detect_keeps_coverage_code_namespace` — a `coverage/` package with real modules
  survives a `detect()` scan.
- `test_collect_files_keeps_coverage_code_namespace` — the issue as reported, via
  `collect_files`, both as the walk target and through the repo root, with a real report
  dir alongside that must still be skipped.
- `test_is_noise_dir_coverage_is_evidence_gated` — the gate directly: name alone isn't
  enough, artefact evidence prunes, no-parent keeps, `lcov-report` still unconditional.
- `test_detect_skips_coverage_dir_by_lcov_info` — guard: a single artefact file with no
  `lcov-report/` subtree is still enough to prune.

The existing `test_detect_skips_coverage_dir` (#870) passes unchanged.

`uv run pytest tests/ -q` → 3903 passed, 3 skipped (baseline on `v8` is 3899 passed,
3 skipped — the delta is exactly these four tests, no regressions).

## Noted but not fixed here

The reporter also flagged that `_parse_gitignore_line` strips inline `#` comments while
git only treats `#` as a comment at line start, so `*_backup_*.py  # temp scripts`
excludes real files for graphify but matches nothing for git. That's a separate
divergence in a different function and belongs in its own issue/PR.
