### PR TITLE
fix(detect): do not prune scan root when explicitly passed even if gitignored (#2358)

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1127,6 +1127,19 @@ def _is_ignored(
                 rel_anchor = str(target.relative_to(anchor)).replace(os.sep, "/")
             except ValueError:
                 continue  # target outside this pattern's anchor: cannot match
+
+            # #2358: when the scan root is a descendant of the anchor (e.g. the
+            # user passed a gitignored `corpus/` directory as the scan target),
+            # rebase the relative path so that only the portion *below* the scan
+            # root is matched.  Without this, unanchored patterns match the scan
+            # root's own directory name in the prefix, silently pruning nested
+            # content while leaving top-level files unaffected.
+            if root != anchor:
+                try:
+                    rel_anchor = str(target.relative_to(root)).replace(os.sep, "/")
+                except ValueError:
+                    pass  # target outside root — keep anchor-relative path
+
             if rel_anchor != ".":
                 matched = _matches(rel_anchor, p, path_relative=path_relative)
                 if matched and directory_only and not target.is_dir():

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -379,6 +379,36 @@ def test_gitignore_nested_negation_overrides_broader_root_rule(tmp_path):
     assert not any(f.endswith("other.py") for f in code)
 
 
+def test_ancestor_gitignore_matching_scan_root_does_not_prune_nested(tmp_path):
+    """When the scan root itself is listed in an ancestor .gitignore, nested
+    files must not be silently pruned (#2358).  The user explicitly pointed
+    detect() at this directory — that is a stronger signal than an inherited
+    ignore rule.  Before the fix, top-level files survived but anything one
+    level deeper was silently dropped."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / ".gitignore").write_text("corpus/\n")
+
+    corpus = repo / "corpus"
+    corpus.mkdir()
+    (corpus / "manifest.md").write_text("# top-level file\n")
+    subdir = corpus / "subdir"
+    subdir.mkdir()
+    (subdir / "notes.md").write_text("# nested file\n")
+    (subdir / "more.md").write_text("# nested file 2\n")
+
+    result = detect(corpus)
+    all_files: list[str] = []
+    for cat_files in result["files"].values():
+        all_files.extend(cat_files)
+
+    assert any("manifest.md" in f for f in all_files), "top-level file must survive"
+    assert any("notes.md" in f for f in all_files), "nested file must survive (#2358)"
+    assert any("more.md" in f for f in all_files), "nested file 2 must survive (#2358)"
+    assert result["total_files"] >= 3, f"expected >=3 files, got {result['total_files']}"
+
+
 def test_nested_ignore_overrides_git_info_exclude_and_root(tmp_path):
     """Precedence across all three sources: a nested `.gitignore` `!` re-include
     outranks both a root `.gitignore` and `.git/info/exclude` (lowest, from


### PR DESCRIPTION
Fixes #2358

## Problem
When the scan root itself is matched by an ancestor `.gitignore` 
(e.g. `corpus/` in the parent repo's `.gitignore`), `detect()` 
silently prunes all nested files while top-level files survive.

## Fix
In `_eval()`, when the scan root is a descendant of the pattern's 
anchor directory, rebase the relative path to the scan root so 
unanchored patterns only match path components *below* the scan 
root — not the scan root's own name.

## Testing
- Added `test_ancestor_gitignore_matching_scan_root_does_not_prune_nested`
- Full `test_detect.py` suite: 227 passed, 0 failed
