### PR TITLE
fix(python): resolve module-qualified calls from inside class methods

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2262,6 +2262,14 @@ def _resolve_python_member_calls(
                 contains_children.setdefault(src, {}).setdefault(
                     _key(tnode.get("label", "")), []).append(tgt)
                 file_of_node[tgt] = src
+        elif e.get("relation") == "method":
+            # [FIX] method di dalam class TERHUBUNG lewat relasi `method`, BUKAN
+            # `contains` -- jadi `file_of_node` nol entri buat mereka dan arm
+            # module-alias di bawah dapet caller_file=None lalu bail. Akibatnya
+            # `modul.fungsi()` di dalam method class GAK PERNAH ke-resolve.
+            src, tgt = e.get("source"), e.get("target")
+            if tgt is not None and tgt not in file_of_node:
+                file_of_node[tgt] = src
     imported_by_filenode: dict[str, set[str]] = {}
     # Local alias bound by `as` on a specific import edge (#2082): `from pkg import
     # mod as alias` / `import pkg.mod as alias` bind `alias`, not `mod`'s own stem,
@@ -2327,7 +2335,15 @@ def _resolve_python_member_calls(
             # receiver also matches the local alias bound on that import edge
             # (#2082), so an aliased import resolves the same as the bare name.
             rkey = _key(receiver)
+            # [FIX] naik TRANSITIF: method -> class -> file
             caller_file = file_of_node.get(caller)
+            for _ in range(8):
+                if caller_file is None or caller_file in imported_by_filenode:
+                    break
+                _up = file_of_node.get(caller_file)
+                if _up is None or _up == caller_file:
+                    break
+                caller_file = _up
             file_aliases = import_alias_by_filenode.get(caller_file, {})
             mods = [t for t in imported_by_filenode.get(caller_file, ())
                     if t in contains_children

--- a/tests/test_python_member_calls.py
+++ b/tests/test_python_member_calls.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify.extract import extract
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _node_id(result: dict, label: str, source_file: str) -> str:
+    matches = [
+        node["id"]
+        for node in result["nodes"]
+        if node.get("label") == label and node.get("source_file") == source_file
+    ]
+    assert len(matches) == 1, f"expected 1 node {label!r} in {source_file!r}, got {matches}"
+    return matches[0]
+
+
+def _has_edge(result: dict, source: str, target: str, relation: str) -> bool:
+    return any(
+        edge["source"] == source
+        and edge["target"] == target
+        and edge["relation"] == relation
+        for edge in result["edges"]
+    )
+
+
+def test_python_module_qualified_call_resolves_from_class_method(tmp_path: Path):
+    """`module.func()` must resolve to a `calls` edge from a class method too.
+
+    The module-alias arm of `_resolve_python_member_calls()` looked `caller_file`
+    up in `file_of_node`, which was populated from `contains` edges only. Methods
+    reach their file through `method` (class -> method) instead, so `caller_file`
+    was `None` for every method and the arm bailed out: `module.func()` resolved
+    from a module-level function but never from a method.
+    """
+    init = _write(tmp_path / "pkg/__init__.py", "")
+    util = _write(tmp_path / "pkg/util.py", "def helper(x):\n    return x + 1\n")
+    app = _write(
+        tmp_path / "app.py",
+        "from pkg import util\n"
+        "from pkg.util import helper\n\n\n"
+        "class Machine:\n"
+        "    def method_qualified(self):\n"
+        "        return util.helper(1)\n\n"
+        "    def method_bare(self):\n"
+        "        return helper(1)\n\n\n"
+        "def function_qualified():\n"
+        "    return util.helper(1)\n",
+    )
+
+    result = extract([init, util, app], cache_root=tmp_path)
+
+    helper = _node_id(result, "helper()", "pkg/util.py")
+    method_qualified = _node_id(result, ".method_qualified()", "app.py")
+    method_bare = _node_id(result, ".method_bare()", "app.py")
+    function_qualified = _node_id(result, "function_qualified()", "app.py")
+
+    # Regression: this is the edge that used to be missing.
+    assert _has_edge(result, method_qualified, helper, "calls")
+
+    # Guard rails -- these already worked and must keep working.
+    assert _has_edge(result, method_bare, helper, "calls")
+    assert _has_edge(result, function_qualified, helper, "calls")


### PR DESCRIPTION
### Summary

In `_resolve_python_member_calls()` (`graphify/extract.py`), qualified calls of the form
`module.func()` resolve only when the caller is a **module-level function**. When the same
call appears inside a **class method**, no `calls` edge is produced.

The module-alias arm bails because `caller_file` is `None`.

### Reproduction

```python
# pkg/util.py
def helper(x):
    return x + 1
```

```python
# app.py
from pkg import util
from pkg.util import helper


class Machine:
    def method_qualified(self):
        return util.helper(1)      # <-- NO calls edge (bug)

    def method_bare(self):
        return helper(1)           # <-- ok


def function_qualified():
    return util.helper(1)          # <-- ok
```

| caller | shape | `calls` edge on main |
|---|---|---|
| `function_qualified()` | module-level + `module.attr` | yes |
| `Machine.method_bare()` | class method + bare name | yes |
| `Machine.method_qualified()` | **class method + `module.attr`** | **no** |

### Root cause

`file_of_node` is populated **only from `contains` edges**:

```python
caller_file = file_of_node.get(caller)
mods = [t for t in imported_by_filenode.get(caller_file, ()) ...]
if len(mods) != 1:
    continue
```

Methods are linked to their class through the **`method`** relation, not `contains`, so
methods get no entry in `file_of_node`. `caller_file` is therefore `None`,
`imported_by_filenode.get(None, ())` is empty, and the arm `continue`s.

Confirmed by instrumenting the resolver: `caller_file=None` for `Machine.method_qualified()`,
while `function_qualified()` resolves to its file.

### Fix

1. Populate `file_of_node` from **`method`** edges (class -> method) as well.
2. Walk **transitively** method -> class -> file when resolving `caller_file`.

16 added lines, no existing line changed.

### Test

`tests/test_python_member_calls.py` (new, follows the existing
`test_<lang>_member_calls.py` naming). It asserts the previously missing edge **and** the
two shapes that already worked, so the fix cannot silently regress them.

- Without this change: **fails** — `assert _has_edge(result, method_qualified, helper, "calls")` -> `False`
- With this change: **passes**

### Full suite

`pytest tests/` on this branch (base `v8`): **3651 passed, 14 failed, 170 skipped**.

The 14 failures are pre-existing and environmental, not caused by this change — verified by a
control run: reverting only the patch and re-running the full suite produces the **same 14
failures**, and `comm` of the two sorted failure lists is empty. They are `test_terraform.py`
(7, `tree_sitter_hcl not installed`), `test_ollama_retry_cap.py` (4), and one each in
`test_extract.py`, `test_install_references.py`, `test_manifest_ingest.py`.

### Impact

Measured on a private ~272-file Python codebase where most functions are methods on classes:

| metric | before | after |
|---|---|---|
| total `calls` edges | 5,436 | 8,191 (**+51%**) |
| cross-module edges between two core modules | 0 | 17 |

On that repository's full graph the change adds **+2,755 edges (+22.9%)**.

The failure is silent: the graph simply reports fewer callers, so an agent can conclude
"nothing else calls this" when callers do exist.

### Related

Similar resolver gaps are open for other languages: #1313 (Go), #2135 (Rust), #1682 (PHP).
I did not find an existing issue for the Python class-method case.

### Not covered here

`from pkg import util as u2` **inside** a method (lazy import + alias) still produces no edge —
the alias is bound in function scope rather than file scope. Left out deliberately to keep this
change small; happy to file it separately.
