### PR TITLE
fix(skill): use native Gemini prompt for semantic cache

### DIFF
--- a/graphify/skill-agents.md
+++ b/graphify/skill-agents.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -304,16 +315,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill-amp.md
+++ b/graphify/skill-amp.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -304,16 +315,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill-claw.md
+++ b/graphify/skill-claw.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -307,16 +318,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -304,16 +315,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill-copilot.md
+++ b/graphify/skill-copilot.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -307,16 +318,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill-droid.md
+++ b/graphify/skill-droid.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -304,16 +315,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill-kilo.md
+++ b/graphify/skill-kilo.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -307,16 +318,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill-kiro.md
+++ b/graphify/skill-kiro.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -307,16 +318,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -299,16 +310,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill-pi.md
+++ b/graphify/skill-pi.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -307,16 +318,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill-trae.md
+++ b/graphify/skill-trae.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -305,16 +316,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill-vscode.md
+++ b/graphify/skill-vscode.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -303,16 +314,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill-windows.md
+++ b/graphify/skill-windows.md
@@ -236,12 +236,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -250,7 +254,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -329,16 +340,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -307,16 +318,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tests/test_skillgen.py
+++ b/tests/test_skillgen.py
@@ -951,16 +951,20 @@ def test_agents_audit_baseline_is_amps_v8_body():
     assert problems == [], "\n".join(problems)
 
 
-def test_semantic_cache_calls_pass_prompt_file_for_every_split_host():
-    """#1939: a skill's cache read and write must both name the extraction prompt
-    they use, or the run replays entries produced by an older prompt (the read) /
-    strands its results where the next read won't look (the write).
+def test_semantic_cache_calls_share_prompt_identity_for_every_split_host():
+    """#1939/#2303: a skill's cache read and write must both name the
+    extraction prompt they use, or the run replays entries produced by an older
+    prompt (the read) / strands its results where the next read won't look (the
+    write).
 
     Locked per host because the two calls live ~80 lines apart in the rendered
     body: adding the argument to one and not the other silently disables the
-    cache rather than failing loudly. The monolith hosts (aider, devin) inline
-    their prompt instead of shipping references/extraction-spec.md and are
-    deliberately excluded — they have no spec path to point at.
+    cache rather than failing loudly. Split-host skills use SPEC_PATH for the
+    subagent prompt, but the Gemini direct path must use the native
+    _extraction_system() prompt because extract_corpus_parallel checkpoints with
+    that fingerprint. The monolith hosts (aider, devin) inline their prompt
+    instead of shipping references/extraction-spec.md and are deliberately
+    excluded — they have no spec path to point at.
     """
     platforms = gen.load_platforms()
     arts = gen.render_all(platforms)
@@ -971,9 +975,14 @@ def test_semantic_cache_calls_pass_prompt_file_for_every_split_host():
     for a in bodies:
         for call in ("check_semantic_cache(", "save_semantic_cache("):
             line = next(ln for ln in a.content.splitlines() if call in ln and "import" not in ln)
-            assert "prompt_file='SPEC_PATH'" in line, (
-                f"{a.path}: {call} must pass prompt_file so entries are attributed "
-                f"to the extraction prompt (#1939) — got: {line.strip()}"
+            assert "**prompt_kwargs" in line, (
+                f"{a.path}: {call} must pass the shared prompt_kwargs so cache "
+                f"reads and writes use the same prompt identity (#1939/#2303) "
+                f"— got: {line.strip()}"
             )
         # The placeholder is inert unless the body tells the agent what to substitute.
         assert "SPEC_PATH below is the **absolute** path" in a.content, a.path
+        assert "'prompt_file': 'SPEC_PATH'" in a.content, a.path
+        assert "from graphify.llm import _extraction_system" in a.content, a.path
+        assert "'prompt': _extraction_system(deep=DEEP_MODE)" in a.content, a.path
+        assert "using_gemini_direct = bool" in a.content, a.path

--- a/tools/skillgen/expected/graphify__skill-agents.md
+++ b/tools/skillgen/expected/graphify__skill-agents.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -304,16 +315,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-amp.md
+++ b/tools/skillgen/expected/graphify__skill-amp.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -304,16 +315,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-claw.md
+++ b/tools/skillgen/expected/graphify__skill-claw.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -307,16 +318,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-codex.md
+++ b/tools/skillgen/expected/graphify__skill-codex.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -304,16 +315,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-copilot.md
+++ b/tools/skillgen/expected/graphify__skill-copilot.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -307,16 +318,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-droid.md
+++ b/tools/skillgen/expected/graphify__skill-droid.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -304,16 +315,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-kilo.md
+++ b/tools/skillgen/expected/graphify__skill-kilo.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -307,16 +318,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-kiro.md
+++ b/tools/skillgen/expected/graphify__skill-kiro.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -307,16 +318,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-opencode.md
+++ b/tools/skillgen/expected/graphify__skill-opencode.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -299,16 +310,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-pi.md
+++ b/tools/skillgen/expected/graphify__skill-pi.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -307,16 +318,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-trae.md
+++ b/tools/skillgen/expected/graphify__skill-trae.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -305,16 +316,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-vscode.md
+++ b/tools/skillgen/expected/graphify__skill-vscode.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -303,16 +314,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-windows.md
+++ b/tools/skillgen/expected/graphify__skill-windows.md
@@ -236,12 +236,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -250,7 +254,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -329,16 +340,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/expected/graphify__skill.md
+++ b/tools/skillgen/expected/graphify__skill.md
@@ -214,12 +214,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -228,7 +232,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -307,16 +318,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```

--- a/tools/skillgen/fragments/core/core.md
+++ b/tools/skillgen/fragments/core/core.md
@@ -173,12 +173,16 @@ Before dispatching subagents, print a timing estimate:
 
 Before dispatching any subagents, check which files already have cached extraction results:
 
-SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939). Substitute the real path in both Step B0 and Step B3 — pass the same one to each, and do not drop the argument.
+SPEC_PATH below is the **absolute** path of the `references/extraction-spec.md` that ships beside this SKILL.md — the same file Step B2 loads and hands to every subagent. It is the extraction prompt for the subagent path, so cache entries are attributed to it: when a graphify upgrade changes the prompt, entries produced by the old one are re-extracted instead of replayed, and unchanged prompts keep their entries (#1939).
+
+If you are taking the Gemini direct path from the key check above (`GEMINI_API_KEY`/`GOOGLE_API_KEY` is set and you use `graphify.llm.extract_corpus_parallel(...)` instead of subagents), do **not** use SPEC_PATH for cache reads. The native Gemini extractor writes checkpoints with `graphify.llm._extraction_system(deep=DEEP_MODE)`, so Step B0 must read with that same prompt text or it will look in the wrong fingerprint directory and miss every cached file (#2303). Substitute the real SPEC_PATH for the subagent path and the real DEEP_MODE boolean for the Gemini path; pass the same `prompt_kwargs` again in Step B3.
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import check_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
@@ -187,7 +191,14 @@ detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encodin
 # every source file (#1392). Video is transcribed to a document in Step 2.5 first.
 all_files = [f for cat in ('document', 'paper', 'image') for f in detect['files'].get(cat, [])]
 
-cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files, root='INPUT_PATH', **prompt_kwargs)
 
 # Always (re)write the cache file: write hits, else DELETE any leftover from a prior
 # run so Part C never merges a stale .graphify_cached.json (#1392).
@@ -242,16 +253,24 @@ print(f'Merged {len(chunks)} chunks: {total_in:,} in / {total_out:,} out tokens'
 "
 ```
 
-Save new results to cache. Pass the same SPEC_PATH as Step B0 — it stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939):
+Save new results to cache. Pass the same prompt identity as Step B0 — `prompt_file=SPEC_PATH` on the subagent path, or `prompt=_extraction_system(deep=DEEP_MODE)` on the Gemini direct path. It stamps each entry with the prompt that produced it, and a write under a different prompt than the read lands where the next run won't look (#1939, #2303):
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+import os
 from graphify.cache import save_semantic_cache
+from graphify.llm import _extraction_system
 from pathlib import Path
 
 new = json.loads(Path('graphify-out/.graphify_semantic_new.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
 uncached = [line for line in Path('graphify-out/.graphify_uncached.txt').read_text(encoding=\"utf-8\").splitlines() if line]
-saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, prompt_file='SPEC_PATH')
+using_gemini_direct = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+prompt_kwargs = (
+    {'prompt': _extraction_system(deep=DEEP_MODE)}
+    if using_gemini_direct
+    else {'prompt_file': 'SPEC_PATH'}
+)
+saved = save_semantic_cache(new.get('nodes', []), new.get('edges', []), new.get('hyperedges', []), root='INPUT_PATH', allowed_source_files=uncached, **prompt_kwargs)
 print(f'Cached {saved} files')
 "
 ```


### PR DESCRIPTION
## Summary
- route split-host skill semantic cache reads and writes through shared `prompt_kwargs`
- use `SPEC_PATH` for subagent extraction, and `_extraction_system(deep=DEEP_MODE)` for the direct Gemini extraction path
- regenerate skill artifacts and expected snapshots
- update skillgen regression coverage for the shared prompt identity

## Tests
- `uv run --frozen python -m tools.skillgen --check`
- `uv run --frozen python -m tools.skillgen --audit-coverage`
- `uv run --frozen python -m tools.skillgen --schema-singleton`
- `uv run --frozen python -m tools.skillgen --monolith-roundtrip`
- `uv run --frozen python -m tools.skillgen --always-on-roundtrip`
- `uv run --frozen pytest tests/test_skillgen.py`
- `uv run --frozen ruff check tests/test_skillgen.py`
- `git diff --check`
- `uv run --frozen graphify update .`

Fixes #2303
