### PR TITLE
Do not warn for intentionally skipped sources

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4608,7 +4608,7 @@ def extract(
     _empty_sources: list[str] = []
     for i, _p in enumerate(paths):
         _res = per_file[i] or {}
-        if _res.get("nodes") or _res.get("error"):
+        if _res.get("nodes") or _res.get("error") or _res.get("skipped"):
             continue
         if _get_extractor(_p) is not None:
             _empty_sources.append(str(_p))

--- a/tests/test_zero_node_no_cache.py
+++ b/tests/test_zero_node_no_cache.py
@@ -52,3 +52,16 @@ def test_no_warning_when_all_files_produce_nodes(tmp_path, capsys):
     ex.extract([f], cache_root=tmp_path / "out", parallel=False)
     err = capsys.readouterr().err
     assert "zero nodes" not in err
+
+
+def test_intentionally_skipped_data_json_does_not_warn(tmp_path, capsys):
+    """Data-shaped JSON is deliberately excluded from the code graph, so its
+    explicit ``skipped`` result must not be reported as a failed extraction that
+    will retry forever."""
+    f = tmp_path / "records.json"
+    f.write_text('[{"id": 1}, {"id": 2}]\n', encoding="utf-8")
+
+    result = ex.extract([f], cache_root=tmp_path / "out", parallel=False)
+
+    assert result["nodes"] == []
+    assert "zero nodes" not in capsys.readouterr().err


### PR DESCRIPTION
Summary: Exclude extractor results that explicitly report skipped from the zero-node failure warning. Data-shaped JSON is deliberately skipped to keep datasets and response dumps from flooding the code graph, so warning that those files failed and will retry is false noise. Regression coverage: new data-JSON skip test; zero-node and extractor registry suites passed with 6 tests; all 87 real PersonalOS intentional JSON skips emitted no false warnings; ruff passed.