### PR TITLE
fix(serve): reserve budget for EDGE lines so query answers keep relations

### DIFF
--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -934,7 +934,8 @@ def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_bu
     so the queried symbol always appears at the top of the output.
     """
     char_budget = token_budget * 3
-    lines = []
+    node_lines: list[str] = []
+    edge_lines: list[str] = []
     # Work-memory overlay (derived sidecar) stashed on the graph at load time.
     # Empty when no sidecar exists, so un-annotated output stays byte-identical.
     overlay = getattr(G, "graph", {}).get("_learning_overlay", {}) or {}
@@ -989,7 +990,7 @@ def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_bu
             f"community={sanitize_label(str(d.get('community_name') or d.get('community', '')))}"
             f"{learning_suffix}]"
         )
-        lines.append(line)
+        node_lines.append(line)
     for u, v in edges:
         if u in nodes and v in nodes:
             raw = G[u][v]
@@ -1024,33 +1025,53 @@ def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_bu
                 f"[{sanitize_label(str(d.get('confidence', '')))}{context_suffix}]--> "
                 f"{sanitize_label(G.nodes[tgt].get('label', tgt))}{at_suffix}"
             )
-            lines.append(line)
-    output = "\n".join(lines)
+            edge_lines.append(line)
+    output = "\n".join(node_lines + edge_lines)
     if len(output) > char_budget:
-        cut_at = output[:char_budget].rfind("\n")
-        cut_at = cut_at if cut_at > 0 else char_budget
-        # Never cut the seed nodes: they render first, so if the budget lands
-        # inside the seed block, extend the cut to cover it. The symbol the
-        # question named must always be in the answer (#BUG2). Seeds are bounded
-        # (_pick_seeds max_k + one per term), so the overshoot is a few lines.
-        if seed_hits:
-            seed_block_end = sum(len(lines[i]) + 1 for i in range(len(seed_hits))) - 1
-            cut_at = max(cut_at, min(seed_block_end, len(output)))
-        total_nodes = sum(1 for l in lines if l.startswith("NODE "))
-        shown_nodes = output[:cut_at].count("\nNODE ") + (1 if output.startswith("NODE ") else 0)
-        cut_count = total_nodes - shown_nodes
+        # EDGE lines are appended after every NODE line, so a single flat cut at
+        # char_budget spends the whole budget on nodes and drops the relations
+        # the traversal was run to find: a 61-node/60-edge subgraph rendered 61
+        # nodes and 26 edges, and a real 2-hop BFS (77 nodes, 84 edges) rendered
+        # zero. An answer with no EDGE lines is a bare node list, not a graph
+        # answer, so reserve half of whatever the seeds leave for edges (#BUG3).
+        def _take(src: list[str], budget: int) -> tuple[list[str], int]:
+            kept, used = [], 0
+            for line in src:
+                need = len(line) + (1 if kept else 0)
+                if used + need > budget:
+                    break
+                kept.append(line)
+                used += need
+            return kept, used
+
+        # Never cut the seed nodes: they render first, so they are charged to the
+        # budget before anything else. The symbol the question named must always
+        # be in the answer (#BUG2). Seeds are bounded (_pick_seeds max_k + one per
+        # term), so the overshoot when they alone exceed the budget is a few lines.
+        seed_lines = node_lines[:len(seed_hits)]
+        seed_chars = sum(len(l) + 1 for l in seed_lines)
+        remaining = max(char_budget - seed_chars, 0)
+        kept_edges, edge_chars = _take(edge_lines, remaining // 2 if edge_lines else 0)
+        kept_nodes, _ = _take(node_lines[len(seed_hits):], remaining - edge_chars)
+        shown_nodes = len(seed_lines) + len(kept_nodes)
+        cut_count = len(node_lines) - shown_nodes
+        cut_edges = len(edge_lines) - len(kept_edges)
         # Prominent notice at the TOP so a truncated answer can never be mistaken
-        # for a complete one — silence used to read as absence (#BUG2). The
+        # for a complete one — silence used to read as absence (#BUG2). Edges are
+        # counted too: the old notice only tallied nodes, so a result that kept
+        # every node while dropping most edges announced "0 cut" (#BUG3). The
         # notice + end marker sit OUTSIDE char_budget by design (two bounded
         # wrapper lines, like the existing end marker).
         output = (
-            f"[!] TRUNCATED: showing {shown_nodes} of {total_nodes} nodes "
+            f"[!] TRUNCATED: showing {shown_nodes} of {len(node_lines)} nodes and "
+            f"{len(kept_edges)} of {len(edge_lines)} edges "
             f"(~{token_budget}-token budget). The answer may be among the "
             f"{cut_count} cut nodes — raise the token budget (CLI: --budget) or "
             f"narrow the query (e.g. context_filter=['call'], or get_node for a "
             f"specific symbol).\n\n"
-            + output[:cut_at]
-            + f"\n... (truncated — {cut_count} more nodes cut by ~{token_budget}-token budget."
+            + "\n".join(seed_lines + kept_nodes + kept_edges)
+            + f"\n... (truncated — {cut_count} more nodes and {cut_edges} more edges"
+            f" cut by ~{token_budget}-token budget."
             f" Narrow with context_filter=['call'] or use get_node for a specific symbol)"
         )
     return output

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1327,6 +1327,55 @@ def test_subgraph_to_text_no_notice_when_under_budget():
     assert "TRUNCATED" not in text and "truncated" not in text
 
 
+# --- BUG3: edges must not be starved by the node block ------------------------
+
+def _wide_graph(n=80):
+    """One seed plus n neighbours, sized so NODE lines alone overrun the budget
+    and the pre-fix renderer emitted zero EDGE lines."""
+    G = nx.Graph()
+    G.add_node("seed", label="seed node", source_file="seed.md", source_location="L1", community=0)
+    for i in range(n):
+        G.add_node(f"n{i}", label=f"neighbour number {i}",
+                   source_file=f"docs/some/path/file{i}.md", source_location="L1", community=0)
+        G.add_edge("seed", f"n{i}", relation="references", confidence="EXTRACTED")
+    return G
+
+
+def test_subgraph_to_text_keeps_edges_when_nodes_overrun_budget():
+    """BUG3: NODE lines render before EDGE lines, so a flat cut spends the whole
+    budget on nodes and returns a bare node list. Relations must survive."""
+    G = _wide_graph()
+    text = _subgraph_to_text(G, set(G.nodes), list(G.edges()), token_budget=2000, seeds=["seed"])
+    assert "TRUNCATED" in text
+    edge_lines = [l for l in text.splitlines() if l.startswith("EDGE ")]
+    node_lines = [l for l in text.splitlines() if l.startswith("NODE ")]
+    assert edge_lines, "every edge was cut: the answer is a node list, not a graph"
+    # Neither block may be starved to make room for the other.
+    assert len(edge_lines) >= len(G.edges()) // 4
+    assert len(node_lines) >= 2
+    assert "seed node" in node_lines[0], "seed must still render first"
+
+
+def test_subgraph_to_text_truncation_notice_counts_cut_edges():
+    """BUG3: the notice tallied nodes only, so a cut that kept every node while
+    dropping most edges announced '0 cut' and read as complete."""
+    G = _wide_graph()
+    text = _subgraph_to_text(G, set(G.nodes), list(G.edges()), token_budget=2000, seeds=["seed"])
+    notice = text.splitlines()[0]
+    shown_e = len([l for l in text.splitlines() if l.startswith("EDGE ")])
+    assert f"{shown_e} of {len(G.edges())} edges" in notice, notice
+    assert "more edges" in text, "end marker must report cut edges too"
+
+
+def test_subgraph_to_text_under_budget_output_is_unchanged_by_edge_reserve():
+    """The reserve only applies past the budget: a fitting subgraph renders every
+    node then every edge, exactly as before."""
+    G = _make_graph()
+    text = _subgraph_to_text(G, {"n1", "n2"}, [("n1", "n2")], token_budget=2000)
+    lines = text.splitlines()
+    assert [l.split()[0] for l in lines] == ["NODE", "NODE", "EDGE"]
+
+
 def test_subgraph_to_text_order_is_deterministic():
     """Equal-degree nodes render in a stable order regardless of set iteration."""
     G = nx.Graph()


### PR DESCRIPTION
## The problem

`_subgraph_to_text` appends every `NODE` line before the first `EDGE` line, then cuts the joined string at `char_budget`. When the nodes alone fill the budget, every edge is dropped and `graphify query` returns a bare node list. The relations the traversal was run to find never reach the caller.

The truncation notice hid this, because it tallied nodes only:

```
[!] TRUNCATED: showing 61 of 61 nodes (~2000-token budget).
The answer may be among the 0 cut nodes ...
```

That output kept all 61 nodes and silently dropped 34 of 60 edges, while reporting `0 cut`. It reads as a complete answer.

## Reproduction

A 61-node / 60-edge star at the default budget of 2000 renders 61 nodes and 26 of 60 edges, notice claims `0 cut`.

The synthetic case above is in the added tests. I also hit this on a private 1381-node documentation graph, where three separate 2-hop BFS questions traversed 84, 57 and 66 edges respectively and rendered **zero** of them at the default budget. Raising `--budget` to 10000 worked around it, which is what pointed at the ordering rather than the traversal.

## The fix

When the output is over budget:

1. Charge the seed block first, so the existing `#BUG2` guarantee (the queried symbol always renders, and renders first) is unchanged.
2. Reserve half of the remainder for `EDGE` lines.
3. Give what is left to the remaining `NODE` lines.

Under budget nothing changes: the output stays byte-identical, still every node followed by every edge. The notice and the end marker now count cut edges alongside cut nodes.

After the fix the same star renders 42 nodes and 47 edges, and the private graph returns 24 to 33 edges per question at the **default** budget.

## Tests

Three added to `tests/test_serve.py`:

- `test_subgraph_to_text_keeps_edges_when_nodes_overrun_budget`
- `test_subgraph_to_text_truncation_notice_counts_cut_edges`
- `test_subgraph_to_text_under_budget_output_is_unchanged_by_edge_reserve`

The first two fail on `v8` without the change and pass with it. The third is a guard that the under-budget path is untouched.

Full suite: 3909 passed, 36 skipped. The 4 failures in `tests/test_ollama_retry_cap.py` are pre-existing in my environment (`ModuleNotFoundError: No module named 'openai'`, an optional extra) and fail identically on a clean `v8` checkout.

## Note on the 50/50 split

Half is a deliberate compromise rather than a tuned value. Edges are cheaper per line and carry both endpoint labels, so an argument exists for giving them more. Happy to change the ratio, make it a parameter, or interleave per seed if you prefer a different shape.