### PR TITLE
fix(build_merge): re-extracted node must not lose to its own stale copy

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -1454,9 +1454,45 @@ def build_merge(
             if norm:
                 tier_sources.add(norm)
     new_sources: set[str] = new_ast_sources | new_sem_sources
-    if new_sources:
+
+    # Tier-scoped replace is not sufficient on its own: a base node whose id is
+    # re-emitted by a new chunk for the SAME source_file is that node's own
+    # freshly-extracted version, never a coexisting other-tier node. Tier scoping
+    # exists to protect the other tier's DISTINCT nodes (#2333), so it must not
+    # keep a stale copy of an id the re-extract just regenerated.
+    #
+    # It can, because _is_ast_tier's shape fallback is a guess: a legacy unstamped
+    # SEMANTIC node whose source_location happens to look like 'L<line>' is read as
+    # AST-tier, so a semantic re-extract does not replace it. It then collides with
+    # its own fresh version, and _collision_rank — which ties here on definer-ness
+    # and source_file — decides on len(label), keeping the SHORTER one. Freshness
+    # is not a factor, so a re-extract that expands a claim loses to the stale text
+    # it was meant to correct. Silent: node counts stay correct, no edge dangles.
+    #
+    # Shape cannot be made reliable here (semantic extractors do emit 'L<line>'
+    # for markdown, and .md is in the AST registry, so a doc legitimately carries
+    # both tiers), so key on identity instead: same id + same file = same entity.
+    new_node_keys: set[tuple[str, str]] = set()
+    for ch in new_chunks:
+        for n in ch.get("nodes", []):
+            nid, sf = n.get("id"), n.get("source_file")
+            if not nid or not sf:
+                continue
+            new_node_keys.add((nid, sf))
+            norm = _norm_source_file(sf, _replace_root)
+            if norm:
+                new_node_keys.add((nid, norm))
+
+    if new_sources or new_node_keys:
         def _kept(item: dict) -> bool:
             sf = item.get("source_file")
+            nid = item.get("id")
+            if nid and sf:
+                if (nid, sf) in new_node_keys:
+                    return False
+                norm = _norm_source_file(sf, _replace_root)
+                if norm and (nid, norm) in new_node_keys:
+                    return False
             own = new_ast_sources if _is_ast_tier(item) else new_sem_sources
             return sf not in own and _norm_source_file(sf, _replace_root) not in own
         existing_nodes = [n for n in existing_nodes if _kept(n)]

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1182,6 +1182,59 @@ def test_is_ast_tier_legacy_fallback():
     assert _is_ast_tier({"_origin": "semantic", "source_location": "L10"}) is False
 
 
+def test_build_merge_reextract_wins_over_legacy_lookalike_node(tmp_path):
+    """#2334 follow-up: a re-extracted node must REPLACE its own prior version
+    even when that prior version is an unstamped legacy item whose
+    source_location happens to look like AST ('L<line>').
+
+    _is_ast_tier's shape fallback reads such an item as AST-tier, so a SEMANTIC
+    re-extract does not replace it. It survives, collides with its own fresh
+    version, and _collision_rank picks the survivor — tying here on definer-ness
+    and source_file, so it decides on len(label) and keeps the SHORTER one.
+    Freshness is not a factor, so a re-extract that EXPANDS a claim loses to the
+    stale text it was meant to correct. Silent: node counts stay correct and no
+    edge dangles, so nothing downstream flags it.
+
+    Shape cannot disambiguate this: semantic extractors do emit 'L<line>' for
+    markdown (build.py's dedup path guards against exactly that -- "may carry
+    drifted 'L<line>' source_locations"), and '.md' is in the AST extractor
+    registry, so a doc legitimately carries both tiers. Identity can: two items
+    sharing an id AND a source_file are the same entity, so the fresh one must
+    win whatever tier each is read as.
+    """
+    graph_path = tmp_path / "graph.json"
+    stale = "Unreconciled: book-to-rank labels off by one between C-23 and C-27"
+    fresh = ("Resolved: the C-23/C-27 book-to-rank off-by-one, closed by C-45 "
+             "mapping to Technical Ranks 2/3/4")
+    assert len(fresh) > len(stale), "fixture must reproduce the losing-by-length case"
+
+    graph_path.write_text(json.dumps({
+        "directed": False,
+        "nodes": [
+            # Legacy semantic node: unstamped, AST-LOOKING source_location.
+            {"id": "notes_rank", "label": stale, "file_type": "concept",
+             "source_file": "notes.md", "source_location": "L38-41"},
+        ],
+        "links": [],
+        "hyperedges": [],
+    }), encoding="utf-8")
+
+    # Semantic re-extract of the same file, same id, corrected (longer) label.
+    chunk = {"nodes": [
+        {"id": "notes_rank", "label": fresh, "file_type": "concept",
+         "source_file": "notes.md", "source_location": "# Rank"},
+    ], "edges": []}
+
+    G = build_merge([chunk], graph_path=graph_path, root=str(tmp_path), directed=False)
+
+    assert G.nodes["notes_rank"]["label"] == fresh, (
+        "re-extracted node lost to its own stale legacy copy: the base item's "
+        "'L<line>' source_location made _is_ast_tier read it as AST-tier, so the "
+        "semantic replace skipped it, and _collision_rank then kept the shorter "
+        "(stale) label"
+    )
+
+
 def test_build_merge_root_collapses_convention_drift(tmp_path):
     """Skill contract: the extraction subagent must emit source_file as the
     verbatim path from FILE_LIST AND the caller must pass root= (the build root).


### PR DESCRIPTION
## The bug

A re-extracted node can be silently replaced by the **stale version it was meant to correct**.

Minimal repro (added as a regression test): a legacy unstamped node for `notes.md` whose `source_location` is `"L38-41"`, then a semantic re-extract of the same id with a corrected, longer label. Before this change the graph keeps the old label.

```
[graphify] note: node 'notes_rank' was extracted twice from 'notes.md' under
different labels — keeping 'Unreconciled: book-to-rank labels off by one between
C-23 and C-27', dropping 'Resolved: the C-23/C-27 book-to-rank off-by-one, closed
by C-45 mapping to Technical Ranks 2/3/4'.
```

## Two things combine

**1. The tier guess.** `_is_ast_tier`'s shape fallback reads any unstamped item with an `L<line>` `source_location` as AST-tier. Semantic extractors do emit that shape for markdown — `build.py`'s own dedup path already guards against it, in a comment that says so explicitly:

> Strict `_origin` check on purpose — NOT `_is_ast_tier` (#2334) ... Those may carry drifted `'L<line>'` source_locations

So a legacy **semantic** node can be read as AST-tier. The tier-scoped replace from #2333/#2336 then does not drop it on a semantic re-extract, and it survives alongside its own fresh version.

**2. The tie-break.** With both present, `_collision_rank` picks the survivor. Definer-ness and `source_file` tie, so it decides on `len(label)` and keeps the **shorter** one. Freshness is not a factor, so a re-extract that expands a claim loses to the text it was correcting.

The failure is silent — node counts unchanged, no dangling edges, and the only signal is a note that reads like routine dedup.

## Why not fix the shape test

`.md` is in the AST extractor registry (`extract.py`: `".md": extract_markdown`), so a doc legitimately carries both tiers, and `_write_two_tier_graph` in the existing tests encodes exactly that. A semantic node with a line-range location is therefore indistinguishable from an AST one by shape alone. Tightening the heuristic would just move the misclassification.

## The fix

Key on identity instead of shape: a base node whose id is re-emitted by a new chunk for the **same** `source_file` is that node's own freshly-extracted version, never a coexisting other-tier node. Drop it whatever tier each side is read as.

Tier scoping still protects the other tier's *distinct* nodes, which is what #2333 was about — an AST heading layer has different ids from the semantic concepts, so it survives untouched. The COEXIST tests are unmodified and still pass.

## Testing

Full suite on Windows / py3.11:

| | failed | passed |
|---|---|---|
| pristine `00efd6e` | 49 | 3681 |
| with this patch | 49 | 3682 |

Identical failure sets — no regressions; the extra pass is the new test. The 49 are pre-existing environment failures on this platform (`skillgen`, `terraform`, `ollama_retry_cap`, `uninstall_scope`, `watch`), unrelated to this path.

Also verified end-to-end against the real 1451-node graph where I hit this: with the patch the re-extract produces the corrected label and **zero** collision notes, because the replace now fires and the collision never happens.

## How I ran into it

A knowledge-base corpus where `wiki/` pages carry adjudicated claims. A re-extract of one page was supposed to update "Unreconciled: ..." to "Resolved: ... closed by C-45"; the graph kept the stale text. Nothing downstream flagged it — the node count was right and no edge dangled. In a corpus whose whole point is that adjudicated answers supersede earlier ones, a silent revert to superseded text is about the worst available failure mode, which is why I chased it to the tie-break rather than just working around it locally.