### PR TITLE
fix: install fails when the packaged bundle is read-only

### DIFF
--- a/graphify/install.py
+++ b/graphify/install.py
@@ -17,6 +17,7 @@ import os
 import platform
 import re
 import shutil
+import stat
 import sys
 from pathlib import Path
 from typing import NoReturn
@@ -165,6 +166,13 @@ def _install_skill_references(skill_dst: Path, refs_src: Path) -> None:
         shutil.rmtree(refs_staged)
     try:
         shutil.copytree(refs_src, refs_staged)
+        # copytree preserves the source's mode bits, and a packaged bundle can
+        # be read-only: a Nix store path, a root-owned site-packages, a
+        # container image layer. Renaming a directory needs write permission on
+        # the directory itself, to update its ".." entry, so the os.replace
+        # below would fail with EACCES. Restore owner-write on the staged copy.
+        for path in (refs_staged, *refs_staged.rglob("*")):
+            path.chmod(path.stat().st_mode | stat.S_IWUSR)
         if refs_dst.exists():
             shutil.rmtree(refs_dst)
         os.replace(refs_staged, refs_dst)

--- a/tests/test_install_references.py
+++ b/tests/test_install_references.py
@@ -514,3 +514,35 @@ def test_amp_user_install_carries_references(tmp_path, monkeypatch):
         main()
 
     assert not skill_dir.exists()
+
+
+def test_install_from_read_only_package_dir(tmp_path, fake_bundle):
+    """Install succeeds when the packaged bundle is read-only.
+
+    Nix store paths are mode 0o555, as are root-owned site-packages and
+    container image layers. copytree preserves those bits onto references.tmp,
+    and renaming a directory needs write permission on the directory itself to
+    update its ".." entry — so the staging rename fails with EACCES unless the
+    staged copy is made writable first.
+    """
+    platform = fake_bundle
+    bundle = mainmod._PLATFORM_CONFIG[platform]["skill_refs"]
+    refs_src = PKG_DIR / "skills" / bundle / "references"
+
+    modes = {p: p.stat().st_mode for p in (refs_src, *refs_src.rglob("*"))}
+    for path in modes:
+        path.chmod(0o555 if path.is_dir() else 0o444)
+    try:
+        _install(tmp_path, platform)
+    finally:
+        for path, mode in modes.items():
+            path.chmod(mode)
+
+    skill_dir = tmp_path / ".claude" / "skills" / "graphify"
+    refs = skill_dir / "references"
+    assert refs.is_dir()
+    assert (refs / "query.md").read_text() == "# query fragment\n"
+    assert not (skill_dir / "references.tmp").exists()
+    # The installed sidecar must stay writable, or the next install cannot
+    # rmtree it to swap in a new one.
+    assert os.access(refs, os.W_OK)


### PR DESCRIPTION
### The bug

`graphify install` aborts when the installed package sits somewhere read-only:

```
PermissionError: [Errno 13] Permission denied:
  '~/.claude/skills/graphify/references.tmp' -> '~/.claude/skills/graphify/references'
```

`_install_skill_references` stages the packaged sidecar with `shutil.copytree`, which preserves the source's mode bits. Where the package is read-only those are `0o555`. Renaming a *directory* requires write permission on the directory itself, because the rename updates its `..` entry — so `os.replace(refs_staged, refs_dst)` fails with `EACCES`, the `except` clause cleans up, and the install dies before `SKILL.md` is written.

Minimal reproduction, independent of graphify:

```python
src.mkdir(); (src / "f.md").write_text("x")
os.chmod(src / "f.md", 0o444); os.chmod(src, 0o555)

shutil.copytree(src, staged)
print(oct(staged.stat().st_mode & 0o777))   # 0o555
os.replace(staged, dst)                      # PermissionError: [Errno 13]
```

### Who hits it

Anywhere the package directory is not writable:

- **Nix** store paths, which are always `0o555` — this is where I found it
- root-owned `site-packages` under a system-managed Python
- container image layers baked read-only
- read-only pipx venvs

It is not a niche-installer problem: nothing about the code path is Nix-specific, and the failure is deterministic rather than intermittent.

### The fix

Restore owner-write on the staged copy before the rename. Eight lines including the comment, and the atomic staging design is untouched — `references.tmp` is still built fully, then renamed into place in one step, so an interrupted install still never exposes a half-written `references/`.

### Test

`test_install_from_read_only_package_dir` in `tests/test_install_references.py`, built on the existing `fake_bundle` fixture and `_install` helper. It chmods the packaged bundle to `0o555`, installs, and restores the original modes in a `finally` so teardown can still clean up.

Verified it is a real regression test: with the fix reverted it fails with the same `PermissionError: [Errno 13]`, and it passes with the fix applied. The wider install suite stays green — 209 passed, 1 skipped across `test_install*`, `test_uninstall_scope`, `test_agents_platform` and `test_atomic_writes`.

### One thing I left alone

`_copy_skill_file` copies `SKILL.md` with `shutil.copy`, which also preserves mode bits, so from a read-only package the installed `SKILL.md` lands `0o444`. That does not break anything — renaming a *file* only needs write permission on the parent directory, so upgrades still work — and users rarely edit it. I have kept this PR to the failure that actually blocks installation, but say the word and I will switch it to `shutil.copyfile` in a follow-up.

### Context

Found while packaging graphify as a Nix flake ([bensleveritt/graphify-nix](https://github.com/bensleveritt/graphify-nix)). Happy to adjust naming or placement to suit your conventions.
