### PR TITLE
feat(mcp): add named project discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## Unreleased
+
+- Feature: shared MCP servers can load an optional named project registry with `--projects-index`. Clients call `list_projects`, then pass the returned public ID as `project` to select a graph without receiving its server filesystem path. Existing `project_path` calls remain supported.
+
 ## 0.9.31 (2026-07-30)
 
 - Feature: the MCP server is dual-compatible with SDK 1.x AND 2.x (#2308, thanks @NiSHoW), lifting the `mcp<2` cap 0.9.30 introduced to `mcp>=1,<3`. The 2.0 SDK removed the low-level decorator API (`Server.list_tools`/`call_tool`/...); `_build_server` now binds the same handlers via the 1.x decorators or the 2.x `on_*` constructor callbacks, picked at runtime, and adapts `Tool.inputSchema`, `Resource.uri` (plain `str` in 2.x), and the dropped `AnyUrl` re-export. Verified with full stdio handshakes under both mcp 1.29 and 2.0.

--- a/README.md
+++ b/README.md
@@ -457,9 +457,10 @@ kimi mcp add --transport stdio graphify -- python -m graphify.serve graphify-out
 # or serve over HTTP so a whole team points at one URL (no local graphify needed):
 python -m graphify.serve graphify-out/graph.json --transport http --port 8080
 python -m graphify.serve graphify-out/graph.json --transport http --host 0.0.0.0 --api-key "$SECRET"
+python -m graphify.serve merged/graph.json --transport http --projects-index projects.json
 ```
 
-The MCP server gives your assistant structured access: `query_graph`, `get_node`, `get_neighbors`, `shortest_path`, `list_prs`, `get_pr_impact`, `triage_prs`.
+The MCP server gives your assistant structured access: `query_graph`, `get_node`, `get_neighbors`, `shortest_path`, `list_projects`, `list_prs`, `get_pr_impact`, `triage_prs`.
 
 ### Shared HTTP server
 
@@ -472,6 +473,7 @@ The MCP server gives your assistant structured access: `query_graph`, `get_node`
 | `--port` | `8080` | HTTP bind port |
 | `--api-key` | env `GRAPHIFY_API_KEY` | Require `Authorization: Bearer <key>` (or `X-API-Key`) |
 | `--path` | `/mcp` | HTTP mount path |
+| `--projects-index` | off | JSON registry of named project graphs for `list_projects` and `project` selection |
 | `--json-response` | off | Return plain JSON instead of SSE streams |
 | `--stateless` | off | No per-session state (for load-balanced / CI deployments) |
 | `--session-timeout` | `3600` | Reap idle stateful sessions after N seconds (`0` disables) |
@@ -483,6 +485,31 @@ docker build -t graphify .
 docker run -p 8080:8080 -v "$(pwd)/graphify-out:/data" graphify \
   /data/graph.json --transport http --host 0.0.0.0 --api-key "$SECRET"
 ```
+
+### Named project registry
+
+For one shared server that hosts several graphs, configure a server-side registry:
+
+```json
+{
+  "projects": [
+    {
+      "id": "catalog-service",
+      "path": "/data/projects/catalog-service",
+      "source_repository": "acme/catalog-service",
+      "node_count": 18360,
+      "edge_count": 56560
+    }
+  ]
+}
+```
+
+`path` must be absolute and contain `graphify-out/graph.json`. It is never
+returned to MCP clients. Clients call `list_projects` to discover the available
+IDs, then pass `project: "catalog-service"` to any graph query tool. Omit
+`project` to use the server's default graph. `project_path` remains available
+for backwards compatibility, but `project` is the safer choice for shared
+servers.
 
 > **WSL / Linux note:** Ubuntu ships `python3`, not `python`. Use a venv to avoid conflicts:
 > ```bash

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -93,6 +93,41 @@ def _max_server_contexts() -> int:
         return 8
 
 
+_PROJECT_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+_PROJECT_PUBLIC_FIELDS = ("source_repository", "node_count", "edge_count")
+
+
+def _load_projects_index(index_path: str | None) -> dict[str, dict]:
+    """Load validated server-side project roots from an optional JSON registry."""
+    if not index_path:
+        return {}
+    try:
+        data = json.loads(Path(index_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read projects index {index_path!r}: {exc}") from exc
+    if not isinstance(data, dict) or not isinstance(data.get("projects"), list):
+        raise ValueError("projects index must be an object with a projects array")
+
+    projects: dict[str, dict] = {}
+    for entry in data["projects"]:
+        if not isinstance(entry, dict):
+            raise ValueError("each projects index entry must be an object")
+        project_id = entry.get("id")
+        if not isinstance(project_id, str) or not _PROJECT_ID_RE.fullmatch(project_id):
+            raise ValueError("project id must match [A-Za-z0-9][A-Za-z0-9._-]*")
+        if project_id in projects:
+            raise ValueError(f"duplicate project id: {project_id}")
+        raw_path = entry.get("path")
+        if not isinstance(raw_path, str) or not Path(raw_path).is_absolute():
+            raise ValueError(f"project {project_id!r} path must be absolute")
+        public = {"id": project_id}
+        for field in _PROJECT_PUBLIC_FIELDS:
+            if field in entry:
+                public[field] = entry[field]
+        projects[project_id] = {"path": str(Path(raw_path).resolve()), "public": public}
+    return projects
+
+
 class _GraphContextCache:
     """Thread-safe graph contexts: one pinned default plus an LRU of projects."""
 
@@ -1220,7 +1255,7 @@ def _community_header(cid: int, community_name) -> str:
     return base
 
 
-def _build_server(graph_path: str):
+def _build_server(graph_path: str, *, projects_index: str | None = None):
     """Build the configured low-level MCP Server (shared by every transport).
 
     All graph query tools and resources are registered here over a single
@@ -1247,6 +1282,7 @@ def _build_server(graph_path: str):
     # while preventing a shared server from retaining every project it serves.
     _default_graph_path = str(Path(graph_path).resolve())
     _ctx_cache = _GraphContextCache(_max_server_contexts())
+    projects = _load_projects_index(projects_index)
 
     def _load_ctx(path: str):
         """Return the current default or project graph context as a tool error.
@@ -1258,11 +1294,15 @@ def _build_server(graph_path: str):
         resolved_path = str(Path(path).resolve())
         return _ctx_cache.load(resolved_path, pinned=resolved_path == _default_graph_path)
 
-    def _resolve_graph_path(project_path) -> str:
-        """Map an optional project_path to a concrete graph.json path. ``None``
-        keeps the server's default graph (backward-compatible); a project_path
-        resolves to ``<project_path>/<GRAPHIFY_OUT>/graph.json``, honouring the
-        GRAPHIFY_OUT override so worktree/shared-output setups keep working."""
+    def _resolve_graph_path(project_path, project) -> str:
+        """Map an optional path or registered project ID to graph.json."""
+        if project_path and project:
+            raise ValueError("project and project_path cannot be used together")
+        if project:
+            entry = projects.get(project)
+            if entry is None:
+                raise ValueError(f"unknown project: {project}")
+            project_path = entry["path"]
         if not project_path:
             return _default_graph_path
         return str(Path(project_path) / _paths.GRAPHIFY_OUT / "graph.json")
@@ -1281,10 +1321,15 @@ def _build_server(graph_path: str):
         # than the process refusing to start (which is what _load_graph would do).
         G, communities = None, {}
 
-    def _select_graph(project_path) -> None:
+    def _select_graph(project_path=None, project=None) -> None:
         nonlocal G, communities, active_graph_path
-        path = _resolve_graph_path(project_path)
-        G, communities = _load_ctx(path)
+        path = _resolve_graph_path(project_path, project)
+        try:
+            G, communities = _load_ctx(path)
+        except (FileNotFoundError, RuntimeError) as exc:
+            if project:
+                raise RuntimeError(f"could not load graph for project {project!r}") from exc
+            raise
         active_graph_path = str(Path(path).resolve())
 
     # NOTE: no decorators here — the handlers below are plain coroutines,
@@ -1435,6 +1480,20 @@ def _build_server(graph_path: str):
                     "this server was started with."
                 ),
             }
+            _schema["properties"]["project"] = {
+                "type": "string",
+                "description": (
+                    "Registered project ID from list_projects. Optional — "
+                    "selects that project's graph without exposing server paths."
+                ),
+            }
+        _tools.append(
+            types.Tool(
+                name="list_projects",
+                description="List configured project IDs available for scoped graph queries.",
+                inputSchema={"type": "object", "properties": {}},
+            )
+        )
         return _tools
 
     def _tool_query_graph(arguments: dict) -> str:
@@ -1725,6 +1784,12 @@ def _build_server(graph_path: str):
             )
         return "\n\n".join(lines)
 
+    def _tool_list_projects(arguments: dict) -> str:
+        return json.dumps(
+            {"projects": [projects[project_id]["public"] for project_id in sorted(projects)]},
+            sort_keys=True,
+        )
+
     _handlers = {
         "query_graph": _tool_query_graph,
         "get_node": _tool_get_node,
@@ -1736,6 +1801,7 @@ def _build_server(graph_path: str):
         "list_prs": _tool_list_prs,
         "get_pr_impact": _tool_get_pr_impact,
         "triage_prs": _tool_triage_prs,
+        "list_projects": _tool_list_projects,
     }
 
     def _load_community_labels() -> dict[int, str]:
@@ -1813,11 +1879,16 @@ def _build_server(graph_path: str):
     async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
         arguments = dict(arguments or {})
         project_path = arguments.pop("project_path", None)
+        project = arguments.pop("project", None)
         handler = _handlers.get(name)
         if not handler:
             return [types.TextContent(type="text", text=f"Unknown tool: {name}")]
         try:
-            _select_graph(project_path)  # bind G/communities to the target graph
+            if name == "list_projects":
+                if project_path or project:
+                    raise ValueError("list_projects does not accept project or project_path")
+                return [types.TextContent(type="text", text=handler(arguments))]
+            _select_graph(project_path, project)  # bind G/communities to the target graph
             return [types.TextContent(type="text", text=handler(arguments))]
         except Exception as exc:
             return [types.TextContent(type="text", text=f"Error executing {name}: {exc}")]
@@ -1868,7 +1939,7 @@ def _build_server(graph_path: str):
     return server
 
 
-def serve(graph_path: str | None = None) -> None:
+def serve(graph_path: str | None = None, *, projects_index: str | None = None) -> None:
     """Start the MCP server over stdio (the default, per-developer transport)."""
     graph_path = graph_path or _default_graph_json()
     try:
@@ -1877,7 +1948,7 @@ def serve(graph_path: str | None = None) -> None:
         raise ImportError('mcp not installed. Run: pip install "graphifyy[mcp]"') from e
     import asyncio
 
-    server = _build_server(graph_path)
+    server = _build_server(graph_path, projects_index=projects_index)
 
     async def main() -> None:
         async with stdio_server() as streams:
@@ -1947,6 +2018,7 @@ class _ApiKeyMiddleware:
 def _build_http_app(
     graph_path: str,
     *,
+    projects_index: str | None = None,
     host: str = "127.0.0.1",
     port: int = 8080,
     api_key: str | None = None,
@@ -1984,7 +2056,7 @@ def _build_http_app(
     # mistaken for "auth on" — normalize it to None so the gate is unambiguous.
     api_key = (api_key or "").strip() or None
 
-    server = _build_server(graph_path)
+    server = _build_server(graph_path, projects_index=projects_index)
 
     # DNS-rebinding protection. When the operator binds a wildcard address they
     # are intentionally exposing the server, so accept any Host header; for a
@@ -2029,6 +2101,7 @@ def _build_http_app(
 def serve_http(
     graph_path: str | None = None,
     *,
+    projects_index: str | None = None,
     host: str = "127.0.0.1",
     port: int = 8080,
     api_key: str | None = None,
@@ -2061,6 +2134,7 @@ def serve_http(
 
     app = _build_http_app(
         graph_path,
+        projects_index=projects_index,
         host=host,
         port=port,
         api_key=api_key,
@@ -2120,6 +2194,12 @@ def _main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument("--path", default="/mcp", help="HTTP mount path (default: /mcp)")
     parser.add_argument(
+        "--projects-index",
+        default=None,
+        metavar="PATH",
+        help="JSON registry of named project graphs available to MCP clients",
+    )
+    parser.add_argument(
         "--json-response",
         action="store_true",
         help="Return plain JSON responses instead of SSE streams",
@@ -2141,6 +2221,7 @@ def _main(argv: list[str] | None = None) -> None:
     if args.transport == "http":
         serve_http(
             graph_path,
+            projects_index=args.projects_index,
             host=args.host,
             port=args.port,
             api_key=args.api_key,
@@ -2150,7 +2231,10 @@ def _main(argv: list[str] | None = None) -> None:
             session_timeout=args.session_timeout,
         )
     else:
-        serve(graph_path)
+        if args.projects_index:
+            serve(graph_path, projects_index=args.projects_index)
+        else:
+            serve(graph_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_serve_http.py
+++ b/tests/test_serve_http.py
@@ -183,6 +183,132 @@ def _project_with_graph(tmp_path, node_count: int, name: str = "proj") -> str:
     return str(proj)
 
 
+def _projects_index(tmp_path: Path, project_id: str, project_path: str) -> str:
+    index = tmp_path / "projects.json"
+    index.write_text(
+        json.dumps(
+            {
+                "projects": [
+                    {
+                        "id": project_id,
+                        "path": project_path,
+                        "source_repository": "example/catalog-service",
+                        "node_count": 3,
+                        "edge_count": 2,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(index)
+
+
+def test_projects_index_rejects_relative_and_duplicate_project_ids(tmp_path):
+    relative = tmp_path / "relative.json"
+    relative.write_text(
+        json.dumps({"projects": [{"id": "identity", "path": "relative"}]}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="absolute"):
+        serve_mod._load_projects_index(str(relative))
+
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text(
+        json.dumps(
+            {
+                "projects": [
+                    {"id": "identity", "path": str(tmp_path / "one")},
+                    {"id": "identity", "path": str(tmp_path / "two")},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate"):
+        serve_mod._load_projects_index(str(duplicate))
+
+
+def test_project_id_routes_to_its_registered_graph(tmp_path):
+    project = _project_with_graph(tmp_path, node_count=3, name="identity")
+    app = serve_mod._build_http_app(
+        _graph_file(tmp_path),
+        projects_index=_projects_index(tmp_path, "catalog-service", project),
+        json_response=True,
+    )
+    with _client(app) as client:
+        headers = _init_session(client)
+        assert "Nodes: 3" in _call_tool(
+            client, headers, "graph_stats", {"project": "catalog-service"}, rid=2
+        )
+        assert "Nodes: 2" in _call_tool(client, headers, "graph_stats", {}, rid=3)
+
+
+def test_registered_project_load_failure_does_not_expose_server_path(tmp_path):
+    missing_path = str(tmp_path / "private-project-root")
+    app = serve_mod._build_http_app(
+        _graph_file(tmp_path),
+        projects_index=_projects_index(tmp_path, "catalog-service", missing_path),
+        json_response=True,
+    )
+    with _client(app) as client:
+        result = _call_tool(
+            client,
+            _init_session(client),
+            "graph_stats",
+            {"project": "catalog-service"},
+            rid=2,
+        )
+    assert "could not load graph for project 'catalog-service'" in result
+    assert missing_path not in result
+
+
+def test_project_selector_rejects_unknown_and_conflicting_selectors(tmp_path):
+    project = _project_with_graph(tmp_path, node_count=3, name="identity")
+    app = serve_mod._build_http_app(
+        _graph_file(tmp_path),
+        projects_index=_projects_index(tmp_path, "catalog-service", project),
+        json_response=True,
+    )
+    with _client(app) as client:
+        headers = _init_session(client)
+        unknown = _call_tool(
+            client, headers, "graph_stats", {"project": "not-configured"}, rid=2
+        )
+        conflicting = _call_tool(
+            client,
+            headers,
+            "graph_stats",
+            {"project": "catalog-service", "project_path": project},
+            rid=3,
+        )
+    assert "unknown project: not-configured" in unknown
+    assert "project and project_path cannot be used together" in conflicting
+
+
+def test_list_projects_returns_public_metadata_without_server_paths(tmp_path):
+    project = _project_with_graph(tmp_path, node_count=3, name="identity")
+    app = serve_mod._build_http_app(
+        _graph_file(tmp_path),
+        projects_index=_projects_index(tmp_path, "catalog-service", project),
+        json_response=True,
+    )
+    with _client(app) as client:
+        result = _call_tool(client, _init_session(client), "list_projects", {}, rid=2)
+    payload = json.loads(result)
+    assert payload == {
+        "projects": [
+            {
+                "id": "catalog-service",
+                "source_repository": "example/catalog-service",
+                "node_count": 3,
+                "edge_count": 2,
+            }
+        ]
+    }
+    assert project not in result
+
+
 def _init_session(client) -> dict:
     init = client.post("/mcp", headers=_MCP_HEADERS, json=_INIT_BODY)
     assert init.status_code == 200
@@ -201,8 +327,7 @@ def _call_tool(client, headers, name, arguments, rid) -> str:
 
 
 def test_project_path_is_optional_on_every_tool(tmp_path):
-    """Multi-project support is additive: every tool gains an optional
-    project_path, and none of them makes it required."""
+    """Graph query tools accept both selectors; discovery accepts neither."""
     app = serve_mod._build_http_app(_graph_file(tmp_path), json_response=True)
     with _client(app) as client:
         headers = _init_session(client)
@@ -210,8 +335,14 @@ def test_project_path_is_optional_on_every_tool(tmp_path):
                             json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
         for tool in resp.json()["result"]["tools"]:
             props = tool["inputSchema"].get("properties", {})
+            if tool["name"] == "list_projects":
+                assert "project" not in props
+                assert "project_path" not in props
+                continue
             assert "project_path" in props, f"{tool['name']} missing project_path"
             assert "project_path" not in tool["inputSchema"].get("required", [])
+            assert "project" in props, f"{tool['name']} missing project"
+            assert "project" not in tool["inputSchema"].get("required", [])
 
 
 def test_project_path_routes_to_that_projects_graph(tmp_path):
@@ -347,12 +478,14 @@ def test_cli_http_passes_flags(monkeypatch):
     serve_mod._main([
         "g.json", "--transport", "http", "--host", "0.0.0.0",
         "--port", "9000", "--api-key", "k", "--stateless",
+        "--projects-index", "projects.json",
     ])
     assert captured["gp"] == "g.json"
     assert captured["host"] == "0.0.0.0"
     assert captured["port"] == 9000
     assert captured["api_key"] == "k"
     assert captured["stateless"] is True
+    assert captured["projects_index"] == "projects.json"
 
 
 def test_cli_api_key_from_env(monkeypatch):


### PR DESCRIPTION
## Summary

Adds an optional, server-side project registry for shared Graphify MCP deployments.

- `--projects-index PATH` loads named project roots at startup.
- `list_projects` exposes stable project IDs and public graph metadata without leaking container paths.
- Graph tools accept `project: <id>` in addition to the existing `project_path` selector.
- Registered-project load errors hide the server filesystem path.

## Why

A shared Graphify MCP deployment needs two valid views of the same codebase:

- **Merged graph by default:** cross-service questions need the integration
  edges between repositories.
- **One service on demand:** a question about only `catalog-service` should
  not compete with similarly named nodes from `billing-service` or another
  repository in the merged graph.

Today `project_path` can technically select a service graph, but it requires a
client to already know a deployment-specific absolute filesystem path. Agents
cannot discover those paths, hardcoding them into every developer's skill does
not scale as projects are added, and exposing the paths from the server is
undesirable.

This change keeps the merged graph as the unchanged default. For a service-only
question, an agent first calls `list_projects`, then supplies the returned
stable ID as `project`. The server maps that ID to the private graph path, so
the same MCP endpoint can answer both cross-service and unambiguous
single-service questions.

## Validation

- `uv run --extra mcp pytest tests/test_serve.py tests/test_serve_http.py -q` (158 passed)
- `uv run ruff check graphify/serve.py tests/test_serve_http.py`

The wider suite was also run; it has an unrelated existing environment-sensitive failure in `test_mixed_repo_without_key_errors_and_points_at_code_only`, where this machine's AWS environment selects the Bedrock path instead of the expected no-key path.
