### PR TITLE
Make path handling work on Windows

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -27,7 +27,7 @@ import os
 import re
 import sys
 import unicodedata
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import networkx as nx
 from .ids import make_id, normalize_id as _normalize_id
 from .paths import default_graph_json as _default_graph_json
@@ -406,7 +406,7 @@ def _semantic_id_remap(nodes: list, root: str | None) -> dict:
             continue
         sf_norm = _norm_source_file(str(sf), root) or str(sf)
         rel = Path(sf_norm)
-        if rel.is_absolute():
+        if rel.is_absolute() or PurePosixPath(sf_norm).is_absolute():
             continue  # can't relativize (no/failed root) — leave id untouched
         if not rel.name:
             # source_file equals the scan root, so _norm_source_file relativized it

--- a/graphify/cache.py
+++ b/graphify/cache.py
@@ -321,6 +321,18 @@ def _normalize_path(path: Path) -> Path:
     return Path(os.path.normcase(s))
 
 
+def _io_path(path: "str | Path") -> str:
+    """Return a Windows extended-length path for filesystem operations."""
+    import sys
+    s = str(path)
+    if sys.platform != "win32" or s.startswith("\\\\?\\"):
+        return s
+    s = os.path.abspath(s)
+    if s.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + s[2:]
+    return "\\\\?\\" + s
+
+
 def file_hash(path: Path, root: Path = Path("."), cache_root: "Path | None" = None) -> str:
     """SHA256 of file contents + path relative to root.
 
@@ -693,18 +705,21 @@ def save_cached(path: Path, result: dict, root: Path = Path("."), kind: str = "a
     location = cache_root if cache_root is not None else root
     target_dir = cache_dir(location, kind, _resolve_prompt_fp(prompt, prompt_file))
     entry = target_dir / f"{h}.json"
-    fd, tmp_path = tempfile.mkstemp(dir=target_dir, prefix=f"{h}.", suffix=".tmp")
+    # Keep the transient name short: the final content-addressed entry already
+    # carries the full SHA-256, while repeating it here can exceed Windows'
+    # legacy MAX_PATH limit in deeply nested checkouts.
+    fd, tmp_path = tempfile.mkstemp(dir=target_dir, prefix=".tmp-", suffix=".tmp")
     try:
         os.write(fd, json.dumps(on_disk).encode())
         os.close(fd)
         try:
-            os.replace(tmp_path, entry)
+            os.replace(_io_path(tmp_path), _io_path(entry))
         except PermissionError:
             # Windows: os.replace can fail with WinError 5 if the target is
             # briefly locked. Fall back to copy-then-delete.
             import shutil
-            shutil.copy2(tmp_path, entry)
-            os.unlink(tmp_path)
+            shutil.copy2(_io_path(tmp_path), _io_path(entry))
+            os.unlink(_io_path(tmp_path))
     except Exception:
         try:
             os.close(fd)

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -12,7 +12,7 @@ import re
 import sys
 import time
 from graphify.paths import GRAPHIFY_OUT as _GRAPHIFY_OUT
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 
 _SEARCH_NUDGE = json.dumps({
@@ -572,9 +572,18 @@ def _run_hook_guard(kind: str, strict: bool = False) -> None:
                 in_project = False
                 for v in explicit:
                     p = Path(v)
-                    if not p.is_absolute():
+                    is_absolute = (
+                        p.is_absolute()
+                        or PurePosixPath(v).is_absolute()
+                        or PureWindowsPath(v).is_absolute()
+                    )
+                    if not is_absolute:
                         in_project = True  # relative -> anchored at cwd == in project
                         break
+                    if not p.is_absolute():
+                        # Absolute under another platform's path grammar cannot
+                        # resolve inside this host's project root.
+                        continue
                     try:
                         p.resolve().relative_to(root)
                         in_project = True

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -5534,6 +5534,10 @@ def extract(
             continue
         sf_path = Path(sf)
         if not sf_path.is_absolute():
+            # ``str(Path(...))`` uses the host separator. Keep persisted
+            # source paths portable even when callers pass relative Paths on
+            # Windows; absolute paths are relativized below.
+            item["source_file"] = sf_path.as_posix()
             continue
         new_sf, canonical_id, keys = _sf_entry(str(sf), sf_path)
         if "id" in item:

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -41,7 +41,7 @@ if [ -z "$GRAPHIFY_PYTHON" ]; then
     if [ -f "$_GFY_PYTHON_FILE" ]; then
         _FROM_FILE=$(cat "$_GFY_PYTHON_FILE" 2>/dev/null | tr -d '[:space:]')
         case "$_FROM_FILE" in
-            *[!a-zA-Z0-9/_.@:\\\\-]*) _FROM_FILE="" ;;  # allowlist (covers Windows paths)
+            *[!a-zA-Z0-9/_.@:\\\\\\\\-]*) _FROM_FILE="" ;;  # allowlist (covers Windows paths)
         esac
         if [ -n "$_FROM_FILE" ] && [ -x "$_FROM_FILE" ] && "$_FROM_FILE" -c "$_GFY_PROBE" 2>/dev/null; then
             GRAPHIFY_PYTHON="$_FROM_FILE"
@@ -79,7 +79,7 @@ if [ -z "$GRAPHIFY_PYTHON" ]; then
         # Allowlist: only keep characters valid in a filesystem path to prevent
         # injection if the shebang contains shell metacharacters.
         case "$GRAPHIFY_PYTHON" in
-            *[!a-zA-Z0-9/_.@:\\\\-]*) GRAPHIFY_PYTHON="" ;;
+            *[!a-zA-Z0-9/_.@:\\\\\\\\-]*) GRAPHIFY_PYTHON="" ;;
         esac
         if [ -n "$GRAPHIFY_PYTHON" ] && ! "$GRAPHIFY_PYTHON" -c "$_GFY_PROBE" 2>/dev/null; then
             GRAPHIFY_PYTHON=""

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -580,9 +580,9 @@ def _read_files(units: "list[Path | FileSlice]", root: Path) -> str:
             print(f"[graphify] skipping {p}: symlink target outside corpus root", file=sys.stderr)
             continue
         try:
-            rel = str(p.relative_to(root))
+            rel = p.relative_to(root).as_posix()
         except ValueError:
-            rel = str(p)
+            rel = p.as_posix()
         try:
             if isinstance(u, FileSlice):
                 content = read_slice_text(u)
@@ -812,9 +812,9 @@ def _build_image_refs(image_files: list[Path], root: Path, *, read_bytes: bool =
             print(f"[graphify] skipping image {p}: symlink target outside corpus root", file=sys.stderr)
             continue
         try:
-            rel = str(p.relative_to(root))
+            rel = p.relative_to(root).as_posix()
         except ValueError:
-            rel = str(p)
+            rel = p.as_posix()
         media = _IMAGE_MEDIA_TYPES.get(p.suffix.lower(), "image/png")
         raw: bytes | None = None
         if read_bytes:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import inspect
+import os
 from pathlib import Path
+import tempfile
 from typing import Any
 
 import pytest
@@ -31,8 +34,32 @@ _ANALYZE_WARNING_FILTERS = (
 )
 
 
+def _can_create_symlinks() -> bool:
+    if os.name != "nt":
+        return True
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        target = root / "target"
+        target.touch()
+        try:
+            (root / "link").symlink_to(target)
+        except OSError as exc:
+            if getattr(exc, "winerror", None) == 1314:
+                return False
+            raise
+    return True
+
+
 def pytest_collection_modifyitems(items: list[Any]) -> None:
+    symlinks_available = _can_create_symlinks()
     for item in items:
+        if not symlinks_available:
+            try:
+                source = inspect.getsource(item.obj)
+            except (OSError, TypeError):
+                source = ""
+            if ".symlink_to(" in source:
+                item.add_marker(pytest.mark.skip(reason="Windows symlink privilege is unavailable"))
         if item.path.name != "test_analyze.py":
             continue
         for warning_filter in _ANALYZE_WARNING_FILTERS:

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -41,8 +41,9 @@ def test_write_text_atomic_preserves_existing_mode(tmp_path):
     p = tmp_path / "graph.json"
     p.write_text("{}", encoding="utf-8")
     os.chmod(p, 0o644)
+    existing_mode = os.stat(p).st_mode & 0o777
     write_text_atomic(p, '{"x": 1}')
-    assert (os.stat(p).st_mode & 0o777) == 0o644
+    assert (os.stat(p).st_mode & 0o777) == existing_mode
 
 
 def test_write_text_atomic_new_file_respects_umask(tmp_path):
@@ -61,7 +62,12 @@ def test_write_text_atomic_writes_through_symlink(tmp_path):
     target = tmp_path / "real.json"
     target.write_text("old", encoding="utf-8")
     link = tmp_path / "link.json"
-    link.symlink_to(target)
+    try:
+        link.symlink_to(target)
+    except OSError as exc:
+        if os.name == "nt" and exc.winerror == 1314:
+            pytest.skip("Windows symlink privilege is unavailable")
+        raise
     write_text_atomic(link, "new")
     assert link.is_symlink()
     assert target.read_text() == "new"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -433,7 +433,11 @@ def test_semantic_prune_removes_orphan_entries(tmp_path):
     h_a = file_hash(f, tmp_path)
     save_cached(f, {"nodes": [{"id": "a"}], "edges": []}, root=tmp_path, kind="semantic")
 
-    f.write_text("# B\n\nContent B.\n")
+    # The rewrite must change the byte length, not just the bytes. file_hash
+    # has a stat fastpath keyed on (size, mtime_ns), so a same-size edit landing
+    # in the same mtime tick returns the stale digest: h_a == h_b, both saves
+    # collapse onto one entry, and the orphan this test prunes is never created.
+    f.write_text("# B\n\nContent B, rewritten.\n")
     h_b = file_hash(f, tmp_path)
     save_cached(f, {"nodes": [{"id": "b"}], "edges": []}, root=tmp_path, kind="semantic")
 
@@ -694,7 +698,10 @@ def test_semantic_prune_sweeps_both_namespaces_against_same_live_set(tmp_path):
     save_semantic_cache([{"id": "da", "source_file": "doc.md"}], [],
                         root=tmp_path, mode="deep")
 
-    f.write_text("# B\n\nContent B.\n")
+    # Byte length must change too -- see the note in
+    # test_semantic_prune_removes_orphan_entries: a same-size rewrite in the
+    # same mtime tick hits file_hash's stat fastpath and yields no orphan.
+    f.write_text("# B\n\nContent B, rewritten.\n")
     h_live = file_hash(f, tmp_path)
     save_semantic_cache([{"id": "pb", "source_file": "doc.md"}], [], root=tmp_path)
     save_semantic_cache([{"id": "db", "source_file": "doc.md"}], [],

--- a/tests/test_cpp_preprocess.py
+++ b/tests/test_cpp_preprocess.py
@@ -4,6 +4,8 @@ A corpus file is attacker-named; cpp does not accept a "--" end-of-options
 terminator, so _cpp_preprocess passes an absolute path which can never be parsed
 as a cpp option.
 """
+from pathlib import Path
+
 from graphify import extract
 
 
@@ -28,5 +30,5 @@ def test_cpp_preprocess_passes_absolute_path(tmp_path, monkeypatch):
     out = extract._cpp_preprocess(f)
     assert out == b"preprocessed"
     last_arg = captured["argv"][-1]
-    assert last_arg.startswith("/"), f"path arg must be absolute, got {last_arg!r}"
+    assert Path(last_arg).is_absolute(), f"path arg must be absolute, got {last_arg!r}"
     assert not last_arg.startswith("-"), "path arg must never look like an option"

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -373,7 +373,7 @@ def test_gitignore_nested_negation_overrides_broader_root_rule(tmp_path):
     result = detect(tmp_path)
     code = result["files"]["code"]
     # nested `!important.py` re-includes it despite the root `*.py` exclude...
-    assert any("vendor/sub/important.py" in f for f in code)
+    assert sub / "important.py" in map(Path, code)
     # ...while the root-excluded and non-re-included files stay out
     assert not any(f.endswith("root.py") for f in code)
     assert not any(f.endswith("other.py") for f in code)
@@ -394,7 +394,7 @@ def test_nested_ignore_overrides_git_info_exclude_and_root(tmp_path):
 
     result = detect(tmp_path)
     code = result["files"]["code"]
-    assert any("a/b/keep.py" in f for f in code), "nested ! must beat root + info/exclude"
+    assert sub / "keep.py" in map(Path, code), "nested ! must beat root + info/exclude"
     assert not any(f.endswith("drop.py") for f in code)
 
 
@@ -863,9 +863,9 @@ def test_path_pattern_single_star_does_not_cross_segment(tmp_path):
     for pattern in ("/src/*.py", "src/*.py"):
         (tmp_path / ".graphifyignore").write_text(f"{pattern}\n")
         result = detect(tmp_path)
-        files = [path for paths in result["files"].values() for path in paths]
-        assert not any(path.endswith("src/main.py") for path in files)
-        assert any(path.endswith("src/app/main.py") for path in files)
+        files = {Path(path) for paths in result["files"].values() for path in paths}
+        assert direct not in files
+        assert nested in files
 
 
 def test_directory_only_negation_does_not_reinclude_file(tmp_path):
@@ -2255,9 +2255,9 @@ def test_detect_surfaces_unreadable_dir_instead_of_silent_skip(tmp_path, capsys)
     dir deleted mid-walk); that under-enumeration used to be invisible and could
     yield a silently partial graph. detect() now records it in walk_errors and
     warns, while still enumerating the rest of the tree."""
-    import os
+    if not hasattr(os, "geteuid"):
+        pytest.skip("POSIX directory permission semantics required")
     if os.geteuid() == 0:
-        import pytest
         pytest.skip("running as root: chmod 000 does not block scandir")
     (tmp_path / "a.py").write_text("def f(): pass\n")
     locked = tmp_path / "locked"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -213,7 +213,7 @@ def test_codex_skill_contains_spawn_agent():
     """Codex skill file must reference spawn_agent."""
     import graphify
 
-    skill = (Path(graphify.__file__).parent / "skill-codex.md").read_text()
+    skill = (Path(graphify.__file__).parent / "skill-codex.md").read_text(encoding="utf-8")
     assert "spawn_agent" in skill
 
 
@@ -225,7 +225,7 @@ def test_codex_skill_uses_graphify_with_existing_graph():
     fast-path block, which jumps straight to the query flow when a graph exists.
     """
     import graphify
-    skill = (Path(graphify.__file__).parent / "skill-codex.md").read_text()
+    skill = (Path(graphify.__file__).parent / "skill-codex.md").read_text(encoding="utf-8")
     assert "Fast path — existing graph" in skill
     assert "skip Steps 1–5 entirely and jump straight to `## For /graphify query`" in skill
     assert "graphify query" in skill

--- a/tests/test_js_import_resolution.py
+++ b/tests/test_js_import_resolution.py
@@ -1407,8 +1407,10 @@ def test_alias_import_does_not_remap_an_owned_symbol_id(tmp_path, monkeypatch):
     }
     target_symbol = _make_id(_file_stem(target), "formatDate")
     mirror_symbol = _make_id(_file_stem(mirror), "formatDate")
-    assert symbols[str(target)] == target_symbol
-    assert symbols[str(mirror)] == mirror_symbol
+    # source_file is persisted posix-normalized, so key on as_posix() rather
+    # than str(): the latter yields backslashes on Windows and never matches.
+    assert symbols[target.as_posix()] == target_symbol
+    assert symbols[mirror.as_posix()] == mirror_symbol
 
     imports = [
         edge
@@ -1418,8 +1420,8 @@ def test_alias_import_does_not_remap_an_owned_symbol_id(tmp_path, monkeypatch):
     by_source: dict[str, list[str]] = {}
     for edge in imports:
         by_source.setdefault(edge["source_file"], []).append(edge["target"])
-    assert by_source[str(button)] == [target_symbol]
-    assert by_source[str(mirror_user)] == [mirror_symbol]
+    assert by_source[button.as_posix()] == [target_symbol]
+    assert by_source[mirror_user.as_posix()] == [mirror_symbol]
     assert all(edge["source"] in node_ids and edge["target"] in node_ids for edge in imports)
 
 


### PR DESCRIPTION
## What

A Windows portability pass. A large share of the suite fails on Windows because of host-separator and path-grammar assumptions; these commits fix the causes rather than the symptoms.

Three commits, each independently reviewable:

**1. `Make path handling work on Windows`** — the code change.
- Absolute-path detection under both grammars: a POSIX-absolute string is not absolute to `PureWindowsPath` and vice versa, so paths that could never resolve inside the project root were being retained (`build.py`, `cli.py`).
- `source_file` persisted via `as_posix()` so stored node ids stay portable instead of carrying the host separator (`extract.py`, `llm.py`).
- Filesystem writes routed through extended-length paths (and the UNC form for shares) so long paths stop failing against `MAX_PATH` in deep checkouts (`cache.py`).
- The shell allowlist escaping had lost a backslash level and rejected legitimate Windows paths (`hooks.py`).
- Symlink-dependent tests skip when Windows denies the privilege (winerror 1314) instead of being reported as failures (`tests/conftest.py`).

**2. `test(js): key source_file lookups on as_posix(), not str()`** — `test_alias_import_does_not_remap_an_owned_symbol_id` keyed its lookups with `str(Path)`, which yields backslashes on Windows and raised `KeyError: 'src\lib\utils.ts'`. The test encoded exactly the behaviour commit 1 deliberately replaces.

**3. `test(cache): give the prune rewrites a different byte length`** — worth a maintainer's attention; details below.

## The prune fix is worth a look

Two `test_semantic_prune_*` tests rewrote a fixture from `"# A\n\nContent A.\n"` to `"# B\n\nContent B.\n"` — both exactly 16 bytes. `file_hash` has a stat fastpath keyed on `(size, mtime_ns)`, so when both writes land in the same mtime tick it skips the re-read and returns the stale digest. The two saves then collapse onto a single cache entry, the `exists()` assertions pass trivially against that one file, and `prune_semantic_cache` correctly reports 0 orphans — because none was ever created.

It presents as a prune bug, and it moves between the two tests depending on machine load. Forcing an identical mtime with `os.utime` reproduces it every time on the old contents and never on the new:

| contents | sizes | stale-digest collision |
|---|---|---|
| old | 16 vs 16 | yes |
| new | 16 vs 27 | no |

Prune itself is correct; only the fixtures were unsound.

**Related, and deliberately not changed here:** the same fastpath means a real edit preserving byte length within one mtime tick will serve a stale cache entry in production too. That is the documented size+mtime tradeoff, so I have left the design alone and am flagging it rather than changing it.

## Test results

CPython 3.13.14 on Windows 11.

| | failed | passed |
|---|---|---|
| before (`0b2bd93`) | 48 | 3728 |
| after | **16** | 3744 |

All **16 remaining failures are pre-existing** — every one is present at `0b2bd93` before these commits, verified by diffing the two failure sets. None is introduced here. They appear to be further Windows-specific issues (`test_watch.py`, `test_install*.py`, `test_obsidian_filename_cap.py`, `test_ollama_retry_cap.py`) and are out of scope for this PR.

I do not have a Linux or macOS machine to hand, so CI verification on those platforms would be worth having. The `as_posix()` change in `extract.py` is the one most worth a second pair of eyes, since it changes the persisted form of `source_file`.
