### PR TITLE
fix: fail closed before project install mutations

### DIFF
--- a/docs/plans/2026-08-03-001-fix-fail-closed-project-install-plan.md
+++ b/docs/plans/2026-08-03-001-fix-fail-closed-project-install-plan.md
@@ -1,0 +1,406 @@
+---
+title: "fix: Make project installs fail closed before mutation"
+type: fix
+created_at: 2026-08-03
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+deepened: 2026-08-03
+---
+
+## Goal Capsule
+
+- **Objective:** Prevent project-scoped Graphify installs from leaving skill files, instruction files, plugins, or version stamps behind when an existing platform configuration cannot be validated.
+- **Authority:** The confirmed behavior in GitHub issue #2416 is authoritative for the Codex case. Existing configuration-preservation and backup behavior remains authoritative unless this plan states otherwise.
+- **Execution profile:** Deep, cross-platform installer hardening with test-first failure-path coverage.
+- **Stop conditions:** Do not broaden the change into a general transaction framework, a redesign of uninstall semantics, or unrelated installer cleanup.
+- **Completion signal:** Every supported project installer that parses existing configuration validates it before its first Graphify-owned mutation, and the failure-path tests prove the original project state is unchanged for validation failures.
+
+---
+
+## Product Contract
+
+### Summary
+
+Issue #2416 reports that a project-scoped Codex install exits with failure after writing the Graphify skill and `AGENTS.md` when an existing `.codex/hooks.json` is invalid. The install command must fail closed: it must preserve user-owned configuration and avoid creating or changing Graphify-owned project artifacts when preflight validation fails.
+
+The maximum-benefit scope applies the same safety contract to project installers that have the same write-before-configuration-validation pattern, while preserving each platform's existing configuration format and merge behavior.
+
+### Problem Frame
+
+The installer performs several independent writes across skill trees, instruction files, plugins, and platform configuration. Existing per-file atomicity protects individual skill/reference writes, but it does not protect the complete project install. Configuration validation currently occurs after earlier writes for Codex and analogous platforms. A failed command therefore leaves a state that looks partially installed even though the command reports failure.
+
+The repository already has strict JSON validation for Claude, CodeBuddy, Codex, and Gemini hook helpers, plus BOM tolerance and rolling backups. The missing contract is validation at the orchestration boundary before any sibling artifact is changed.
+
+### Requirements
+
+- R1. A project install must preflight every existing platform configuration file that it will parse or modify before creating or changing any Graphify-owned project artifact.
+- R2. A missing configuration file remains a valid first-install state and must continue through normal installation.
+- R3. Invalid JSON, invalid JSONC, a non-object top level, or an invalid managed collection must produce a non-zero failure without overwriting the original configuration.
+- R4. When preflight validation fails, the project state must not gain or change Graphify skill files, references, version stamps, instruction sections, plugins, generated configuration, or backups from that install attempt.
+- R5. A valid existing configuration must preserve unrelated user settings and existing user hooks or plugins while retaining current Graphify merge, backup, BOM, JSONC, and idempotency semantics.
+- R6. Failure output must identify the configuration that blocked installation and tell the user to repair or move it before retrying.
+- R7. The same safety contract must cover the supported project-install paths for Codex, Claude, Gemini, OpenCode, and Kilo. The CodeBuddy helper must not regress when called with an explicit project directory, but adding a new CodeBuddy project CLI surface is outside this plan.
+- R8. Existing global-install behavior and project/global scope isolation must remain unchanged except where the shared validation contract prevents unsafe mutation of an invalid existing configuration.
+
+### Acceptance Examples
+
+- AE1. **Codex invalid configuration:** Given an existing invalid `.codex/hooks.json`, when a project Codex install runs, then it exits non-zero, leaves that file byte-identical, creates no Graphify skill tree or backup, and leaves `AGENTS.md` byte-identical or absent as it was before the command.
+- AE2. **Codex first install:** Given no `.codex/hooks.json`, when a project Codex install runs, then it creates the skill tree, Graphify `AGENTS.md` section, and valid hook configuration.
+- AE3. **Codex malformed structure:** Given valid JSON whose top level is not an object, whose `hooks` value is not an object, or whose `PreToolUse` value is not a list, when installation runs, then it fails before any project mutation and preserves the original bytes.
+- AE4. **Valid merge:** Given a valid platform configuration containing unrelated settings and user-owned managed-section entries, when installation runs, then those values survive and exactly one current Graphify entry is installed.
+- AE5. **OpenCode and Kilo invalid configuration:** Given malformed existing OpenCode JSON or Kilo JSON/JSONC, when the corresponding project install runs, then it refuses the install instead of replacing the configuration with an empty object or writing a plugin first.
+- AE6. **JSONC preservation:** Given a valid Kilo JSONC configuration, when installation runs, then the source JSONC remains unchanged and the existing sibling-output behavior remains valid while the plugin registration is added safely.
+- AE7. **Reinstall:** Given a successful install followed by a second install, then the Graphify section/plugin/hook is not duplicated and an unchanged configuration does not create backup churn.
+- AE8. **Scope isolation:** Given a global Graphify skill and a project install attempt, when project preflight fails, then the global skill and all unrelated project files remain unchanged.
+
+### Success Criteria
+
+- A disposable repository reproduces the issue before the change and remains byte-identical after the invalid-configuration failure following the change.
+- Failure-path tests cover both syntax errors and structurally invalid but parseable configurations.
+- Valid-install tests continue to pass for skill layout, instruction content, hook/plugin merging, JSONC handling, backups, and idempotency.
+- The implementation does not introduce a new dependency or a broad transaction abstraction.
+
+### Scope Boundaries
+
+#### In scope
+
+- Preflight validation for project installation paths that parse existing platform configuration.
+- Codex as the required issue fix.
+- Equivalent strict validation ordering for Claude and Gemini hook-backed project installs.
+- Fail-closed install behavior for OpenCode and Kilo malformed configuration, including Kilo JSONC parsing.
+- End-to-end project-state regression tests and focused helper tests.
+- Preservation of existing configuration merge, backup, JSONC, and scope behavior.
+
+#### Deferred to Follow-Up Work
+
+- A general rollback or transaction framework for arbitrary disk-write failures after preflight succeeds.
+- A full uninstall redesign for malformed or wrong-shaped configuration files.
+- Adding a new project-scoped CodeBuddy CLI command.
+- Broad tightening of Graphify hook matching beyond the validation-ordering defect unless a new regression demonstrates that it is required for this work.
+- Translating new troubleshooting text into every README translation.
+
+### Dependencies and Assumptions
+
+- The existing platform configuration formats and Graphify-owned sections remain the intended contracts.
+- “No mutation on failure” applies to validation failures covered by preflight, not to every possible permission, disk-full, or process-interruption failure after writes begin.
+- The project test suite can run through the repository's existing `uv` environment.
+- The repository's current atomic staging helpers remain the pattern for individual file writes; this plan does not replace them.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Use preflight-first validation instead of a full transaction layer.** (session-settled: user-approved — chosen over a full transaction layer: maximize coverage while keeping the fix within the existing installer architecture.) The issue is caused by a deterministic validation failure that can be detected before any Graphify-owned write. Preflight fixes that class across platforms with a small surface and low compatibility risk. A full rollback layer would need to track user files, newly created directories, backups, JSONC sibling files, and partial I/O failures across unrelated installers.
+- KTD2. **Validate managed structure, not only JSON syntax.** A parseable list, scalar, non-object `hooks`, or non-list managed collection can still fail later after earlier writes. Each installer preflight must validate the containers it will mutate and return or retain the parsed representation needed by the write phase.
+- KTD3. **Place validation at the combined-install orchestration boundary.** Hook/plugin helpers must remain safe when called directly, but project entrypoints must validate before skill, packaged command, instruction, plugin, or configuration writes. Reordering only the final hook call would still leave the skill tree partially installed.
+- KTD4. **Keep install parsing strict and uninstall parsing conservative.** Existing uninstall paths are best-effort and outside this issue's scope. Install paths must refuse invalid existing configuration; uninstall changes should be limited to compatibility fixes required by the new install tests.
+- KTD5. **Preserve platform-specific formats.** JSON files remain BOM-tolerant where they are today. Kilo JSONC remains readable without rewriting the source JSONC; the plan changes only the decision to refuse malformed input before plugin writes.
+- KTD6. **Define preflight by command and scope, not by platform name alone.** Skill-only commands that do not read platform configuration must retain their current behavior. Combined project commands and direct combined helpers must validate every configuration and packaged asset that their selected flow will use before mutation. This avoids rejecting files for an install path that does not modify them while preventing untested routing gaps.
+
+### High-Level Technical Design
+
+The install lifecycle will gain a read-only validation phase before the existing mutation phase. The validator must not create parent directories, write backups, or alter in-memory state that is later persisted until all required existing configuration files pass validation.
+
+```mermaid
+flowchart TD
+    A[Project install request] --> B[Identify platform configuration]
+    B --> C{Configuration exists?}
+    C -->|No| D[Use empty first-install state]
+    C -->|Yes| E[Read and validate syntax and managed structure]
+    E -->|Invalid| F[Report configuration path and exit non-zero]
+    F --> G[Leave project state unchanged]
+    E -->|Valid| H[Retain parsed preflight state]
+    D --> H
+    H --> I[Install skill and references]
+    I --> J[Update instruction file]
+    J --> K[Write or merge hook/plugin configuration]
+    K --> L[Print success and version-control hint]
+```
+
+The platform-specific validation contract is:
+
+- Codex, Claude, and Gemini require an object root, an object `hooks` value when present, and a list for their managed hook collection when present.
+- OpenCode requires an object root and a list-valued `plugin` collection when present.
+- Kilo accepts valid JSON or comment/trailing-comma JSONC, requires an object root and a list-valued `plugin` collection when present, and keeps the existing JSONC source untouched.
+- Each combined flow also checks required packaged assets before its first project write, including Kilo's native command source.
+- Missing files produce the existing empty state and are created only after preflight completes.
+- A skill-only install path that does not parse a platform configuration does not acquire a new configuration refusal step.
+
+### Sequencing
+
+1. Add or extract read-only validation primitives while preserving the direct helper safety tests.
+2. Add Codex project preflight and its end-to-end failure regression.
+3. Apply the same orchestration boundary to Claude and Gemini and add strict-platform failure coverage.
+4. Make OpenCode and Kilo installation parsing fail closed and validate before plugin/skill/instruction writes.
+5. Run the cross-platform regression matrix and update only concise English install guidance if the final user-facing recovery behavior needs documentation.
+
+### Assumptions
+
+- Preflight validation is deterministic and does not need a write-based probe.
+- A valid configuration with no managed collection is equivalent to an empty managed collection and remains installable.
+- Existing Graphify entries are identified and replaced using current platform-specific matching rules; changing ownership detection is not required to solve #2416.
+- The final implementation may consolidate duplicated validators or retain small platform-specific wrappers, provided the externally visible contract and tests remain identical.
+
+### Sources and Research
+
+- GitHub issue #2416: Codex project installation mutates the skill and `AGENTS.md` before rejecting invalid `.codex/hooks.json`.
+- `graphify/install.py`: `_project_install()`, `_agents_install()`, `_install_codex_hook()`, `_read_settings_for_merge()`, `_install_opencode_plugin()`, `_load_json_like()`, `_install_kilo_plugin()`, `gemini_install()`, and `claude_install()` establish the current ordering and safety patterns.
+- `tests/test_settings_merge.py`: direct hook-helper preservation, BOM, invalid JSON, malformed structure, backup, and idempotency coverage.
+- `tests/test_install.py`: successful project installs, scope isolation, AGENTS integration, OpenCode/Kilo plugin behavior, and CLI hook assertions.
+- `tests/test_install_roundtrip.py`, `tests/test_install_references.py`, and `tests/test_atomic_writes.py`: existing per-file atomicity and cleanup patterns.
+- No relevant durable learnings were present under `docs/solutions/`.
+- No PR was linked to issue #2416 at planning time.
+
+---
+
+## System-Wide Impact
+
+- **Project files:** The installer will touch fewer files on validation failure and will preserve user-owned configuration bytes.
+- **Platform integrations:** Codex, Claude, Gemini, OpenCode, and Kilo share the same lifecycle guarantee but retain distinct configuration formats and managed sections.
+- **CLI behavior:** Existing commands continue to use the same flags and success paths. Invalid pre-existing configuration becomes an explicit install failure instead of a partial success.
+- **Command routing:** `install --project --platform P`, platform subcommands with `--project`, and direct combined helpers do not all perform the same writes. The implementation and tests must cover only the configuration each route actually reads, while ensuring every route that does read it preflights before mutation.
+- **Version-control workflow:** The git-add hint is emitted only after preflight and all installation writes complete, so failed validation cannot advertise a partial installation as ready to commit.
+- **Global/project isolation:** Project preflight must not delete or rewrite global skill trees, and existing project-scope tests must remain green.
+
+---
+
+## Risks & Dependencies
+
+- **Risk: validation is incomplete.** A syntax-only check could still allow a scalar `hooks` or `plugin` value that fails during mutation. Mitigation: validate every container the write phase accesses and test each malformed shape.
+- **Risk: validation creates side effects.** Calling an installer helper that creates parent directories before reading configuration would preserve the defect. Mitigation: keep preflight read-only and test that invalid first attempts do not create empty platform directories or backups.
+- **Risk: Kilo JSONC behavior regresses.** Kilo intentionally keeps the original JSONC and writes a sibling JSON file. Mitigation: retain the existing JSONC round-trip tests and add malformed JSONC refusal tests.
+- **Risk: valid configuration behavior changes.** Strict readers may affect existing user files with omitted managed collections or BOMs. Mitigation: preserve missing-key defaults, BOM handling, unrelated keys, user entries, and backup/idempotency assertions.
+- **Risk: scope expands into transaction semantics.** Write failures after successful preflight can still leave partial state. Mitigation: state the validation-failure guarantee precisely and defer full rollback to follow-up work.
+- **Dependency: existing test environment.** Verification depends on the repository's current Python and `uv` setup, with no new runtime dependency.
+
+---
+
+## Implementation Units
+
+### U1. Establish read-only install preflight contracts
+
+**Goal:** Provide reusable validation boundaries that distinguish missing configuration from invalid syntax or invalid managed structure without creating directories or writing files.
+
+**Requirements:** R1, R2, R3, R5, R6, R7.
+
+**Dependencies:** None.
+
+**Files:**
+
+- `graphify/install.py`
+- `tests/test_settings_merge.py`
+- `tests/test_install.py`
+
+**Approach:**
+
+1. Reuse the current strict JSON reader semantics for BOM-tolerant hook configuration and preserve its actionable refusal path.
+2. Separate read-only parsing and managed-shape validation from mutation so the combined installers can preflight before copying skills or editing instruction files.
+3. Add install-only strict handling for OpenCode JSON and Kilo JSON/JSONC rather than changing uninstall's best-effort loader by default.
+4. Include required packaged assets in the preflight result, especially the Kilo command source that is currently checked after skill installation.
+5. Preserve missing-file defaults and valid configurations that omit the managed collection.
+6. Ensure preflight does not create the configuration parent directory, backup file, sibling JSON file, plugin file, command file, or skill tree.
+
+**Execution note:** Add characterization coverage around current valid, missing, BOM, malformed, and wrong-shaped configuration behavior before changing shared helpers.
+
+**Patterns to follow:** `_read_settings_for_merge()` and its parameterized tests; `_strip_json_comments()` and Kilo JSONC preservation tests; existing atomic staging helpers for file writes.
+
+**Test scenarios:**
+
+- A missing hook or plugin configuration returns an empty install state without creating its parent directory.
+- Valid object configuration with no managed collection remains installable.
+- Invalid JSON and undecodable configuration refuse installation without changing bytes.
+- Valid non-object top-level JSON refuses installation.
+- A non-object managed `hooks` value refuses installation.
+- A non-list managed hook collection refuses installation.
+- A non-object OpenCode or Kilo top level refuses installation.
+- A non-list OpenCode or Kilo `plugin` value refuses installation.
+- BOM-prefixed valid JSON remains accepted and preserves existing unrelated values.
+- Valid Kilo JSONC with comments and trailing commas remains accepted while the source JSONC stays unchanged.
+- Invalid Kilo JSONC refuses installation without creating the sibling JSON output.
+
+**Verification:** The helper-level tests prove all platform validators have a side-effect-free failure path and retain existing merge-format behavior.
+
+### U2. Make Codex project installation preflight before mutation
+
+**Goal:** Fix issue #2416 for both public project-scoped Codex command forms without changing successful installation behavior.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R8; covers AE1, AE2, AE3, AE4, AE7, and AE8.
+
+**Dependencies:** U1.
+
+**Files:**
+
+- `graphify/install.py`
+- `tests/test_install.py`
+- `tests/test_settings_merge.py`
+
+**Approach:**
+
+1. Map the two public Codex project command forms and direct combined helper to their actual write sets.
+2. Invoke Codex preflight before `_copy_skill_file()` in the project-install path.
+3. Ensure the shared AGENTS installer does not write `AGENTS.md` before Codex configuration validation when it is called through either project or platform-specific install routing.
+4. Pass or reuse the validated state so the mutation phase does not introduce a second, differently-behaving validation path.
+5. Keep the current hook merge, backup, hook replacement, no-op hook command, and git-add hint behavior for valid installs.
+6. Keep malformed existing `.codex/hooks.json` byte-identical and avoid creating any Graphify-owned files or backup on failure.
+
+**Execution note:** Start with a failing end-to-end test that snapshots the complete disposable project state before the invalid install.
+
+**Patterns to follow:** Existing project Codex success and scope-isolation tests; direct invalid JSON coverage in `tests/test_settings_merge.py`; `_copy_skill_file()` reference staging and version-stamp behavior.
+
+**Test scenarios:**
+
+- `graphify install --project --platform codex` with invalid existing `.codex/hooks.json` exits non-zero and leaves the complete project manifest and contents unchanged.
+- `graphify codex install --project` has the same no-mutation failure behavior.
+- Invalid Codex configuration does not create `.codex/skills/graphify`, references, `.graphify_version`, `AGENTS.md`, or `.codex/hooks.json.graphify-bak` when they were absent.
+- Invalid Codex configuration does not alter pre-existing `AGENTS.md`, user skill files, global skill files, or unrelated `.codex` files.
+- Parseable but structurally invalid Codex configurations fail before any project mutation.
+- A missing Codex configuration installs the skill, references, AGENTS section, and valid hook file.
+- A valid Codex configuration preserves unrelated settings and user hook entries, creates the expected backup only when changed, and emits the project git-add hint only after success.
+- A successful Codex reinstall remains idempotent and does not duplicate Graphify hooks or rewrite an unchanged backup.
+
+**Verification:** The issue reproduction becomes a passing regression test, and both CLI forms retain the existing successful project-install and scope-isolation behavior.
+
+### U3. Apply preflight ordering to strict hook-backed project installers
+
+**Goal:** Remove the same write-before-validation failure mode from Claude, Gemini, and the explicit project-directory CodeBuddy helper without adding a new CodeBuddy CLI surface.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8; covers AE3, AE4, AE7, and AE8.
+
+**Dependencies:** U1.
+
+**Files:**
+
+- `graphify/install.py`
+- `tests/test_install.py`
+- `tests/test_settings_merge.py`
+
+**Approach:**
+
+1. Map the actual project write sets for Claude, Gemini, and the direct project-directory CodeBuddy helper before selecting their preflight boundary.
+2. Preflight the platform hook configuration before the skill and instruction-file writes in Claude and Gemini project installation.
+3. Apply the same boundary to `codebuddy_install(project_dir)` when called directly, while leaving the unsupported project-scoped CodeBuddy CLI surface unchanged.
+4. Preserve platform-specific instruction files, strict Claude hook mode, Gemini hook payloads, existing backups, and valid merge semantics.
+5. Keep global/project destination resolution and user-scope isolation unchanged.
+6. Ensure failure output identifies the platform configuration path and does not print success or version-control guidance.
+
+**Patterns to follow:** `claude_install()`, `gemini_install()`, `codebuddy_install()`, `_read_settings_for_merge()`, and the existing parameterized settings tests.
+
+**Test scenarios:**
+
+- Claude project install with invalid `.claude/settings.json` leaves the skill, Claude registration files, root instruction file, settings file, and backup state unchanged.
+- Gemini project install with invalid `.gemini/settings.json` leaves the skill, `GEMINI.md`, settings file, and backup state unchanged.
+- Explicit `codebuddy_install(project_dir)` with invalid `.codebuddy/settings.json` leaves the project state unchanged.
+- Strict-platform configurations with invalid nested `hooks` or managed collections fail before any project mutation.
+- Missing configuration succeeds for each strict platform.
+- Valid configuration preserves unrelated settings, user hooks, BOM behavior, strict mode behavior, and idempotency.
+- A global skill remains intact when a project-scoped strict install fails.
+
+**Verification:** The cross-platform failure tests prove that the common defect is fixed at the combined installer boundary, not only inside the final hook writer.
+
+### U4. Make OpenCode and Kilo project configuration handling fail closed
+
+**Goal:** Prevent OpenCode and Kilo from replacing malformed existing configuration with an empty object or writing plugin files before configuration validation.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7; covers AE5, AE6, AE7, and AE8.
+
+**Dependencies:** U1.
+
+**Files:**
+
+- `graphify/install.py`
+- `tests/test_install.py`
+- `tests/test_install_roundtrip.py`
+
+**Approach:**
+
+1. Map the actual write sets for OpenCode and Kilo across generic platform and platform-specific project commands.
+2. Validate existing OpenCode configuration before writing `.opencode/plugins/graphify.js` or changing `AGENTS.md`.
+3. Reject malformed OpenCode JSON and invalid `plugin` structure instead of silently falling back to `{}`.
+4. Validate Kilo JSON or JSONC and the required native command source before writing `.kilo/plugins/graphify.js`, the generated JSON registration, or project instructions.
+5. Preserve Kilo's precedence between `kilo.json` and `kilo.jsonc`, source JSONC preservation, sibling JSON registration, and plugin URI behavior.
+6. Ensure every project route that writes the platform plugin uses the same preflight guarantee, while skill-only routes do not begin reading configuration they previously ignored.
+7. Keep uninstall behavior best-effort unless a compatibility regression requires a narrow guard.
+
+**Patterns to follow:** `_kilo_config_path()`, `_kilo_config_write_path()`, `_strip_json_comments()`, current OpenCode/Kilo merge tests, and project round-trip tests.
+
+**Test scenarios:**
+
+- OpenCode invalid JSON fails before creating the plugin file, changing `AGENTS.md`, or replacing the configuration.
+- OpenCode valid JSON with a missing `plugin` key installs normally.
+- OpenCode valid JSON with a non-list `plugin` value refuses installation without mutation.
+- Kilo invalid JSON fails before plugin or sibling JSON creation.
+- Kilo invalid JSONC fails before plugin or sibling JSON creation and preserves the invalid source bytes.
+- Kilo valid JSONC remains unchanged while the sibling JSON registration is written as before.
+- Kilo configuration with a non-list `plugin` value refuses installation rather than silently resetting it.
+- Successful OpenCode and Kilo reinstall remains idempotent and preserves unrelated configuration keys.
+- Project failures do not modify global Kilo skill or command artifacts.
+
+**Verification:** Existing plugin and JSONC round-trip tests remain green, and new failure tests prove that malformed configuration is never replaced or hidden by a partial plugin installation.
+
+### U5. Consolidate end-to-end failure-state verification and user guidance
+
+**Goal:** Make the no-mutation contract easy to verify and clear to users without expanding into a general transaction framework.
+
+**Requirements:** R4, R6, R8; covers AE1, AE5, AE8.
+
+**Dependencies:** U2, U3, U4.
+
+**Files:**
+
+- `tests/test_install.py`
+- `tests/test_install_roundtrip.py`
+- `README.md` (only if the final error/recovery behavior is not already accurately documented)
+
+**Approach:**
+
+1. Reuse a small test helper to snapshot relative file paths and bytes before a failed project install.
+2. Parameterize the snapshot cases by actual command route and platform write set instead of assuming every platform command touches the same files.
+3. Assert both absence of newly-created Graphify artifacts and byte identity of pre-existing user files.
+4. Cover success output boundaries so failure does not emit the success message or git-add hint.
+5. Add concise English README guidance only if the final refusal behavior needs a documented repair-and-rerun instruction.
+6. Do not update translated READMEs or add a new user-facing command in this issue fix.
+
+**Test scenarios:**
+
+- A failed project install with an existing invalid configuration leaves the full disposable repository snapshot unchanged.
+- A failed install does not leave temporary staging directories, backups, generated sibling configuration, or empty platform directories.
+- A failed project install preserves an existing user `AGENTS.md` or platform instruction section byte-for-byte.
+- A failed project install preserves global skill and command artifacts.
+- Successful project installs still produce the documented files and version-control hint.
+
+**Verification:** The full installation regression suite demonstrates the contract across supported platforms and documents any intentionally deferred rollback behavior.
+
+---
+
+## Verification Contract
+
+| Gate | Applies to | Completion signal |
+|---|---|---|
+| Focused settings tests | U1, U2, U3 | Strict validators preserve current BOM, malformed-structure, backup, and merge behavior. |
+| Project install regression tests | U2, U3, U4, U5 | Invalid existing configuration fails before any project mutation; valid and missing configurations succeed. |
+| Install lifecycle tests | U4, U5 | Existing round-trip, reference staging, JSONC, scope-isolation, and idempotency behavior remains green. |
+| Atomic-write regression tests | U1, U4 | Existing atomic file-write guarantees remain green; no new temporary artifacts remain. |
+| Static quality checks | All implementation units | `ruff` and the repository's configured Python checks report no new violations. |
+| Full suite | All units | `uv run pytest` passes without modifying unrelated working-tree files. |
+| Disposable smoke verification | U2, U5 | The issue reproduction command returns failure and leaves the repository manifest and bytes unchanged. |
+
+The focused verification set is `tests/test_settings_merge.py` and `tests/test_install.py`. The broader targeted set is `tests/test_install_roundtrip.py`, `tests/test_install_references.py`, and `tests/test_atomic_writes.py`. The final gate is the complete repository test suite and configured lint/type checks.
+
+---
+
+## Definition of Done
+
+- The Codex reproduction from issue #2416 fails closed with no partial Graphify project installation.
+- Preflight occurs before the first Graphify-owned mutation for Codex, Claude, Gemini, OpenCode, and Kilo project-install paths covered by the implementation.
+- Existing invalid configuration remains byte-identical and no backup is created before successful mutation.
+- Missing and valid configurations preserve current successful behavior, including user settings, user hooks/plugins, BOM handling, JSONC handling, backups, idempotency, and scope isolation.
+- Tests cover syntax-invalid and structurally invalid configurations for every hardened platform.
+- Tests cover both public command routing and direct combined-install paths where they differ.
+- Error output remains actionable and success/git-add output is not emitted after failed preflight.
+- No full transaction abstraction, unrelated uninstall redesign, new dependency, or unrelated cleanup is included.
+- No abandoned experimental code, temporary files, or test-only workaround remains in the final diff.
+- The plan's implementation units and verification gates are satisfied, and the final diff contains only issue-related changes.

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -608,17 +608,19 @@ def install(platform: str = "claude", *, project: bool = False, project_dir: Pat
 
     cfg = _PLATFORM_CONFIG[platform]
     project_dir = project_dir or Path(".")
+    if platform == "opencode":
+        # The plugin writer mutates both the plugin file and opencode.json. Read
+        # and validate the existing config before any skill or project writes.
+        _preflight_opencode_config(
+            (project_dir if project else Path(".")) / _OPENCODE_CONFIG_PATH
+        )
+    if platform == "kilo":
+        # Kilo Code also supports a native /graphify command file. Check the
+        # packaged source before installing the skill or global command.
+        command_src = _kilo_command_source()
     skill_dst = _copy_skill_file(platform, project=project, project_dir=project_dir)
 
     if platform == "kilo":
-        # Kilo Code also supports a native /graphify command file.
-        command_src = Path(__file__).parent / "command-kilo.md"
-        if not command_src.exists():
-            print(
-                f"error: command-kilo.md not found in package - reinstall graphify",
-                file=sys.stderr,
-            )
-            sys.exit(1)
         command_dst = Path.home() / ".config" / "kilo" / "command" / "graphify.md"
         command_dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(command_src, command_dst)
@@ -1216,6 +1218,20 @@ export const GraphifyPlugin = async ({ directory }) => {
 _KILO_PLUGIN_PATH = Path(".kilo") / "plugins" / "graphify.js"
 _KILO_CONFIG_JSON_PATH = Path(".kilo") / "kilo.json"
 _KILO_CONFIG_JSONC_PATH = Path(".kilo") / "kilo.jsonc"
+
+
+def _kilo_command_source() -> Path:
+    """Return the packaged native command, refusing incomplete installations."""
+    command_src = Path(__file__).parent / "command-kilo.md"
+    if not command_src.exists():
+        print(
+            "error: command-kilo.md not found in package - reinstall graphify",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return command_src
+
+
 def _strip_json_comments(raw: str) -> str:
     """Remove JSONC-style comments while leaving string content intact."""
     result: list[str] = []
@@ -1306,8 +1322,10 @@ def _kilo_config_write_path(project_dir: Path) -> Path:
     """Write automated Kilo edits to kilo.json so existing JSONC stays untouched."""
     kilo_dir = (project_dir or Path(".")) / ".kilo"
     return kilo_dir / _KILO_CONFIG_JSON_PATH.name
-def _install_kilo_plugin(project_dir: Path) -> None:
+def _install_kilo_plugin(project_dir: Path, config: dict | None = None) -> None:
     """Write graphify.js plugin and register it without rewriting user JSONC."""
+    if config is None:
+        config = _preflight_kilo_config(project_dir)
     plugin_file = project_dir / _KILO_PLUGIN_PATH
     plugin_file.parent.mkdir(parents=True, exist_ok=True)
     plugin_file.write_text(_KILO_PLUGIN_JS, encoding="utf-8")
@@ -1316,9 +1334,10 @@ def _install_kilo_plugin(project_dir: Path) -> None:
     config_file = _kilo_config_path(project_dir)
     write_config_file = _kilo_config_write_path(project_dir)
     write_config_file.parent.mkdir(parents=True, exist_ok=True)
-    config = _load_json_like(config_file)
     plugins = config.get("plugin")
     if not isinstance(plugins, list):
+        # The preflight above rejects this for existing files. This default is
+        # only for a missing first-install config.
         plugins = []
         config["plugin"] = plugins
     entry = plugin_file.resolve().as_uri()
@@ -1398,22 +1417,16 @@ def _preflight_opencode_config(config_file: Path) -> dict:
     return _read_json_for_install(config_file, managed_collection="plugin")
 
 
-def _install_opencode_plugin(project_dir: Path) -> None:
+def _install_opencode_plugin(project_dir: Path, config: dict | None = None) -> None:
     """Write graphify.js plugin and register it in opencode.json."""
+    if config is None:
+        config = _preflight_opencode_config(project_dir / _OPENCODE_CONFIG_PATH)
     plugin_file = project_dir / _OPENCODE_PLUGIN_PATH
     plugin_file.parent.mkdir(parents=True, exist_ok=True)
     plugin_file.write_text(_OPENCODE_PLUGIN_JS, encoding="utf-8")
     print(f"  {_OPENCODE_PLUGIN_PATH}  ->  tool.execute.before hook written")
 
     config_file = project_dir / _OPENCODE_CONFIG_PATH
-    if config_file.exists():
-        try:
-            config = json.loads(config_file.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            config = {}
-    else:
-        config = {}
-
     plugins = config.setdefault("plugin", [])
     entry = _OPENCODE_PLUGIN_PATH.as_posix()
     if entry not in plugins:
@@ -1524,6 +1537,17 @@ def _agents_install(
 ) -> None:
     """Write the graphify section to the local AGENTS.md for always-on platforms."""
     project_dir = project_dir or Path(".")
+    opencode_config = None
+    kilo_config = None
+    # These helpers are also called directly by platform-specific commands.
+    # Validate before touching AGENTS.md, not only inside the final plugin write.
+    if platform == "opencode":
+        opencode_config = _preflight_opencode_config(
+            project_dir / _OPENCODE_CONFIG_PATH
+        )
+    elif platform == "kilo":
+        _kilo_command_source()
+        kilo_config = _preflight_kilo_config(project_dir)
     if platform == "codex" and codex_settings is None:
         codex_settings = _read_settings_for_merge(
             project_dir / ".codex" / "hooks.json", managed_collection="PreToolUse"
@@ -1547,9 +1571,9 @@ def _agents_install(
     if platform == "codex":
         _install_codex_hook(project_dir or Path("."), existing=codex_settings)
     elif platform == "opencode":
-        _install_opencode_plugin(project_dir or Path("."))
+        _install_opencode_plugin(project_dir or Path("."), config=opencode_config)
     elif platform == "kilo":
-        _install_kilo_plugin(project_dir or Path("."))
+        _install_kilo_plugin(project_dir or Path("."), config=kilo_config)
 
     print()
     print(
@@ -1629,6 +1653,9 @@ def _project_install(platform_name: str, project_dir: Path | None = None, strict
             codex_settings = _read_settings_for_merge(
                 project_dir / ".codex" / "hooks.json", managed_collection="PreToolUse"
             )
+        elif platform_name == "opencode":
+            # This must precede the skill and AGENTS.md writes below.
+            _preflight_opencode_config(project_dir / _OPENCODE_CONFIG_PATH)
         skill_dst = _copy_skill_file(platform_name, project=True, project_dir=project_dir)
         _agents_install(project_dir, platform_name, codex_settings=codex_settings)
         hint_paths = [_project_scope_root(skill_dst, project_dir), project_dir / "AGENTS.md"]
@@ -1764,8 +1791,13 @@ def _kilo_uninstall_global() -> list[str]:
     return removed
 def _kilo_install(project_dir: Path) -> None:
     """Install native Kilo skill + command globally and always-on project wiring locally."""
+    project_dir = project_dir or Path(".")
+    # This command combines global and project writes. Validate every input,
+    # including the packaged native command, before either scope is mutated.
+    _preflight_kilo_config(project_dir)
+    _kilo_command_source()
     install(platform="kilo")
-    _agents_install(project_dir or Path("."), "kilo")
+    _agents_install(project_dir, "kilo")
 def _kilo_uninstall(project_dir: Path) -> None:
     """Remove Kilo always-on project wiring and global skill/command files."""
     _agents_uninstall(project_dir or Path("."), platform="kilo")

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -720,31 +720,60 @@ def gemini_install(project_dir: Path | None = None, *, project: bool = False) ->
     print("Gemini CLI will now check the knowledge graph before answering")
     print("codebase questions and rebuild it after code changes.")
 def _refuse_to_modify(settings_path: Path) -> "NoReturn":
-    """Abort a hook install rather than clobber a config file we can't parse (#2167)."""
+    """Abort an install rather than clobber an invalid configuration (#2167)."""
     print(
-        f"[graphify] refusing to modify {settings_path}: not valid JSON "
-        "(fix or move it and re-run)",
+        f"[graphify] refusing to modify {settings_path}: not valid JSON or "
+        "expected structure (fix or move it and re-run)",
         file=sys.stderr,
     )
     sys.exit(1)
-def _read_settings_for_merge(settings_path: Path) -> dict:
+
+
+def _read_json_for_install(
+    config_file: Path, *, managed_collection: str | None = None, jsonc: bool = False
+) -> dict:
+    """Read and validate an install configuration without filesystem mutation.
+
+    Missing files are the valid empty first-install state. Existing files must be
+    objects, and an explicitly present managed collection must be a list. The
+    caller can therefore perform this read before creating any install artifact.
+    """
+    if not config_file.exists():
+        return {}
+    try:
+        raw = config_file.read_text(encoding="utf-8-sig")
+        if jsonc:
+            raw = _strip_json_comments(raw)
+        loaded = json.loads(raw)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        _refuse_to_modify(config_file)
+    if not isinstance(loaded, dict):
+        _refuse_to_modify(config_file)
+    if managed_collection is not None:
+        if managed_collection in loaded and not isinstance(loaded[managed_collection], list):
+            _refuse_to_modify(config_file)
+    return loaded
+
+
+def _read_settings_for_merge(
+    settings_path: Path, *, managed_collection: str | None = None
+) -> dict:
     """Load an existing settings/hooks JSON file for a read-modify-write merge.
 
     A missing file yields a fresh ``{}`` (first install). An existing file that
-    cannot be parsed as a JSON object aborts via ``_refuse_to_modify`` instead of
-    silently falling back to ``{}`` — the old fallback rewrote the whole file and
-    destroyed every setting the user had (#2167). Reads with ``utf-8-sig`` so a
-    UTF-8 BOM (the most likely parse-error trigger, same class as #2163) is
-    tolerated rather than fatal.
+    cannot be parsed as a JSON object, or has invalid hook structure, aborts via
+    ``_refuse_to_modify`` instead of silently falling back to ``{}`` — the old
+    fallback rewrote the whole file and destroyed every setting the user had
+    (#2167). Reads with ``utf-8-sig`` so a UTF-8 BOM (the most likely parse-error
+    trigger, same class as #2163) is tolerated rather than fatal.
     """
-    if not settings_path.exists():
-        return {}
-    try:
-        settings = json.loads(settings_path.read_text(encoding="utf-8-sig"))
-    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
-        settings = None
-    if not isinstance(settings, dict):
+    settings = _read_json_for_install(settings_path)
+    hooks = settings.get("hooks")
+    if "hooks" in settings and not isinstance(hooks, dict):
         _refuse_to_modify(settings_path)
+    if managed_collection is not None and isinstance(hooks, dict):
+        if managed_collection in hooks and not isinstance(hooks[managed_collection], list):
+            _refuse_to_modify(settings_path)
     return settings
 def _write_settings_with_backup(settings_path: Path, settings: dict) -> None:
     """Serialize ``settings`` to ``settings_path``, backing up the previous file.
@@ -763,8 +792,8 @@ def _write_settings_with_backup(settings_path: Path, settings: dict) -> None:
     settings_path.write_text(output, encoding="utf-8")
 def _install_gemini_hook(project_dir: Path) -> None:
     settings_path = project_dir / ".gemini" / "settings.json"
+    settings = _read_settings_for_merge(settings_path, managed_collection="BeforeTool")
     settings_path.parent.mkdir(parents=True, exist_ok=True)
-    settings = _read_settings_for_merge(settings_path)
     hooks = settings.setdefault("hooks", {})
     if not isinstance(hooks, dict):
         _refuse_to_modify(settings_path)
@@ -1254,6 +1283,18 @@ def _kilo_config_path(project_dir: Path) -> Path:
     if jsonc_path.exists():
         return jsonc_path
     return json_path
+
+
+def _preflight_kilo_config(project_dir: Path) -> dict:
+    """Read Kilo JSON/JSONC and validate its managed plugin collection."""
+    config_file = _kilo_config_path(project_dir)
+    return _read_json_for_install(
+        config_file,
+        managed_collection="plugin",
+        jsonc=config_file.suffix == ".jsonc",
+    )
+
+
 def _kilo_config_write_path(project_dir: Path) -> Path:
     """Write automated Kilo edits to kilo.json so existing JSONC stays untouched."""
     kilo_dir = (project_dir or Path(".")) / ".kilo"
@@ -1343,6 +1384,13 @@ export const GraphifyPlugin = async ({ directory }) => {
 """
 _OPENCODE_PLUGIN_PATH = Path(".opencode") / "plugins" / "graphify.js"
 _OPENCODE_CONFIG_PATH = Path(".opencode") / "opencode.json"
+
+
+def _preflight_opencode_config(config_file: Path) -> dict:
+    """Read OpenCode JSON and validate its managed plugin collection."""
+    return _read_json_for_install(config_file, managed_collection="plugin")
+
+
 def _install_opencode_plugin(project_dir: Path) -> None:
     """Write graphify.js plugin and register it in opencode.json."""
     plugin_file = project_dir / _OPENCODE_PLUGIN_PATH
@@ -1418,9 +1466,8 @@ def _resolve_graphify_exe() -> str:
 def _install_codex_hook(project_dir: Path) -> None:
     """Add graphify PreToolUse hook to .codex/hooks.json."""
     hooks_path = project_dir / ".codex" / "hooks.json"
+    existing = _read_settings_for_merge(hooks_path, managed_collection="PreToolUse")
     hooks_path.parent.mkdir(parents=True, exist_ok=True)
-
-    existing = _read_settings_for_merge(hooks_path)
 
     graphify_exe = _resolve_graphify_exe()
     hook_entry = {
@@ -1731,9 +1778,8 @@ def claude_install(project_dir: Path | None = None, strict: bool = False) -> Non
 def _install_claude_hook(project_dir: Path, strict: bool = False) -> None:
     """Add graphify PreToolUse hook to .claude/settings.json."""
     settings_path = project_dir / ".claude" / "settings.json"
+    settings = _read_settings_for_merge(settings_path, managed_collection="PreToolUse")
     settings_path.parent.mkdir(parents=True, exist_ok=True)
-
-    settings = _read_settings_for_merge(settings_path)
 
     hooks = settings.setdefault("hooks", {})
     if not isinstance(hooks, dict):
@@ -1913,9 +1959,8 @@ def codebuddy_install(project_dir: Path | None = None) -> None:
 def _install_codebuddy_hook(project_dir: Path) -> None:
     """Add graphify PreToolUse hook to .codebuddy/settings.json."""
     settings_path = project_dir / ".codebuddy" / "settings.json"
+    settings = _read_settings_for_merge(settings_path, managed_collection="PreToolUse")
     settings_path.parent.mkdir(parents=True, exist_ok=True)
-
-    settings = _read_settings_for_merge(settings_path)
 
     hooks = settings.setdefault("hooks", {})
     if not isinstance(hooks, dict):

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -1285,6 +1285,8 @@ def _strip_json_comments(raw: str) -> str:
             in_string = True
         i += 1
 
+    if block_comment:
+        raise json.JSONDecodeError("Unterminated block comment", raw, len(raw))
     return re.sub(r",(\s*[}\]])", r"\1", "".join(result))
 def _load_json_like(config_file: Path) -> dict:
     if not config_file.exists():
@@ -1533,15 +1535,18 @@ def _uninstall_codex_hook(project_dir: Path) -> None:
     hooks_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
     print(f"  .codex/hooks.json  ->  PreToolUse hook removed")
 def _agents_install(
-    project_dir: Path, platform: str, *, codex_settings: dict | None = None
+    project_dir: Path,
+    platform: str,
+    *,
+    codex_settings: dict | None = None,
+    opencode_config: dict | None = None,
 ) -> None:
     """Write the graphify section to the local AGENTS.md for always-on platforms."""
     project_dir = project_dir or Path(".")
-    opencode_config = None
     kilo_config = None
     # These helpers are also called directly by platform-specific commands.
     # Validate before touching AGENTS.md, not only inside the final plugin write.
-    if platform == "opencode":
+    if platform == "opencode" and opencode_config is None:
         opencode_config = _preflight_opencode_config(
             project_dir / _OPENCODE_CONFIG_PATH
         )
@@ -1649,15 +1654,23 @@ def _project_install(platform_name: str, project_dir: Path | None = None, strict
         _print_project_git_add_hint([project_dir / ".kiro"])
     elif platform_name in ("aider", "amp", "codex", "opencode", "claw", "droid", "trae", "trae-cn", "hermes"):
         codex_settings = None
+        opencode_config = None
         if platform_name == "codex":
             codex_settings = _read_settings_for_merge(
                 project_dir / ".codex" / "hooks.json", managed_collection="PreToolUse"
             )
         elif platform_name == "opencode":
             # This must precede the skill and AGENTS.md writes below.
-            _preflight_opencode_config(project_dir / _OPENCODE_CONFIG_PATH)
+            opencode_config = _preflight_opencode_config(
+                project_dir / _OPENCODE_CONFIG_PATH
+            )
         skill_dst = _copy_skill_file(platform_name, project=True, project_dir=project_dir)
-        _agents_install(project_dir, platform_name, codex_settings=codex_settings)
+        _agents_install(
+            project_dir,
+            platform_name,
+            codex_settings=codex_settings,
+            opencode_config=opencode_config,
+        )
         hint_paths = [_project_scope_root(skill_dst, project_dir), project_dir / "AGENTS.md"]
         if platform_name == "opencode":
             hint_paths.append(project_dir / ".opencode")

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -692,7 +692,14 @@ def _gemini_hook() -> dict:
     }
 def gemini_install(project_dir: Path | None = None, *, project: bool = False) -> None:
     """Copy skill file, write GEMINI.md section, and install BeforeTool hook."""
+    explicit_dir = project_dir is not None
     project_dir = project_dir or Path(".")
+    # Project installs must validate before copying the skill or editing GEMINI.md.
+    # Keep the global path's historical ordering and scope behavior unchanged.
+    if project or explicit_dir:
+        _read_settings_for_merge(
+            project_dir / ".gemini" / "settings.json", managed_collection="BeforeTool"
+        )
     skill_dst = _copy_skill_file("gemini", project=project, project_dir=project_dir)
 
     target = project_dir / "GEMINI.md"
@@ -1601,6 +1608,10 @@ def _project_install(platform_name: str, project_dir: Path | None = None, strict
     project_dir = project_dir or Path(".")
     platform_name = _canonical_platform(platform_name)
     if platform_name in ("claude", "windows"):
+        # Validate before install() copies the skill or writes .claude/CLAUDE.md.
+        _read_settings_for_merge(
+            project_dir / ".claude" / "settings.json", managed_collection="PreToolUse"
+        )
         install(platform=platform_name, project=True, project_dir=project_dir)
         claude_install(project_dir, strict=strict)
         _print_project_git_add_hint([project_dir / ".claude", project_dir / "CLAUDE.md"])
@@ -1762,6 +1773,10 @@ def _kilo_uninstall(project_dir: Path) -> None:
     print("; ".join(removed) if removed else "nothing to remove")
 def claude_install(project_dir: Path | None = None, strict: bool = False) -> None:
     """Write the graphify section to the local CLAUDE.md."""
+    if project_dir is not None:
+        _read_settings_for_merge(
+            project_dir / ".claude" / "settings.json", managed_collection="PreToolUse"
+        )
     target = (project_dir or Path(".")) / "CLAUDE.md"
 
     if target.exists():
@@ -1946,6 +1961,13 @@ def _strip_graphify_md_section(target: Path) -> bool:
     return True
 def codebuddy_install(project_dir: Path | None = None) -> None:
     """Install the graphify skill and CODEBUDDY.md section for CodeBuddy."""
+    # The CLI has no project-scoped CodeBuddy command, but callers may use this
+    # helper directly with a project directory. Validate before any project write.
+    existing_settings = None
+    if project_dir is not None:
+        existing_settings = _read_settings_for_merge(
+            project_dir / ".codebuddy" / "settings.json", managed_collection="PreToolUse"
+        )
     _copy_skill_file("codebuddy", project=bool(project_dir), project_dir=project_dir)
     target = (project_dir or Path(".")) / "CODEBUDDY.md"
 
@@ -1964,15 +1986,17 @@ def codebuddy_install(project_dir: Path | None = None) -> None:
         print(f"graphify section written to {target.resolve()}")
 
     # Also write CodeBuddy PreToolUse hook to .codebuddy/settings.json
-    _install_codebuddy_hook(project_dir or Path("."))
+    _install_codebuddy_hook(project_dir or Path("."), existing=existing_settings)
 
     print()
     print("CodeBuddy will now check the knowledge graph before answering")
     print("codebase questions and rebuild it after code changes.")
-def _install_codebuddy_hook(project_dir: Path) -> None:
+def _install_codebuddy_hook(project_dir: Path, existing: dict | None = None) -> None:
     """Add graphify PreToolUse hook to .codebuddy/settings.json."""
     settings_path = project_dir / ".codebuddy" / "settings.json"
-    settings = _read_settings_for_merge(settings_path, managed_collection="PreToolUse")
+    if existing is None:
+        existing = _read_settings_for_merge(settings_path, managed_collection="PreToolUse")
+    settings = existing
     settings_path.parent.mkdir(parents=True, exist_ok=True)
 
     hooks = settings.setdefault("hooks", {})

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -608,10 +608,11 @@ def install(platform: str = "claude", *, project: bool = False, project_dir: Pat
 
     cfg = _PLATFORM_CONFIG[platform]
     project_dir = project_dir or Path(".")
+    opencode_config = None
     if platform == "opencode":
         # The plugin writer mutates both the plugin file and opencode.json. Read
         # and validate the existing config before any skill or project writes.
-        _preflight_opencode_config(
+        opencode_config = _preflight_opencode_config(
             (project_dir if project else Path(".")) / _OPENCODE_CONFIG_PATH
         )
     if platform == "kilo":
@@ -659,7 +660,9 @@ def install(platform: str = "claude", *, project: bool = False, project_dir: Pat
             print(f"  CODEBUDDY.md     ->  created at {codebuddy_md}")
 
     if platform == "opencode":
-        _install_opencode_plugin(project_dir if project else Path("."))
+        _install_opencode_plugin(
+            project_dir if project else Path("."), config=opencode_config
+        )
 
     # Refresh version stamps in all other previously-installed skill dirs so
     # stale-version warnings don't fire for platforms not explicitly re-installed.

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -1463,10 +1463,11 @@ def _resolve_graphify_exe() -> str:
                 found = str(candidate)
                 break
     return (found or "graphify").replace("\\", "/")
-def _install_codex_hook(project_dir: Path) -> None:
+def _install_codex_hook(project_dir: Path, existing: dict | None = None) -> None:
     """Add graphify PreToolUse hook to .codex/hooks.json."""
     hooks_path = project_dir / ".codex" / "hooks.json"
-    existing = _read_settings_for_merge(hooks_path, managed_collection="PreToolUse")
+    if existing is None:
+        existing = _read_settings_for_merge(hooks_path, managed_collection="PreToolUse")
     hooks_path.parent.mkdir(parents=True, exist_ok=True)
 
     graphify_exe = _resolve_graphify_exe()
@@ -1511,9 +1512,16 @@ def _uninstall_codex_hook(project_dir: Path) -> None:
     existing["hooks"]["PreToolUse"] = filtered
     hooks_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
     print(f"  .codex/hooks.json  ->  PreToolUse hook removed")
-def _agents_install(project_dir: Path, platform: str) -> None:
+def _agents_install(
+    project_dir: Path, platform: str, *, codex_settings: dict | None = None
+) -> None:
     """Write the graphify section to the local AGENTS.md for always-on platforms."""
-    target = (project_dir or Path(".")) / "AGENTS.md"
+    project_dir = project_dir or Path(".")
+    if platform == "codex" and codex_settings is None:
+        codex_settings = _read_settings_for_merge(
+            project_dir / ".codex" / "hooks.json", managed_collection="PreToolUse"
+        )
+    target = project_dir / "AGENTS.md"
 
     if target.exists():
         content = target.read_text(encoding="utf-8")
@@ -1530,7 +1538,7 @@ def _agents_install(project_dir: Path, platform: str) -> None:
         print(f"graphify section written to {target.resolve()}")
 
     if platform == "codex":
-        _install_codex_hook(project_dir or Path("."))
+        _install_codex_hook(project_dir or Path("."), existing=codex_settings)
     elif platform == "opencode":
         _install_opencode_plugin(project_dir or Path("."))
     elif platform == "kilo":
@@ -1605,8 +1613,13 @@ def _project_install(platform_name: str, project_dir: Path | None = None, strict
         _kiro_install(project_dir)
         _print_project_git_add_hint([project_dir / ".kiro"])
     elif platform_name in ("aider", "amp", "codex", "opencode", "claw", "droid", "trae", "trae-cn", "hermes"):
+        codex_settings = None
+        if platform_name == "codex":
+            codex_settings = _read_settings_for_merge(
+                project_dir / ".codex" / "hooks.json", managed_collection="PreToolUse"
+            )
         skill_dst = _copy_skill_file(platform_name, project=True, project_dir=project_dir)
-        _agents_install(project_dir, platform_name)
+        _agents_install(project_dir, platform_name, codex_settings=codex_settings)
         hint_paths = [_project_scope_root(skill_dst, project_dir), project_dir / "AGENTS.md"]
         if platform_name == "opencode":
             hint_paths.append(project_dir / ".opencode")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -99,6 +99,60 @@ def test_install_project_codex_writes_skill_and_agents(tmp_path, monkeypatch):
     assert not (home / ".codex" / "skills" / "graphify" / "SKILL.md").exists()
 
 
+@pytest.mark.parametrize(
+    "argv,hooks",
+    [
+        (["graphify", "install", "--project", "--platform", "codex"], b"{ not json"),
+        (
+            ["graphify", "codex", "install", "--project"],
+            b'{"hooks": {"PreToolUse": "not-a-list"}}',
+        ),
+    ],
+    ids=["invalid-json", "invalid-managed-collection"],
+)
+def test_codex_project_install_preflight_leaves_project_unchanged(
+    tmp_path, monkeypatch, capsys, argv, hooks
+):
+    """Both public Codex project forms must validate before any project write."""
+    from graphify.__main__ import main
+
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    hooks_path = project / ".codex" / "hooks.json"
+    hooks_path.parent.mkdir()
+    hooks_path.write_bytes(hooks)
+    agents = project / "AGENTS.md"
+    agents.write_bytes(b"# User instructions\\n")
+    (project / ".codex" / "user-settings.json").write_bytes(b'{"keep": true}\\n')
+
+    def snapshot(root):
+        return {
+            path.relative_to(root): (path.is_dir(), path.read_bytes() if path.is_file() else None)
+            for path in root.rglob("*")
+        }
+
+    before = snapshot(project)
+    global_skill = home / ".codex" / "skills" / "graphify" / "SKILL.md"
+    global_skill.parent.mkdir(parents=True)
+    global_skill.write_bytes(b"user global skill")
+    global_before = global_skill.read_bytes()
+
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(sys, "argv", argv)
+    with patch("graphify.__main__.Path.home", return_value=home):
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+    assert excinfo.value.code == 1
+    assert snapshot(project) == before
+    assert global_skill.read_bytes() == global_before
+    assert not hooks_path.with_name(hooks_path.name + ".graphify-bak").exists()
+    captured = capsys.readouterr()
+    assert str(hooks_path.relative_to(project)) in captured.err
+    assert "git add" not in captured.out
+
+
 def test_claude_subcommand_project_install_and_uninstall_are_project_scoped(tmp_path, monkeypatch):
     from graphify.__main__ import main
     home = tmp_path / "home"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1007,6 +1007,24 @@ def test_kilo_preflight_rejects_non_list_plugins(tmp_path, capsys):
     assert config_file.read_text(encoding="utf-8") == '{"plugin": null}'
 
 
+def test_kilo_preflight_rejects_unterminated_block_comment(tmp_path, capsys):
+    from graphify.install import _preflight_kilo_config
+
+    config_file = tmp_path / ".kilo" / "kilo.jsonc"
+    config_file.parent.mkdir(parents=True)
+    original = b'{"plugin": []} /* unterminated'
+    config_file.write_bytes(original)
+
+    with pytest.raises(SystemExit) as excinfo:
+        _preflight_kilo_config(tmp_path)
+
+    assert excinfo.value.code == 1
+    assert str(config_file) in capsys.readouterr().err
+    assert config_file.read_bytes() == original
+    assert not (tmp_path / ".kilo" / "kilo.json").exists()
+    assert not (tmp_path / ".kilo" / "plugins").exists()
+
+
 def test_opencode_agents_install_merges_existing_config(tmp_path):
     """opencode install preserves existing .opencode/opencode.json keys."""
     import json as _json

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -883,6 +883,39 @@ def test_opencode_agents_install_registers_plugin_in_config(tmp_path):
     assert any("graphify.js" in p for p in config.get("plugin", []))
 
 
+def test_opencode_agents_install_preflights_before_agents_or_plugin(tmp_path):
+    config_file = tmp_path / ".opencode" / "opencode.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_bytes(b"{ broken")
+    agents_file = tmp_path / "AGENTS.md"
+    original_agents = b"# User rules\n"
+    agents_file.write_bytes(original_agents)
+
+    with pytest.raises(SystemExit):
+        _agents_install(tmp_path, "opencode")
+
+    assert agents_file.read_bytes() == original_agents
+    assert not (tmp_path / ".opencode" / "plugins" / "graphify.js").exists()
+    assert config_file.read_bytes() == b"{ broken"
+
+
+def test_opencode_project_install_preflights_before_skill_or_agents(tmp_path):
+    from graphify.install import _project_install
+
+    config_file = tmp_path / ".opencode" / "opencode.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text('{"plugin": null}', encoding="utf-8")
+    agents_file = tmp_path / "AGENTS.md"
+    agents_file.write_text("# User rules\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        _project_install("opencode", tmp_path)
+
+    assert agents_file.read_text(encoding="utf-8") == "# User rules\n"
+    assert not (tmp_path / ".opencode" / "skills").exists()
+    assert not (tmp_path / ".opencode" / "plugins").exists()
+
+
 def test_opencode_preflight_rejects_invalid_config_without_side_effects(tmp_path, capsys):
     from graphify.install import _preflight_opencode_config
 
@@ -1039,6 +1072,41 @@ def test_kilo_agents_install_merges_existing_config(tmp_path):
     assert (
         tmp_path / ".kilo" / "plugins" / "graphify.js"
     ).resolve().as_uri() in config["plugin"]
+
+
+def test_kilo_agents_install_preflights_before_agents_or_plugin(tmp_path):
+    config_file = tmp_path / ".kilo" / "kilo.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_bytes(b"{ broken")
+    agents_file = tmp_path / "AGENTS.md"
+    original_agents = b"# User rules\n"
+    agents_file.write_bytes(original_agents)
+
+    with pytest.raises(SystemExit):
+        _agents_install(tmp_path, "kilo")
+
+    assert agents_file.read_bytes() == original_agents
+    assert not (tmp_path / ".kilo" / "plugins" / "graphify.js").exists()
+    assert config_file.read_bytes() == b"{ broken"
+
+
+def test_kilo_install_preflights_before_global_or_project_mutation(tmp_path):
+    home_dir = tmp_path / "home"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    home_dir.mkdir()
+    config_file = project_dir / ".kilo" / "kilo.jsonc"
+    config_file.parent.mkdir(parents=True)
+    original = b"// malformed JSONC\n{"
+    config_file.write_bytes(original)
+
+    with pytest.raises(SystemExit):
+        _kilo_install(project_dir, home_dir)
+
+    assert config_file.read_bytes() == original
+    assert not (project_dir / "AGENTS.md").exists()
+    assert not (project_dir / ".kilo" / "plugins").exists()
+    assert not (home_dir / ".config" / "kilo").exists()
 
 
 def test_kilo_agents_install_preserves_existing_jsonc_config(tmp_path):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -153,6 +153,97 @@ def test_codex_project_install_preflight_leaves_project_unchanged(
     assert "git add" not in captured.out
 
 
+@pytest.mark.parametrize(
+    "platform,config_rel,config_bytes,skill_rel,instruction_rel",
+    [
+        (
+            "claude",
+            Path(".claude") / "settings.json",
+            b'{"hooks": {"PreToolUse": "not-a-list"}}',
+            Path(".claude") / "skills" / "graphify" / "SKILL.md",
+            Path("CLAUDE.md"),
+        ),
+        (
+            "gemini",
+            Path(".gemini") / "settings.json",
+            b'{"hooks": {"BeforeTool": "not-a-list"}}',
+            Path(".gemini") / "skills" / "graphify" / "SKILL.md",
+            Path("GEMINI.md"),
+        ),
+    ],
+    ids=["claude-invalid-settings", "gemini-invalid-settings"],
+)
+def test_strict_project_install_preflight_leaves_project_unchanged(
+    tmp_path, monkeypatch, capsys, platform, config_rel, config_bytes, skill_rel, instruction_rel
+):
+    """Claude and Gemini must validate settings before project artifacts."""
+    from graphify.__main__ import main
+
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    config_path = project / config_rel
+    config_path.parent.mkdir()
+    config_path.write_bytes(config_bytes)
+    instruction = project / instruction_rel
+    instruction.write_bytes(b"# User instructions\\n")
+    before = {
+        path.relative_to(project): (path.is_dir(), path.read_bytes() if path.is_file() else None)
+        for path in project.rglob("*")
+    }
+    global_skill = home / skill_rel
+    global_skill.parent.mkdir(parents=True)
+    global_skill.write_bytes(b"user global skill")
+
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(sys, "argv", ["graphify", "install", "--project", "--platform", platform])
+    with patch("graphify.__main__.Path.home", return_value=home):
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+    assert excinfo.value.code == 1
+    after = {
+        path.relative_to(project): (path.is_dir(), path.read_bytes() if path.is_file() else None)
+        for path in project.rglob("*")
+    }
+    assert after == before
+    assert global_skill.read_bytes() == b"user global skill"
+    assert not config_path.with_name(config_path.name + ".graphify-bak").exists()
+    captured = capsys.readouterr()
+    assert str(config_path.relative_to(project)) in captured.err
+    assert "git add" not in captured.out
+    assert not (project / skill_rel).exists()
+
+
+def test_codebuddy_project_helper_preflight_leaves_project_unchanged(tmp_path, capsys):
+    """The explicit project-directory CodeBuddy helper must fail closed."""
+    from graphify.install import codebuddy_install
+
+    project = tmp_path / "project"
+    project.mkdir()
+    settings = project / ".codebuddy" / "settings.json"
+    settings.parent.mkdir()
+    settings.write_bytes(b'{"hooks": {"PreToolUse": "not-a-list"}}')
+    instruction = project / "CODEBUDDY.md"
+    instruction.write_bytes(b"# User instructions\\n")
+    before = {
+        path.relative_to(project): (path.is_dir(), path.read_bytes() if path.is_file() else None)
+        for path in project.rglob("*")
+    }
+
+    with pytest.raises(SystemExit) as excinfo:
+        codebuddy_install(project)
+
+    assert excinfo.value.code == 1
+    after = {
+        path.relative_to(project): (path.is_dir(), path.read_bytes() if path.is_file() else None)
+        for path in project.rglob("*")
+    }
+    assert after == before
+    assert not settings.with_name(settings.name + ".graphify-bak").exists()
+    assert str(settings) in capsys.readouterr().err
+
+
 def test_claude_subcommand_project_install_and_uninstall_are_project_scoped(tmp_path, monkeypatch):
     from graphify.__main__ import main
     home = tmp_path / "home"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -738,6 +738,97 @@ def test_opencode_agents_install_registers_plugin_in_config(tmp_path):
     assert any("graphify.js" in p for p in config.get("plugin", []))
 
 
+def test_opencode_preflight_rejects_invalid_config_without_side_effects(tmp_path, capsys):
+    from graphify.install import _preflight_opencode_config
+
+    config_file = tmp_path / ".opencode" / "opencode.json"
+    config_file.parent.mkdir(parents=True)
+    original = b"{ not json"
+    config_file.write_bytes(original)
+
+    with pytest.raises(SystemExit) as excinfo:
+        _preflight_opencode_config(config_file)
+
+    assert excinfo.value.code == 1
+    assert str(config_file) in capsys.readouterr().err
+    assert config_file.read_bytes() == original
+    assert list(tmp_path.rglob("*")) == [config_file.parent, config_file]
+
+
+def test_opencode_preflight_rejects_non_list_plugins(tmp_path, capsys):
+    from graphify.install import _preflight_opencode_config
+
+    config_file = tmp_path / ".opencode" / "opencode.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text('{"plugin": "oops"}', encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        _preflight_opencode_config(config_file)
+
+    assert excinfo.value.code == 1
+    assert str(config_file) in capsys.readouterr().err
+
+
+def test_opencode_preflight_allows_missing_or_omitted_plugins(tmp_path):
+    from graphify.install import _preflight_opencode_config
+
+    config_file = tmp_path / ".opencode" / "opencode.json"
+    assert _preflight_opencode_config(config_file) == {}
+    assert not config_file.parent.exists()
+
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text('{"model": "keep"}', encoding="utf-8")
+    assert _preflight_opencode_config(config_file) == {"model": "keep"}
+
+
+def test_kilo_preflight_rejects_invalid_jsonc_without_sibling(tmp_path, capsys):
+    from graphify.install import _preflight_kilo_config
+
+    config_file = tmp_path / ".kilo" / "kilo.jsonc"
+    config_file.parent.mkdir(parents=True)
+    original = b"// broken\n{"
+    config_file.write_bytes(original)
+
+    with pytest.raises(SystemExit) as excinfo:
+        _preflight_kilo_config(tmp_path)
+
+    assert excinfo.value.code == 1
+    assert str(config_file) in capsys.readouterr().err
+    assert config_file.read_bytes() == original
+    assert not (tmp_path / ".kilo" / "kilo.json").exists()
+    assert not (tmp_path / ".kilo" / "plugins").exists()
+
+
+def test_kilo_preflight_accepts_jsonc_without_mutating_source(tmp_path):
+    from graphify.install import _preflight_kilo_config
+
+    config_file = tmp_path / ".kilo" / "kilo.jsonc"
+    config_file.parent.mkdir(parents=True)
+    original = '// user comment\n{"model": "keep", "plugin": [],}\n'
+    config_file.write_text(original, encoding="utf-8")
+
+    result = _preflight_kilo_config(tmp_path)
+
+    assert result == {"model": "keep", "plugin": []}
+    assert config_file.read_text(encoding="utf-8") == original
+    assert not (tmp_path / ".kilo" / "kilo.json").exists()
+
+
+def test_kilo_preflight_rejects_non_list_plugins(tmp_path, capsys):
+    from graphify.install import _preflight_kilo_config
+
+    config_file = tmp_path / ".kilo" / "kilo.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text('{"plugin": null}', encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        _preflight_kilo_config(tmp_path)
+
+    assert excinfo.value.code == 1
+    assert str(config_file) in capsys.readouterr().err
+    assert config_file.read_text(encoding="utf-8") == '{"plugin": null}'
+
+
 def test_opencode_agents_install_merges_existing_config(tmp_path):
     """opencode install preserves existing .opencode/opencode.json keys."""
     import json as _json

--- a/tests/test_settings_merge.py
+++ b/tests/test_settings_merge.py
@@ -24,6 +24,7 @@ from graphify.install import (
     _install_codebuddy_hook,
     _install_codex_hook,
     _install_gemini_hook,
+    _read_settings_for_merge,
 )
 
 # installer key -> (function, settings file relative to project dir, hooks section)
@@ -154,6 +155,38 @@ def test_non_dict_hooks_section_aborts(tmp_path, capsys):
     assert excinfo.value.code == 1
     assert str(settings_path) in capsys.readouterr().err
     assert settings_path.read_bytes() == original
+
+
+def test_preflight_missing_settings_is_empty_without_creating_parent(tmp_path):
+    settings_path = tmp_path / ".codex" / "hooks.json"
+
+    assert _read_settings_for_merge(settings_path, managed_collection="PreToolUse") == {}
+    assert not settings_path.parent.exists()
+
+
+def test_preflight_allows_omitted_managed_hook_collection(tmp_path):
+    settings_path = _seed(tmp_path, "codex", {"theme": "dark", "hooks": {}})
+
+    assert _read_settings_for_merge(settings_path, managed_collection="PreToolUse") == {
+        "theme": "dark",
+        "hooks": {},
+    }
+
+
+@ALL_INSTALLERS
+def test_preflight_rejects_non_list_managed_hook_collection(tmp_path, installer, capsys):
+    """Read-only hook preflight rejects a malformed managed collection."""
+    section = _INSTALLERS[installer][2]
+    settings_path = _seed(tmp_path, installer, {"hooks": {section: "oops"}})
+    original = settings_path.read_bytes()
+
+    with pytest.raises(SystemExit) as excinfo:
+        _read_settings_for_merge(settings_path, managed_collection=section)
+
+    assert excinfo.value.code == 1
+    assert str(settings_path) in capsys.readouterr().err
+    assert settings_path.read_bytes() == original
+    assert not settings_path.with_name(settings_path.name + ".graphify-bak").exists()
 
 
 # ---------------------------------------------------------------- backup


### PR DESCRIPTION
## Summary

Project installs now fail before changing Graphify-owned files when an existing platform configuration is malformed. Previously, an invalid configuration could leave behind a partially installed skill, `AGENTS.md` entry, command, or plugin; the installer now validates the configuration and managed structure first, then reuses the validated state for writes. The safety contract covers combined Codex, Claude, Gemini, CodeBuddy, OpenCode, and Kilo project flows while preserving skill-only routes and existing JSON/JSONC formats.

Session-settled decisions carried from planning: preflight-first validation (user-approved, over a full transaction layer).

Fixes #2416

## Validation

- Focused install, merge, and round-trip tests: **183 passed**
- `pyright graphify/install.py`: **0 errors**
- Ruff checks for changed Python files: **passed**
- Full suite with the optional `openai` dependency: **3928 passed, 36 skipped**; one unrelated failure remains in `tests/test_labeling.py::test_label_communities_batches_when_over_batch_size` because its observed batch order is `[100, 50, 100]` instead of `[100, 100, 50]`

## New concepts

### Side-effect-free preflight validation

Preflight validation checks an existing configuration before an installer performs any mutation, and can pass the parsed result into the write phase.

Why this change uses it:

```python
config = preflight(config_path)  # Reject bad input before any project writes.
copy_skill()
write_plugin(config)
```

This is safer than adding rollback for a multi-file install: malformed input is deterministic, while rollback would need to preserve user files and account for partial I/O. The project routes apply the pattern before skills, instructions, commands, plugins, and configuration writes; skill-only routes do not read unrelated configuration. Do not use this pattern to broaden validation into flows that neither read nor mutate the configuration.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
