### PR TITLE
fix(cache): prevent stale same-tick stat-index hits

### DIFF
--- a/graphify/cache.py
+++ b/graphify/cache.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import tempfile
+import time
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
@@ -16,6 +17,14 @@ from pathlib import Path
 # absolute path ("/shared/graphify-out"). Single source of truth in graphify.paths
 # (#1423); re-exported here as _GRAPHIFY_OUT for the existing call sites.
 from graphify.paths import GRAPHIFY_OUT as _GRAPHIFY_OUT
+
+# Files whose latest content/metadata timestamp is within this window are not
+# eligible for the stat-only fastpath.  Some filesystems return identical size,
+# mtime_ns and ctime_ns for two rapid same-size writes; trusting that signature
+# can replay a stale content hash.  Once the timestamp is older than the
+# coarsest common local-filesystem tick (FAT: 2 seconds), normal writes advance
+# at least one signature field and the fastpath is safe again.
+_STAT_STABILITY_WINDOW_NS = 2_000_000_000
 
 # AST cache entries are the output of graphify's own extractor code, so they
 # are only valid for the version that wrote them: keying purely on file
@@ -178,11 +187,11 @@ def _body_content(content: bytes) -> bytes:
     return text[closer.start() + 3:].encode()
 
 
-# Stat-based index: maps absolute path → {size, mtime_ns, hash}.
-# Loaded once per process, flushed via atexit. Skips full file reads when
-# size+mtime_ns are unchanged — same trade-off as make(1).
-# Correctness risks: `touch` causes a harmless extra re-hash; same-size edits
-# within NFS second-resolution mtime have a 1-second window (same as make).
+# Stat-based index: maps absolute path to size/mtime plus cached hashes and/or
+# word count. Loaded once per process and flushed via atexit. Recent values are
+# marked volatile independently and re-read until the timestamp safety window
+# closes; this prevents a refreshed hash from promoting a stale sibling count.
+# `touch` still causes a harmless extra read.
 # `graphify extract --force` / `graphify update --force` (or GRAPHIFY_FORCE=1)
 # skip the cache reads and re-dispatch everything when needed (#1894).
 _stat_index: dict[str, dict] = {}
@@ -321,12 +330,65 @@ def _normalize_path(path: Path) -> Path:
     return Path(os.path.normcase(s))
 
 
+def _stat_signature(st: os.stat_result) -> tuple[int, int]:
+    """Portable fields used to validate an index entry and a file read."""
+    return st.st_size, st.st_mtime_ns
+
+
+def _entry_matches_stat(entry: object, st: os.stat_result) -> bool:
+    """Whether an index entry describes the portable stat signature."""
+    return (
+        isinstance(entry, dict)
+        and entry.get("size") == st.st_size
+        and entry.get("mtime_ns") == st.st_mtime_ns
+    )
+
+
+def _stat_is_stable(st: os.stat_result) -> bool:
+    """Whether a stat-only cache hit is safe from coarse timestamp collisions."""
+    now_ns = time.time_ns()
+    if now_ns - st.st_mtime_ns >= _STAT_STABILITY_WINDOW_NS:
+        return True
+    # A restored artifact can carry an mtime far in the future. Its local ctime
+    # still ages after copy/metadata creation, avoiding permanent re-reads while
+    # preserving the recent-write guard for ordinary files.
+    return (st.st_mtime_ns > now_ns
+            and now_ns - st.st_ctime_ns >= _STAT_STABILITY_WINDOW_NS)
+
+
+def _drop_stat_entry(abs_key: str) -> None:
+    """Discard sibling hash/word-count data that may describe stale contents."""
+    global _stat_index_dirty
+    if _stat_index.pop(abs_key, None) is not None:
+        _stat_index_dirty = True
+
+
+def _read_consistent_bytes(path: Path) -> tuple[bytes, os.stat_result | None]:
+    """Return bytes confirmed by two consecutive equal snapshots."""
+    raw = path.read_bytes()
+    try:
+        st = path.stat()
+    except OSError:
+        return raw, None
+    for _ in range(2):
+        confirm = path.read_bytes()
+        try:
+            confirm_st = path.stat()
+        except OSError:
+            return confirm, None
+        if (confirm == raw
+                and _stat_signature(st) == _stat_signature(confirm_st)):
+            return confirm, confirm_st
+        raw, st = confirm, confirm_st
+    return raw, None
+
 def file_hash(path: Path, root: Path = Path("."), cache_root: "Path | None" = None) -> str:
     """SHA256 of file contents + path relative to root.
 
-    Uses a stat-based fastpath (size + mtime_ns) to skip full reads when the
-    file hasn't changed. Falls through to full SHA256 on first encounter or
-    when stat changes. Index is flushed atomically at process exit.
+    Uses a stat-based fastpath to skip full reads when the file hasn't changed.
+    Recently modified files bypass it until their timestamps are stable, which
+    prevents rapid same-size rewrites on coarse-timestamp filesystems from
+    replaying a stale digest. Index is flushed atomically at process exit.
 
     Using a relative path (not absolute) makes cache entries portable across
     machines and checkout directories, so shared caches and CI work correctly.
@@ -360,24 +422,35 @@ def file_hash(path: Path, root: Path = Path("."), cache_root: "Path | None" = No
     except ValueError:
         salt = resolved.as_posix().lower()
 
-    st: "os.stat_result | None" = None
+    st_before: "os.stat_result | None" = None
     try:
-        st = p.stat()
+        st_before = p.stat()
         entry = _stat_index.get(abs_key)
-        if (isinstance(entry, dict)
-                and entry.get("size") == st.st_size
-                and entry.get("mtime_ns") == st.st_mtime_ns):
-            hashes = entry.get("hashes")
-            if isinstance(hashes, dict):
-                cached = hashes.get(salt)
-                if isinstance(cached, str):
-                    return cached
-            # Legacy single-digest entries ("hash") don't record which salt
-            # produced them, so they are never trusted (#1989) — recompute once.
+        if _stat_is_stable(st_before) and _entry_matches_stat(entry, st_before):
+            assert isinstance(entry, dict)
+            if (not entry.get("volatile", False)
+                    and entry.get("hashes_volatile") is False):
+                hashes = entry.get("hashes")
+                if isinstance(hashes, dict):
+                    cached = hashes.get(salt)
+                    if isinstance(cached, str):
+                        try:
+                            st_confirm = p.stat()
+                        except OSError:
+                            st_before = None
+                        else:
+                            if (_stat_signature(st_before) == _stat_signature(st_confirm)
+                                    and _stat_is_stable(st_confirm)):
+                                return cached
+                            # A writer raced the hit-path stat. Read against the
+                            # confirmed signature so the refreshed value can be cached.
+                            st_before = st_confirm
+            # Legacy single-digest entries ("hash") and volatile entries are
+            # never trusted; recompute once before promoting a stable digest.
     except OSError:
         pass
 
-    raw = p.read_bytes()
+    raw, st_after = _read_consistent_bytes(p)
     content = _body_content(raw) if p.suffix.lower() == ".md" else raw
     h = hashlib.sha256()
     h.update(content)
@@ -385,21 +458,34 @@ def file_hash(path: Path, root: Path = Path("."), cache_root: "Path | None" = No
     h.update(salt.encode())
     digest = h.hexdigest()
 
-    if st is not None:
+    # Record only a self-consistent read. Recent entries remain volatile:
+    # callers rehash them until the timestamp window closes, then one stable
+    # read promotes the entry and restores the stat-only fastpath.
+    if st_after is not None:
         entry = _stat_index.get(abs_key)
-        if (isinstance(entry, dict)
-                and entry.get("size") == st.st_size
-                and entry.get("mtime_ns") == st.st_mtime_ns):
+        if _entry_matches_stat(entry, st_after):
+            assert isinstance(entry, dict)
             hashes = entry.get("hashes")
             if not isinstance(hashes, dict):
                 hashes = {}
                 entry["hashes"] = hashes
             hashes[salt] = digest       # preserve a co-located word_count / other salts
             entry.pop("hash", None)     # retire the un-salted legacy digest
+            recent = not _stat_is_stable(st_after)
+            entry["hashes_volatile"] = recent
+            if recent and "word_count" in entry:
+                entry["word_count_volatile"] = True
+            entry.pop("volatile", None)
         else:
-            _stat_index[abs_key] = {"size": st.st_size, "mtime_ns": st.st_mtime_ns,
-                                    "hashes": {salt: digest}}
+            _stat_index[abs_key] = {
+                "size": st_after.st_size,
+                "mtime_ns": st_after.st_mtime_ns,
+                "hashes": {salt: digest},
+                "hashes_volatile": not _stat_is_stable(st_after),
+            }
         _stat_index_dirty = True
+    elif st_before is not None:
+        _drop_stat_entry(abs_key)
 
     return digest
 
@@ -422,31 +508,57 @@ def cached_word_count(path: Path, root: Path, compute, cache_root: "Path | None"
     root = _normalize_path(Path(root))
     _ensure_stat_index(root, cache_root=cache_root)
     abs_key = str(p.resolve())
-    st: "os.stat_result | None" = None
+    st_before: "os.stat_result | None" = None
     try:
-        st = p.stat()
+        st_before = p.stat()
         entry = _stat_index.get(abs_key)
-        if (entry
-                and entry.get("size") == st.st_size
-                and entry.get("mtime_ns") == st.st_mtime_ns
-                and "word_count" in entry):
-            return entry["word_count"]
+        if _stat_is_stable(st_before) and _entry_matches_stat(entry, st_before):
+            assert isinstance(entry, dict)
+            if (not entry.get("volatile", False)
+                    and entry.get("word_count_volatile") is False
+                    and "word_count" in entry):
+                try:
+                    st_confirm = p.stat()
+                except OSError:
+                    st_before = None
+                else:
+                    if (_stat_signature(st_before) == _stat_signature(st_confirm)
+                            and _stat_is_stable(st_confirm)):
+                        return entry["word_count"]
+                    st_before = st_confirm
     except OSError:
         pass
 
     wc = compute(Path(path))
 
-    if st is not None:
+    st_after: "os.stat_result | None" = None
+    try:
+        st_after = p.stat()
+    except OSError:
+        pass
+
+    if (st_before is not None
+            and st_after is not None
+            and _stat_signature(st_before) == _stat_signature(st_after)):
         entry = _stat_index.get(abs_key)
-        if (entry
-                and entry.get("size") == st.st_size
-                and entry.get("mtime_ns") == st.st_mtime_ns):
+        if _entry_matches_stat(entry, st_after):
+            assert isinstance(entry, dict)
             entry["word_count"] = wc  # augment the existing hash entry in place
+            recent = not _stat_is_stable(st_after)
+            entry["word_count_volatile"] = recent
+            if recent and "hashes" in entry:
+                entry["hashes_volatile"] = True
+            entry.pop("volatile", None)
         else:
             _stat_index[abs_key] = {
-                "size": st.st_size, "mtime_ns": st.st_mtime_ns, "word_count": wc,
+                "size": st_after.st_size,
+                "mtime_ns": st_after.st_mtime_ns,
+                "word_count": wc,
+                "word_count_volatile": not _stat_is_stable(st_after),
             }
         _stat_index_dirty = True
+    elif st_before is not None:
+        _drop_stat_entry(abs_key)
 
     return wc
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,7 @@
 """Tests for graphify/cache.py."""
+import os
+from typing import cast
+
 import pytest
 from pathlib import Path
 from graphify.cache import file_hash, cache_dir, load_cached, save_cached, cached_files, clear_cache, _body_content
@@ -32,6 +35,151 @@ def test_file_hash_changes(tmp_path):
     f1.write_text("content one")
     f2.write_text("content two")
     assert file_hash(f1) != file_hash(f2)
+
+
+def test_file_hash_rehashes_recent_same_size_same_mtime_rewrite(tmp_path, monkeypatch):
+    """A same-tick rewrite must not reuse the first content digest."""
+    from graphify import cache as _cache
+
+    _reset_stat_index()
+    mtime_ns = 1_700_000_000_000_000_000
+    monkeypatch.setattr(
+        _cache.time,
+        "time_ns",
+        lambda: mtime_ns + _cache._STAT_STABILITY_WINDOW_NS // 2,
+    )
+    f = tmp_path / "same-stat.txt"
+    stamp = mtime_ns
+    f.write_text("content A")
+    os.utime(f, ns=(stamp, stamp))
+    before = f.stat()
+    h1 = file_hash(f, root=tmp_path)
+
+    f.write_text("content B")
+    os.utime(f, ns=(stamp, stamp))
+    after = f.stat()
+    assert (before.st_size, before.st_mtime_ns) == (after.st_size, after.st_mtime_ns)
+
+    h2 = file_hash(f, root=tmp_path)
+    assert h1 != h2
+
+
+def test_file_hash_stable_file_uses_stat_fastpath(tmp_path, monkeypatch):
+    """The volatile-file guard must not disable warm reads for stable files."""
+    from graphify import cache as _cache
+
+    _reset_stat_index()
+    f = tmp_path / "stable.txt"
+    f.write_text("stable content")
+    st = f.stat()
+    monkeypatch.setattr(
+        _cache.time,
+        "time_ns",
+        lambda: max(st.st_mtime_ns, st.st_ctime_ns) + _cache._STAT_STABILITY_WINDOW_NS + 1,
+    )
+    h1 = file_hash(f, root=tmp_path)
+
+    def fail_read(_self):
+        raise AssertionError("stable stat-index hit unexpectedly read file contents")
+
+    monkeypatch.setattr(Path, "read_bytes", fail_read)
+    assert file_hash(f, root=tmp_path) == h1
+
+
+def test_file_hash_future_mtime_uses_aged_ctime_fastpath(tmp_path, monkeypatch):
+    """A future-dated restored file stops rehashing after its ctime ages."""
+    from graphify import cache as _cache
+
+    _reset_stat_index()
+    f = tmp_path / "future.txt"
+    f.write_text("future artifact")
+    initial = f.stat()
+    future_ns = initial.st_ctime_ns + 10 * _cache._STAT_STABILITY_WINDOW_NS
+    os.utime(f, ns=(future_ns, future_ns))
+    st = f.stat()
+    now_ns = st.st_ctime_ns + _cache._STAT_STABILITY_WINDOW_NS + 1
+    assert st.st_mtime_ns > now_ns
+    monkeypatch.setattr(_cache.time, "time_ns", lambda: now_ns)
+    h1 = file_hash(f, root=tmp_path)
+
+    def fail_read(_self):
+        raise AssertionError("aged future-mtime entry unexpectedly read contents")
+
+    monkeypatch.setattr(Path, "read_bytes", fail_read)
+    assert file_hash(f, root=tmp_path) == h1
+
+
+def test_future_mtime_ctime_fallback_matches_windows_creation_time(monkeypatch):
+    from graphify import cache as _cache
+
+    now_ns = 2_000_000_000_000_000_000
+    monkeypatch.setattr(_cache.time, "time_ns", lambda: now_ns)
+
+    class FakeWindowsStat:
+        st_mtime_ns = now_ns + 10 * _cache._STAT_STABILITY_WINDOW_NS
+        st_ctime_ns = now_ns - _cache._STAT_STABILITY_WINDOW_NS - 1
+
+    assert _cache._stat_is_stable(cast(os.stat_result, FakeWindowsStat()))
+    FakeWindowsStat.st_ctime_ns = now_ns
+    assert not _cache._stat_is_stable(cast(os.stat_result, FakeWindowsStat()))
+
+
+def test_file_hash_rechecks_stat_before_warm_return(tmp_path, monkeypatch):
+    """A writer between hit-path stats must force a content refresh."""
+    from graphify import cache as _cache
+
+    _reset_stat_index()
+    f = tmp_path / "hit-race.txt"
+    f.write_text("content A")
+    monkeypatch.setattr(_cache.time, "time_ns", lambda: 10**30)
+    h1 = file_hash(f, root=tmp_path)
+    new_mtime_ns = f.stat().st_mtime_ns + 1
+    real_stat = Path.stat
+    calls = 0
+
+    def rewrite_after_hit_stat(path, *args, **kwargs):
+        nonlocal calls
+        result = real_stat(path, *args, **kwargs)
+        if path == f:
+            calls += 1
+            if calls == 2:  # is_file(), then the hit-path stat
+                path.write_text("content B")
+                os.utime(path, ns=(new_mtime_ns, new_mtime_ns))
+        return result
+
+    monkeypatch.setattr(Path, "stat", rewrite_after_hit_stat)
+    h2 = file_hash(f, root=tmp_path)
+    assert h2 != h1
+
+
+def test_file_hash_confirms_same_stat_write_during_read(tmp_path, monkeypatch):
+    """A same-stat write during the first read must return current content."""
+    from graphify import cache as _cache
+
+    _reset_stat_index()
+    f = tmp_path / "raced.txt"
+    f.write_text("before")
+    fixed_mtime_ns = f.stat().st_mtime_ns
+    real_read_bytes = Path.read_bytes
+    changed = False
+
+    def read_then_change(path):
+        nonlocal changed
+        raw = real_read_bytes(path)
+        if path == f and not changed:
+            changed = True
+            path.write_text("after!")
+            os.utime(path, ns=(fixed_mtime_ns, fixed_mtime_ns))
+        return raw
+
+    monkeypatch.setattr(_cache.time, "time_ns", lambda: 10**30)
+    monkeypatch.setattr(Path, "read_bytes", read_then_change)
+    raced_hash = file_hash(f, root=tmp_path)
+    expected = _cache.hashlib.sha256(b"after!\x00raced.txt").hexdigest()
+    assert raced_hash == expected
+
+    monkeypatch.setattr(Path, "read_bytes", real_read_bytes)
+    assert file_hash(f, root=tmp_path) == raced_hash
 
 
 def test_cache_roundtrip(tmp_file, cache_root):

--- a/tests/test_stat_index_portability.py
+++ b/tests/test_stat_index_portability.py
@@ -18,6 +18,7 @@ import hashlib
 import json
 import os
 import shutil
+import time
 from pathlib import Path
 
 from graphify import cache
@@ -54,6 +55,13 @@ def _count_read_bytes(monkeypatch):
     return calls
 
 
+def _age_for_stat_fastpath(*paths: Path) -> None:
+    """Put test files outside the recent-write safety window."""
+    stamp = time.time_ns() - cache._STAT_STABILITY_WINDOW_NS - 1_000_000
+    for path in paths:
+        os.utime(path, ns=(stamp, stamp))
+
+
 def _fail_compute(p: Path) -> int:
     raise AssertionError(f"word-count compute invoked for {p}; expected a warm stat hit")
 
@@ -69,6 +77,7 @@ def test_cache_hits_survive_corpus_move(tmp_path, monkeypatch):
     sub = a / "sub"
     sub.mkdir()
     (sub / "f2.md").write_text("hello world one two\n")
+    _age_for_stat_fastpath(a / "f1.py", sub / "f2.md")
 
     digests_a = {
         "f1.py": cache.file_hash(a / "f1.py", a),
@@ -122,14 +131,13 @@ def test_deleted_entries_are_pruned_on_flush(tmp_path):
 
 
 def test_legacy_absolute_index_migrates_gracefully(tmp_path, monkeypatch):
-    """A pre-#2199 index keyed by absolute paths still HITS on the unmoved
-    root, and the first flush prunes dead entries and rewrites live keys
-    relative (self-heals)."""
+    """A pre-volatile index is revalidated once and rewritten portably."""
     _reset_stat_index()
     a = tmp_path / "a"
     a.mkdir()
     f1 = a / "f1.py"
     f1.write_text("x = 1\n")
+    _age_for_stat_fastpath(f1)
     st = f1.stat()
     salt = "f1.py"
     digest = hashlib.sha256(f1.read_bytes() + b"\x00" + salt.encode()).hexdigest()
@@ -147,11 +155,9 @@ def test_legacy_absolute_index_migrates_gracefully(tmp_path, monkeypatch):
 
     reads = _count_read_bytes(monkeypatch)
     assert cache.file_hash(f1, a) == digest
-    assert reads["n"] == 0, "legacy absolute key should still serve a warm hit"
+    assert reads["n"] == 2, "legacy hash must pass two-snapshot revalidation"
+    assert cache._stat_index[str(f1.resolve())]["hashes_volatile"] is False
 
-    # Force a write so the self-heal is observable (a pure warm run leaves the
-    # index clean and flush is a no-op by design).
-    cache._stat_index_dirty = True
     cache._flush_stat_index()
 
     on_disk = _read_index(a)
@@ -165,6 +171,7 @@ def test_out_of_root_key_round_trips_absolute(tmp_path, monkeypatch):
     a.mkdir()
     outside = tmp_path / "outside.txt"
     outside.write_text("out of root\n")
+    _age_for_stat_fastpath(outside)
 
     d1 = cache.file_hash(outside, a)
     cache._flush_stat_index()

--- a/tests/test_word_count_cache.py
+++ b/tests/test_word_count_cache.py
@@ -4,6 +4,7 @@ the corpus.
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from graphify import cache
@@ -16,6 +17,12 @@ def test_word_count_cached_until_file_changes(tmp_path, monkeypatch):
 
     f = tmp_path / "doc.txt"
     f.write_text("one two three four five")
+    st = f.stat()
+    monkeypatch.setattr(
+        cache.time,
+        "time_ns",
+        lambda: st.st_mtime_ns + cache._STAT_STABILITY_WINDOW_NS + 1,
+    )
 
     calls = {"n": 0}
     def compute(p: Path) -> int:
@@ -31,6 +38,38 @@ def test_word_count_cached_until_file_changes(tmp_path, monkeypatch):
     # Change the file → recompute.
     f.write_text("only three words now")  # 4 words
     assert cache.cached_word_count(f, tmp_path, compute) == 4
+    assert calls["n"] == 2
+
+
+def test_word_count_rechecks_stat_before_warm_return(tmp_path, monkeypatch):
+    monkeypatch.setattr(cache, "_stat_index", {})
+    monkeypatch.setattr(cache, "_stat_index_root", None)
+    f = tmp_path / "hit-race.txt"
+    f.write_text("one two")
+    monkeypatch.setattr(cache.time, "time_ns", lambda: 10**30)
+    calls = {"n": 0}
+
+    def compute(path: Path) -> int:
+        calls["n"] += 1
+        return len(path.read_text().split())
+
+    assert cache.cached_word_count(f, tmp_path, compute) == 2
+    new_mtime_ns = f.stat().st_mtime_ns + 1
+    real_stat = Path.stat
+    stat_calls = 0
+
+    def rewrite_after_hit_stat(path, *args, **kwargs):
+        nonlocal stat_calls
+        result = real_stat(path, *args, **kwargs)
+        if path == f:
+            stat_calls += 1
+            if stat_calls == 1:
+                path.write_text("seventh")
+                os.utime(path, ns=(new_mtime_ns, new_mtime_ns))
+        return result
+
+    monkeypatch.setattr(Path, "stat", rewrite_after_hit_stat)
+    assert cache.cached_word_count(f, tmp_path, compute) == 1
     assert calls["n"] == 2
 
 
@@ -99,3 +138,95 @@ def test_file_hash_ignores_legacy_unsalted_entry(tmp_path, monkeypatch):
     assert cache.file_hash(f, tmp_path) == exp        # recomputed, not "deadbeef"
     entry = cache._stat_index[key]
     assert "hash" not in entry and entry["hashes"]["m.py"] == exp
+
+
+def test_flagless_legacy_word_count_revalidates_once(tmp_path, monkeypatch):
+    monkeypatch.setattr(cache, "_stat_index", {})
+    monkeypatch.setattr(cache, "_stat_index_root", None)
+    f = tmp_path / "legacy.txt"
+    f.write_text("two words")
+    st = f.stat()
+    monkeypatch.setattr(
+        cache.time,
+        "time_ns",
+        lambda: st.st_mtime_ns + cache._STAT_STABILITY_WINDOW_NS + 1,
+    )
+    key = str(cache._normalize_path(f).resolve())
+    cache._stat_index[key] = {
+        "size": st.st_size,
+        "mtime_ns": st.st_mtime_ns,
+        "word_count": 999,
+    }
+    calls = {"n": 0}
+
+    def compute(path: Path) -> int:
+        calls["n"] += 1
+        return len(path.read_text().split())
+
+    assert cache.cached_word_count(f, tmp_path, compute) == 2
+    assert calls["n"] == 1
+    assert cache._stat_index[key]["word_count_volatile"] is False
+    assert cache.cached_word_count(f, tmp_path, compute) == 2
+    assert calls["n"] == 1
+
+
+def test_recent_same_stat_rewrite_refreshes_shared_entry_after_reload(tmp_path, monkeypatch):
+    """Hash/count volatility survives persistence and promotes independently."""
+    def reset_index_state() -> None:
+        monkeypatch.setattr(cache, "_stat_index", {})
+        monkeypatch.setattr(cache, "_stat_index_root", None)
+        monkeypatch.setattr(cache, "_stat_index_anchor", None)
+        monkeypatch.setattr(cache, "_stat_index_dirty", False)
+
+    reset_index_state()
+    f = tmp_path / "shared.txt"
+    mtime_ns = 1_700_000_000_000_000_000
+    now_ns = mtime_ns + cache._STAT_STABILITY_WINDOW_NS // 2
+    monkeypatch.setattr(cache.time, "time_ns", lambda: now_ns)
+
+    calls = {"n": 0}
+
+    def compute(path: Path) -> int:
+        calls["n"] += 1
+        return len(path.read_text().split())
+
+    f.write_text("one two")
+    os.utime(f, ns=(mtime_ns, mtime_ns))
+    h1 = cache.file_hash(f, tmp_path)
+    assert cache.cached_word_count(f, tmp_path, compute) == 2
+    key = str(cache._normalize_path(f).resolve())
+    assert cache._stat_index[key]["hashes_volatile"] is True
+    assert cache._stat_index[key]["word_count_volatile"] is True
+    cache._flush_stat_index()
+
+    reset_index_state()
+    f.write_text("seventh")  # same byte length, one word instead of two
+    os.utime(f, ns=(mtime_ns, mtime_ns))
+    h2 = cache.file_hash(f, tmp_path)
+    assert h2 != h1
+    assert cache.cached_word_count(f, tmp_path, compute) == 1
+    assert calls["n"] == 2
+    assert cache._stat_index[key]["hashes_volatile"] is True
+    assert cache._stat_index[key]["word_count_volatile"] is True
+
+    monkeypatch.setattr(
+        cache.time,
+        "time_ns",
+        lambda: mtime_ns + cache._STAT_STABILITY_WINDOW_NS + 1,
+    )
+    assert cache.file_hash(f, tmp_path) == h2
+    assert cache._stat_index[key]["hashes_volatile"] is False
+    assert cache._stat_index[key]["word_count_volatile"] is True
+    assert cache.cached_word_count(f, tmp_path, compute) == 1
+    assert calls["n"] == 3
+    assert cache._stat_index[key]["word_count_volatile"] is False
+
+    def fail_read(_path: Path) -> bytes:
+        raise AssertionError("promoted hash unexpectedly read file contents")
+
+    def fail_compute(_path: Path) -> int:
+        raise AssertionError("promoted word count unexpectedly recomputed")
+
+    monkeypatch.setattr(Path, "read_bytes", fail_read)
+    assert cache.file_hash(f, tmp_path) == h2
+    assert cache.cached_word_count(f, tmp_path, fail_compute) == 1


### PR DESCRIPTION
## Problem

The persisted stat index could reuse a stale file hash or word count when a rapid rewrite kept the same size and `mtime_ns`. That could replay semantic cache data for the previous contents.

## Changes

- treat recent and flagless stat-index values as requiring revalidation
- track hash and word-count volatility independently
- confirm warm-hit stats and require two equal byte snapshots before caching a hash
- preserve stable portable cache hits and handle future-dated restored files
- add deterministic same-stat, reload, migration, race, and portability regressions

## Verification

- Python 3.12, `uv run --frozen --all-extras pytest -q`: 3984 passed, 3 skipped
- focused cache/stat-index tests: 80 passed
- seven race/volatile regressions: 20 repeated runs
- Ruff: pass
- Pyright for `graphify/cache.py`: 0 errors
- `git diff --check`: pass
