### PR TITLE
fix(skill): prune orphaned semantic cache entries

### DIFF
--- a/graphify/skill-agents.md
+++ b/graphify/skill-agents.md
@@ -581,6 +581,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-aider.md
+++ b/graphify/skill-aider.md
@@ -689,6 +689,21 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries against the full live semantic corpus.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-amp.md
+++ b/graphify/skill-amp.md
@@ -581,6 +581,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-claw.md
+++ b/graphify/skill-claw.md
@@ -584,6 +584,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -581,6 +581,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-copilot.md
+++ b/graphify/skill-copilot.md
@@ -584,6 +584,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-devin.md
+++ b/graphify/skill-devin.md
@@ -807,6 +807,21 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries against the full live semantic corpus.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-droid.md
+++ b/graphify/skill-droid.md
@@ -581,6 +581,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-kilo.md
+++ b/graphify/skill-kilo.md
@@ -584,6 +584,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-kiro.md
+++ b/graphify/skill-kiro.md
@@ -584,6 +584,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -576,6 +576,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-pi.md
+++ b/graphify/skill-pi.md
@@ -584,6 +584,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-trae.md
+++ b/graphify/skill-trae.md
@@ -582,6 +582,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-vscode.md
+++ b/graphify/skill-vscode.md
@@ -580,6 +580,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill-windows.md
+++ b/graphify/skill-windows.md
@@ -606,6 +606,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -584,6 +584,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tests/test_skillgen.py
+++ b/tests/test_skillgen.py
@@ -487,8 +487,9 @@ def test_monoliths_change_only_sanctioned_lines():
     The round-trip (multiset diff vs the pinned v8 blob) must come back clean:
     each added/removed line matches one of the documented sanctioned predicates
     in gen — the enum unification, the unified description, the chunk-cleanup
-    rewrite (#1172), the four #1392 runbook fixes, and semantic-cache source
-    scoping (#1757). Anything else is drift.
+    rewrite (#1172), the four #1392 runbook fixes, semantic-cache source scoping
+    (#1757), and semantic-cache pruning in the skill runbooks (#2307). Anything
+    else is drift.
     """
     platforms = gen.load_platforms()
     for key in ("aider", "devin"):
@@ -569,6 +570,21 @@ def test_generated_runbooks_pass_root_to_save_manifest():
                     f"{path.relative_to(REPO_ROOT)}: save_manifest without root= (#1417): {ln.strip()!r}"
                 )
     assert checked >= 4, f"expected save_manifest calls across the runbooks, found {checked}"
+
+
+def test_generated_runbooks_prune_orphaned_semantic_cache_entries():
+    """#2307: every shipped full runbook sweeps against the full live corpus."""
+    targets = [
+        REPO_ROOT / "graphify" / "skill.md",
+        REPO_ROOT / "graphify" / "skill-aider.md",
+        REPO_ROOT / "graphify" / "skill-devin.md",
+    ]
+    for path in targets:
+        body = path.read_text(encoding="utf-8")
+        assert "from graphify.cache import file_hash, prune_semantic_cache" in body, path
+        assert "for _file in _corpus.get(_kind, []):" in body, path
+        assert "file_hash(_path, root=Path('INPUT_PATH'))" in body, path
+        assert "prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)" in body, path
 
 
 def test_devin_keeps_its_multi_field_frontmatter():

--- a/tools/skillgen/expected/graphify__skill-agents.md
+++ b/tools/skillgen/expected/graphify__skill-agents.md
@@ -581,6 +581,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-aider.md
+++ b/tools/skillgen/expected/graphify__skill-aider.md
@@ -689,6 +689,21 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries against the full live semantic corpus.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-amp.md
+++ b/tools/skillgen/expected/graphify__skill-amp.md
@@ -581,6 +581,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-claw.md
+++ b/tools/skillgen/expected/graphify__skill-claw.md
@@ -584,6 +584,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-codex.md
+++ b/tools/skillgen/expected/graphify__skill-codex.md
@@ -581,6 +581,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-copilot.md
+++ b/tools/skillgen/expected/graphify__skill-copilot.md
@@ -584,6 +584,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-devin.md
+++ b/tools/skillgen/expected/graphify__skill-devin.md
@@ -807,6 +807,21 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries against the full live semantic corpus.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-droid.md
+++ b/tools/skillgen/expected/graphify__skill-droid.md
@@ -581,6 +581,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-kilo.md
+++ b/tools/skillgen/expected/graphify__skill-kilo.md
@@ -584,6 +584,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-kiro.md
+++ b/tools/skillgen/expected/graphify__skill-kiro.md
@@ -584,6 +584,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-opencode.md
+++ b/tools/skillgen/expected/graphify__skill-opencode.md
@@ -576,6 +576,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-pi.md
+++ b/tools/skillgen/expected/graphify__skill-pi.md
@@ -584,6 +584,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-trae.md
+++ b/tools/skillgen/expected/graphify__skill-trae.md
@@ -582,6 +582,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-vscode.md
+++ b/tools/skillgen/expected/graphify__skill-vscode.md
@@ -580,6 +580,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill-windows.md
+++ b/tools/skillgen/expected/graphify__skill-windows.md
@@ -606,6 +606,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/expected/graphify__skill.md
+++ b/tools/skillgen/expected/graphify__skill.md
@@ -584,6 +584,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/fragments/core/aider.md
+++ b/tools/skillgen/fragments/core/aider.md
@@ -689,6 +689,21 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries against the full live semantic corpus.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/fragments/core/core.md
+++ b/tools/skillgen/fragments/core/core.md
@@ -519,6 +519,22 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries. Hash the full live semantic corpus, not
+# only this update's changed subset, so unchanged documents keep their entries.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/fragments/core/devin.md
+++ b/tools/skillgen/fragments/core/devin.md
@@ -807,6 +807,21 @@ _cleared = _dispatched - _stamped
 _scan = {f for fl in _corpus.values() for f in fl}
 save_manifest(_manifest_files, root='INPUT_PATH', scan_corpus=_scan, clear_semantic=_cleared or None)
 
+# Prune orphaned semantic cache entries against the full live semantic corpus.
+from contextlib import suppress
+from graphify.cache import file_hash, prune_semantic_cache
+_live_hashes = set()
+for _kind in _sem_types:
+    for _file in _corpus.get(_kind, []):
+        _path = Path('INPUT_PATH') / _file
+        if _path.is_file():
+            with suppress(OSError):
+                _live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))
+with suppress(OSError):
+    _pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)
+    if _pruned:
+        print(f'Pruned {_pruned} orphaned semantic cache entries.')
+
 # Update cumulative cost tracker
 input_tok = extract.get('input_tokens', 0)
 output_tok = extract.get('output_tokens', 0)

--- a/tools/skillgen/gen.py
+++ b/tools/skillgen/gen.py
@@ -954,6 +954,26 @@ def _is_semantic_cache_scope_fix_line(line: str) -> bool:
     ) or stripped.startswith("saved = save_semantic_cache(")
 
 
+def _is_semantic_cache_prune_fix_line(line: str) -> bool:
+    """Whether a line prunes orphaned semantic cache entries (#2307)."""
+    stripped = line.strip()
+    return (
+        "from contextlib import suppress" in line
+        or "from graphify.cache import file_hash, prune_semantic_cache" in line
+        or "Prune orphaned semantic cache entries" in line
+        or stripped == "_live_hashes = set()"
+        or stripped == "for _kind in _sem_types:"
+        or stripped == "for _file in _corpus.get(_kind, []):"
+        or stripped == "_path = Path('INPUT_PATH') / _file"
+        or stripped == "if _path.is_file():"
+        or stripped == "with suppress(OSError):"
+        or "_live_hashes.add(file_hash(_path, root=Path('INPUT_PATH')))" in line
+        or "_pruned = prune_semantic_cache(Path('INPUT_PATH'), _live_hashes)" in line
+        or stripped == "if _pruned:"
+        or "Pruned {_pruned} orphaned semantic cache entries." in line
+    )
+
+
 # Every line that may differ between a rendered monolith and its pristine v8
 # baseline. Each predicate documents one sanctioned change-class; a blank line is
 # allowed because the multi-line fix blocks insert spacing. Anything else failing
@@ -974,6 +994,7 @@ _SANCTIONED_MONOLITH_DIFFS = (
     _is_obsidian_usage_comment_line,
     _is_uv_from_interpreter_fix_line,
     _is_semantic_cache_scope_fix_line,
+    _is_semantic_cache_prune_fix_line,
 )
 
 
@@ -992,7 +1013,8 @@ def monolith_roundtrip(platform: Platform) -> list[str]:
     unification, the unified frontmatter description, the chunk-cleanup rewrite
     (#1172), the four #1392 runbook fixes (directed propagation, content-only
     semantic scope, stale-cache unlink, and the zero-node/shrink-guard ordering),
-    and semantic-cache source scoping (#1757).
+    semantic-cache source scoping (#1757), and semantic cache pruning in the
+    skill runbooks (#2307).
 
     The comparison is a multiset diff, not a positional zip: a line whose text is
     unchanged but merely *moved* (the report-write line shifted below ``to_json``


### PR DESCRIPTION
## Summary
- prune semantic cache entries after every skill-driven graph build
- hash the full live document, paper, and image corpus so incremental runs retain unchanged entries
- use the same corpus-root hash anchor as the CLI extraction path and keep cleanup best-effort

## Verification
- `uv run --frozen pytest tests/test_skillgen.py`
- `uv run --frozen pytest tests/test_cache.py -k semantic_prune`
- `uv run --frozen python -m tools.skillgen --check`
- `uv run --frozen python -m tools.skillgen --audit-coverage`
- `uv run --frozen python -m tools.skillgen --schema-singleton`
- `uv run --frozen python -m tools.skillgen --monolith-roundtrip`
- `uv run --frozen python -m tools.skillgen --always-on-roundtrip`
- `uv run --frozen ruff check tools/skillgen/gen.py tests/test_skillgen.py`

Fixes #2307