### PR TITLE
fix(hooks): skip post-checkout rebuild when PREV_HEAD equals NEW_HEAD (#2421)

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -355,6 +355,10 @@ if [ "$BRANCH_SWITCH" != "1" ]; then
     exit 0
 fi
 
+# A no-op checkout (e.g. `git checkout -b` with no start point) reports a
+# branch switch but leaves the tree unchanged ΓÇö nothing to rebuild (#2421).
+[ "$PREV_HEAD" = "$NEW_HEAD" ] && exit 0
+
 # Only run if graphify-out/ exists (graph has been built before)
 if [ ! -d "graphify-out" ]; then
     exit 0

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -530,6 +530,15 @@ def test_hooks_honor_skip_env(name, script):
     )
 
 
+def test_checkout_hook_skips_same_head_noop():
+    """`git checkout -b` with no start point passes identical PREV/NEW heads.
+    Rebuild must short-circuit ΓÇö PREV_HEAD/NEW_HEAD were previously assigned
+    and never read (#2421 / leftover from #1809)."""
+    assert "PREV_HEAD=$1" in _CHECKOUT_SCRIPT
+    assert "NEW_HEAD=$2" in _CHECKOUT_SCRIPT
+    assert '[ "$PREV_HEAD" = "$NEW_HEAD" ] && exit 0' in _CHECKOUT_SCRIPT
+
+
 @pytest.mark.parametrize("name,script", _HOOK_SCRIPTS)
 def test_hooks_skip_linked_worktrees(name, script):
     """Both hooks must short-circuit in a linked worktree (git-dir != common-dir),


### PR DESCRIPTION
Fixes #2421

## Problem

`_CHECKOUT_SCRIPT` in `graphify/hooks.py` assigns `PREV_HEAD=` and `NEW_HEAD=` but never reads either variable.

`git checkout -b <new>` with no start point reports a branch switch (`BRANCH_SWITCH=1`) while leaving the tree byte-identical — git passes the **same** SHA as `` and ``. That still launched `_REBUILD_BODY_CHECKOUT`, a full background rebuild (no `changed_paths`), mutating `graphify-out/` seconds later.

The `GRAPHIFY_SKIP_HOOK` half of #1809 already landed; the same-head short-circuit did not. The unused assignments were the tell.

## Fix

After the existing branch-switch guard, short-circuit when the heads match:

```sh
# A no-op checkout (e.g. `git checkout -b` with no start point) reports a
# branch switch but leaves the tree unchanged — nothing to rebuild (#2421).
[ "$PREV_HEAD" = "$NEW_HEAD" ] && exit 0
```

Real branch switches (`PREV_HEAD != NEW_HEAD`) are unchanged. Rebase/merge/cherry-pick, missing `graphify-out/`, worktree, and `GRAPHIFY_SKIP_HOOK` guards are untouched.

## Testing

- Added `test_checkout_hook_skips_same_head_noop` asserting the short-circuit is present in `_CHECKOUT_SCRIPT`
- `uv run pytest tests/test_hooks.py::test_checkout_hook_skips_same_head_noop tests/test_hooks.py::test_hooks_honor_skip_env -q` → passed
- `python -m tools.skillgen --check` → OK (no skill artifacts touched)

## Notes

CI runs on Ubuntu. Local Windows full-suite noise (path separators / `geteuid` / env backends) is unrelated to this one-line hook-template change.