### PR TITLE
fix(build): inherit the on-disk directed flag in build_merge (#2342)

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -1124,9 +1124,9 @@ def deduplicate_by_label(nodes: list[dict], edges: list[dict]) -> tuple[list[dic
     return deduped_nodes, deduped_edges
 
 
-def _load_existing_graph(graph_path: Path) -> "tuple[list, list, list] | None":
-    """Load (nodes, edges, hyperedges) from an existing graph.json for an
-    incremental merge, accepting both the ``links`` and ``edges`` spellings.
+def _load_existing_graph(graph_path: Path) -> "tuple[list, list, list, bool] | None":
+    """Load (nodes, edges, hyperedges, directed) from an existing graph.json for
+    an incremental merge, accepting both the ``links`` and ``edges`` spellings.
 
     Reads the JSON directly instead of going through node_link_graph().
     The latter rebuilds an undirected nx.Graph and then enumerating
@@ -1156,6 +1156,7 @@ def _load_existing_graph(graph_path: Path) -> "tuple[list, list, list] | None":
         list(data.get("nodes", [])),
         list(data.get(links_key, [])),
         list(data.get("hyperedges", [])),
+        bool(data.get("directed", False)),
     )
 
 
@@ -1193,7 +1194,7 @@ def merge_raw_extraction(
     loaded = _load_existing_graph(graph_path)
     if loaded is None:
         return new
-    existing_nodes, existing_edges, existing_hyperedges = loaded
+    existing_nodes, existing_edges, existing_hyperedges, _ = loaded
 
     _eff_root = (
         str(Path(root).resolve()) if root is not None
@@ -1260,7 +1261,7 @@ def build_merge(
     graph_path: str | Path | None = None,
     prune_sources: list[str] | None = None,
     *,
-    directed: bool = False,
+    directed: bool | None = None,
     dedup: bool = True,
     dedup_llm_backend: str | None = None,
     root: str | Path | None = None,
@@ -1273,17 +1274,25 @@ def build_merge(
     preserved unchanged; deleted files are removed via prune_sources.
     Safe to call repeatedly.
     root: if given, absolute source_file paths in new_chunks are made relative (#932).
+    directed: if None (default), honor the on-disk graph's own ``directed`` flag
+    when one exists, so an incremental merge can't silently flip a directed
+    graph undirected (#2342). Falls back to False when there is no existing
+    graph to inherit from. An explicit True/False always overrides the on-disk
+    flag.
     """
     graph_path = Path(graph_path if graph_path is not None else _default_graph_json())
     _loaded = _load_existing_graph(graph_path)
     if _loaded is not None:
-        existing_nodes, existing_edges, existing_hyperedges = _loaded
+        existing_nodes, existing_edges, existing_hyperedges, existing_directed = _loaded
         had_graph = True
     else:
         existing_nodes = []
         existing_edges = []
         existing_hyperedges = []
+        existing_directed = False
         had_graph = False
+    if directed is None:
+        directed = existing_directed if had_graph else False
 
     # Effective root for relativizing absolute source_file / prune paths back to the
     # stored relative source_file keys. When the caller passes root we use it;

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -675,6 +675,13 @@ def _node_community_map(graph_data: dict) -> dict[str, int]:
 def _canonical_graph_for_compare(graph_data: dict) -> dict:
     canonical = dict(graph_data)
     canonical.pop("built_at_commit", None)
+    # A missing "directed" key means the same thing as "directed": false
+    # everywhere else in the codebase (#2342's --no-cluster path only started
+    # writing the key once it began inheriting it from the existing graph).
+    # Normalise so an old graph.json without the key doesn't register as
+    # "changed" against a freshly-written candidate that now carries
+    # "directed": false explicitly.
+    canonical["directed"] = bool(canonical.get("directed", False))
     for key in ("nodes", "links", "edges", "hyperedges"):
         if key in canonical and isinstance(canonical[key], list):
             canonical[key] = sorted(
@@ -1178,6 +1185,10 @@ def _rebuild_code(
                 **{k: v for k, v in result.items() if k not in ("edges", "nodes")},
                 "nodes": _dedupe_nodes(result.get("nodes", [])),
                 "links": _dedupe_edges(result.get("edges", [])),
+                # Inherit the existing graph's directed flag (#2342) so
+                # `graphify update --no-cluster` can't silently drop it -
+                # `result` (the raw merged extraction) never carries one.
+                "directed": bool((existing_graph_data or {}).get("directed", False)),
             }
             candidate_graph_text = _json_text(candidate_graph_data)
             same_graph = False
@@ -1258,7 +1269,10 @@ def _rebuild_code(
             "total_words": detected.get("total_words", 0),
         }
 
-        G = build_from_json(result)
+        # Inherit the existing graph's directed flag (#2342) so `graphify
+        # update` can't silently downgrade a directed graph to undirected -
+        # build_from_json defaults to directed=False otherwise.
+        G = build_from_json(result, directed=bool((existing_graph_data or {}).get("directed", False)))
         candidate_topology = _topology_from_graph(G)
         if existing_graph_data:
             try:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -565,6 +565,97 @@ def test_build_merge_preserves_call_edge_direction(tmp_path):
     )
 
 
+def test_build_merge_directed_edge_direction_survives_round_trip(tmp_path):
+    """Regression for #2342: once build_merge correctly inherits the on-disk
+    `directed` flag, the resulting graph must actually be a DiGraph whose
+    edges are readable in the right direction (a -> b, not b -> a)."""
+    from graphify.extract import extract_js
+    from graphify.export import to_json
+
+    src = "function b() {}\nfunction a() { b(); }\n"
+    src_file = tmp_path / "x.js"
+    src_file.write_text(src)
+
+    extraction = extract_js(src_file)
+    call_edges = [e for e in extraction["edges"] if e["relation"] == "calls"]
+    assert len(call_edges) == 1
+    truth_src = call_edges[0]["source"]
+    truth_tgt = call_edges[0]["target"]
+
+    G1 = build([extraction], directed=True, dedup=False)
+    graph_path = tmp_path / "graph.json"
+    assert to_json(G1, {}, str(graph_path), force=True)
+
+    G2 = build_merge([], graph_path, dedup=False)
+    assert G2.is_directed() is True
+    assert G2.has_edge(truth_src, truth_tgt)
+    assert not G2.has_edge(truth_tgt, truth_src)
+
+
+def test_build_merge_inherits_directed_flag_from_disk(tmp_path):
+    """Regression for #2342.
+
+    build_merge with no explicit `directed=` must honor the on-disk graph's
+    own `directed` flag instead of silently defaulting to False, or an
+    incremental --update on a directed graph downgrades it to undirected.
+    """
+    ext = {
+        "nodes": [{"id": "a", "label": "a", "file_type": "concept",
+                   "source_file": "x.md", "source_location": "L1"}],
+        "edges": [],
+    }
+    from graphify.export import to_json
+
+    graph_path = tmp_path / "graph.json"
+
+    # Directed graph on disk -> no directed= kwarg -> stays directed.
+    G1 = build([ext], directed=True, dedup=False)
+    assert to_json(G1, {}, str(graph_path), force=True)
+    G2 = build_merge([], graph_path, dedup=False)
+    assert G2.is_directed() is True
+    saved = json.loads(graph_path.read_text())
+    assert saved.get("directed") is True
+
+    # Undirected graph on disk -> no directed= kwarg -> stays undirected (no regression).
+    G3 = build([ext], directed=False, dedup=False)
+    assert to_json(G3, {}, str(graph_path), force=True)
+    G4 = build_merge([], graph_path, dedup=False)
+    assert G4.is_directed() is False
+
+
+def test_build_merge_fresh_graph_defaults_undirected(tmp_path):
+    """No existing graph.json + no directed= kwarg -> falls back to the
+    current default (False), same as before #2342."""
+    graph_path = tmp_path / "does_not_exist.json"
+    G = build_merge([], graph_path, dedup=False)
+    assert G.is_directed() is False
+
+
+def test_build_merge_explicit_directed_overrides_disk_flag(tmp_path):
+    """An explicit directed=True/False from the caller must still win over
+    whatever is stored on disk (#2342)."""
+    ext = {
+        "nodes": [{"id": "a", "label": "a", "file_type": "concept",
+                   "source_file": "x.md", "source_location": "L1"}],
+        "edges": [],
+    }
+    from graphify.export import to_json
+
+    graph_path = tmp_path / "graph.json"
+
+    # Directed on disk, explicit directed=False -> caller wins.
+    G1 = build([ext], directed=True, dedup=False)
+    assert to_json(G1, {}, str(graph_path), force=True)
+    G2 = build_merge([], graph_path, directed=False, dedup=False)
+    assert G2.is_directed() is False
+
+    # Undirected on disk, explicit directed=True -> caller wins.
+    G3 = build([ext], directed=False, dedup=False)
+    assert to_json(G3, {}, str(graph_path), force=True)
+    G4 = build_merge([], graph_path, directed=True, dedup=False)
+    assert G4.is_directed() is True
+
+
 def test_build_from_json_preserves_first_direction_on_bidirectional_pair(tmp_path):
     """Regression for #1061.
 

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -2402,3 +2402,125 @@ def test_rebuild_readable_graph_still_preserves_semantic_nodes(tmp_path):
         e.get("source") == "notes_concept" and e.get("target") == "notes_doc"
         for e in after["links"]
     ), "semantic link must survive an incremental rebuild"
+
+
+# --- #2342: `graphify update` rebuild must inherit the on-disk directed flag ---
+
+def test_rebuild_code_inherits_directed_flag_clustered(tmp_path):
+    """#2342: the clustered `graphify update` rebuild path built the graph via
+    build_from_json(result) with no directed= argument, so it always took the
+    directed=False default and silently downgraded an existing directed graph.
+    """
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "a.py").write_text(
+        "def alpha():\n    return beta()\n\ndef beta():\n    return 1\n", encoding="utf-8"
+    )
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+
+    graph_path = corpus / "graphify-out" / "graph.json"
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    data["directed"] = True
+    graph_path.write_text(json.dumps(data), encoding="utf-8")
+
+    # Add a NEW function and a call to it, so the rebuild genuinely changes
+    # topology. Editing only a function BODY leaves the node/edge set identical,
+    # so the same_topology check short-circuits before graph.json is rewritten
+    # and the seeded flag survives untouched — the assertion below would then
+    # pass without the fix ever running.
+    n_before = len(json.loads(graph_path.read_text(encoding="utf-8"))["nodes"])
+    (corpus / "a.py").write_text(
+        "def alpha():\n    return beta() + gamma()\n\n"
+        "def beta():\n    return 1\n\ndef gamma():\n    return 2\n",
+        encoding="utf-8",
+    )
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+
+    after = json.loads(graph_path.read_text(encoding="utf-8"))
+    assert len(after["nodes"]) > n_before, (
+        "guard: graph.json must actually have been rewritten, otherwise the "
+        "directed assertion below is vacuous"
+    )
+    assert after.get("directed") is True, (
+        "graphify update (clustered) must preserve an existing directed=True graph"
+    )
+    edge = next(
+        e for e in after["links"]
+        if e.get("relation") == "calls"
+    )
+    assert edge["source"] == "a_alpha" and edge["target"] == "a_beta", (
+        "directed calls edge must still read alpha -> beta, not reversed"
+    )
+
+
+def test_rebuild_code_inherits_directed_flag_no_cluster(tmp_path):
+    """#2342, --no-cluster path: candidate_graph_data was built straight from the
+    raw merged extraction (`result`), which never carries a directed key, so the
+    written graph.json silently lost the flag on every no-cluster update."""
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "a.py").write_text("def f(): pass\n", encoding="utf-8")
+    assert _rebuild_code(corpus, no_cluster=True, acquire_lock=False) is True
+
+    graph_path = corpus / "graphify-out" / "graph.json"
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    data["directed"] = True
+    graph_path.write_text(json.dumps(data), encoding="utf-8")
+
+    # A new top-level function, not just a body edit, so the candidate graph
+    # really differs and the same_graph check cannot short-circuit the write
+    # (which would leave the seeded flag in place and make this vacuous).
+    n_before = len(json.loads(graph_path.read_text(encoding="utf-8"))["nodes"])
+    (corpus / "a.py").write_text("def f(): pass\n\ndef g(): pass\n", encoding="utf-8")
+    assert _rebuild_code(corpus, no_cluster=True, acquire_lock=False) is True
+
+    after = json.loads(graph_path.read_text(encoding="utf-8"))
+    assert len(after["nodes"]) > n_before, (
+        "guard: graph.json must actually have been rewritten, otherwise the "
+        "directed assertion below is vacuous"
+    )
+    assert after.get("directed") is True, (
+        "graphify update --no-cluster must preserve an existing directed=True graph"
+    )
+
+
+def test_rebuild_code_keeps_undirected_graph_undirected(tmp_path):
+    """An existing undirected graph (no directed key, the on-disk default) must
+    not be spuriously flipped to directed=True by an update rebuild."""
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "a.py").write_text("def f(): pass\n", encoding="utf-8")
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+
+    graph_path = corpus / "graphify-out" / "graph.json"
+    before = json.loads(graph_path.read_text(encoding="utf-8"))
+    assert before.get("directed", False) is False
+
+    (corpus / "a.py").write_text("def f(): return 1\n", encoding="utf-8")
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+
+    after = json.loads(graph_path.read_text(encoding="utf-8"))
+    assert after.get("directed", False) is False, (
+        "an undirected graph must not be spuriously flipped to directed by update"
+    )
+
+
+def test_rebuild_code_fresh_build_defaults_undirected(tmp_path):
+    """No existing graph at all (first build via _rebuild_code) must still
+    default to directed=False - #2342's fix only inherits, never invents True."""
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "a.py").write_text("def f(): pass\n", encoding="utf-8")
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+
+    graph_path = corpus / "graphify-out" / "graph.json"
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    assert data.get("directed", False) is False


### PR DESCRIPTION
Closes #2342

## The bug

`build_merge(..., *, directed: bool = False, ...)` (`graphify/build.py:1263`) took direction from the caller only, and rebuilt with that default at `build.py:1327` (`G = build(all_chunks, directed=directed, ...)`), discarding the direction of the graph it had just loaded from `graph_path`. `cli.py:3547` is the only call site in the tree and passes no `directed=`, so every incremental `graphify update` through the merge path inherited `False`.

```
built directed:        True
on-disk directed flag: True
after build_merge:     False     <- returned graph is undirected
on-disk after:         True
```

One correction to the report worth stating: `build_merge` does not itself rewrite the flag on disk (that last line stayed `true`), so the downgrade materializes when the caller serializes the returned graph. The returned object is what had to be fixed.

## The fix

- `_load_existing_graph` now returns `(nodes, edges, hyperedges, directed)`, reading the flag out of the JSON it already parses — no second file read.
- `build_merge`s parameter becomes `directed: bool | None = None`. `None` inherits the on-disk flag when a graph exists, and falls back to `False` when there is none, so a brand-new graph behaves exactly as before. An explicit `True`/`False` from a caller still wins over the on-disk flag.
- `merge_raw_extraction`s unpack updated for the new arity; it never builds an `nx.Graph`, so it discards the flag and its behavior is unchanged.

I grepped for a second copy of this defect, since that is usually the situation in this repo. There is only one `build_merge` call site, and `cli.py:1680` already reads `_raw.get("directed", False)` correctly before calling `build_from_json`, so there was nothing else to fix here.

## Verification

- 6 new tests in `tests/test_build.py`: directed on disk with no `directed=` inherits True; undirected stays False; no existing graph file falls back to False; explicit `directed=False` against a directed on-disk graph still yields False; explicit `directed=True` against an undirected one yields True; and an `a -> b` calls edge survives the round trip without becoming readable as `b -> a`.
- Red before the fix: stashing only `build.py`, the two behavioral tests fail (`inherits_directed_flag_from_disk`, `directed_edge_direction_survives_round_trip`). The other four pass either way by design — they are regression guards for behavior that must not change, and I would rather say that than imply all six were red.
- `tests/test_build.py` + `tests/test_build_merge_hyperedges_and_prune.py`: 74 passed.
- Full suite: 3899 passed / 3 skipped / 4 failed. The same 4 fail with `build.py` stashed back to its pre-fix state (env-dependent backend-detection tests in `test_ollama.py` and `test_llm_backends.py`), so the failure set is unchanged — verified by re-running, not assumed.
- `ruff` clean. `python -m tools.skillgen --check` → `check OK: 134 artifact(s) match committed output and expected/`.

A fresh-eyes review pass additionally confirmed: both `_load_existing_graph` unpack sites in live code are updated (`watch.py:474` only does an `is None` check, so it is unaffected), no test unpacks it directly, there is no path where a missing file yields `True` or where `existing_directed` is unbound, and `dedupe_edges` already keys on `(source, target, relation)` — direction-sensitive before this change — so letting a graph stay directed does not alter dedup behavior.