### PR TITLE
fix(watch): preserve direct calls to unchanged files during incremental updates

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4591,6 +4591,7 @@ def extract(
     root: Path | None = None,
     parallel: bool = True,
     max_workers: int | None = None,
+    direct_call_resolution_context_nodes: list[dict] | None = None,
 ) -> dict:
     """Extract AST nodes and edges from a list of code files.
 
@@ -4613,6 +4614,27 @@ def extract(
             use ProcessPoolExecutor for multi-core extraction.
         max_workers: max subprocess count. Defaults to cpu_count (or the
             value of GRAPHIFY_MAX_WORKERS if set), bounded by len(uncached_work).
+        direct_call_resolution_context_nodes: read-only AST nodes from files
+            that are NOT being extracted this run (an incremental rebuild's
+            unchanged corpus, #2406). They extend the label/file indexes of the
+            SHARED DIRECT cross-file call pass only, so a changed caller can
+            still bind a plain `foo()` to an unchanged callee. They are never
+            parsed, mutated, or returned — only edges sourced by `paths` are
+            emitted.
+
+            Deliberately NOT covered (each needs data this list cannot carry,
+            so an incremental rebuild still drops these edge families until the
+            next full rebuild):
+              * member calls (`obj.method()`, #2437) — `run_language_resolvers` below
+                resolves them from `per_file` type tables and the `contains`/
+                `method` edges of the callee's file. Neither survives in
+                graph.json, so the context would have to be reparsed.
+              * `indirect_call` (#2438) — its target guard reads the `_callable` /
+                `_callable_class` markers, which are stripped before the graph
+                is persisted (see the `n.pop` calls near the end of this
+                function). Inferring callability from a persisted label would
+                reintroduce the same-named-data-symbol false positives #1566
+                and #2137 removed.
     """
     paths = [Path(p) for p in paths]
     anchor_root = Path(root) if root is not None else None
@@ -5296,7 +5318,28 @@ def extract(
     # identifiers, and they were polluting matches for short names — #563).
     global_label_to_nids: dict[str, list[str]] = {}      # exact-case (all languages)
     global_label_to_nids_ci: dict[str, list[str]] = {}   # case-INSENSITIVE-language nodes
-    for n in all_nodes:
+    # #2406: on an incremental rebuild only the CHANGED files are parsed, so
+    # `all_nodes` alone cannot see a callee that lives in an unchanged file and
+    # every changed->unchanged DIRECT call silently vanished (while the file-level
+    # `imports` edge survived, because the JS/Python symbol-resolution pass
+    # reads the import TARGET off disk instead of off the node list). Extend the
+    # resolution indexes — and ONLY the indexes — with the caller-supplied
+    # unchanged-corpus nodes. Fresh nodes win on id collision, nothing is
+    # appended to `all_nodes`, and raw_calls still come solely from `paths`, so
+    # the emitted edges remain sourced by the re-extracted files.
+    #
+    # Scope: this list feeds ONLY the shared direct-call loop below. The member-call
+    # resolvers (run_language_resolvers) and the indirect_call guard keep reading
+    # `all_nodes`, because the data each needs is not persisted — see the
+    # `direct_call_resolution_context_nodes` docstring entry.
+    resolution_nodes = all_nodes
+    if direct_call_resolution_context_nodes:
+        _fresh_ids = {n["id"] for n in all_nodes}
+        resolution_nodes = all_nodes + [
+            n for n in direct_call_resolution_context_nodes
+            if n.get("id") and n["id"] not in _fresh_ids
+        ]
+    for n in resolution_nodes:
         if n.get("file_type") == "rationale" or n.get("type") == "namespace":
             continue
         raw = n.get("label", "")
@@ -5344,7 +5387,7 @@ def extract(
     # absolute-derived id — which would spuriously fail import evidence and (with
     # the #1659 JS/TS gate below) drop a legitimately-imported call.
     sf_to_file_nid: dict[str, str] = {}
-    for n in all_nodes:
+    for n in resolution_nodes:
         sf = n.get("source_file")
         if sf and n.get("label") == Path(str(sf)).name:
             sf_to_file_nid.setdefault(str(sf), n["id"])
@@ -5353,7 +5396,7 @@ def extract(
     # (test/non-test classification + path proximity). Kept separate from the
     # file-node-id map because tie-breaking compares the actual file paths.
     nid_to_source_file: dict[str, str] = {}
-    for n in all_nodes:
+    for n in resolution_nodes:
         sf = n.get("source_file")
         if not sf:
             continue

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1157,8 +1157,71 @@ def _rebuild_code(
             # AST heading layer intact alongside the semantic layer.
             extract_targets = [p for p in code_files if p not in semantic_doc_files]
 
+        # #2406: an incremental rebuild parses only the changed files, so the
+        # shared cross-file DIRECT call resolver could not see a callee living in
+        # an unchanged file and every changed->unchanged `calls` edge disappeared
+        # (reconcile evicts the old one as AST-tier output of a re-extracted
+        # source, and nothing regenerates it). Hand extract() read-only resolution
+        # context: the persisted AST nodes of files this run is NOT re-extracting.
+        #
+        # Scoping rules, in order of importance:
+        #   * AST-tier only — semantic/LLM nodes are not symbol definitions.
+        #   * never a file in extract_targets (its fresh nodes are authoritative)
+        #     nor a deleted one (its persisted symbols are gone).
+        #   * only sources still in the scanned corpus, so a renamed/removed file
+        #     cannot stay a resolver target.
+        # extract() uses these purely to widen the shared direct-call pass's
+        # label/file indexes; nothing is parsed, mutated, or emitted from them.
+        # Member calls (#2437) and indirect_call (#2438) are NOT covered — they
+        # need per-file type tables / `_callable` markers that graph.json does not
+        # carry, so those edge families still wait for a full rebuild (see
+        # extract()'s docstring).
+        direct_call_resolution_context_nodes: list[dict] = []
+        if changed_paths is not None and existing_graph.exists():
+            try:
+                check_graph_file_size_cap(existing_graph)
+                ctx_graph = json.loads(existing_graph.read_text(encoding="utf-8"))
+                ctx_paths = _StoredSourcePaths(
+                    ctx_graph,
+                    out=out,
+                    project_root=project_root,
+                    watch_root=watch_root,
+                    normalize_source=_nsf,
+                )
+                ctx_live = {
+                    ctx_paths.absolute_identity(str(p), project_root) for p in code_files
+                }
+                ctx_live -= {
+                    ctx_paths.absolute_identity(str(p), project_root) for p in extract_targets
+                }
+                ctx_live -= deleted_source_identities
+                ctx_live.discard(None)
+                for node in ctx_graph.get("nodes", []):
+                    if not node.get("id") or not _is_ast_tier(node):
+                        continue
+                    source_file = node.get("source_file")
+                    if not source_file or ctx_paths.identity(source_file) not in ctx_live:
+                        continue
+                    direct_call_resolution_context_nodes.append({
+                        "id": node["id"],
+                        "label": node.get("label"),
+                        "source_file": source_file,
+                        "file_type": node.get("file_type"),
+                        "type": node.get("type"),
+                    })
+            except Exception:
+                # Unreadable/oversized graph: resolve with the changed batch only
+                # (pre-#2406 behavior). Reconcile below still fails closed on it.
+                direct_call_resolution_context_nodes = []
+
         commit = _git_head(cwd=watch_root)
-        result = extract(extract_targets, cache_root=watch_root) if extract_targets else {
+        result = extract(
+            extract_targets,
+            cache_root=watch_root,
+            direct_call_resolution_context_nodes=(
+                direct_call_resolution_context_nodes or None
+            ),
+        ) if extract_targets else {
             "nodes": [], "edges": [], "hyperedges": [],
             "input_tokens": 0, "output_tokens": 0,
         }

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -2602,3 +2602,395 @@ def test_rebuild_code_fresh_build_defaults_undirected(tmp_path):
     graph_path = corpus / "graphify-out" / "graph.json"
     data = json.loads(graph_path.read_text(encoding="utf-8"))
     assert data.get("directed", False) is False
+
+
+def test_incremental_rebuild_preserves_call_to_unchanged_typescript_target(tmp_path):
+    """#2406: rebuilding a changed caller retains its SHARED DIRECT calls into unchanged files.
+
+    Scope is the shared direct-call pass (a plain `shared()`), not member calls
+    or indirect_call — see the two xfail tests at the end of this file.
+
+    A later edit that removes the call must still remove the edge, preventing a
+    stale-edge-preservation workaround.
+    """
+    import json
+
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+
+    target = corpus / "B.ts"
+    caller = corpus / "A.ts"
+
+    target.write_text(
+        """
+export function shared(): number {
+  return 1;
+}
+""".lstrip(),
+        encoding="utf-8",
+    )
+    caller.write_text(
+        """
+import { shared } from "./B";
+
+export function run(): number {
+  return shared();
+}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    graph_path = corpus / "graphify-out" / "graph.json"
+
+    def load_graph():
+        return json.loads(graph_path.read_text(encoding="utf-8"))
+
+    def node_id(graph, label, source_file):
+        return next(
+            node["id"]
+            for node in graph.get("nodes", [])
+            if node.get("label") == label
+            and node.get("source_file") == source_file
+        )
+
+    def has_call(graph):
+        run_id = node_id(graph, "run()", "A.ts")
+        shared_id = node_id(graph, "shared()", "B.ts")
+        return any(
+            edge.get("relation") == "calls"
+            and edge.get("source") == run_id
+            and edge.get("target") == shared_id
+            for edge in graph.get("links", graph.get("edges", []))
+        )
+
+    # Full-corpus baseline resolves A.run() -> B.shared().
+    assert _rebuild_code(
+        corpus,
+        no_cluster=True,
+        acquire_lock=False,
+    ) is True
+    assert has_call(load_graph()), "full rebuild must create the cross-file call edge"
+
+    # Change only the caller while retaining the same call. The unchanged target
+    # must remain available to the cross-file resolver.
+    caller.write_text(
+        """
+import { shared } from "./B";
+
+export function run(): number {
+  return shared() + 1;
+}
+""".lstrip(),
+        encoding="utf-8",
+    )
+    assert _rebuild_code(
+        corpus,
+        changed_paths=[caller],
+        no_cluster=True,
+        acquire_lock=False,
+    ) is True
+    assert has_call(
+        load_graph()
+    ), "incremental rebuild dropped the call edge to an unchanged target"
+
+    # Removing the call must remove the edge; do not merely preserve old outgoing
+    # edges from changed files.
+    caller.write_text(
+        """
+export function run(): number {
+  return 1;
+}
+""".lstrip(),
+        encoding="utf-8",
+    )
+    assert _rebuild_code(
+        corpus,
+        changed_paths=[caller],
+        no_cluster=True,
+        acquire_lock=False,
+    ) is True
+
+    final_graph = load_graph()
+    run_id = node_id(final_graph, "run()", "A.ts")
+    assert not any(
+        edge.get("relation") == "calls"
+        and edge.get("source") == run_id
+        for edge in final_graph.get("links", final_graph.get("edges", []))
+    ), "removed call must not survive as a stale edge"
+
+
+# --- #2406 incremental shared-direct-call resolution helpers -----------------
+
+def _2406_graph(corpus):
+    import json
+    return json.loads(
+        (corpus / "graphify-out" / "graph.json").read_text(encoding="utf-8")
+    )
+
+
+def _2406_nid(graph, label, source_file):
+    return next(
+        (
+            node["id"]
+            for node in graph.get("nodes", [])
+            if node.get("label") == label and node.get("source_file") == source_file
+        ),
+        None,
+    )
+
+
+def _2406_calls(graph):
+    """(source_id, target_id) of every `calls` edge."""
+    return [
+        (edge.get("source"), edge.get("target"))
+        for edge in graph.get("links", graph.get("edges", []))
+        if edge.get("relation") == "calls"
+    ]
+
+
+def _2406_seed(tmp_path, caller_src, target_src="export function shared(): number {\n  return 1;\n}\n"):
+    """Build a two-file TS corpus and do the initial full rebuild."""
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir(parents=True)
+    (corpus / "B.ts").write_text(target_src, encoding="utf-8")
+    (corpus / "A.ts").write_text(caller_src, encoding="utf-8")
+    assert _rebuild_code(corpus, no_cluster=True, acquire_lock=False) is True
+    return corpus
+
+
+_2406_CALLER = (
+    'import { shared } from "./B";\n'
+    "\n"
+    "export function run(): number {\n"
+    "  return shared();\n"
+    "}\n"
+)
+
+
+def test_incremental_rebuild_drops_call_when_import_is_removed(tmp_path):
+    """#2406: no import evidence => the persisted target must not be resolved."""
+    from graphify.watch import _rebuild_code
+
+    corpus = _2406_seed(tmp_path, _2406_CALLER)
+    caller = corpus / "A.ts"
+    # `shared` is now a local no-op call with no import backing it.
+    caller.write_text(
+        "declare function shared(): number;\n"
+        "\n"
+        "export function run(): number {\n"
+        "  return shared();\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    assert _rebuild_code(
+        corpus, changed_paths=[caller], no_cluster=True, acquire_lock=False
+    ) is True
+
+    graph = _2406_graph(corpus)
+    shared_id = _2406_nid(graph, "shared()", "B.ts")
+    run_id = _2406_nid(graph, "run()", "A.ts")
+    assert (run_id, shared_id) not in _2406_calls(graph)
+
+
+def test_incremental_rebuild_uses_fresh_nodes_when_target_also_changed(tmp_path):
+    """#2406: a changed target's persisted symbols must never win over fresh ones."""
+    from graphify.watch import _rebuild_code
+
+    corpus = _2406_seed(tmp_path, _2406_CALLER)
+    caller, target = corpus / "A.ts", corpus / "B.ts"
+    target.write_text(
+        "export function renamed(): number {\n  return 2;\n}\n", encoding="utf-8"
+    )
+    caller.write_text(
+        'import { renamed } from "./B";\n'
+        "\n"
+        "export function run(): number {\n"
+        "  return renamed();\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    assert _rebuild_code(
+        corpus,
+        changed_paths=[caller, target],
+        no_cluster=True,
+        acquire_lock=False,
+    ) is True
+
+    graph = _2406_graph(corpus)
+    calls = _2406_calls(graph)
+    run_id = _2406_nid(graph, "run()", "A.ts")
+    assert (run_id, _2406_nid(graph, "renamed()", "B.ts")) in calls
+    # The stale `shared()` node is gone entirely, so nothing can point at it.
+    assert _2406_nid(graph, "shared()", "B.ts") is None
+
+
+def test_incremental_rebuild_context_excludes_deleted_target(tmp_path):
+    """#2406: a deleted file cannot remain a resolver target."""
+    from graphify.watch import _rebuild_code
+
+    corpus = _2406_seed(tmp_path, _2406_CALLER)
+    caller, target = corpus / "A.ts", corpus / "B.ts"
+    target.unlink()
+    caller.write_text(
+        "export function run(): number {\n  return shared();\n}\n", encoding="utf-8"
+    )
+    assert _rebuild_code(
+        corpus,
+        changed_paths=[caller, target],
+        no_cluster=True,
+        acquire_lock=False,
+    ) is True
+
+    graph = _2406_graph(corpus)
+    assert _2406_nid(graph, "shared()", "B.ts") is None
+    assert _2406_calls(graph) == []
+
+
+def test_incremental_rebuild_does_not_reparse_unchanged_targets(tmp_path, monkeypatch):
+    """#2406 keeps the incremental contract: only changed files are extracted."""
+    import graphify.extract as extract_mod
+    from graphify.watch import _rebuild_code
+
+    corpus = _2406_seed(tmp_path, _2406_CALLER)
+    caller = corpus / "A.ts"
+
+    seen: list[list[str]] = []
+    real_extract = extract_mod.extract
+
+    def spy(paths, *args, **kwargs):
+        seen.append([Path(p).name for p in paths])
+        return real_extract(paths, *args, **kwargs)
+
+    monkeypatch.setattr(extract_mod, "extract", spy)
+    caller.write_text(_2406_CALLER.replace("shared();", "shared() + 1;"), encoding="utf-8")
+    assert _rebuild_code(
+        corpus, changed_paths=[caller], no_cluster=True, acquire_lock=False
+    ) is True
+
+    assert seen == [["A.ts"]]
+
+
+def test_incremental_rebuild_matches_full_rebuild_and_does_not_duplicate(tmp_path):
+    """#2406: full/incremental parity for edges sourced by the changed file."""
+    from graphify.watch import _rebuild_code
+
+    corpus = _2406_seed(tmp_path, _2406_CALLER)
+    caller = corpus / "A.ts"
+    edited = _2406_CALLER.replace("shared();", "shared() + 1;")
+    caller.write_text(edited, encoding="utf-8")
+
+    # Two incremental rebuilds in a row must be idempotent (no duplicate edges).
+    for _ in range(2):
+        assert _rebuild_code(
+            corpus, changed_paths=[caller], no_cluster=True, acquire_lock=False
+        ) is True
+    incremental = _2406_calls(_2406_graph(corpus))
+    assert len(incremental) == len(set(incremental))
+
+    # Same final corpus, built from scratch.
+    fresh = _2406_seed(tmp_path / "fresh", edited)
+    assert sorted(_2406_calls(_2406_graph(fresh))) == sorted(incremental)
+
+
+def test_incremental_rebuild_preserves_python_call_to_unchanged_target(tmp_path):
+    """#2406 is language-agnostic: the shared DIRECT cross-file call pass carries it."""
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "b.py").write_text("def shared():\n    return 1\n", encoding="utf-8")
+    caller = corpus / "a.py"
+    caller.write_text(
+        "from b import shared\n\n\ndef run():\n    return shared()\n", encoding="utf-8"
+    )
+    assert _rebuild_code(corpus, no_cluster=True, acquire_lock=False) is True
+    full = _2406_calls(_2406_graph(corpus))
+    assert full, "full rebuild must resolve the cross-file python call"
+
+    caller.write_text(
+        "from b import shared\n\n\ndef run():\n    return shared() + 1\n",
+        encoding="utf-8",
+    )
+    assert _rebuild_code(
+        corpus, changed_paths=[caller], no_cluster=True, acquire_lock=False
+    ) is True
+    assert sorted(_2406_calls(_2406_graph(corpus))) == sorted(full)
+
+
+# --- #2406 admitted scope gaps ----------------------------------------------
+# Both edge families resolve on a FULL rebuild but are dropped by an incremental
+# one, because the resolution context extract() receives is deliberately limited
+# to the shared direct-call pass. Each needs data graph.json does not persist:
+# member calls need the callee file's per-file type table plus its contains/method
+# edges (tracked in #2437); indirect_call needs the `_callable`/`_callable_class`
+# markers that extract() strips before writing the graph (tracked in #2438).
+# xfail(strict=True) so that whoever closes either issue is told to delete the
+# marker rather than leaving it stale.
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#2437 (#2406 scope gap): member-call resolvers read per_file type "
+           "tables, which an incremental rebuild has only for the changed files",
+)
+def test_incremental_rebuild_drops_member_call_to_unchanged_target(tmp_path):
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "B.ts").write_text(
+        "export class Service {\n  ping(): number { return 1; }\n}\n", encoding="utf-8"
+    )
+    caller = corpus / "A.ts"
+    body = (
+        'import { Service } from "./B";\n\n'
+        "export function run(): number {\n"
+        "  const service = new Service();\n"
+        "  return service.ping()%s;\n}\n"
+    )
+    caller.write_text(body % "", encoding="utf-8")
+    assert _rebuild_code(corpus, no_cluster=True, acquire_lock=False) is True
+    full = _2406_calls(_2406_graph(corpus))
+    assert full, "full rebuild must resolve the cross-file member call"
+
+    caller.write_text(body % " + 1", encoding="utf-8")
+    assert _rebuild_code(
+        corpus, changed_paths=[caller], no_cluster=True, acquire_lock=False
+    ) is True
+    assert sorted(_2406_calls(_2406_graph(corpus))) == sorted(full)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#2438 (#2406 scope gap): the indirect_call target guard reads the "
+           "_callable marker, which is stripped before the graph is persisted",
+)
+def test_incremental_rebuild_drops_indirect_call_to_unchanged_target(tmp_path):
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "b.py").write_text("def handler():\n    return 1\n", encoding="utf-8")
+    caller = corpus / "a.py"
+    body = "from b import handler\n\n\ndef run(pool):\n%s    return pool.submit(handler)\n"
+    caller.write_text(body % "", encoding="utf-8")
+    assert _rebuild_code(corpus, no_cluster=True, acquire_lock=False) is True
+
+    def indirects(graph):
+        return [
+            (e.get("source"), e.get("target"))
+            for e in graph.get("links", graph.get("edges", []))
+            if e.get("relation") == "indirect_call"
+        ]
+
+    full = indirects(_2406_graph(corpus))
+    assert full, "full rebuild must resolve the cross-file indirect call"
+
+    caller.write_text(body % "    x = 1\n", encoding="utf-8")
+    assert _rebuild_code(
+        corpus, changed_paths=[caller], no_cluster=True, acquire_lock=False
+    ) is True
+    assert sorted(indirects(_2406_graph(corpus))) == sorted(full)


### PR DESCRIPTION
## Summary

Incremental rebuilds previously re-extracted only the changed files. The shared direct-call resolver therefore lacked the unchanged target nodes it needed to bind a plain `foo()` to its definition in another file.

Reconciliation correctly removed the changed source's old AST edges — that part was never wrong — but with the callee absent from the extraction batch, the missing direct call could not be regenerated. The result: a cross-file `calls` edge that a full build resolves silently disappears after an incremental update, and only returns on the next full rebuild. (The file-level `imports` edge survived, because the JS/Python symbol-resolution pass reads the import target off disk rather than off the node list — which is why the loss was easy to miss.)

This patch supplies a **read-only AST context** containing unchanged, live, in-corpus nodes exclusively to the shared direct-call resolver:

* Fresh changed-file nodes remain authoritative — on any id collision the freshly extracted node wins.
* Context nodes are **not parsed, not returned, not persisted, and not treated as newly extracted**. They extend the resolver's label/file indexes and nothing else; `all_nodes` is untouched and `raw_calls` still come solely from the re-extracted `paths`.
* Context is scoped to AST-tier nodes only, excludes any file in this run's extract targets, excludes deleted files, and excludes sources no longer in the scanned corpus — so a renamed or removed file can never remain a resolver target.
* Removed calls, removed imports, removed targets, and deleted files still remove their old edges. Preserving stale outgoing edges was explicitly not the approach, and there are tests asserting the edge disappears when the call is deleted.
* If the persisted graph is unreadable or exceeds the size cap, resolution falls back to the changed batch alone (pre-existing behavior).

## Scope

This is intentionally a narrow fix.

* **Fixed:** the exact direct-call reproduction in #2406, for both TypeScript and Python.
* **Not fixed:** language-specific **member calls** (`obj.method()`) and **`indirect_call`** edges. Both require resolver metadata that `graph.json` does not persist — per-file type tables plus the callee's `contains`/`method` edges for member calls, and the `_callable`/`_callable_class` markers (stripped before write) for indirect calls. Inferring either from persisted labels would reintroduce the same-named data-symbol false positives that #1566 and #2137 removed. These remain tracked in the two follow-up issues below.
* The PR deliberately avoids a graph-schema change and avoids a full-corpus reparse. The incremental contract holds: only changed files are extracted, and there is a test asserting exactly that.

Addresses #2406
Related to #2437
Related to #2438

## Testing

All runs on `uv run --frozen`, with the OpenAI extra synced via `uv sync --frozen --group dev --extra openai`. `uv.lock` is unchanged.

| Command | Result |
| --- | --- |
| `pytest tests/test_watch.py -q` | `97 passed, 2 skipped, 2 xfailed` |
| `pytest tests/test_js_import_resolution.py tests/test_extract.py -q` | `222 passed, 1 skipped` |
| `pytest tests/test_ollama_retry_cap.py -q` | `4 passed` |
| `pytest -q` (full suite) | `3915 passed, 35 skipped, 2 xfailed` |
| `ruff check graphify tests` | `All checks passed!` |
| `git diff --check` | clean (no output, exit 0) |

The two `xfail(strict=True)` tests are the admitted scope gaps above, and each corresponds to one of the newly filed follow-up issues:

* `test_incremental_rebuild_drops_member_call_to_unchanged_target` → #2437
* `test_incremental_rebuild_drops_indirect_call_to_unchanged_target` → #2438

They are strict on purpose: whoever closes either issue will be told to delete the marker rather than leave it silently stale.

New passing coverage added alongside them:

* TypeScript and Python cross-file direct call preserved across an incremental rebuild.
* Edge is removed when the call is removed (no stale-edge workaround).
* Edge is not resolved when the import evidence is gone.
* Fresh nodes win when the target file also changed.
* Deleted target file is excluded from the resolution context.
* Only changed files are extracted (incremental contract).
* Repeat incremental rebuilds are idempotent, and match a from-scratch full build.
