### PR TITLE
fix: extract JS/TS object-literal shorthand methods

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -1723,6 +1723,39 @@ def _require_imports_js(node, source: bytes, file_nid: str, stem: str, edges: li
 
 _JS_FUNCTION_VALUE_TYPES = frozenset({"arrow_function", "function_expression", "function", "generator_function"})
 
+# Nodes the object-literal scan must not descend through. Function values are
+# execution boundaries (their bodies are separate scopes, walked via
+# function_bodies); class nodes are stopped so methods inside a class expression
+# are never claimed as object-literal members — `const C = class { m() {} }` must
+# not look like an object literal. Class-expression extraction is out of #2419 scope.
+_JS_OBJECT_SCAN_STOP_TYPES = _JS_FUNCTION_VALUE_TYPES | frozenset({
+    "class", "class_declaration", "class_body",
+})
+
+def _js_object_literal_methods(value) -> list:
+    """Shorthand `method_definition` nodes beneath one module-level binding initializer.
+
+    Descends only through structural containers (object literals, pairs, call
+    arguments, wrapper expressions) and stops at `_JS_OBJECT_SCAN_STOP_TYPES`
+    plus each collected `method_definition` (its body is a separate scope).
+
+    Methods are flattened onto the binding, so two nested objects under the same
+    const with a same-named method collapse to one node — nested property-path
+    ownership is not modelled.
+    """
+    found = []
+    stack = [value]
+    while stack:
+        cur = stack.pop()
+        for child in cur.named_children:
+            if child.type in _JS_OBJECT_SCAN_STOP_TYPES:
+                continue
+            if child.type == "method_definition":
+                found.append(child)
+                continue  # do not traverse the body
+            stack.append(child)
+    return found
+
 def _js_member_assignment_target(left, source: bytes):
     """Classify the symbol an `assignment_expression` LHS defines when its RHS
     is a function. Returns (kind, owner_name, member_name) or None.
@@ -1907,6 +1940,31 @@ def _js_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
                             add_node_fn(const_nid, const_name, line)
                             add_edge_fn(file_nid, const_nid, "contains", line)
                             const_found = True
+                            # This branch returns True, so the main walker never
+                            # descends into the initializer — shorthand methods
+                            # inside it would otherwise be lost (#2419).
+                            emitted: set[str] = set()
+                            for meth in _js_object_literal_methods(value):
+                                meth_name_node = meth.child_by_field_name("name")
+                                if meth_name_node is None:
+                                    continue
+                                meth_name = _read_text(meth_name_node, source)
+                                if not normalize_id(meth_name):
+                                    continue
+                                meth_nid = _make_id(const_nid, meth_name)
+                                if meth_nid in emitted:
+                                    continue
+                                emitted.add(meth_nid)
+                                meth_line = meth.start_point[0] + 1
+                                add_node_fn(meth_nid, f".{meth_name}()", meth_line)
+                                add_edge_fn(const_nid, meth_nid, "method", meth_line)
+                                if callable_def_nids is not None:
+                                    callable_def_nids.add(meth_nid)
+                                if local_bound_names is not None:
+                                    local_bound_names[meth_nid] = _js_local_bound_names(meth, source)
+                                meth_body = meth.child_by_field_name("body")
+                                if meth_body:
+                                    function_bodies.append((meth_nid, meth_body))
         if arrow_found:
             return True
         if const_found:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -2048,6 +2048,160 @@ def test_ts_local_const_does_not_emit_phantom_node(tmp_path):
     assert "topLevel" in labels, f"module-level TS const 'topLevel' missing: {labels}"
 
 
+_OBJECT_LITERAL_JS = (
+    "function helper() { return 1; }\n"
+    "\n"
+    "export const topLevelObj = {\n"
+    "  objMethod() {\n"
+    "    return helper();\n"
+    "  }\n"
+    "};\n"
+    "\n"
+    "export const Factory = service({\n"
+    "  methods: {\n"
+    "    nestedMethod() {\n"
+    "      return helper();\n"
+    "    },\n"
+    "    async nestedAsync() {\n"
+    "      return helper();\n"
+    "    }\n"
+    "  }\n"
+    "});\n"
+)
+
+
+def _owner_of(r, method_label):
+    """Return the labels of nodes owning `method_label` via a `method` edge."""
+    by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    return {
+        by_id.get(e["source"], e["source"])
+        for e in r["edges"]
+        if e["relation"] == "method" and by_id.get(e["target"]) == method_label
+    }
+
+
+def test_js_object_literal_methods_owned_by_const(tmp_path):
+    """Shorthand methods in module-level object literals become const-owned methods (#2419).
+
+    `_js_extra_walk` emits the const node and returns True, so the main walker
+    never descends into the initializer — these methods used to vanish entirely.
+    """
+    f = tmp_path / "obj_literal.js"
+    f.write_text(_OBJECT_LITERAL_JS)
+    r = extract_js(f)
+    labels = _labels(r)
+
+    for m in (".objMethod()", ".nestedMethod()", ".nestedAsync()"):
+        assert m in labels, f"missing object-literal method {m}: {labels}"
+        assert labels.count(m) == 1, f"duplicate node for {m}: {labels}"
+
+    assert _owner_of(r, ".objMethod()") == {"topLevelObj"}
+    assert _owner_of(r, ".nestedMethod()") == {"Factory"}
+    assert _owner_of(r, ".nestedAsync()") == {"Factory"}
+
+    # Calls inside the method bodies must be attributed to the method nodes.
+    calls = _calls(r)
+    for m in (".objMethod()", ".nestedMethod()", ".nestedAsync()"):
+        assert (m, "helper()") in calls, f"call from {m} to helper() missing: {calls}"
+
+    # Methods are owned by the const via `method`, never `contains`-ed by the file.
+    method_ids = {n["id"] for n in r["nodes"] if n["label"].startswith(".")}
+    ownership = [(e["source"], e["target"], e["relation"]) for e in r["edges"]
+                 if e["target"] in method_ids]
+    assert all(rel == "method" for _, _, rel in ownership), f"non-method ownership edge: {ownership}"
+    assert len(ownership) == len(set(ownership)) == 3, f"bad ownership edges: {ownership}"
+
+
+def test_ts_object_literal_methods_owned_by_const(tmp_path):
+    """TypeScript shares `_js_extra_walk`, so the same path must be active (#2419)."""
+    f = tmp_path / "obj_literal.ts"
+    f.write_text(
+        "function helper(): number { return 1; }\n"
+        "\n"
+        "export const topLevelObj = {\n"
+        "  objMethod(): number {\n"
+        "    return helper();\n"
+        "  }\n"
+        "};\n"
+    )
+    r = extract_js(f)
+
+    assert ".objMethod()" in _labels(r), f"TS object-literal method missing: {_labels(r)}"
+    assert _owner_of(r, ".objMethod()") == {"topLevelObj"}
+    assert (".objMethod()", "helper()") in _calls(r)
+
+
+def test_js_object_literal_scan_respects_scope_and_execution_boundaries(tmp_path):
+    """Locals and callback bodies must stay unindexed (#2419).
+
+    The initializer scan stops at function-value nodes, so a method defined in
+    an object returned from a callback is not attributed to the outer binding.
+    """
+    f = tmp_path / "boundaries.js"
+    f.write_text(
+        "function helper() { return 1; }\n"
+        "\n"
+        "function outer() {\n"
+        "  const local = {\n"
+        "    localMethod() { return helper(); }\n"
+        "  };\n"
+        "  return local;\n"
+        "}\n"
+        "\n"
+        "export const CallbackFactory = configure(() => {\n"
+        "  return {\n"
+        "    callbackLocal() { return helper(); }\n"
+        "  };\n"
+        "});\n"
+    )
+    r = extract_js(f)
+    labels = _labels(r)
+
+    assert ".localMethod()" not in labels, f"local-object method leaked: {labels}"
+    assert ".callbackLocal()" not in labels, f"callback-body method leaked: {labels}"
+    assert "local" not in labels, f"function-local const leaked: {labels}"
+
+    callers = {src for src, _ in _calls(r)}
+    assert "CallbackFactory" not in callers, f"callback call leaked onto the const: {_calls(r)}"
+
+
+def test_js_class_expression_const_is_not_object_literal_scanned(tmp_path):
+    """`const C = class { m() {} }` must keep the existing class handling (#2419)."""
+    f = tmp_path / "class_expr.js"
+    f.write_text(
+        "export const Constructor = class {\n"
+        "  classExpressionMethod() {}\n"
+        "};\n"
+    )
+    r = extract_js(f)
+    labels = _labels(r)
+
+    assert "Constructor" in labels, f"module-level binding missing: {labels}"
+    assert ".classExpressionMethod()" not in labels, (
+        f"class-expression method leaked into the object-literal scan: {labels}"
+    )
+
+
+def test_js_object_literal_duplicate_method_names_collapse(tmp_path):
+    """Flattening onto the binding means same-named nested methods share one node (#2419).
+
+    Nested property paths are not modelled; the guard is that this yields exactly
+    one node and one ownership edge, never duplicates.
+    """
+    f = tmp_path / "dupes.js"
+    f.write_text(
+        "export const Service = {\n"
+        "  first: { run() {} },\n"
+        "  second: { run() {} }\n"
+        "};\n"
+    )
+    r = extract_js(f)
+
+    assert _labels(r).count(".run()") == 1, f"duplicate .run() node: {_labels(r)}"
+    method_edges = [(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "method"]
+    assert len(method_edges) == len(set(method_edges)) == 1, f"duplicate method edges: {method_edges}"
+
+
 def test_ts_constructor_injection_calls_edge(tmp_path):
     """this.repo.findById() in a class with constructor(private repo: IUserRepository)
     must produce a calls edge from getUser() to findById() (#1316)."""


### PR DESCRIPTION
Fixes #2419

## Summary

Extract JavaScript and TypeScript object-literal shorthand methods from module-level binding initializers.

This covers module-object and factory-style patterns such as:

```js
export const Service = create({
    methods: {
        run() {},
        async refresh() {},
    },
});
```

The extracted methods are owned by the enclosing module-level binding and their body calls are attributed to the method nodes.

## Root cause

The JS/TS module-level const path emitted the binding node and returned before the generic walker entered the initializer subtree. As a result, `method_definition` nodes under object literals were never visited.

## Implementation

* Scan an already-confirmed module-level binding initializer for shorthand `method_definition` nodes.
* Stop at function, callback, method-body, and class ownership boundaries.
* Reuse Graphify's existing method IDs, labels, `method` edges, callable registration, local-binding registration, and deferred function-body processing.
* Preserve the existing generic walker and `_js_extra_walk()` return contract.
* Prevent duplicate nodes and ownership edges under Graphify's existing flattened binding/member ID model.

## Safety

Regression coverage verifies:

* Top-level object-literal methods
* Nested factory-style methods
* Async shorthand methods
* JavaScript and TypeScript parity
* Correct const ownership
* Correct method-body call attribution
* No local-object leakage
* No callback-body leakage
* No class-expression misclassification
* No duplicate method nodes or ownership edges
* Existing module-level arrow behavior remains unchanged

## Verification

* `336 passed` in `tests/test_languages.py`
* `3980 passed, 3 skipped` in the full suite
* Focused final review: `8 passed, 328 deselected`
* Ruff passed
* `git diff --check` passed

## Deferred scope

This PR intentionally does not add support for function-valued property pairs such as:

```js
{
    handler: function () {},
    callback: () => {},
}
```

It also does not change god-node ranking or class-expression extraction.
