### PR TITLE
fix(detect): gate coverage/ pruning on real report markers (#2339)

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -795,7 +795,8 @@ _SKIP_DIRS = {
     ".tox", ".nox", ".eggs", "*.egg-info",  # nox is tox's successor, same .nox/ venv shape (#1804)
     "graphify-out", GRAPHIFY_OUT_NAME,  # never treat own output as source input (#524); honour GRAPHIFY_OUT (#1423)
     # Coverage/test-artefact dirs — generated, never architecturally meaningful
-    "coverage", "lcov-report",              # Vitest/Istanbul/nyc HTML reports (#870)
+    # "coverage"/"lcov-report" are gated on real report markers below (#2339) — a
+    # real source package named coverage/ was silently pruned with no trace.
     "visual-tests", "visual-test",          # Playwright/visual-regression bundles (#869)
     "__snapshots__",                        # Jest/Vitest snapshot dir (unambiguous)
     "storybook-static",                     # Storybook production build output
@@ -848,6 +849,34 @@ def _has_venv_markers(d: "Path") -> bool:
     return False
 
 
+def _has_coverage_markers(d: "Path") -> bool:
+    """True only when *d* has actual coverage/test-report structure on disk.
+
+    "coverage"/"lcov-report" is a real source-directory name too (e.g. a
+    package named coverage/), so pruning it by name alone silently drops
+    legitimate source with no trace (#2339). Prune it only on real evidence:
+    known report files (lcov.info, coverage-final.json, clover.xml,
+    coverage.xml, cobertura.xml), an index.html alongside Istanbul/nyc's
+    static assets (base.css/prettify.js/block-navigation.js/sorter.js), any
+    *.gcov file, or a nested lcov-report/ subdir.
+    """
+    try:
+        for name in ("lcov.info", "coverage-final.json", "clover.xml", "coverage.xml", "cobertura.xml"):
+            if (d / name).is_file():
+                return True
+        if (d / "index.html").is_file():
+            for asset in ("base.css", "prettify.js", "block-navigation.js", "sorter.js"):
+                if (d / asset).is_file():
+                    return True
+        if next(d.glob("*.gcov"), None) is not None:
+            return True
+        if (d / "lcov-report").is_dir():
+            return True
+    except OSError:
+        pass
+    return False
+
+
 def _is_noise_dir(part: str, parent: "Path | None" = None) -> bool:
     """Return True if this directory name looks like a venv, cache, or dep dir."""
     if part in _SKIP_DIRS:
@@ -858,6 +887,13 @@ def _is_noise_dir(part: str, parent: "Path | None" = None) -> bool:
         if parent is None:
             return False  # cannot verify; keep a possibly-real code dir
         return _has_venv_markers(parent / part)
+    if part in ("coverage", "lcov-report"):
+        # Ambiguous: a real coverage report OR a real source dir (e.g. a
+        # package named coverage/). Prune only on actual report evidence,
+        # mirroring the "snapshots" gating (#1666/#2058/#2339).
+        if parent is None:
+            return False  # cannot verify; keep a possibly-real code dir
+        return _has_coverage_markers(parent / part)
     if part == "snapshots":
         # Prune only when it looks like an actual JS/Vitest snapshot dir.
         if parent is None:

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -2,7 +2,7 @@ import os
 import unicodedata
 import pytest
 from pathlib import Path
-from graphify.detect import classify_file, count_words, detect, detect_incremental, save_manifest, FileType, _looks_like_paper, _is_ignored, _load_graphifyignore, _is_sensitive
+from graphify.detect import classify_file, count_words, detect, detect_incremental, save_manifest, FileType, _looks_like_paper, _is_ignored, _load_graphifyignore, _is_sensitive, _is_noise_dir
 from graphify import detect as detect_mod
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -697,6 +697,78 @@ def test_detect_skips_visual_tests_dir(tmp_path):
     all_files = [f for files in result["files"].values() for f in files]
     assert not any("visual-tests" in f for f in all_files)
     assert any("app.py" in f for f in all_files)
+
+
+def test_detect_keeps_coverage_code_package(tmp_path):
+    """#2339: a real Python package named coverage/ is not a report dir and
+    must not be pruned by name alone."""
+    pkg = tmp_path / "coverage"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "impact.py").write_text("def measure(): pass")
+    (tmp_path / "main.py").write_text("import coverage")
+    result = detect(tmp_path)
+    all_files = [f for files in result["files"].values() for f in files]
+    assert any("impact.py" in f for f in all_files)
+    assert any("main.py" in f for f in all_files)
+
+
+def test_detect_skips_real_lcov_report(tmp_path):
+    """#2339: a genuine Istanbul/nyc report dir is still pruned on real evidence."""
+    cov = tmp_path / "coverage" / "lcov-report"
+    cov.mkdir(parents=True)
+    (cov / "index.html").write_text("<html>coverage report</html>")
+    (cov / "base.css").write_text("body {}")
+    (tmp_path / "main.py").write_text("def hello(): pass")
+    result = detect(tmp_path)
+    all_files = [f for files in result["files"].values() for f in files]
+    cov_prefix = str(tmp_path / "coverage")
+    assert not any(f.startswith(cov_prefix) for f in all_files)
+    assert any("main.py" in f for f in all_files)
+
+
+def test_detect_skips_real_lcov_info(tmp_path):
+    """#2339: a bare coverage/ dir holding lcov.info is still pruned."""
+    cov = tmp_path / "coverage"
+    cov.mkdir()
+    (cov / "lcov.info").write_text("SF:src/foo.js\nend_of_record")
+    (tmp_path / "main.py").write_text("def hello(): pass")
+    result = detect(tmp_path)
+    all_files = [f for files in result["files"].values() for f in files]
+    cov_prefix = str(tmp_path / "coverage")
+    assert not any(f.startswith(cov_prefix) for f in all_files)
+    assert any("main.py" in f for f in all_files)
+
+
+def test_detect_keeps_nested_coverage_code_package(tmp_path):
+    """#2339: name match at any depth — a nested real coverage/ package is kept."""
+    pkg = tmp_path / "src" / "pkg" / "coverage"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")
+    (pkg / "impact.py").write_text("def measure(): pass")
+    (tmp_path / "main.py").write_text("import src.pkg.coverage")
+    result = detect(tmp_path)
+    all_files = [f for files in result["files"].values() for f in files]
+    assert any("impact.py" in f for f in all_files)
+
+
+def test_detect_skips_nested_real_lcov_report(tmp_path):
+    """#2339: name match at any depth — a nested real report dir is still pruned."""
+    cov = tmp_path / "src" / "pkg" / "coverage" / "lcov-report"
+    cov.mkdir(parents=True)
+    (cov / "index.html").write_text("<html>coverage report</html>")
+    (cov / "base.css").write_text("body {}")
+    (tmp_path / "main.py").write_text("def hello(): pass")
+    result = detect(tmp_path)
+    all_files = [f for files in result["files"].values() for f in files]
+    cov_prefix = str(tmp_path / "src" / "pkg" / "coverage")
+    assert not any(f.startswith(cov_prefix) for f in all_files)
+    assert any("main.py" in f for f in all_files)
+
+
+def test_is_noise_dir_coverage_no_parent_returns_false():
+    """#2339: with no parent to verify, coverage/ is kept, not pruned by name."""
+    assert _is_noise_dir("coverage", None) is False
 
 
 def test_detect_skips_snapshots_dir(tmp_path):


### PR DESCRIPTION
Closes #2339

## The bug

`"coverage"` and `"lcov-report"` were in the unconditional `_SKIP_DIRS` set (`graphify/detect.py:798`), and `_is_noise_dir(part, parent)` matches a bare directory name at any depth with no content check. A real source package named `coverage/` was therefore pruned before anything read it, with no warning.

```
/tmp/cov-repro/main.py            (import coverage)
/tmp/cov-repro/coverage/__init__.py
/tmp/cov-repro/coverage/impact.py

before: detect(...)["files"]["code"] == ["/private/tmp/cov-repro/main.py"]
after:  ["/private/tmp/cov-repro/coverage/__init__.py",
         "/private/tmp/cov-repro/coverage/impact.py",
         "/private/tmp/cov-repro/main.py"]
```

## The fix

No new mechanism — this follows the precedent already in the same function. `env`/`.env`/`*_env` and `snapshots` were previously moved out of the unconditional set and are pruned only on real evidence (`_has_venv_markers`, and the `*.snap` / `_JS_SNAPSHOT_TEST_ROOTS` gate) for exactly this bug class (#1666 / #2058).

- `coverage`/`lcov-report` move out of `_SKIP_DIRS`.
- New `_has_coverage_markers(d)`, styled after `_has_venv_markers`: prunes on `lcov.info`, `coverage-final.json`, `clover.xml`, `coverage.xml`, `cobertura.xml`, an `index.html` alongside Istanbul/nyc static assets (`base.css`/`prettify.js`/`block-navigation.js`/`sorter.js`), any `*.gcov`, or a nested `lcov-report/`.
- As with the existing gates, a `None` parent cannot be verified, so the directory is kept.

`__snapshots__` and `storybook-static` stay unconditional — those names are unambiguous.

## Scope decision, stated rather than hidden

`visual-tests`/`visual-test` (`detect.py:799`) and `dist-protected` (`:802`) are pruned the same unconditional way and are plausible real directory names, so they are the same bug class. I looked for evidence as crisp as the coverage markers and did not find any — Playwright/visual-regression output has no equivalent of `lcov.info` or `index.html`+`base.css`. Rather than guess at a marker set, I left both alone. Happy to follow up if you know the right signal.

## Verification

- 6 new tests in `tests/test_detect.py`: real `coverage/` package kept, genuine lcov/Istanbul report still pruned, both again for a `coverage/` nested deeper in the tree, and `_is_noise_dir("coverage", None) is False`.
- Red before the fix: stashed only `detect.py`, 3 of the 6 fail (the 3 "still pruned" ones pass either way by design).
- `tests/test_detect.py`: 232 passed. `test_detect_skips_coverage_dir` and `test_detect_skips_visual_tests_dir` stay green for the right reason — they plant report-like files, so the evidence gate still prunes them.
- Full suite: 3829 passed / 36 skipped / 8 failed, and the same 8 fail on a clean `v8` tree in this environment (1 in `test_llm_backends.py` from a missing `openai` module, 7 env-dependent ollama backend-detection tests). Failure set unchanged — I verified that by stashing and re-running, not by assuming.
- `ruff` clean. `python -m tools.skillgen --check` → `check OK: 134 artifact(s) match committed output and expected/`.

Reviewed by a fresh-eyes pass that traced `_is_noise_dir` end to end, confirmed the new gate is actually reached (no earlier `_SKIP_DIRS` short-circuit), confirmed the only `_is_noise_dir` caller (`detect.py:1334`, the `os.walk` prune loop) always passes a real parent, and confirmed `_has_coverage_markers` runs once per directory rather than once per file.