### PR TITLE
fix(hooks): refresh managed sections safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 ## 0.9.50 (2026-08-25)
 
+- Fix: `graphify hook install` now rejects malformed or duplicated managed-section markers without writing, and scopes Graphify's generated shell body so an early exit cannot suppress unrelated hook content that follows it.
 - Fix: Ruby methods whose names end in `!`, `?`, or `=` now keep distinct node ids, so `save` and `save!` (or `foo` and `foo=`) no longer collide into one node; the label keeps the raw spelling and member-call resolution still matches (#3077, thanks @hopstreax).
 - Fix: a Ruby call on a qualified constant receiver (`ActiveRecord::Base.transaction`) now matches the receiver's full constant path, so it no longer binds to an unrelated lone class named `Base`; an edge is emitted only on a single unambiguous match (#3078, thanks @rohit-jsfreaky).
 - Fix: a CommonJS member export wrapped in a higher-order function (`exports.x = wrap(fn)`, `module.exports.y = onCall({...}, handler)`) is now captured, reaching through the wrapper to the function it wraps without fabricating the wrapper as the export's identity (#3035, thanks @hopstreax).

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -306,6 +306,7 @@ fi
 
 _HOOK_SCRIPT = """\
 # graphify-hook-start
+(
 # Auto-rebuilds the knowledge graph after each commit (code files only, no LLM needed).
 # Installed by: graphify hook install
 
@@ -355,12 +356,14 @@ _GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
 mkdir -p "$(dirname "$_GRAPHIFY_LOG")"
 export GRAPHIFY_REBUILD_LOG="$_GRAPHIFY_LOG"
 echo "[graphify hook] launching background rebuild (log: $_GRAPHIFY_LOG)"
-""" + _detached_launch(_REBUILD_BODY_COMMIT) + """# graphify-hook-end
+""" + _detached_launch(_REBUILD_BODY_COMMIT) + """)
+# graphify-hook-end
 """
 
 
 _CHECKOUT_SCRIPT = """\
 # graphify-checkout-hook-start
+(
 # Auto-rebuilds the knowledge graph (code only) when switching branches.
 # Installed by: graphify hook install
 
@@ -412,7 +415,8 @@ _GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
 mkdir -p "$(dirname "$_GRAPHIFY_LOG")"
 export GRAPHIFY_REBUILD_LOG="$_GRAPHIFY_LOG"
 echo "[graphify] Branch switched - launching background rebuild (log: $_GRAPHIFY_LOG)"
-""" + _detached_launch(_REBUILD_BODY_CHECKOUT) + """# graphify-checkout-hook-end
+""" + _detached_launch(_REBUILD_BODY_CHECKOUT) + """)
+# graphify-checkout-hook-end
 """
 
 
@@ -535,25 +539,30 @@ def _install_hook(
     name: str,
     script: str,
     marker: str,
-    marker_end: str = "",
+    marker_end: str,
 ) -> str:
-    """Install a single git hook, appending if an existing hook is present, or updating
-    an existing graphify block in-place."""
+    """Install or update one managed Graphify section in a git hook."""
     hook_path = hooks_dir / name
     if hook_path.exists():
-        content = hook_path.read_text(encoding="utf-8")
-        if marker in content:
-            if marker_end and marker_end in content:
-                start_idx = content.find(marker)
-                end_idx = content.find(marker_end)
-                if start_idx != -1 and end_idx != -1 and end_idx >= start_idx:
-                    end_idx += len(marker_end)
-                    new_content = content[:start_idx] + script.rstrip() + content[end_idx:]
-                    if new_content == content:
-                        return f"already installed at {hook_path}"
-                    hook_path.write_text(new_content, encoding="utf-8", newline="\n")
-                    return f"updated existing {name} hook at {hook_path}"
-            return f"already installed at {hook_path}"
+        with hook_path.open("r", encoding="utf-8", newline="") as stream:
+            content = stream.read()
+        if marker in content or marker_end in content:
+            valid_markers = (
+                content.count(marker) == 1
+                and content.count(marker_end) == 1
+                and content.index(marker) < content.index(marker_end)
+            )
+            if not valid_markers:
+                raise RuntimeError(f"malformed Graphify section in {hook_path}")
+            start = content.index(marker)
+            end = content.index(marker_end, start) + len(marker_end)
+            updated = content[:start] + script.rstrip("\r\n") + content[end:]
+            if updated == content:
+                return f"already installed at {hook_path}"
+            with hook_path.open("w", encoding="utf-8", newline="") as stream:
+                stream.write(updated)
+            hook_path.chmod(0o755)
+            return f"updated existing {name} hook at {hook_path}"
         hook_path.write_text(content.rstrip() + "\n\n" + script, encoding="utf-8", newline="\n")
         return f"appended to existing {name} hook at {hook_path}"
     hook_path.write_text("#!/bin/sh\n" + script, encoding="utf-8", newline="\n")
@@ -767,8 +776,20 @@ def install(path: Path = Path(".")) -> str:
     hook = _HOOK_SCRIPT.replace("__PINNED_PYTHON__", pinned).replace("__VIZ_LIMIT_EXPORT__", viz_export)
     checkout = _CHECKOUT_SCRIPT.replace("__PINNED_PYTHON__", pinned).replace("__VIZ_LIMIT_EXPORT__", viz_export)
 
-    commit_msg = _install_hook(hooks_dir, "post-commit", hook, _HOOK_MARKER, _HOOK_MARKER_END)
-    checkout_msg = _install_hook(hooks_dir, "post-checkout", checkout, _CHECKOUT_MARKER, _CHECKOUT_MARKER_END)
+    commit_msg = _install_hook(
+        hooks_dir,
+        "post-commit",
+        hook,
+        _HOOK_MARKER,
+        _HOOK_MARKER_END,
+    )
+    checkout_msg = _install_hook(
+        hooks_dir,
+        "post-checkout",
+        checkout,
+        _CHECKOUT_MARKER,
+        _CHECKOUT_MARKER_END,
+    )
     merge_msg = _register_merge_driver(root)
 
     return f"post-commit: {commit_msg}\npost-checkout: {checkout_msg}\nmerge driver: {merge_msg}"

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -534,6 +534,29 @@ def _hooks_dir(root: Path) -> Path:
     return d
 
 
+def _validated_hook_content(
+    hooks_dir: Path,
+    name: str,
+    marker: str,
+    marker_end: str,
+) -> str | None:
+    """Read a hook and reject malformed managed-section markers."""
+    hook_path = hooks_dir / name
+    if not hook_path.exists():
+        return None
+    with hook_path.open("r", encoding="utf-8", newline="") as stream:
+        content = stream.read()
+    if marker in content or marker_end in content:
+        valid_markers = (
+            content.count(marker) == 1
+            and content.count(marker_end) == 1
+            and content.index(marker) < content.index(marker_end)
+        )
+        if not valid_markers:
+            raise RuntimeError(f"malformed Graphify section in {hook_path}")
+    return content
+
+
 def _install_hook(
     hooks_dir: Path,
     name: str,
@@ -543,17 +566,9 @@ def _install_hook(
 ) -> str:
     """Install or update one managed Graphify section in a git hook."""
     hook_path = hooks_dir / name
-    if hook_path.exists():
-        with hook_path.open("r", encoding="utf-8", newline="") as stream:
-            content = stream.read()
-        if marker in content or marker_end in content:
-            valid_markers = (
-                content.count(marker) == 1
-                and content.count(marker_end) == 1
-                and content.index(marker) < content.index(marker_end)
-            )
-            if not valid_markers:
-                raise RuntimeError(f"malformed Graphify section in {hook_path}")
+    content = _validated_hook_content(hooks_dir, name, marker, marker_end)
+    if content is not None:
+        if marker in content:
             start = content.index(marker)
             end = content.index(marker_end, start) + len(marker_end)
             updated = content[:start] + script.rstrip("\r\n") + content[end:]
@@ -775,6 +790,15 @@ def install(path: Path = Path(".")) -> str:
     pinned = _pinned_python()
     hook = _HOOK_SCRIPT.replace("__PINNED_PYTHON__", pinned).replace("__VIZ_LIMIT_EXPORT__", viz_export)
     checkout = _CHECKOUT_SCRIPT.replace("__PINNED_PYTHON__", pinned).replace("__VIZ_LIMIT_EXPORT__", viz_export)
+
+    # Validate both managed sections before writing either hook.
+    _validated_hook_content(hooks_dir, "post-commit", _HOOK_MARKER, _HOOK_MARKER_END)
+    _validated_hook_content(
+        hooks_dir,
+        "post-checkout",
+        _CHECKOUT_MARKER,
+        _CHECKOUT_MARKER_END,
+    )
 
     commit_msg = _install_hook(
         hooks_dir,

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -5,12 +5,33 @@ import subprocess
 from types import SimpleNamespace
 from pathlib import Path
 import pytest
-from graphify.hooks import install, uninstall, status, _hooks_dir, _HOOK_MARKER, _CHECKOUT_MARKER
+from graphify.hooks import (
+    _CHECKOUT_MARKER,
+    _CHECKOUT_MARKER_END,
+    _HOOK_MARKER,
+    _HOOK_MARKER_END,
+    _hooks_dir,
+    install,
+    status,
+    uninstall,
+)
 
 
 def _make_git_repo(tmp_path: Path) -> Path:
     subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
     return tmp_path
+
+
+def _find_hook_shell() -> str | None:
+    shell = shutil.which("sh")
+    if shell:
+        return shell
+    git = shutil.which("git")
+    if git:
+        candidate = Path(git).resolve().parent.parent / "bin" / "sh.exe"
+        if candidate.is_file():
+            return str(candidate)
+    return None
 
 
 def test_install_creates_hook(tmp_path):
@@ -40,6 +61,64 @@ def test_install_idempotent(tmp_path):
     # marker appears only once
     hook = repo / ".git" / "hooks" / "post-commit"
     assert hook.read_text().count(_HOOK_MARKER) == 1
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        f"#!/bin/sh\n{_HOOK_MARKER}\necho incomplete\n",
+        f"#!/bin/sh\n{_HOOK_MARKER_END}\necho orphan\n",
+        (
+            f"#!/bin/sh\n{_HOOK_MARKER}\none\n{_HOOK_MARKER}\ntwo\n"
+            f"{_HOOK_MARKER_END}\n"
+        ),
+        (
+            f"#!/bin/sh\n{_HOOK_MARKER}\none\n{_HOOK_MARKER_END}\ntwo\n"
+            f"{_HOOK_MARKER_END}\n"
+        ),
+        f"#!/bin/sh\n{_HOOK_MARKER_END}\n{_HOOK_MARKER}\n",
+    ],
+)
+def test_install_rejects_malformed_managed_section_without_writing(tmp_path, content):
+    repo = _make_git_repo(tmp_path)
+    hook = repo / ".git" / "hooks" / "post-commit"
+    hook.write_text(content, encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="malformed Graphify section"):
+        install(repo)
+
+    assert hook.read_text(encoding="utf-8") == content
+
+
+@pytest.mark.parametrize(
+    ("hook_name", "hook_args"),
+    [("post-commit", ()), ("post-checkout", ("old", "new", "1"))],
+)
+def test_graphify_exit_does_not_suppress_following_hook_content(
+    tmp_path, hook_name, hook_args
+):
+    shell = _find_hook_shell()
+    if shell is None:
+        pytest.skip("POSIX shell is required to execute the installed hook")
+    repo = _make_git_repo(tmp_path)
+    install(repo)
+    hook = repo / ".git" / "hooks" / hook_name
+    with hook.open("a", encoding="utf-8") as stream:
+        stream.write("\necho preserved > following-hook-ran.txt\n")
+    environment = os.environ.copy()
+    environment["GRAPHIFY_SKIP_HOOK"] = "1"
+
+    result = subprocess.run(
+        [shell, str(hook), *hook_args],
+        cwd=repo,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert (repo / "following-hook-ran.txt").is_file()
 
 
 def test_install_appends_to_existing_hook(tmp_path):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -848,7 +848,7 @@ def test_checkout_hook_skips_same_head_noop_at_runtime():
     assert guard in _CHECKOUT_SCRIPT, "guard missing from the checkout script"
     # Real script through the same-head guard, then a sentinel — stops before the
     # graphify-out check / detached launch so nothing is actually rebuilt.
-    prefix = _CHECKOUT_SCRIPT.split(guard)[0] + guard + "\necho RAN\n"
+    prefix = _CHECKOUT_SCRIPT.split(guard)[0] + guard + "\necho RAN\n)\n"
 
     def run(prev, new, flag):
         # sh -c CMD name arg1 arg2 arg3  ->  $0=name $1=prev $2=new $3=flag

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -90,6 +90,29 @@ def test_install_rejects_malformed_managed_section_without_writing(tmp_path, con
     assert hook.read_text(encoding="utf-8") == content
 
 
+def test_install_validates_both_hooks_before_writing(tmp_path):
+    repo = _make_git_repo(tmp_path)
+    hooks = repo / ".git" / "hooks"
+    post_commit = hooks / "post-commit"
+    post_checkout = hooks / "post-checkout"
+    post_commit.write_text(
+        f"#!/bin/sh\n{_HOOK_MARKER}\necho stale\n{_HOOK_MARKER_END}\n",
+        encoding="utf-8",
+    )
+    post_checkout.write_text(
+        f"#!/bin/sh\n{_CHECKOUT_MARKER}\necho incomplete\n",
+        encoding="utf-8",
+    )
+    original_commit = post_commit.read_text(encoding="utf-8")
+    original_checkout = post_checkout.read_text(encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="malformed Graphify section"):
+        install(repo)
+
+    assert post_commit.read_text(encoding="utf-8") == original_commit
+    assert post_checkout.read_text(encoding="utf-8") == original_checkout
+
+
 @pytest.mark.parametrize(
     ("hook_name", "hook_args"),
     [("post-commit", ()), ("post-checkout", ("old", "new", "1"))],


### PR DESCRIPTION
## Summary

- refresh existing Graphify-managed hook sections instead of appending duplicate blocks
- preserve third-party hook content before and after managed sections
- run managed hook bodies in a subshell so an internal `exit 0` cannot suppress later hook content
- reject malformed Graphify marker layouts without modifying the hook file

## Testing

- focused hook regression tests: 7 passed
- Ruff and Python compilation checks passed