### PR TITLE
fix(build): prefer higher-info relation on same-pair edge collapse

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -71,6 +71,32 @@ _EDGE_LANG_FAMILY: dict[str, str] = {
 }
 
 
+# When a simple Graph/DiGraph collapses parallel edges on the same node pair,
+# alphabetical last-write-wins (via the deterministic sort below) made
+# ``references`` always beat ``calls`` (``"calls" < "references"``), silently
+# deleting the higher-information call edge (#2391). Higher score wins the
+# collapse; relations absent from this table score 0 so unlisted types keep
+# first-wins behavior rather than inventing a new alphabetical bias.
+_RELATION_PRIORITY: dict[str, int] = {
+    "calls": 100,
+    "indirect_call": 90,
+    "imports": 80,
+    "imports_from": 80,
+    "inherits": 70,
+    "mixes_in": 70,
+    "implements": 70,
+    "contains": 40,
+    "method": 40,
+    "references": 20,
+}
+
+
+def _relation_priority(relation: object) -> int:
+    if not isinstance(relation, str):
+        return 0
+    return _RELATION_PRIORITY.get(relation, 0)
+
+
 # Synonym mapper for known invalid file_type values that LLM subagents commonly
 # emit. Keeps semantic intent close (markdown→document, tool→code) and falls
 # back to "concept" for any other invalid value (see #840).
@@ -1049,6 +1075,23 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
                 existing.get("_src") == tgt and existing.get("_tgt") == src
             ):
                 continue
+            # Different relations on the same pair: prefer the higher-information
+            # relation instead of alphabetical last-write-wins (#2391). Equal
+            # priority keeps the first-seen edge (same spirit as #1061).
+            if existing.get("relation") != attrs.get("relation"):
+                if _relation_priority(attrs.get("relation")) <= _relation_priority(
+                    existing.get("relation")
+                ):
+                    continue
+        elif G.is_directed() and G.has_edge(src, tgt):
+            # DiGraph still collapses same-direction parallel relations; apply
+            # the same priority rule so directed builds don't reintroduce #2391.
+            existing = edge_data(G, src, tgt)
+            if existing.get("relation") != attrs.get("relation"):
+                if _relation_priority(attrs.get("relation")) <= _relation_priority(
+                    existing.get("relation")
+                ):
+                    continue
         G.add_edge(src, tgt, **attrs)
     hyperedges = extraction.get("hyperedges", [])
     if hyperedges:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -715,6 +715,98 @@ def test_build_from_json_preserves_first_direction_on_bidirectional_pair(tmp_pat
     )
 
 
+# ---------------------------------------------------------------------------
+# #2391 — relation priority on same-pair edge collapse
+# ---------------------------------------------------------------------------
+# Simple Graph/DiGraph keeps one edge per node pair. build_from_json sorts by
+# (source, target, relation) then last-write-wins via add_edge, so alphabetical
+# order made `references` always overwrite `calls`. Prefer higher-information
+# relations instead.
+
+
+def _pair_extraction(edges):
+    return {
+        "nodes": [
+            {"id": "fn_a", "label": "a", "file_type": "code", "source_file": "a.py"},
+            {"id": "fn_b", "label": "b", "file_type": "code", "source_file": "b.py"},
+        ],
+        "edges": edges,
+        "input_tokens": 0,
+        "output_tokens": 0,
+    }
+
+
+def test_relation_priority_calls_beats_references_regardless_of_input_order():
+    """#2391: a return-type `references` edge must not delete a real `calls`."""
+    calls = {
+        "source": "fn_a", "target": "fn_b", "relation": "calls",
+        "source_location": "L271", "confidence": "EXTRACTED", "source_file": "a.py",
+    }
+    refs = {
+        "source": "fn_a", "target": "fn_b", "relation": "references",
+        "source_location": "L260", "confidence": "EXTRACTED", "source_file": "a.py",
+    }
+    for edges in ([calls, refs], [refs, calls]):
+        G = build_from_json(_pair_extraction(edges))
+        assert G.number_of_edges() == 1
+        data = edge_data(G, "fn_a", "fn_b")
+        assert data["relation"] == "calls", (
+            f"expected calls to survive collapse, got {data.get('relation')!r}"
+        )
+        assert data.get("source_location") == "L271"
+        assert data.get("_src") == "fn_a"
+        assert data.get("_tgt") == "fn_b"
+
+
+def test_relation_priority_indirect_call_beats_contains():
+    """#2391: indirect_call is higher-information than a structural contains."""
+    edges = [
+        {
+            "source": "fn_a", "target": "fn_b", "relation": "contains",
+            "source_location": "L1", "confidence": "EXTRACTED", "source_file": "a.py",
+        },
+        {
+            "source": "fn_a", "target": "fn_b", "relation": "indirect_call",
+            "source_location": "L9", "confidence": "INFERRED", "source_file": "a.py",
+        },
+    ]
+    G = build_from_json(_pair_extraction(edges))
+    data = edge_data(G, "fn_a", "fn_b")
+    assert data["relation"] == "indirect_call"
+    assert data.get("source_location") == "L9"
+
+
+def test_relation_priority_sole_references_still_kept():
+    """#2391: without a competing higher relation, references still survives."""
+    edges = [
+        {
+            "source": "fn_a", "target": "fn_b", "relation": "references",
+            "source_location": "L260", "confidence": "EXTRACTED", "source_file": "a.py",
+        },
+    ]
+    G = build_from_json(_pair_extraction(edges))
+    assert edge_data(G, "fn_a", "fn_b")["relation"] == "references"
+
+
+def test_relation_priority_calls_beats_references_directed():
+    """#2391 also applies on DiGraph (same-direction parallel relations)."""
+    edges = [
+        {
+            "source": "fn_a", "target": "fn_b", "relation": "references",
+            "source_location": "L260", "confidence": "EXTRACTED", "source_file": "a.py",
+        },
+        {
+            "source": "fn_a", "target": "fn_b", "relation": "calls",
+            "source_location": "L271", "confidence": "EXTRACTED", "source_file": "a.py",
+        },
+    ]
+    G = build_from_json(_pair_extraction(edges), directed=True)
+    assert G.is_directed()
+    data = edge_data(G, "fn_a", "fn_b")
+    assert data["relation"] == "calls"
+    assert data.get("source_location") == "L271"
+
+
 # Regression tests for #796 — edge_data / edge_datas helpers must tolerate
 # MultiGraph and MultiDiGraph, which networkx's node_link_graph() produces
 # whenever the loaded JSON has multigraph: true. Plain G.edges[u, v] crashes


### PR DESCRIPTION
## Summary

Fixes #2391.

`build_from_json` sorts edges by `(source, target, relation)` then inserts them into a simple `nx.Graph` / `nx.DiGraph` with last-write-wins `add_edge`. That made alphabetical order the survivor whenever two different relations landed on the same node pair — so `references` always overwrote `calls` (`"calls" < "references"`), silently deleting the higher-information call edge.

This adds a small `_RELATION_PRIORITY` table so the higher-information relation wins the collapse instead. Unlisted relations score 0 (first-wins), so obscure types do not pick up a new alphabetical bias. Equal priority keeps the first-seen edge, same spirit as the #1061 reverse-direction guard (left intact).

Out of scope (can follow up if wanted):
- Multigraph path / `--multigraph` wiring (related open PR #709)
- Retaining discarded relations in an `also_relations` attribute

## Test plan

- [x] `uv run pytest tests/test_build.py -q` — **72 passed**
- [x] Regression: `calls` + `references` both input orders → survivor is `calls` with `source_location=L271`
- [x] `indirect_call` beats `contains`
- [x] Sole `references` still kept
- [x] Same priority rule on `directed=True`
- [x] Existing #1061 bidirectional `calls` direction test still green

## Notes

- Author: arimu1
- Platform: macOS (local pytest); CI should cover Linux matrix
- AI-assisted implementation (Grok 4.5 / Grok Build), human-reviewed