### PR TITLE
fix(build): preserve calls edges over references on undirected collap…

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -917,6 +917,20 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
     for alias_key, candidates in _alias_candidates.items():
         if len(candidates) == 1:
             norm_to_id.setdefault(alias_key, next(iter(candidates)))
+    # Relation collapse priority (#2391). The undirected graph stores one edge per
+    # node pair, so when two edges land on the same (src, tgt) with different
+    # relations the higher-information relation must win the collapse. Higher =
+    # more information (calls/instantiates outrank uses, which outrank
+    # references/imports). The deterministic (source, target, relation) sort alone
+    # would always let the alphabetically-last "references" overwrite "calls".
+    _RELATION_PRIORITY = {
+        "calls": 3, "indirect_call": 3, "instantiates": 3,
+        "uses": 2, "uses_component": 2, "uses_static_prop": 2,
+        "binds_method": 2, "bound_to": 2, "defines": 2,
+        "imports": 1, "imports_from": 1, "re_exports": 1, "includes": 1,
+        "references": 1, "references_constant": 1,
+        "depends_on": 1, "crate_depends_on": 1,
+    }
     # Iterate edges in a deterministic order. The graph is undirected and stores
     # direction in _src/_tgt; when two edges collapse onto the same node pair the
     # last write wins, so an unstable iteration order flips _src/_tgt run-to-run
@@ -1043,12 +1057,23 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
         # earlier one's _src/_tgt, silently flipping the surviving edge's caller
         # and callee. First-seen direction wins instead — drop the redundant
         # reverse-direction duplicate so the original direction is preserved (#1061).
+        # When the two edges carry DIFFERENT relations, the higher-information
+        # relation wins the collapse (#2391): without the priority table, the
+        # deterministic (source, target, relation) sort writes "references"
+        # (alphabetically last) second and it clobbers a real "calls" edge (e.g.
+        # a return-type annotation landing on the same pair).
         if not G.is_directed() and G.has_edge(src, tgt):
             existing = edge_data(G, src, tgt)
-            if existing.get("relation") == attrs.get("relation") and (
+            existing_rel = existing.get("relation")
+            new_rel = attrs.get("relation")
+            if existing_rel == new_rel and (
                 existing.get("_src") == tgt and existing.get("_tgt") == src
             ):
-                continue
+                continue  # reverse-direction duplicate of the same relation (#1061)
+            if existing_rel != new_rel and _RELATION_PRIORITY.get(
+                new_rel, 0
+            ) < _RELATION_PRIORITY.get(existing_rel, 0):
+                continue  # lower-information relation loses the collapse (#2391)
         G.add_edge(src, tgt, **attrs)
     hyperedges = extraction.get("hyperedges", [])
     if hyperedges:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -720,6 +720,53 @@ def test_build_from_json_preserves_first_direction_on_bidirectional_pair(tmp_pat
 # whenever the loaded JSON has multigraph: true. Plain G.edges[u, v] crashes
 # on those with `ValueError: not enough values to unpack (expected 3, got 2)`.
 
+def _same_pair_calls_references_extraction(calls_first: bool) -> dict:
+    """An extraction with a `calls` and a `references` edge on the SAME (src, tgt)
+    pair — the shape that triggers #2391 (a return-type annotation landing on the
+    same undirected node pair as a real call)."""
+    edges = [
+        {"source": "caller", "target": "callee", "relation": "calls",
+         "confidence": "EXTRACTED", "source_file": "a.ts"},
+        {"source": "caller", "target": "callee", "relation": "references",
+         "confidence": "INFERRED", "source_file": "a.ts"},
+    ]
+    if not calls_first:
+        edges.reverse()
+    return {
+        "nodes": [
+            {"id": "caller", "label": "caller", "file_type": "code", "source_file": "a.ts"},
+            {"id": "callee", "label": "callee", "file_type": "code", "source_file": "a.ts"},
+        ],
+        "edges": edges,
+        "input_tokens": 0,
+        "output_tokens": 0,
+    }
+
+
+def test_build_from_json_calls_survives_references_collapse_either_order():
+    """Regression for #2391.
+
+    The deterministic (source, target, relation) edge sort processes `calls`
+    before `references` (c < r), so on an undirected nx.Graph the second
+    add_edge("references") used to plain-overwrite the real "calls" edge on the
+    same pair — silently dropping the call from call-graph queries. The
+    higher-information relation must win the collapse regardless of the input
+    order the two edges arrive in.
+    """
+    for calls_first in (True, False):
+        G = build_from_json(_same_pair_calls_references_extraction(calls_first))
+        # One undirected edge between the pair survives.
+        assert G.number_of_edges() == 1
+        data = edge_data(G, "caller", "callee")
+        # The call survives; the lower-information reference loses the collapse.
+        assert data["relation"] == "calls", (
+            f"calls edge clobbered by references when calls_first={calls_first}: "
+            f"got relation {data['relation']!r}"
+        )
+        assert data["_src"] == "caller"
+        assert data["_tgt"] == "callee"
+
+
 def test_edge_data_simple_graph():
     G = nx.Graph()
     G.add_edge("a", "b", relation="calls", confidence="EXTRACTED")


### PR DESCRIPTION
Fixes #2391.

The sort by (source, target, relation) before G.add_edge was added for deterministic collapse order, but that also meant alphabetical order picked the survivor whenever two different relations landed on the same (src, tgt) pair — references always beat calls since "calls" < "references". G.add_edge just overwrites, no merge.

Added a small _RELATION_PRIORITY table so the higher-information relation wins the collapse instead of whichever sorts last. Unlisted relations default to priority 0, so anything not in the table keeps the old behavior — no regression there.

Left out the multigraph route and the also_relations merge idea from the issue to keep this focused on the actual data-loss bug; can follow up separately if maintainers want either.

Added a test covering both input orderings (since the bug is order-dependent) confirming calls survives a collapse with references either way.

Ran the full test_build.py suite before/after on a clean checkout — the 14 pre-existing failures (missing rapidfuzz/tree-sitter-javascript deps, one unrelated _semantic_id_remap bug) are identical with and without this change.