### PR TITLE
fix: token permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: ["v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   skillgen-check:
     # Fast lint-style guard: the skill files under graphify/ are generated from

--- a/.github/workflows/release-graph.yml
+++ b/.github/workflows/release-graph.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-graph:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I ran OpenSSF Scorecard and noticed that the `Token-Permissions` check was scoring `0/10`.

The warning showed that `ci.yml` and `release-graph.yml` did not define top-level token permissions, so I added:

```yml
permissions:
  contents: read
```

This makes the default GitHub Actions token read-only for these workflows, while still allowing jobs to request higher permissions explicitly if needed.
