### PR TITLE
fix(windows): read-only directory removal, and a CLI crash without a home dir

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -496,7 +496,16 @@ def _run_cli() -> None:
         # Resolve each platform's real user-scope destination so per-platform
         # overrides (gemini, opencode, devin, antigravity, amp) check the dir
         # they actually install into, not the bare cfg['skill_dst'].
-        for skill_dst in {_platform_skill_destination(name) for name in _PLATFORM_CONFIG}:
+        # Resolving one needs a home directory, and an environment without
+        # HOME/USERPROFILE (`env -i`, a bare CI container, a service account)
+        # makes Path.home() raise RuntimeError. The stamp check is advisory, so
+        # skip it there instead of taking the whole CLI down — this used to kill
+        # even `graphify --version`, which needs no filesystem at all.
+        try:
+            skill_dsts = {_platform_skill_destination(name) for name in _PLATFORM_CONFIG}
+        except (RuntimeError, OSError):
+            skill_dsts = set()
+        for skill_dst in skill_dsts:
             _check_skill_version(skill_dst)
 
     if len(sys.argv) >= 2 and sys.argv[1] in ("-v", "--version", "version"):

--- a/graphify/cache.py
+++ b/graphify/cache.py
@@ -16,6 +16,7 @@ from pathlib import Path
 # absolute path ("/shared/graphify-out"). Single source of truth in graphify.paths
 # (#1423); re-exported here as _GRAPHIFY_OUT for the existing call sites.
 from graphify.paths import GRAPHIFY_OUT as _GRAPHIFY_OUT
+from graphify.paths import clear_readonly, rmtree
 
 # AST cache entries are the output of graphify's own extractor code, so they
 # are only valid for the version that wrote them: keying purely on file
@@ -49,16 +50,22 @@ def _cleanup_stale_ast_entries(ast_base: Path, current_dir: Path) -> None:
     _cleaned_ast_dirs.add(key)
     if not ast_base.is_dir():
         return
-    import shutil
 
     for child in ast_base.iterdir():
         if child == current_dir:
             continue
         try:
             if child.is_dir() and child.name.startswith("v"):
-                shutil.rmtree(child, ignore_errors=True)
+                rmtree(child, ignore_errors=True)
             elif child.suffix == ".json":
-                child.unlink()
+                try:
+                    child.unlink()
+                except OSError:
+                    # Windows refuses unlink on a read-only entry, and an output
+                    # dir under OneDrive carries that attribute. Clear it and
+                    # retry rather than leaving the stale entry forever.
+                    clear_readonly(child)
+                    child.unlink()
         except OSError:
             pass
 

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -29,6 +29,8 @@ except Exception:
     __version__ = "unknown"
 
 from graphify.paths import GRAPHIFY_OUT as _GRAPHIFY_OUT
+from graphify.paths import clear_readonly as _clear_readonly
+from graphify.paths import rmtree as _rmtree
 
 
 @functools.lru_cache(maxsize=None)
@@ -162,15 +164,22 @@ def _install_skill_references(skill_dst: Path, refs_src: Path) -> None:
     refs_dst = skill_dst.parent / "references"
     refs_staged = skill_dst.parent / "references.tmp"
     if refs_staged.exists():
-        shutil.rmtree(refs_staged)
+        _rmtree(refs_staged)
     try:
         shutil.copytree(refs_src, refs_staged)
+        # copytree's copystat hands the source tree's mode to the copy. When the
+        # package lives under OneDrive (or any read-only checkout) that means a
+        # read-only sidecar the user cannot update or uninstall, so strip the bit
+        # from the staged copy before it is published.
+        _clear_readonly(refs_staged)
+        for entry in refs_staged.rglob("*"):
+            _clear_readonly(entry)
         if refs_dst.exists():
-            shutil.rmtree(refs_dst)
+            _rmtree(refs_dst)
         os.replace(refs_staged, refs_dst)
     except Exception:
         if refs_staged.exists():
-            shutil.rmtree(refs_staged, ignore_errors=True)
+            _rmtree(refs_staged, ignore_errors=True)
         raise
 def _copy_skill_file(platform_name: str, *, project: bool = False, project_dir: Path | None = None) -> Path:
     """Copy a packaged skill file and write its version stamp.
@@ -212,7 +221,7 @@ def _copy_skill_file(platform_name: str, *, project: bool = False, project_dir: 
         # Monolith (or progressive-with-no-refs): clear any orphan references/.
         orphan_refs = skill_dst.parent / "references"
         if orphan_refs.exists():
-            shutil.rmtree(orphan_refs)
+            _rmtree(orphan_refs)
 
     # SKILL.md last (crash-safety), via an atomic temp + rename.
     tmp_dst = skill_dst.with_suffix(skill_dst.suffix + ".tmp")
@@ -243,7 +252,7 @@ def _remove_skill_file(platform_name: str, *, project: bool = False, project_dir
         removed = True
     refs_dir = skill_dst.parent / "references"
     if refs_dir.exists():
-        shutil.rmtree(refs_dir)
+        _rmtree(refs_dir)
         removed = True
     for d in (skill_dst.parent, skill_dst.parent.parent, skill_dst.parent.parent.parent):
         try:
@@ -853,7 +862,7 @@ def vscode_install(project_dir: Path | None = None) -> None:
     else:
         orphan_refs = skill_dst.parent / "references"
         if orphan_refs.exists():
-            shutil.rmtree(orphan_refs)
+            _rmtree(orphan_refs)
     (skill_dst.parent / ".graphify_version").write_text(__version__, encoding="utf-8")
     print(f"  skill installed  ->  {skill_dst}")
 
@@ -889,7 +898,7 @@ def vscode_uninstall(project_dir: Path | None = None) -> None:
         version_file.unlink()
     refs_dir = skill_dst.parent / "references"
     if refs_dir.exists():
-        shutil.rmtree(refs_dir)
+        _rmtree(refs_dir)
     for d in (
         skill_dst.parent,
         skill_dst.parent.parent,
@@ -1061,7 +1070,7 @@ def _antigravity_uninstall(project_dir: Path, *, project: bool = False) -> None:
         version_file.unlink()
     refs_dir = skill_dst.parent / "references"
     if refs_dir.exists():
-        shutil.rmtree(refs_dir)
+        _rmtree(refs_dir)
     for d in (
         skill_dst.parent,
         skill_dst.parent.parent,
@@ -1509,7 +1518,7 @@ def _amp_legacy_cleanup() -> None:
     """
     legacy = Path.home() / ".amp" / "skills" / "graphify"
     if legacy.exists():
-        shutil.rmtree(legacy, ignore_errors=True)
+        _rmtree(legacy, ignore_errors=True)
         if not legacy.exists():
             print(f"  legacy removed   ->  {legacy}")
 def _amp_install(project_dir: Path | None = None) -> None:
@@ -1808,10 +1817,9 @@ def uninstall_all(project_dir: Path | None = None, purge: bool = False) -> None:
         pass
 
     if purge:
-        import shutil as _shutil
         out = pd / _GRAPHIFY_OUT
         if out.exists():
-            _shutil.rmtree(out)
+            _rmtree(out)
             print(f"\n  {_GRAPHIFY_OUT}/  ->  deleted (--purge)")
         else:
             print(f"\n  {_GRAPHIFY_OUT}/  ->  not found (nothing to purge)")

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import stat
+import sys
 import tempfile
 from pathlib import Path, PurePosixPath
 
@@ -91,6 +93,51 @@ def write_json_atomic(path: "str | Path", obj, *, indent: "int | None" = None, e
     large graphs). ``ensure_ascii`` mirrors ``json.dump`` so callers that emit raw
     UTF-8 (non-ASCII labels/paths) keep byte-for-byte output. See :func:`_atomic_replace`."""
     _atomic_replace(path, lambda f: json.dump(obj, f, indent=indent, ensure_ascii=ensure_ascii))
+
+
+def clear_readonly(path: "str | Path") -> None:
+    """Drop the read-only bit from ``path`` (no-op when it is already writable).
+
+    Windows maps a missing owner-write bit to FILE_ATTRIBUTE_READONLY, and both
+    ``DeleteFile`` and ``RemoveDirectory`` refuse an entry that carries it.
+    OneDrive marks the directories it syncs read-only, so a package dir or an
+    output dir living under OneDrive hands that attribute to anything copied out
+    of it. Failures are swallowed: this only ever runs to make a later removal
+    succeed.
+    """
+    try:
+        os.chmod(path, os.stat(path).st_mode | stat.S_IWRITE)
+    except OSError:
+        pass
+
+
+def _on_rmtree_error(func, path, _exc) -> None:
+    """``rmtree`` error hook: clear the read-only bit and retry the failed call.
+
+    The signature is compatible with both the 3.12+ ``onexc`` hook and the older
+    ``onerror`` one, which pass the exception and the ``sys.exc_info()`` tuple
+    respectively; neither is used here.
+    """
+    clear_readonly(path)
+    func(path)
+
+
+def rmtree(path: "str | Path", *, ignore_errors: bool = False) -> None:
+    """``shutil.rmtree`` that survives read-only entries on Windows.
+
+    A tree copied out of a OneDrive-synced directory inherits its read-only
+    attribute (``copytree`` propagates it through ``copystat``), so removing it
+    later raised ``PermissionError: [WinError 5]`` on the final ``rmdir`` even
+    though every file inside had already been deleted.
+    """
+    try:
+        if sys.version_info >= (3, 12):
+            shutil.rmtree(path, onexc=_on_rmtree_error)
+        else:
+            shutil.rmtree(path, onerror=_on_rmtree_error)
+    except OSError:
+        if not ignore_errors:
+            raise
 
 # Directory segments that, when they appear as a whole path component, mark the
 # whole path as a test location. Matched against path *segments* (not raw

--- a/tests/test_install_references.py
+++ b/tests/test_install_references.py
@@ -23,9 +23,35 @@ import pytest
 
 import graphify
 import graphify.__main__ as mainmod
+from graphify.paths import rmtree as robust_rmtree
 
 
 PKG_DIR = Path(graphify.__file__).parent
+
+
+def _restore_bundle(bundle_dir, backup_dir, skills_root, created_root):
+    """Put the real committed bundle back after a test staged a fake in its slot.
+
+    Uses graphify.paths.rmtree, which clears the read-only bit before deleting: a
+    OneDrive-synced checkout marks these directories read-only, and the plain
+    ``shutil.rmtree(..., ignore_errors=True)`` this used to call failed silently
+    there. That mattered because ``shutil.move`` onto an EXISTING directory nests
+    the source inside it rather than replacing it, so a silent clear-failure
+    deleted the committed bundle from the working tree instead of restoring it.
+    The assert makes that case loud and, crucially, leaves the real bundle safe in
+    its temp dir rather than moving it somewhere destructive.
+    """
+    if bundle_dir.exists():
+        robust_rmtree(bundle_dir, ignore_errors=True)
+    if backup_dir is not None:
+        assert not bundle_dir.exists(), (
+            f"could not clear the staged bundle at {bundle_dir}; refusing to move "
+            f"the real one back from {backup_dir} (it would nest, not replace)"
+        )
+        shutil.move(str(backup_dir), str(bundle_dir))
+        robust_rmtree(backup_dir.parent, ignore_errors=True)
+    elif created_root:
+        robust_rmtree(skills_root, ignore_errors=True)
 
 
 @pytest.fixture()
@@ -55,13 +81,7 @@ def fake_bundle():
     try:
         yield platform
     finally:
-        if bundle_dir.exists():
-            shutil.rmtree(bundle_dir, ignore_errors=True)
-        if backup_dir is not None:
-            shutil.move(str(backup_dir), str(bundle_dir))
-            shutil.rmtree(backup_dir.parent, ignore_errors=True)
-        elif created_root:
-            shutil.rmtree(skills_root, ignore_errors=True)
+        _restore_bundle(bundle_dir, backup_dir, skills_root, created_root)
 
 
 def _install(tmp_path, platform):
@@ -205,13 +225,7 @@ def test_hard_fail_when_bundle_dir_present_but_references_missing(tmp_path, monk
                 mainmod._copy_skill_file("claude")
         assert exc.value.code == 1
     finally:
-        if bundle_dir.exists():
-            shutil.rmtree(bundle_dir, ignore_errors=True)
-        if backup_dir is not None:
-            shutil.move(str(backup_dir), str(bundle_dir))
-            shutil.rmtree(backup_dir.parent, ignore_errors=True)
-        elif created_root:
-            shutil.rmtree(skills_root, ignore_errors=True)
+        _restore_bundle(bundle_dir, backup_dir, skills_root, created_root)
 
 
 def _first_unbuilt_progressive_host():

--- a/tests/test_skill_version_warning.py
+++ b/tests/test_skill_version_warning.py
@@ -9,6 +9,7 @@ upgrading the package instead.
 """
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -58,3 +59,21 @@ def test_matching_version_is_silent(tmp_path, monkeypatch, capsys):
     skill_dst = _make_skill(tmp_path, "0.9.3")
     mainmod._check_skill_version(skill_dst)
     assert capsys.readouterr().err == ""
+
+
+def test_cli_survives_unresolvable_home(monkeypatch, capsys):
+    """The stamp check is advisory and must never take the CLI down.
+
+    Resolving each platform's skill destination needs a home directory. In an
+    environment without HOME/USERPROFILE (`env -i`, a bare CI container, a
+    service account) Path.home() raises RuntimeError, which used to propagate
+    out of the check and kill even `graphify --version` — a command that touches
+    no filesystem at all.
+    """
+    def _no_home():
+        raise RuntimeError("Could not determine home directory.")
+
+    monkeypatch.setattr("graphify.__main__.Path.home", _no_home)
+    monkeypatch.setattr(sys, "argv", ["graphify", "--version"])
+    mainmod._run_cli()
+    assert f"graphify {mainmod.__version__}" in capsys.readouterr().out

--- a/uv.lock
+++ b/uv.lock
@@ -1090,7 +1090,7 @@ wheels = [
 
 [[package]]
 name = "graphifyy"
-version = "0.9.31"
+version = "0.9.32"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Two independent Windows bugs, found while running the suite on Windows 11 with the
checkout under a OneDrive-synced folder. Both are invisible to CI, which only runs
`ubuntu-latest`.

Windows test failures go from **114 to 43**. Nothing else changes: `3914 passed`
before and after on the same host, no test newly fails.

A third, unrelated commit rides along: `uv.lock` still pinned `graphifyy 0.9.31`
while `pyproject.toml` declares `0.9.32`, so every `uv sync` / `uv run` rewrote
the lockfile as a side effect and left the tree dirty. Regenerated with
`uv lock` — a single line, no other package re-resolved. Happy to drop it if you
would rather handle the lockfile separately.

---

## 1. Read-only directories break every tree removal

`shutil.rmtree` deletes the files inside a directory fine, then fails on the final
`rmdir`:

```
PermissionError: [WinError 5] Access is denied:
  '...\.claude\skills\graphify\references'
```

Windows derives `FILE_ATTRIBUTE_READONLY` from a missing owner-write bit, and
`RemoveDirectoryW` refuses any directory carrying it. OneDrive marks the
directories it syncs read-only, and `copytree`'s `copystat` hands that attribute
to every copy — so a `references/` sidecar installed out of a OneDrive-synced
package can never be removed again. `graphify install` (reinstall path),
`graphify uninstall`, and ~90 install tests all died on this.

### The fix

`clear_readonly()` and `rmtree()` in `graphify/paths.py` — already the shared home
for filesystem helpers (`_atomic_replace`, `write_text_atomic`), and it already
documents a sibling Windows `PermissionError` workaround. The hook signature is
compatible with both the 3.12+ `onexc` parameter and the older `onerror` one, so
it works across the declared `requires-python = ">=3.10"` range.

Every removal in the package now routes through it:

**`graphify/install.py`** — all 7 `rmtree` call sites. `_install_skill_references`
additionally strips the attribute from the staged copy after `copytree`, so a
fresh install is writable in the first place rather than merely removable
afterwards.

**`graphify/cache.py`** — `_cleanup_stale_ast_entries` was silently skipping
read-only entries in two places: `rmtree(child, ignore_errors=True)` for stale
`v*/` dirs, and `child.unlink()` inside a bare `except OSError: pass` for the
pre-versioning flat `*.json` entries. Neither surfaced anything, so AST cache
entries written by older versions accumulated forever.

**`tests/test_install_references.py`** — this one is worth calling out separately,
because the test suite was **deleting committed files from the working tree on
every run**. The `fake_bundle` fixture moves the real `graphify/skills/claude/`
bundle aside, stages a fake in its slot, then restores on teardown:

```python
if bundle_dir.exists():
    shutil.rmtree(bundle_dir, ignore_errors=True)
if backup_dir is not None:
    shutil.move(str(backup_dir), str(bundle_dir))
```

On a read-only directory the `rmtree` fails silently (`ignore_errors=True`), so
`bundle_dir` still exists — and `shutil.move` onto an **existing** directory nests
the source inside it rather than replacing it. Net result on my checkout, twice:

```
D graphify/skills/claude/references/add-watch.md
D graphify/skills/claude/references/exports.md
... (all 8 files)
```

The teardown is now a shared `_restore_bundle()` helper used by both copies of
this pattern. It uses the robust `rmtree` and asserts the slot is actually empty
before moving, so if the clear ever fails again the real bundle stays safe in its
temp dir and the test fails loudly instead of destroying the checkout.

---

## 2. `graphify --version` crashes without a home directory

```
RuntimeError: Could not determine home directory.
  File "graphify/install.py", line 121, in _platform_skill_destination
    return Path.home() / cfg["skill_dst"]
```

`_run_cli` resolves every platform's skill destination up front to check for a
stale version stamp. Resolving one needs a home directory, and in an environment
without `HOME`/`USERPROFILE` — `env -i`, a bare CI container, a service account —
`Path.home()` raises. That propagated out of a purely advisory check and took down
the whole CLI, including `graphify --version`, which touches no filesystem at all.

The stamp check now degrades to a no-op when the destinations cannot be resolved.
`_check_skill_version` itself was already written this defensively (every
filesystem call guarded); only the destination resolution upstream of it was not.

Covered by a regression test in `tests/test_skill_version_warning.py`, verified to
fail without the fix.

---

## Testing

```
uv sync --all-extras
uv run pytest tests/ -q
```

| | before | after |
|---|---|---|
| failed | 114 | 43 |
| passed | 3841 | 3914 |

Host: Windows 11, Python 3.13.14, uv 0.11.19, checkout under OneDrive.

The remaining 43 failures are pre-existing and unrelated to this change — all
platform assumptions in the tests rather than product bugs. For the record, since
they are equally invisible to your CI:

| cause | count | example |
|---|---|---|
| symlink creation needs Developer Mode / admin | 15 | `OSError: [WinError 1314]` |
| `\` vs `/` path separator in assertions | 9 | `assert 'sub\\b.py' == 'sub/b.py'` |
| platform-specific install destinations | 6 | hermes uses `%LOCALAPPDATA%`, gemini uses `~/.agents` on Windows — deliberate in `install.py`, but the tests assert the POSIX paths |
| `MAX_PATH` 260 limit | 3 | long Obsidian filenames |
| no POSIX file modes | 1 | `assert (33206 & 511) == 420` |
| console encoding | 1 | `'mod_е¤„зђ†ж•°жЌ®' != 'mod_处理数据'` |
| other path/cache details | 8 | |

Happy to split this into separate PRs if you would rather review them
individually — they are already three independent commits:

```
chore: sync uv.lock with the pyproject version
fix(windows): survive read-only directories when removing trees
fix(cli): do not crash when the home directory cannot be resolved
```