### PR TITLE
docs(readme): document libpq env vars for --postgres connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ These are only needed for **headless / CI extraction** (`graphify extract`). Whe
 | `AZURE_OPENAI_API_VERSION` | Azure API version override | optional — default `2024-12-01-preview` |
 | `AZURE_OPENAI_DEPLOYMENT` or `GRAPHIFY_AZURE_MODEL` | Azure deployment name | optional — default `gpt-4o` |
 | `AWS_*` / `~/.aws/credentials` | AWS Bedrock — standard credential chain | `--backend bedrock` (no API key, uses IAM) |
+| `PG*` (`PGPASSWORD`, `PGSSLMODE`, …) | Standard libpq connection env vars, read by psycopg | optional — `--postgres` fills unset DSN fields from these |
 | `GRAPHIFY_MAX_WORKERS` | AST parallelism thread count | optional — also `--max-workers` flag |
 | `GRAPHIFY_MAX_OUTPUT_TOKENS` | Raise output cap for dense corpora | optional — e.g. `32768` for large files |
 | `GRAPHIFY_API_TIMEOUT` | Per-call timeout in seconds for HTTP, claude-cli, Anthropic SDK, and Bedrock backends (default: 600) | optional — also `--api-timeout` flag |
@@ -765,6 +766,7 @@ graphify extract ./docs --backend claude-cli   # route through Claude Code CLI -
 graphify extract ./docs --backend azure        # Azure OpenAI (set AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT)
 graphify extract ./docs --max-workers 16       # AST parallelism (also GRAPHIFY_MAX_WORKERS)
 graphify extract --postgres "postgresql://user:pass@host/db"   # introspect live PostgreSQL schema directly
+graphify extract --postgres "postgresql://user@host/db?sslmode=require"   # password-free: libpq env vars (PGPASSWORD, PGSSLROOTCERT, ~/.pgpass) still apply
 graphify extract ./my-workspace --cargo        # introspect Rust Cargo workspace dependencies directly
 graphify extract ./docs --token-budget 30000   # smaller semantic chunks for local/small models
 graphify extract ./docs --max-concurrency 2    # fewer parallel LLM calls (useful for local inference)


### PR DESCRIPTION
`introspect_postgres()` passes its DSN straight to `psycopg.connect()` (`pg_introspect.py:22`), so any connection field the DSN omits falls back to the standard libpq environment variables — `PGPASSWORD`, `PGSSLMODE`, `PGSSLROOTCERT`, `~/.pgpass`, and the rest.

That is already how you make a password-free `--postgres` connection, and it is what makes token-based auth work on managed PostgreSQL — on Azure Database for PostgreSQL Flexible Server, for instance, Entra ID auth works by putting a short-lived access token in `PGPASSWORD`:

```bash
export PGPASSWORD=$(az account get-access-token \
  --resource https://ossrdbms-aad.database.windows.net --query accessToken -o tsv)
graphify extract --postgres "postgresql://me@my-server.postgres.database.azure.com/mydb?sslmode=require"
```

None of that is documented — the only `--postgres` example in the README embeds a plaintext password in the DSN, which also puts the credential in shell history and `ps` output.

**Docs only, no code change.** Adds the `PG*` row to the environment-variable table and a password-free `--postgres` example alongside the existing one.