### PR TITLE
fix(dart): extract ordinary local function calls

### DIFF
--- a/graphify/extractors/dart.py
+++ b/graphify/extractors/dart.py
@@ -30,6 +30,14 @@ def extract_dart(path: Path) -> dict:
         return token
     src_clean = comment_string_pattern.sub(_comment_replace, src)
 
+    # Keep string lengths/newlines stable so declaration offsets can be reused
+    # while ordinary-call scanning cannot mistake string contents for code.
+    def _mask_string(match: re.Match) -> str:
+        token = match.group(0)
+        return "".join("\n" if char == "\n" else " " for char in token)
+
+    call_scan_src = comment_string_pattern.sub(_mask_string, src_clean)
+
     stem = _file_stem(path)
     file_nid = _make_id(str(path))
 
@@ -430,12 +438,25 @@ def extract_dart(path: Path) -> dict:
     # 5. Top-level and member functions/methods (supports typed/generic/record return types and Riverpod/Bloc references)
     # Restrict indentation to 0-2 spaces to avoid matching nested local functions or methods inside multiline switch statements
     method_pattern = r"^\s{0,2}(?:factory\s+|static\s+|async\s+|external\s+|abstract\s+)?(?:\([^)]+\)|[a-zA-Z0-9_<>,.?]+)(?:\s+[a-zA-Z0-9_<>,.?]+){0,3}\s+(\w+(?:\.\w+)?)\s*\("
-    for m in re.finditer(method_pattern, src_clean, re.MULTILINE):
-        raw_name = m.group(1)
-        name = raw_name.split(".")[-1]
-        if name in {"if", "for", "while", "switch", "catch", "return", "void", "dynamic", "final", "const", "get", "set"}:
-            continue
-        if re.match(r"^[A-Z]", name):
+    method_matches = list(re.finditer(method_pattern, src_clean, re.MULTILINE))
+    excluded_function_names = {
+        "if", "for", "while", "switch", "catch", "return", "void",
+        "dynamic", "final", "const", "get", "set",
+    }
+
+    def _function_name(match: re.Match) -> str | None:
+        name = match.group(1).split(".")[-1]
+        if name in excluded_function_names or re.match(r"^[A-Z]", name):
+            return None
+        return name
+
+    local_function_names = {
+        name for match in method_matches if (name := _function_name(match)) is not None
+    }
+
+    for m in method_matches:
+        name = _function_name(m)
+        if name is None:
             continue
         nid = _make_id(stem, name)
         add_node(nid, name)
@@ -453,9 +474,11 @@ def extract_dart(path: Path) -> dict:
         if has_body and arrow_pos != -1 and arrow_pos < brace_pos:
             has_body = False
 
+        call_body = ""
         if has_body:
             end_pos = _find_matching_brace(src_clean, start_idx)
             func_body = src_clean[brace_pos:end_pos]
+            call_body = call_scan_src[brace_pos:end_pos]
 
             # Extract Riverpod provider references: ref.watch(provider)
             for rm in re.finditer(r"\bref\.(?:watch|read|listen)\s*\(\s*(\w+)\b", func_body):
@@ -498,6 +521,23 @@ def extract_dart(path: Path) -> dict:
                 route_nid = _make_id(route_class)
                 add_node(route_nid, route_class, source_file=None)
                 add_edge(nid, route_nid, "navigates", context="route_object")
+
+        elif arrow_pos != -1 and semi_pos != -1 and arrow_pos < semi_pos:
+            call_body = call_scan_src[arrow_pos + 2:semi_pos]
+
+        # Ordinary calls to functions declared in this file. Restricting targets
+        # to local declarations avoids fabricating edges for builtins, imported
+        # APIs, and methods whose receiver type this regex extractor cannot know.
+        for call_match in re.finditer(
+            r"(?<![.\w])([a-zA-Z_]\w*)\s*(?:<[^(){};]+>)?\s*\(",
+            call_body,
+        ):
+            callee_name = call_match.group(1)
+            if callee_name not in local_function_names:
+                continue
+            callee_nid = _make_id(stem, callee_name)
+            add_node(callee_nid, callee_name)
+            add_edge(nid, callee_nid, "calls", context="local_function_call")
 
     # 6. Imports and Exports
     for m in re.finditer(r"""^\s*import\s+['"]([^'"]+)['"]""", src_clean, re.MULTILINE):

--- a/tests/test_dart.py
+++ b/tests/test_dart.py
@@ -562,6 +562,43 @@ class TestDart(unittest.TestCase):
         )
         self.assertIsNotNone(impl_obj)
 
+    def test_local_function_calls_include_block_and_arrow_callers(self):
+        code_content = textwrap.dedent("""
+        int helper(int value) => value * 2;
+
+        int blockCaller() {
+          final decoy = 'helper(0)';
+          // helper(1) must not create a second edge.
+          return helper(21);
+        }
+
+        int arrowCaller() => helper(22);
+        int externalCaller() => externalHelper(23);
+        """)
+        file_path = self.temp_path / "local_calls.dart"
+        file_path.write_text(code_content, encoding="utf-8")
+
+        result = extract_dart(file_path)
+        stem = _file_stem(file_path)
+        helper_id = _make_id(stem, "helper")
+        call_edges = [
+            edge
+            for edge in result["edges"]
+            if edge["relation"] == "calls" and edge["target"] == helper_id
+        ]
+
+        self.assertEqual(
+            {edge["source"] for edge in call_edges},
+            {_make_id(stem, "blockCaller"), _make_id(stem, "arrowCaller")},
+        )
+        self.assertEqual(len(call_edges), 2)
+        self.assertFalse(
+            any(
+                edge["relation"] == "calls" and edge["target"] == _make_id(stem, "externalHelper")
+                for edge in result["edges"]
+            )
+        )
+
     def test_roadmap_bug_fixes(self):
         """Test all 5 roadmap bug fixes (Bug A, B, C, D, E)."""
         # Create parent and part child files to test Bug D (Part of file redirect)


### PR DESCRIPTION
## Problem

The Dart extractor creates nodes for ordinary top-level functions, but it does not emit a `calls` edge for a same-file invocation. As a result, `graphify affected "dartHelper"` returns no callers while an equivalent JavaScript fixture returns `jsCaller()`.

Reproduced on graphify 0.9.28 and the latest 0.9.31 release. A public minimal fixture and normalized graph excerpts are available at [`hjosugi/dart-lab@5c5ae0a`](https://github.com/hjosugi/dart-lab/blob/5c5ae0a19142d3a8f9ed16c4d2a35719c3409ea1/fixtures/graphify-call-edges/README.md).

## Change

- pre-scan Dart functions/methods declared in the file
- scan block and arrow bodies for bare invocations whose target is one of those local declarations
- mask strings before the call scan so text such as `"helper()"` does not create an edge
- avoid fabricating edges for imported functions, builtins, or receiver-qualified methods
- add a regression test covering block/arrow callers, string/comment decoys, and an external call

This remains deliberately narrow because the current Dart extractor is regex-based and cannot resolve receiver types.

## Validation

- new regression test fails on unmodified `v8` and passes with this patch
- `uv run pytest tests/test_dart.py -q` — 6 passed
- end-to-end fixture runner — Dart changes from `status: reproduced` to `status: upstream_fixed`; `affected` returns `dartCaller`
- `uv run ruff check graphify/extractors/dart.py tests/test_dart.py`
- `uv run pyright graphify/extractors/dart.py`
- full suite excluding two unrelated assertions that also fail on an unmodified worktree: 3,831 passed, 35 skipped, 2 deselected
  - `tests/test_detect.py::test_graphifyignore_hermetic_without_vcs`
  - `tests/test_hooks.py::test_no_git_repo_raises`
