### PR TITLE
fix(extract): preserve stub edges that would become self-loops

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1923,9 +1923,16 @@ def _rewire_unique_stub_nodes(nodes: list[dict], edges: list[dict]) -> None:
     # a unique Go `get_db()` (mirrors the #1718/#1749 interop guard).
     stub_ids = {str(s.get("id")) for s in stubs if s.get("id")}
     stub_families: dict[str, set] = {}
+    stub_neighbors: dict[str, set[str]] = {}
     supertype_stub_ids: set[str] = set()  # stubs used as a base type — never a function
     _SUPERTYPE_RELATIONS = {"inherits", "implements", "extends"}
     for edge in edges:
+        source = edge.get("source")
+        target = edge.get("target")
+        if isinstance(source, str) and source in stub_ids and isinstance(target, str):
+            stub_neighbors.setdefault(source, set()).add(target)
+        if isinstance(target, str) and target in stub_ids and isinstance(source, str):
+            stub_neighbors.setdefault(target, set()).add(source)
         rel = edge.get("relation")
         for endpoint in ("source", "target"):
             nid = edge.get(endpoint)
@@ -1962,7 +1969,14 @@ def _rewire_unique_stub_nodes(nodes: list[dict], edges: list[dict]) -> None:
         if len(candidates) != 1:
             continue
         target_id = candidates[0].get("id")
-        if isinstance(target_id, str) and target_id and target_id != stub_id:
+        # Resolving a stub onto the other endpoint of one of its own edges
+        # would turn that relationship into a false self-loop (#2374).
+        if (
+            isinstance(target_id, str)
+            and target_id
+            and target_id != stub_id
+            and target_id not in stub_neighbors.get(stub_id, set())
+        ):
             remap[stub_id] = target_id
 
     if not remap:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2937,3 +2937,33 @@ def test_rewire_does_not_bind_supertype_stub_to_function():
               "source_file": "store.py", "weight": 1.0}]
     _rewire_unique_stub_nodes(nodes, edges)
     assert edges[0]["target"] == "BookStore"  # inherits stub not bound to function
+
+
+def test_rewire_keeps_incident_stub_when_unique_match_would_make_a_self_loop():
+    """#2374: never resolve a stub onto the other end of its own edge."""
+    from graphify.extract import _rewire_unique_stub_nodes
+
+    nodes = [
+        {
+            "id": "decorated_list_tools",
+            "label": "list_tools()",
+            "file_type": "code",
+            "source_file": "decorated.py",
+            "source_location": "L5",
+        },
+        {"id": "list_tools", "label": "list_tools", "file_type": "code", "source_file": ""},
+    ]
+    edges = [
+        {
+            "source": "decorated_list_tools",
+            "target": "list_tools",
+            "relation": "references",
+            "source_file": "decorated.py",
+            "context": "decorator",
+        }
+    ]
+
+    _rewire_unique_stub_nodes(nodes, edges)
+
+    assert edges[0]["target"] == "list_tools"
+    assert "list_tools" in {node["id"] for node in nodes}

--- a/tests/test_kotlin_object_literal.py
+++ b/tests/test_kotlin_object_literal.py
@@ -80,6 +80,30 @@ def test_object_literal_implements_supertype(tmp_path):
         "object : EventListener must implement the in-corpus interface"
 
 
+def test_object_literal_keeps_an_unresolved_supertype_stub(tmp_path):
+    """#2374: rewiring an anonymous object onto its own base makes a false loop."""
+    r = _extract(tmp_path, {
+        "Anonymous.kt": (
+            "package demo\n"
+            "\n"
+            "import library.ExternalBase\n"
+            "\n"
+            "class Factory {\n"
+            "    fun make() = object : ExternalBase() {}\n"
+            "}\n"
+        ),
+    })
+    obj_nid = _find(r, "ExternalBase", "object")
+    stub = next(
+        node["id"]
+        for node in r["nodes"]
+        if node["label"] == "ExternalBase" and not node.get("source_file")
+    )
+
+    assert (obj_nid, stub) in _edges(r, "inherits")
+    assert all(edge["source"] != edge["target"] for edge in r["edges"])
+
+
 def test_object_literal_member_calls_sibling_member(tmp_path):
     r = _extract(tmp_path, _REGISTRY)
     process = _find(r, ".process()", "object")

--- a/tests/test_python_decorators.py
+++ b/tests/test_python_decorators.py
@@ -106,6 +106,29 @@ def test_attribute_decorator_targets_the_symbol_not_the_module(tmp_path):
     assert _make_id("app") not in targets
 
 
+def test_qualified_decorator_does_not_rewire_onto_the_decorated_function(tmp_path):
+    """#2374: @app.list_tools() must not become a self-reference."""
+    f = _write(tmp_path / "pkg" / "decorated.py",
+               "class App:\n"
+               "    pass\n"
+               "\n"
+               "app = App()\n"
+               "\n"
+               "@app.list_tools()\n"
+               "async def list_tools():\n"
+               "    return []\n")
+    r = extract([f], cache_root=tmp_path)
+    owner = _func_nid("pkg/decorated.py", "list_tools")
+    stub = next(
+        node["id"]
+        for node in r["nodes"]
+        if node["label"] == "list_tools" and not node.get("source_file")
+    )
+
+    assert stub in _deco_edges(r, owner)
+    assert all(edge["source"] != edge["target"] for edge in r["edges"])
+
+
 def test_stacked_decorators_all_emit(tmp_path):
     f = _write(tmp_path / "pkg" / "stack.py",
                "from deco import a, b, c\n"


### PR DESCRIPTION
## Summary
- keep a unique stub unresolved when rewiring it onto an existing edge neighbor would produce a false self-loop
- cover the generic rewire guard plus Python qualified decorators and Kotlin anonymous-object supertypes

Fixes #2374

## Validation
- `uv run --frozen pytest tests/test_extract.py tests/test_python_decorators.py tests/test_kotlin_object_literal.py` (180 passed, 1 skipped)
- `uv run --frozen ruff check graphify tests`
- `uv run --frozen graphify update .`

The full suite completed with 3,898 passed / 36 skipped; its 12 unrelated failures are caused by an optional `openai` dependency missing from this environment, `example.com` resolving to a blocked internal test address, and an existing batch-order assertion.