### PR TITLE
fix(cli): point explain truncation at affected for full blast-radius (#2420)

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -1404,7 +1404,14 @@ def dispatch_command(cmd: str) -> None:
                 print(f"  {arrow} {G.nodes[nb].get('label', nb)} [{rel}] [{conf}]{at}")
             if len(connections) > 20:
                 remainder = connections[20:]
-                print(f"  ... and {len(remainder)} more")
+                # #2420: agents often treat the visible 20 as the full answer.
+                # Point them at `affected`, which returns the uncapped reverse
+                # blast-radius (imports_from / calls / …).
+                print(
+                    f"  ... and {len(remainder)} more — "
+                    f"run 'graphify affected \"{label}\" --depth 1' "
+                    f"for the full reverse blast-radius"
+                )
                 # #2009: a bare count silently hides the answer on high-degree
                 # nodes ("who calls this, what's the impact?"). Group the cut
                 # connections by direction + file so their shape is visible

--- a/tests/test_explain_cli.py
+++ b/tests/test_explain_cli.py
@@ -185,6 +185,15 @@ def test_explain_truncation_notice_present_for_high_degree_node(monkeypatch, tmp
     assert "... and 10 more" in out
 
 
+def test_explain_truncation_points_to_affected(monkeypatch, tmp_path, capsys):
+    """#2420: truncation must name `affected` so agents don't treat the
+    visible 20 as the complete dependant set."""
+    p = _write_high_degree_graph(tmp_path, n_callers=30)
+    out = _run(monkeypatch, p, "hub", capsys)
+    assert 'graphify affected "hub" --depth 1' in out
+    assert "full reverse blast-radius" in out
+
+
 def test_explain_groups_cut_callers_by_file_instead_of_dropping_them(monkeypatch, tmp_path, capsys):
     """#2009: past the top-20 cutoff, the remaining callers must still be
     accounted for — grouped by file with counts — instead of vanishing


### PR DESCRIPTION
Fixes #2420

## Problem

`graphify explain` prints at most 20 connections. On high-degree nodes the header correctly reports `Connections (N)` and `... and M more`, but nothing in that truncation line points at `affected`, which returns the **uncapped** reverse blast-radius.

Agents often read the visible 20 as the complete answer and under-report dependants. Issue suggestion **(1)** is the cheapest fix with no behavior change to the cap.

## Fix

Extend the truncation line only:

```text
... and 139 more — run 'graphify affected "payroll.service.js" --depth 1' for the full reverse blast-radius
```

- Cap remains 20; sort key unchanged
- No skillgen / hook-guard edits in this PR
- Suggestions (2)/(3)/(4) (`--limit`, per-direction caps, skill text) left for follow-ups

## Evidence

Synthetic 25-edge hub:

```text
Node: payroll.service.js
Connections (25):
  ...
  ... and 5 more — run 'graphify affected "payroll.service.js" --depth 1' for the full reverse blast-radius
  Grouped by file:
```

## Testing

- Added `test_explain_truncation_points_to_affected`
- Existing #2009 high-degree / grouping tests still pass
- `python -m tools.skillgen --check` → OK

## Notes

Intentionally small (suggestion 1 only) so it can be cherry-picked cleanly.