### PR TITLE
fix(extract): fail on AST extraction errors

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -3096,8 +3096,7 @@ def dispatch_command(cmd: str) -> None:
                 ast_result = _ast_extract(code_files, **ast_kwargs)
             except Exception as exc:
                 print(f"[graphify extract] AST extraction failed: {exc}", file=sys.stderr)
-                ast_result = {"nodes": [], "edges": [], "input_tokens": 0, "output_tokens": 0}
-                _extraction_incomplete = True  # the whole AST pass was lost
+                sys.exit(1)
         stages.mark("AST extract")
 
         # Semantic extraction on docs/papers/images. Check cache first.

--- a/tests/test_extract_cli.py
+++ b/tests/test_extract_cli.py
@@ -1,6 +1,7 @@
 """Tests for `graphify extract` CLI dispatch path in graphify.__main__."""
 from __future__ import annotations
 
+import importlib
 import os
 
 import pytest
@@ -17,6 +18,45 @@ def _make_corpus(tmp_path):
     (tmp_path / "main.go").write_text("package main\nfunc main() {}\n")
     (tmp_path / "README.md").write_text("# Notes\nThe main function entry point.\n")
     return tmp_path
+
+
+def test_extract_exits_nonzero_when_ast_extraction_raises(
+    monkeypatch, tmp_path, capsys
+):
+    """An AST failure must not be presented as a successful empty corpus."""
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "main.go").write_text("package main\nfunc main() {}\n")
+    out_dir = tmp_path / "out"
+
+    def _ast_failed(paths, **kwargs):
+        raise RuntimeError("worker pool failed")
+
+    extractmod = importlib.import_module("graphify.extract")
+    monkeypatch.setattr(extractmod, "extract", _ast_failed)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        mainmod.sys,
+        "argv",
+        [
+            "graphify",
+            "extract",
+            str(corpus),
+            "--code-only",
+            "--out",
+            str(out_dir),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        mainmod.main()
+
+    assert exc_info.value.code == 1
+    assert (
+        "[graphify extract] AST extraction failed: worker pool failed"
+        in capsys.readouterr().err
+    )
+    assert not (out_dir / "graphify-out" / "graph.json").exists()
 
 
 def test_extract_exits_nonzero_when_all_semantic_chunks_fail(


### PR DESCRIPTION
## Summary

- Exit with status code `1` when AST extraction raises an exception.
- Stop replacing failed extraction with a successful-looking empty AST result.
- Prevent downstream processing and `graph.json` creation after a total AST failure.
- Add regression coverage for the failure path.

Corpora with no code files remain unaffected because AST extraction is only attempted when `code_files` is non-empty.

## Tests

- `186 passed, 1 skipped`
- Ruff checks passed.
- `graphify update .` completed successfully.

Fixes #2445