### PR TITLE
fix(cluster): honor --resolution on the community split passes

### DIFF
--- a/graphify/cluster.py
+++ b/graphify/cluster.py
@@ -300,7 +300,7 @@ def cluster(
     final_communities: list[list[str]] = []
     for nodes in raw.values():
         if len(nodes) > max_size:
-            final_communities.extend(_split_community(G, nodes))
+            final_communities.extend(_split_community(G, nodes, resolution))
         else:
             final_communities.append(nodes)
 
@@ -309,7 +309,7 @@ def cluster(
     second_pass: list[list[str]] = []
     for nodes in final_communities:
         if len(nodes) >= _COHESION_SPLIT_MIN_SIZE and cohesion_score(G, nodes) < _COHESION_SPLIT_THRESHOLD:
-            splits = _split_community(G, nodes)
+            splits = _split_community(G, nodes, resolution)
             second_pass.extend(splits if len(splits) > 1 else [nodes])
         else:
             second_pass.append(nodes)
@@ -325,14 +325,19 @@ def cluster(
     return {i: sorted(nodes) for i, nodes in enumerate(final_communities)}
 
 
-def _split_community(G: nx.Graph, nodes: list[str]) -> list[list[str]]:
-    """Run a second Leiden pass on a community subgraph to split it further."""
+def _split_community(G: nx.Graph, nodes: list[str], resolution: float = 1.0) -> list[list[str]]:
+    """Run a second Leiden pass on a community subgraph to split it further.
+
+    ``resolution`` mirrors the value cluster() partitioned the whole graph with,
+    so --resolution keeps its meaning on the split passes instead of silently
+    reverting to 1.0 here.
+    """
     subgraph = G.subgraph(nodes)
     if subgraph.number_of_edges() == 0:
         # No edges - split into individual nodes
         return [[n] for n in sorted(nodes)]
     try:
-        sub_partition = _partition(subgraph)
+        sub_partition = _partition(subgraph, resolution=resolution)
         sub_communities: dict[int, list[str]] = {}
         for node, cid in sub_partition.items():
             sub_communities.setdefault(cid, []).append(node)

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -177,3 +177,43 @@ def test_partition_is_invariant_to_edge_endpoint_orientation():
     assert _grouping(_partition(forward, 1.0)) == _grouping(_partition(flipped, 1.0)), (
         "partition drifted with edge-endpoint orientation / insertion order"
     )
+
+
+def test_split_community_forwards_resolution_to_partition(monkeypatch):
+    from graphify import cluster as cluster_mod
+
+    seen: list[float] = []
+
+    def fake_partition(G, resolution=1.0):
+        seen.append(resolution)
+        return {n: 0 for n in G.nodes}
+
+    monkeypatch.setattr(cluster_mod, "_partition", fake_partition)
+    G = nx.complete_graph(6)
+    G = nx.relabel_nodes(G, {i: str(i) for i in G.nodes})
+    cluster_mod._split_community(G, list(G.nodes), resolution=3.0)
+    assert seen == [3.0]
+
+
+def test_cluster_forwards_resolution_to_split_passes(monkeypatch):
+    from graphify import cluster as cluster_mod
+
+    seen: list[float] = []
+
+    def fake_split(G, nodes, resolution=1.0):
+        seen.append(resolution)
+        return [sorted(nodes)]
+
+    monkeypatch.setattr(cluster_mod, "_split_community", fake_split)
+
+    # Two 20-node cliques joined by a single edge: 40 nodes total, so max_size is
+    # max(10, 40 * 0.25) = 10 and each clique trips the oversized-split path.
+    G = nx.Graph()
+    for offset in (0, 20):
+        clique = [f"n{offset + i}" for i in range(20)]
+        G.add_edges_from((a, b) for i, a in enumerate(clique) for b in clique[i + 1:])
+    G.add_edge("n0", "n20")
+
+    cluster_mod.cluster(G, resolution=0.5)
+    assert seen, "expected the oversized-community split path to run"
+    assert set(seen) == {0.5}


### PR DESCRIPTION
`_split_community()` calls `_partition()` without forwarding `resolution`, so it always re-partitions at the default `1.0`. `cluster(resolution=...)` (the `--resolution` flag added in 2d783e5) therefore applies to the top-level partition but is silently dropped by **both** split passes:

- the oversized-community split (`cluster.py:214`)
- the cohesion re-split (`cluster.py:223`)

So `graphify build --resolution 0.5` partitions the graph at 0.5, then re-partitions its largest communities at 1.0 — the opposite granularity to the one requested.

### Change

Thread `cluster()`'s `resolution` through to both call sites and give `_split_community()` a `resolution: float = 1.0` parameter.

Default behaviour is unchanged — the default is 1.0 either way, which is what the split passes were already hardcoding. Only runs that pass an explicit `--resolution` change.

### Tests

Two tests in `tests/test_cluster.py`, both verified to fail without the fix:

- `test_split_community_forwards_resolution_to_partition` — asserts the kwarg reaches `_partition`
- `test_cluster_forwards_resolution_to_split_passes` — end-to-end through `cluster()` on a graph that trips the oversized-split path

Full suite: 3904 passed, 36 skipped. Two failures on this branch are pre-existing on a clean `v8` checkout and unrelated (`test_ollama_retry_cap.py` needs the `openai` extra; `test_labeling.py::test_label_communities_batches_when_over_batch_size` asserts a batch completion order).