### PR TITLE
fix(skill): share code extension source

### DIFF
--- a/graphify/skill-aider.md
+++ b/graphify/skill-aider.md
@@ -777,13 +777,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('.graphify_incremental.json').read()) if Path('.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skill-devin.md
+++ b/graphify/skill-devin.md
@@ -916,13 +916,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/agents/references/update.md
+++ b/graphify/skills/agents/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/amp/references/update.md
+++ b/graphify/skills/amp/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/claude/references/update.md
+++ b/graphify/skills/claude/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/claw/references/update.md
+++ b/graphify/skills/claw/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/codex/references/update.md
+++ b/graphify/skills/codex/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/copilot/references/update.md
+++ b/graphify/skills/copilot/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/droid/references/update.md
+++ b/graphify/skills/droid/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/kilo/references/update.md
+++ b/graphify/skills/kilo/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/kiro/references/update.md
+++ b/graphify/skills/kiro/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/opencode/references/update.md
+++ b/graphify/skills/opencode/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/pi/references/update.md
+++ b/graphify/skills/pi/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/trae/references/update.md
+++ b/graphify/skills/trae/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/vscode/references/update.md
+++ b/graphify/skills/vscode/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/graphify/skills/windows/references/update.md
+++ b/graphify/skills/windows/references/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tests/test_skillgen.py
+++ b/tests/test_skillgen.py
@@ -574,6 +574,8 @@ def test_generated_runbooks_pass_root_to_save_manifest():
 
 def test_generated_update_runbooks_use_detect_code_extensions():
     """#2227: no shipped update runbook carries a stale extension literal."""
+    from graphify.detect import CODE_EXTENSIONS
+
     targets = [
         REPO_ROOT / "graphify" / "skill-aider.md",
         REPO_ROOT / "graphify" / "skill-devin.md",
@@ -584,6 +586,9 @@ def test_generated_update_runbooks_use_detect_code_extensions():
         assert "from graphify.detect import CODE_EXTENSIONS" in body, path
         assert "Path(f).suffix.lower() in CODE_EXTENSIONS" in body, path
         assert "code_exts = {" not in body, path
+
+    assert all(Path(file).suffix.lower() in CODE_EXTENSIONS for file in ("change.sql", "script.ps1", "analysis.R"))
+    assert not all(Path(file).suffix.lower() in CODE_EXTENSIONS for file in ("change.sql", "notes.md"))
 
 
 def test_devin_keeps_its_multi_field_frontmatter():

--- a/tests/test_skillgen.py
+++ b/tests/test_skillgen.py
@@ -487,8 +487,9 @@ def test_monoliths_change_only_sanctioned_lines():
     The round-trip (multiset diff vs the pinned v8 blob) must come back clean:
     each added/removed line matches one of the documented sanctioned predicates
     in gen — the enum unification, the unified description, the chunk-cleanup
-    rewrite (#1172), the four #1392 runbook fixes, and semantic-cache source
-    scoping (#1757). Anything else is drift.
+    rewrite (#1172), the four #1392 runbook fixes, semantic-cache source scoping
+    (#1757), and the shared code-extension set for incremental runbooks (#2227).
+    Anything else is drift.
     """
     platforms = gen.load_platforms()
     for key in ("aider", "devin"):
@@ -569,6 +570,20 @@ def test_generated_runbooks_pass_root_to_save_manifest():
                     f"{path.relative_to(REPO_ROOT)}: save_manifest without root= (#1417): {ln.strip()!r}"
                 )
     assert checked >= 4, f"expected save_manifest calls across the runbooks, found {checked}"
+
+
+def test_generated_update_runbooks_use_detect_code_extensions():
+    """#2227: no shipped update runbook carries a stale extension literal."""
+    targets = [
+        REPO_ROOT / "graphify" / "skill-aider.md",
+        REPO_ROOT / "graphify" / "skill-devin.md",
+    ]
+    targets += sorted((REPO_ROOT / "graphify" / "skills").glob("*/references/update.md"))
+    for path in targets:
+        body = path.read_text(encoding="utf-8")
+        assert "from graphify.detect import CODE_EXTENSIONS" in body, path
+        assert "Path(f).suffix.lower() in CODE_EXTENSIONS" in body, path
+        assert "code_exts = {" not in body, path
 
 
 def test_devin_keeps_its_multi_field_frontmatter():

--- a/tools/skillgen/expected/graphify__skill-aider.md
+++ b/tools/skillgen/expected/graphify__skill-aider.md
@@ -777,13 +777,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('.graphify_incremental.json').read()) if Path('.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skill-devin.md
+++ b/tools/skillgen/expected/graphify__skill-devin.md
@@ -916,13 +916,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__agents__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__agents__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__amp__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__amp__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__claude__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claude__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__claw__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claw__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__codex__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__codex__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__copilot__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__copilot__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__droid__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__droid__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__kilo__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kilo__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__kiro__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kiro__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__opencode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__opencode__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__pi__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__pi__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__trae__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__trae__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__vscode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__vscode__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/expected/graphify__skills__windows__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__windows__references__update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/fragments/core/aider.md
+++ b/tools/skillgen/fragments/core/aider.md
@@ -777,13 +777,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('.graphify_incremental.json').read()) if Path('.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/fragments/core/devin.md
+++ b/tools/skillgen/fragments/core/devin.md
@@ -916,13 +916,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/fragments/references/shared/update.md
+++ b/tools/skillgen/fragments/references/shared/update.md
@@ -50,13 +50,13 @@ If new files exist, first check whether all changed files are code files:
 ```bash
 $(cat graphify-out/.graphify_python) -c "
 import json
+from graphify.detect import CODE_EXTENSIONS
 from pathlib import Path
 
 result = json.loads(open('graphify-out/.graphify_incremental.json', encoding='utf-8').read()) if Path('graphify-out/.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc','.f','.F','.f90','.F90','.f95','.F95','.f03','.F03','.f08','.F08'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
-code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+code_only = all(Path(f).suffix.lower() in CODE_EXTENSIONS for f in all_changed)
 print('code_only:', code_only)
 "
 ```

--- a/tools/skillgen/gen.py
+++ b/tools/skillgen/gen.py
@@ -954,6 +954,21 @@ def _is_semantic_cache_scope_fix_line(line: str) -> bool:
     ) or stripped.startswith("saved = save_semantic_cache(")
 
 
+def _is_code_extensions_fix_line(line: str) -> bool:
+    """Whether a line replaces a stale code-extension literal (#2227).
+
+    The incremental runbooks used their own extension sets, so new extractors
+    silently triggered semantic work. They now import the detection module's
+    source-of-truth ``CODE_EXTENSIONS`` set.
+    """
+    return (
+        "from graphify.detect import CODE_EXTENSIONS" in line
+        or line.strip().startswith("code_exts = {")
+        or "Path(f).suffix.lower() in CODE_EXTENSIONS" in line
+        or "Path(f).suffix.lower() in code_exts" in line
+    )
+
+
 # Every line that may differ between a rendered monolith and its pristine v8
 # baseline. Each predicate documents one sanctioned change-class; a blank line is
 # allowed because the multi-line fix blocks insert spacing. Anything else failing
@@ -974,6 +989,7 @@ _SANCTIONED_MONOLITH_DIFFS = (
     _is_obsidian_usage_comment_line,
     _is_uv_from_interpreter_fix_line,
     _is_semantic_cache_scope_fix_line,
+    _is_code_extensions_fix_line,
 )
 
 
@@ -992,7 +1008,8 @@ def monolith_roundtrip(platform: Platform) -> list[str]:
     unification, the unified frontmatter description, the chunk-cleanup rewrite
     (#1172), the four #1392 runbook fixes (directed propagation, content-only
     semantic scope, stale-cache unlink, and the zero-node/shrink-guard ordering),
-    and semantic-cache source scoping (#1757).
+    semantic-cache source scoping (#1757), and the shared code-extension set
+    used by incremental runbooks (#2227).
 
     The comparison is a multiset diff, not a positional zip: a line whose text is
     unchanged but merely *moved* (the report-write line shifted below ``to_json``


### PR DESCRIPTION
## Summary
- make every shipped `--update` runbook import `graphify.detect.CODE_EXTENSIONS`
- keep split-platform and Aider/Devin runbooks aligned as new extractors are added
- guard the generated output and explicitly sanction the monolith baseline update

## Verification
- `uv run --frozen pytest tests/test_skillgen.py`
- `uv run --frozen python -m tools.skillgen --check`
- `uv run --frozen python -m tools.skillgen --audit-coverage`
- `uv run --frozen python -m tools.skillgen --schema-singleton`
- `uv run --frozen python -m tools.skillgen --monolith-roundtrip`
- `uv run --frozen python -m tools.skillgen --always-on-roundtrip`
- `uv run --frozen ruff check tools/skillgen/gen.py tests/test_skillgen.py`

Fixes #2227