### PR TITLE
Graph integrity: $ref resolution, collapse provenance, dangling classification, acceptance policy

### DIFF
--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -478,7 +478,7 @@ def suggest_questions(
     G = _source_backed_analysis_graph(G)
     communities = {
         cid: [node_id for node_id in nodes if node_id in G]
-        for cid, nodes in communities.items()
+        for cid, nodes in (communities or {}).items()
     }
     if community_labels:
         community_labels = {int(k) if isinstance(k, str) else k: v for k, v in community_labels.items()}

--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -106,12 +106,45 @@ def _is_json_key_node(G: nx.Graph, node_id: str) -> bool:
     return label in _JSON_NOISE_LABELS
 
 
+def _is_query_memory_path(path: str) -> bool:
+    """Return whether *path* belongs to Graphify's saved-query memory."""
+    normalised = str(path or "").replace("\\", "/").casefold().lstrip("/")
+    return normalised.startswith("graphify-out/memory/") or "/graphify-out/memory/" in f"/{normalised}"
+
+
+def _source_backed_analysis_graph(G: nx.Graph) -> nx.Graph:
+    """Remove saved-query memory from architecture ranking without mutating *G*.
+
+    Query memories intentionally remain in the persistent graph for retrieval and
+    semantic continuity.  They are prior assistant output, though, not independent
+    evidence about the system, so including them in degree, centrality, surprise,
+    or cohesion calculations creates a feedback loop where remembered answers can
+    outrank source-backed structure.
+    """
+    memory_nodes = {
+        node_id for node_id, data in G.nodes(data=True)
+        if _is_query_memory_path(data.get("source_file", ""))
+    }
+    memory_edges = [
+        (u, v) for u, v, data in G.edges(data=True)
+        if _is_query_memory_path(data.get("source_file", ""))
+    ]
+    if not memory_nodes and not memory_edges:
+        return G
+    analysis_graph = G.subgraph([n for n in G.nodes if n not in memory_nodes]).copy()
+    analysis_graph.remove_edges_from(
+        (u, v) for u, v in memory_edges if u in analysis_graph and v in analysis_graph
+    )
+    return analysis_graph
+
+
 def god_nodes(G: nx.Graph, top_n: int = 10) -> list[dict]:
     """Return the top_n most-connected real entities - the core abstractions.
 
     File-level hub nodes are excluded: they accumulate import/contains edges
     mechanically and don't represent meaningful architectural abstractions.
     """
+    G = _source_backed_analysis_graph(G)
     degree = dict(G.degree())
     sorted_nodes = sorted(degree.items(), key=lambda x: x[1], reverse=True)
     result = []
@@ -148,6 +181,12 @@ def surprising_connections(
     Concept nodes (empty source_file, or injected semantic annotations) are excluded
     from surprising connections because they are intentional, not discovered.
     """
+    G = _source_backed_analysis_graph(G)
+    communities = {
+        cid: [node_id for node_id in nodes if node_id in G]
+        for cid, nodes in (communities or {}).items()
+    }
+
     # Identify unique source files (ignore empty/null source_file)
     source_files = {
         data.get("source_file", "")
@@ -157,9 +196,9 @@ def surprising_connections(
     is_multi_source = len(source_files) > 1
 
     if is_multi_source:
-        return _cross_file_surprises(G, communities or {}, top_n)
+        return _cross_file_surprises(G, communities, top_n)
     else:
-        return _cross_community_surprises(G, communities or {}, top_n)
+        return _cross_community_surprises(G, communities, top_n)
 
 
 def _is_concept_node(G: nx.Graph, node_id: str) -> bool:
@@ -436,6 +475,11 @@ def suggest_questions(
     Based on: AMBIGUOUS edges, bridge nodes, underexplored god nodes, isolated nodes.
     Each question has a 'type', 'question', and 'why' field.
     """
+    G = _source_backed_analysis_graph(G)
+    communities = {
+        cid: [node_id for node_id in nodes if node_id in G]
+        for cid, nodes in communities.items()
+    }
     if community_labels:
         community_labels = {int(k) if isinstance(k, str) else k: v for k, v in community_labels.items()}
 

--- a/graphify/build.py
+++ b/graphify/build.py
@@ -609,6 +609,52 @@ def _doc_twin_remap(nodes: list) -> dict[str, str]:
     return remap
 
 
+def _provenance_key(G: nx.Graph, src: str, tgt: str) -> tuple[str, str]:
+    """Endpoint key matching the graph's own collapse rule.
+
+    An undirected Graph collapses (a,b) and (b,a) onto one edge, so provenance
+    must key on the unordered pair; a DiGraph keeps them apart.
+    """
+    if G.is_directed() or src <= tgt:
+        return (src, tgt)
+    return (tgt, src)
+
+
+def _edge_observation(attrs: dict, src: str, tgt: str) -> tuple[str, str, str, str]:
+    """One edge observation, as the deterministic tuple provenance is built from."""
+    return (
+        str(attrs.get("relation") or ""),
+        str(attrs.get("source_file") or ""),
+        str(attrs.get("source_location") or ""),
+        f"{attrs.get('_src', src)}->{attrs.get('_tgt', tgt)}",
+    )
+
+
+def _apply_edge_provenance(G: nx.Graph, observations: dict) -> None:
+    """Attach collapsed-edge provenance to each surviving edge.
+
+    The simple-graph design is deliberate — parallel edges are not needed for
+    traversal — but the observations that collapsed into each surviving edge are
+    real evidence and must not vanish silently. Every field is a sorted set or a
+    count, so the result is byte-identical across rebuilds of the same corpus.
+
+    ``directions`` is recorded only when the same endpoint pair was genuinely
+    observed both ways; a single direction adds no information and would bloat
+    every edge in the graph.
+    """
+    for (src, tgt), records in observations.items():
+        if not G.has_edge(src, tgt):
+            continue
+        data = G.edges[src, tgt]
+        data["evidence_count"] = len(records)
+        data["relations"] = sorted({r for r, _, _, _ in records if r})
+        data["source_files"] = sorted({f for _, f, _, _ in records if f})
+        data["source_locations"] = sorted({loc for _, _, loc, _ in records if loc})
+        directions = sorted({d for _, _, _, d in records})
+        if len(directions) > 1:
+            data["directions"] = directions
+
+
 def build_from_json(extraction: dict, *, directed: bool = False, root: str | Path | None = None) -> nx.Graph:
     """Build a NetworkX graph from an extraction dict.
 
@@ -917,6 +963,12 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
     for alias_key, candidates in _alias_candidates.items():
         if len(candidates) == 1:
             norm_to_id.setdefault(alias_key, next(iter(candidates)))
+    # Observations per surviving endpoint pair, for collapsed-edge provenance
+    # (#2311). Populated inside the loop below and applied once after it.
+    from collections import defaultdict as _defaultdict
+    _edge_observations: dict[tuple[str, str], list[tuple[str, str, str, str]]] = (
+        _defaultdict(list)
+    )
     # Iterate edges in a deterministic order. The graph is undirected and stores
     # direction in _src/_tgt; when two edges collapse onto the same node pair the
     # last write wins, so an unstable iteration order flips _src/_tgt run-to-run
@@ -1036,6 +1088,17 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
         # causing display functions to show edges backwards.
         attrs["_src"] = src
         attrs["_tgt"] = tgt
+        # Record this observation BEFORE any collapse. The graph is a simple
+        # Graph/DiGraph by design, so repeated observations of the same node pair
+        # collapse onto one edge and every attribute but the last is lost. That
+        # is fine for traversal but destroys provenance: 1,112 edges in a real
+        # corpus collapsed with no trace of what produced them. Accumulating here
+        # — after every drop-`continue` above, so dropped edges are not counted,
+        # but before the reciprocal-drop and add_edge below — keeps the evidence
+        # deterministically without adding parallel edges (#2311).
+        _edge_observations[_provenance_key(G, src, tgt)].append(
+            _edge_observation(attrs, src, tgt)
+        )
         # When the graph is undirected and the same node pair appears twice with
         # the same relation but opposite directions (e.g. a `calls` b and b `calls` a),
         # nx.Graph collapses them into one edge. The deterministic sort above means
@@ -1050,6 +1113,7 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
             ):
                 continue
         G.add_edge(src, tgt, **attrs)
+    _apply_edge_provenance(G, _edge_observations)
     hyperedges = extraction.get("hyperedges", [])
     if hyperedges:
         # Relativize hyperedge source_file the same way nodes and edges are

--- a/graphify/diagnostics.py
+++ b/graphify/diagnostics.py
@@ -109,6 +109,34 @@ def _variant_group_count(
     return groups
 
 
+# Relations whose target is legitimately outside the corpus: a Python stdlib or
+# third-party module, a Swift system framework, an npm package. The corpus never
+# contains a node for them, so the edge cannot resolve and never will. This is an
+# expected unresolved EXTERNAL reference, not a broken internal one, and conflating
+# the two hid 31 real semantic danglers behind 43 harmless import edges (#2311).
+_EXTERNAL_IMPORT_RELATIONS = frozenset({"imports", "imports_from"})
+
+
+def _classify_dangling(edge: dict[str, str], node_ids: set[str]) -> str:
+    """Classify a dangling edge as an expected external ref or an unexpected one.
+
+    Only a MISSING TARGET counts as external: an import edge whose *source* is
+    absent is a broken producer, not an outside module. An external module id is
+    a bare name — a dangling target carrying path separators is a corpus file the
+    extractor failed to emit, which is a real defect.
+    """
+    source_present = edge["source"] in node_ids
+    target = edge["target"]
+    if (
+        source_present
+        and edge["relation"] in _EXTERNAL_IMPORT_RELATIONS
+        and "/" not in target
+        and "\\" not in target
+    ):
+        return "external_import"
+    return "unexpected"
+
+
 def _tuple_arity_from_annotation(line: str) -> int:
     match = _TYPE_TUPLE_RE.search(line)
     if not match:
@@ -184,6 +212,10 @@ def diagnose_extraction(
     non_object_edges = 0
     missing_endpoint_edges = 0
     dangling_endpoint_edges = 0
+    external_import_edges = 0
+    unexpected_dangling_edges = 0
+    external_import_targets: set[str] = set()
+    unexpected_dangling_examples: list[dict[str, str]] = []
     self_loop_edges = 0
     valid_candidate_edges = 0
 
@@ -198,6 +230,25 @@ def diagnose_extraction(
             continue
         if source not in node_ids or target not in node_ids:
             dangling_endpoint_edges += 1
+            if _classify_dangling(edge, node_ids) == "external_import":
+                external_import_edges += 1
+                external_import_targets.add(target)
+            else:
+                unexpected_dangling_edges += 1
+                if len(unexpected_dangling_examples) < 40:
+                    unexpected_dangling_examples.append(
+                        {
+                            "source": source,
+                            "target": target,
+                            "missing": (
+                                "target" if source in node_ids else
+                                "source" if target in node_ids else "both"
+                            ),
+                            "relation": edge["relation"],
+                            "source_file": edge["source_file"],
+                            "source_location": edge["source_location"],
+                        }
+                    )
             continue
         if source == target:
             self_loop_edges += 1
@@ -232,12 +283,20 @@ def diagnose_extraction(
     graph_type = ""
     post_build_edge_count: int | None = None
     post_build_node_count: int | None = None
+    provenance_edge_count: int | None = None
     try:
         graph_input = deepcopy(extraction)
         graph: nx.Graph = build_from_json(graph_input, directed=directed, root=root)
         graph_type = type(graph).__name__
         post_build_edge_count = graph.number_of_edges()
         post_build_node_count = graph.number_of_nodes()
+        # Edges that absorbed more than one observation and therefore carry
+        # collapse provenance. Pinning this count is how a caller detects
+        # provenance silently disappearing between rebuilds (#2311).
+        provenance_edge_count = sum(
+            1 for _, _, data in graph.edges(data=True)
+            if int(data.get("evidence_count", 1) or 1) > 1
+        )
     except Exception as exc:
         build_error = f"{type(exc).__name__}: {exc}"
 
@@ -252,6 +311,10 @@ def diagnose_extraction(
         "non_object_edges": non_object_edges,
         "missing_endpoint_edges": missing_endpoint_edges,
         "dangling_endpoint_edges": dangling_endpoint_edges,
+        "external_import_edges": external_import_edges,
+        "external_import_targets": sorted(external_import_targets),
+        "unexpected_dangling_edges": unexpected_dangling_edges,
+        "unexpected_dangling_examples": unexpected_dangling_examples,
         "self_loop_edges": self_loop_edges,
         "valid_candidate_edges": valid_candidate_edges,
         "exact_duplicate_edges": _count_extra(exact_counts),
@@ -271,10 +334,102 @@ def diagnose_extraction(
         "post_build_graph_type": graph_type,
         "post_build_node_count": post_build_node_count,
         "post_build_edge_count": post_build_edge_count,
+        "provenance_edge_count": provenance_edge_count,
         "post_build_error": build_error,
         "producer_suppression": scan_producer_suppression_sites(suppression_path),
         "examples": examples,
     }
+
+
+def evaluate_acceptance(
+    summary: dict[str, Any],
+    *,
+    allow_self_loops: bool = False,
+    expected_provenance_edges: int | None = None,
+) -> dict[str, Any]:
+    """Turn a diagnostic summary into a pass/fail acceptance decision.
+
+    The split is the whole point. Some findings mean the graph is WRONG and the
+    build should be rejected; others are permanent properties of an honest graph
+    over a real corpus and must be reported without failing, or the gate becomes
+    noise that everyone learns to skip.
+
+    FAILS on:
+      * malformed or missing endpoint fields
+      * self-loops (unless ``allow_self_loops``, for corpora where recursion is
+        legitimately modelled)
+      * unexpected dangling semantic endpoints — every one is a real defect once
+        extraction has run under the current prompt
+      * unverified code nodes (symbols an extractor could not confirm in source)
+      * build errors
+      * nondeterministic loss of semantic provenance, when the caller pins the
+        expected count via ``expected_provenance_edges``
+
+    REPORTS without failing:
+      * verified external imports (stdlib/third-party targets the corpus cannot
+        contain)
+      * deterministic simple-graph edge consolidation
+    """
+    failures: list[str] = []
+    informational: list[str] = []
+
+    if summary.get("non_object_edges"):
+        failures.append(f"{summary['non_object_edges']} malformed (non-object) edges")
+    if summary.get("missing_endpoint_edges"):
+        failures.append(
+            f"{summary['missing_endpoint_edges']} edges with missing endpoint fields"
+        )
+    if summary.get("unexpected_dangling_edges"):
+        failures.append(
+            f"{summary['unexpected_dangling_edges']} unexpected dangling semantic endpoints"
+        )
+    if summary.get("unverified_node_count"):
+        failures.append(f"{summary['unverified_node_count']} unverified code nodes")
+    if summary.get("post_build_error"):
+        failures.append(f"graph build error: {summary['post_build_error']}")
+    self_loops = summary.get("self_loop_edges", 0)
+    if self_loops and not allow_self_loops:
+        failures.append(f"{self_loops} self-loop edges not explicitly allowed")
+
+    provenance_edges = summary.get("provenance_edge_count")
+    if expected_provenance_edges is not None and provenance_edges is not None:
+        if provenance_edges != expected_provenance_edges:
+            failures.append(
+                "semantic provenance changed nondeterministically: expected "
+                f"{expected_provenance_edges} edges carrying collapse provenance, "
+                f"found {provenance_edges}"
+            )
+
+    external = summary.get("external_import_edges", 0)
+    if external:
+        informational.append(
+            f"{external} verified external imports "
+            f"({len(summary.get('external_import_targets', []))} distinct modules)"
+        )
+    collapsed = summary.get("undirected_same_endpoint_collapsed_edges", 0)
+    if collapsed:
+        informational.append(
+            f"{collapsed} deterministic simple-graph edge consolidations across "
+            f"{summary.get('same_endpoint_group_count', 0)} endpoint groups"
+        )
+    if self_loops and allow_self_loops:
+        informational.append(f"{self_loops} self-loop edges (explicitly allowed)")
+
+    return {
+        "passed": not failures,
+        "failures": failures,
+        "informational": informational,
+    }
+
+
+def format_acceptance_report(verdict: dict[str, Any]) -> str:
+    lines = ["[graphify] acceptance policy"]
+    for failure in verdict["failures"]:
+        lines.append(f"  FAIL  {failure}")
+    for note in verdict["informational"]:
+        lines.append(f"  info  {note}")
+    lines.append("PASS" if verdict["passed"] else "FAIL")
+    return "\n".join(lines)
 
 
 def _read_json_file(path: str | Path) -> dict[str, Any]:
@@ -333,9 +488,14 @@ def format_diagnostic_json(summary: dict[str, Any]) -> dict[str, Any]:
         "summary": {
             key: value
             for key, value in summary.items()
-            if key not in {"examples", "producer_suppression"}
+            if key not in {
+                "examples",
+                "producer_suppression",
+                "unexpected_dangling_examples",
+            }
         },
         "examples": summary.get("examples", []),
+        "unexpected_dangling_examples": summary.get("unexpected_dangling_examples", []),
         "producer_suppression": summary.get("producer_suppression", {}),
         "notes": [
             "Diagnostics are read-only.",
@@ -358,6 +518,14 @@ def format_diagnostic_report(summary: dict[str, Any]) -> str:
         f"valid_candidate_edges: {summary['valid_candidate_edges']}",
         f"missing_endpoint_edges: {summary['missing_endpoint_edges']}",
         f"dangling_endpoint_edges: {summary['dangling_endpoint_edges']}",
+        (
+            "  expected_external_imports: "
+            f"{summary.get('external_import_edges', 0)}"
+        ),
+        (
+            "  unexpected_dangling_edges: "
+            f"{summary.get('unexpected_dangling_edges', 0)}"
+        ),
         f"self_loop_edges: {summary['self_loop_edges']}",
         f"exact_duplicate_edges: {summary['exact_duplicate_edges']}",
         f"directed_unique_endpoint_pairs: {summary['directed_unique_endpoint_pairs']}",

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -5544,7 +5544,16 @@ def extract(
             # Promote to EXTRACTED when there's a direct import edge from the
             # caller's file pointing at either the callee symbol itself or the
             # file the callee lives in.
-            if has_import_evidence:
+            # A Swift `TypeName(...)` constructor names its type explicitly in
+            # source. Swift types in the same module need no per-file import, so a
+            # uniquely resolved type definition is source-backed evidence equal to
+            # an imported symbol call. Ambiguous candidates were already rejected
+            # above; the class-node guard prevents capitalized free functions from
+            # being promoted accidentally.
+            explicit_swift_constructor = (
+                rc.get("explicit_type_constructor") is True and tgt in class_nids
+            )
+            if has_import_evidence or explicit_swift_constructor:
                 confidence = "EXTRACTED"
                 confidence_score = 1.0
             else:

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4692,13 +4692,63 @@ def extract(
     # #1666: surface any source file an extractor accepted but that produced zero
     # nodes (not even a file node). Such a file is silently absent from the graph,
     # so affected/explain are blind to and through it with no other signal.
+    def _is_non_graph_bearing(p: Path, res: dict) -> bool:
+        """True when producing zero nodes is the correct, permanent outcome.
+
+        Deliberately narrow. Only two shapes qualify:
+
+        * Xcode asset-catalogue metadata (``Contents.json`` inside a
+          ``.xcassets``/``.colorset``/``.imageset``/``.appiconset`` bundle) —
+          colour components and catalogue version stamps, no relationships.
+        * JSON the extractor itself classified as data rather than config, i.e.
+          a fixture or dataset. It already said so via ``skipped``; that is a
+          decision, not a failure.
+
+        An Icon Composer ``icon.json`` does NOT qualify — it names the assets its
+        layers draw, and is extracted.
+        """
+        _skipped = str(res.get("skipped") or "")
+        if _skipped.startswith("data json"):
+            return True
+        if p.name.casefold() == "contents.json":
+            return any(
+                parent.name.casefold().endswith(
+                    (".xcassets", ".colorset", ".imageset", ".appiconset",
+                     ".symbolset", ".dataset")
+                )
+                for parent in p.parents
+            )
+        return False
+
     _empty_sources: list[str] = []
+    _non_graph_bearing: list[str] = []
     for i, _p in enumerate(paths):
         _res = per_file[i] or {}
         if _res.get("nodes") or _res.get("error"):
             continue
-        if _get_extractor(_p) is not None:
+        if _get_extractor(_p) is None:
+            continue
+        # A file with no relationships to express is not a defect. Xcode asset
+        # metadata and data fixtures are intentionally non-graph-bearing: they
+        # will produce zero nodes on every run forever, so warning about them
+        # each time trains the reader to ignore a warning that does sometimes
+        # mean something. Report them separately, as information (#2311).
+        if _is_non_graph_bearing(_p, _res):
+            _non_graph_bearing.append(str(_p))
+        else:
             _empty_sources.append(str(_p))
+    if _non_graph_bearing:
+        _shown_ok = ", ".join(Path(x).name for x in _non_graph_bearing[:5])
+        _more_ok = (
+            f" (+{len(_non_graph_bearing) - 5} more)"
+            if len(_non_graph_bearing) > 5 else ""
+        )
+        print(
+            f"  note: {len(_non_graph_bearing)} intentionally non-graph-bearing "
+            f"file(s) produced no nodes: {_shown_ok}{_more_ok}. Expected — asset "
+            f"metadata and data fixtures carry no relationships (#2311).",
+            file=sys.stderr, flush=True,
+        )
     if _empty_sources:
         _shown = ", ".join(Path(x).name for x in _empty_sources[:5])
         _more = f" (+{len(_empty_sources) - 5} more)" if len(_empty_sources) > 5 else ""

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -4481,6 +4481,17 @@ def _extract_generic(
                         "source_location": f"L{node.start_point[0] + 1}",
                         "receiver": swift_receiver or member_receiver,
                     }
+                    # Swift modules expose their own types without per-file import
+                    # statements.  Preserve the direct syntactic evidence from an
+                    # uppercase `TypeName(...)` constructor call so the corpus-level
+                    # resolver can mark a unique type target EXTRACTED rather than
+                    # downgrading it merely because there is no import edge.
+                    if (
+                        config.ts_module == "tree_sitter_swift"
+                        and not is_member_call
+                        and _swift_constructor_type(node, source) == callee_name
+                    ):
+                        rc_entry["explicit_type_constructor"] = True
                     # Ruby: attach the receiver's inferred type from the method's
                     # local `var = Const.new` bindings, when unambiguously known.
                     if member_receiver and config.ts_module == "tree_sitter_ruby":

--- a/graphify/extractors/json_config.py
+++ b/graphify/extractors/json_config.py
@@ -21,6 +21,32 @@ _CONFIG_JSON_KEYS = frozenset({
     "extends", "$ref", "$schema", "compilerOptions",
 })
 
+def _json_pointer_parts(ref: str) -> list[str] | None:
+    """Decode an INTERNAL JSON Pointer `$ref` into its path components.
+
+    Returns the component list for a same-document pointer ("#/$defs/asset" ->
+    ["$defs", "asset"], "#" -> []), or None when ``ref`` is not an internal
+    pointer — an external file/URL reference ("common.json#/$defs/x"), or a bare
+    "#name" anchor, which is a plain-name anchor rather than a path and cannot
+    be resolved positionally.
+
+    Escapes are decoded per RFC 6901: ``~1`` before ``~0``, so a literal ``~1``
+    in a key survives a round trip instead of being mangled into ``/``.
+    """
+    if not ref.startswith("#"):
+        return None
+    pointer = ref[1:]
+    if not pointer:
+        return []
+    if not pointer.startswith("/"):
+        return None
+    return [
+        part.replace("~1", "/").replace("~0", "~")
+        for part in pointer.split("/")[1:]
+        if part
+    ]
+
+
 def _is_config_json(path: Path, obj_node, source: bytes) -> bool:
     """True if a .json file is a recognized config/manifest worth AST-extracting.
 
@@ -84,6 +110,14 @@ def extract_json(path: Path) -> dict:
     nodes: list[dict] = []
     edges: list[dict] = []
     seen_ids: set[str] = set()
+    # Internal `$ref` bookkeeping (#2311): the full JSON path of every key node
+    # emitted, so a same-document pointer resolves to the exact node this walk
+    # produced; the deferred pointer edges; and the external refs, reported so
+    # diagnostics can classify them as expected outside references.
+    path_to_nid: dict[tuple[str, ...], str] = {}
+    pending_internal_refs: list[tuple[str, tuple[str, ...], int, str]] = []
+    external_refs: list[str] = []
+    unresolved_internal_refs: list[str] = []
 
     # Keys whose string values become imports (package.json dep blocks)
     _DEP_KEYS = frozenset({
@@ -129,7 +163,8 @@ def extract_json(path: Path) -> dict:
         return pair_node.child_by_field_name("value")
 
     def walk_object(obj_node, parent_nid: str, parent_key: str | None,
-                    depth: int, pair_count: list) -> None:
+                    depth: int, pair_count: list,
+                    parent_path: tuple[str, ...] = ()) -> None:
         if depth > 6:
             return
         for child in obj_node.children:
@@ -153,13 +188,18 @@ def extract_json(path: Path) -> dict:
             line = child.start_point[0] + 1
             add_node(key_nid, key, line)
             add_edge(parent_nid, key_nid, "contains", line)
+            # Record the full JSON path -> node id so an internal `$ref`
+            # ("#/$defs/asset") resolves to the node this walk already emitted,
+            # exactly rather than by reconstructing the id scheme (#2311).
+            cur_path = parent_path + (key,)
+            path_to_nid[cur_path] = key_nid
 
             val = _val_node(child)
             if val is None:
                 continue
 
             if val.type == "object":
-                walk_object(val, key_nid, key, depth + 1, pair_count)
+                walk_object(val, key_nid, key, depth + 1, pair_count, cur_path)
 
             elif val.type == "array":
                 # For "extends" arrays (tsconfig, eslint): each string element.
@@ -187,10 +227,32 @@ def extract_json(path: Path) -> dict:
                         add_edge(file_nid, ref_nid, "extends", line, context="import")
 
                 elif key == "$ref" and val_text:
-                    # Namespace $ref values to prevent edge hijacking into code nodes (J-4)
-                    ref_nid = _make_id("ref", val_text)
-                    if ref_nid:
-                        add_edge(parent_nid, ref_nid, "references", line)
+                    # A `$ref` is either INTERNAL ("#/$defs/asset" — a pointer at
+                    # another part of this same document) or EXTERNAL (another
+                    # file or a URL). The two need opposite treatment, and
+                    # conflating them is what left every `$ref` dangling: the
+                    # edge was emitted but no node ever was (#2311).
+                    pointer = _json_pointer_parts(val_text)
+                    if pointer is not None:
+                        # Internal: the target node is one this same walk emits.
+                        # Defer resolution — the pointer may name a key that has
+                        # not been reached yet — and drop it later if the pointer
+                        # resolves to nothing, rather than emitting a dangler.
+                        pending_internal_refs.append(
+                            (parent_nid, tuple(pointer), line, val_text)
+                        )
+                    else:
+                        # External: a genuine outside reference. Namespace it to
+                        # prevent edge hijacking into code nodes (J-4), and emit
+                        # the node so the edge resolves — matching what the
+                        # `extends` branches above already do.
+                        ref_nid = _make_id("ref", val_text)
+                        if ref_nid:
+                            add_node(ref_nid, val_text, line, file_type="concept")
+                            add_edge(parent_nid, ref_nid, "references", line,
+                                     context="import")
+                            external_refs.append(val_text)
+
 
                 elif parent_key in _DEP_KEYS and val_text:
                     dep_nid = _make_id(key)
@@ -208,9 +270,30 @@ def extract_json(path: Path) -> dict:
         # orphan key-nodes (#1224); it's left to the LLM semantic pass.
         if not _is_config_json(path, doc, source):
             return {"nodes": [], "edges": [], "skipped": "data json (not a config/manifest)"}
-        walk_object(doc, file_nid, None, 0, [0])
+        walk_object(doc, file_nid, None, 0, [0], ())
     else:
         # Top-level array or scalar => data JSON, never a config/manifest.
         return {"nodes": [], "edges": [], "skipped": "data json (non-object root)"}
 
-    return {"nodes": nodes, "edges": edges}
+    # Resolve deferred internal `$ref` pointers now that every key node exists
+    # (#2311). Sorted for determinism: the pending list follows document order,
+    # but the emitted edge order must not depend on it. A pointer at the document
+    # root ("#") targets the file node. A pointer that resolves to nothing —
+    # depth cap, pair cap, or a genuinely absent definition — is DROPPED rather
+    # than emitted as a dangling edge, and reported instead.
+    for parent_nid, pointer, line, ref_text in sorted(
+        pending_internal_refs, key=lambda r: (r[1], r[0], r[2])
+    ):
+        target_nid = file_nid if not pointer else path_to_nid.get(pointer)
+        if target_nid:
+            add_edge(parent_nid, target_nid, "references", line,
+                     context="schema_ref")
+        else:
+            unresolved_internal_refs.append(ref_text)
+
+    result: dict = {"nodes": nodes, "edges": edges}
+    if external_refs:
+        result["external_refs"] = sorted(set(external_refs))
+    if unresolved_internal_refs:
+        result["unresolved_internal_refs"] = sorted(set(unresolved_internal_refs))
+    return result

--- a/graphify/extractors/json_config.py
+++ b/graphify/extractors/json_config.py
@@ -57,6 +57,12 @@ def _is_config_json(path: Path, obj_node, source: bytes) -> bool:
     name = path.name.casefold()
     if name in _CONFIG_JSON_NAMES:
         return True
+    # Xcode Icon Composer descriptor: `<AppIcon>.icon/icon.json`. It is a real
+    # manifest — it names the image assets each icon layer draws — but its
+    # top-level keys (fill/groups/supported-platforms) match no generic probe, so
+    # it was skipped as data JSON and the icon->asset edges were lost (#2311).
+    if name == "icon.json" and path.parent.name.casefold().endswith(".icon"):
+        return True
     # Common compound config names: *.eslintrc.json, *.prettierrc.json, etc.
     if name.endswith((".eslintrc.json", ".prettierrc.json", ".babelrc.json",
                       "tsconfig.json", "jsconfig.json")):
@@ -206,7 +212,15 @@ def extract_json(path: Path) -> dict:
                 # Prefix with "ref_" so external refs don't collide with real
                 # code/file node IDs that share the same collapsed _make_id (J-4).
                 for item in val.children:
-                    if item.type == "string":
+                    if item.type == "object":
+                        # Objects nested in arrays were never walked, so any
+                        # structure below an array was invisible — e.g. an Icon
+                        # Composer's groups[].layers[].image-name (#2311). The
+                        # element shares its array key's path: array indices are
+                        # positional noise, not names worth minting ids from.
+                        walk_object(item, key_nid, key, depth + 1, pair_count,
+                                    cur_path)
+                    elif item.type == "string":
                         content = item.child_by_field_name("string_content")
                         ref = _read_text(content, source) if content else _read_text(item, source).strip('"\'')
                         if ref:
@@ -253,6 +267,14 @@ def extract_json(path: Path) -> dict:
                                      context="import")
                             external_refs.append(val_text)
 
+                elif key == "image-name" and val_text:
+                    # Icon Composer layer -> the asset file it draws. A real
+                    # dependency: renaming the asset breaks the icon.
+                    asset_nid = _make_id("asset", val_text)
+                    if asset_nid:
+                        add_node(asset_nid, val_text, line, file_type="concept")
+                        add_edge(parent_nid, asset_nid, "references", line,
+                                 context="asset")
 
                 elif parent_key in _DEP_KEYS and val_text:
                     dep_nid = _make_id(key)
@@ -285,6 +307,14 @@ def extract_json(path: Path) -> dict:
         pending_internal_refs, key=lambda r: (r[1], r[0], r[2])
     ):
         target_nid = file_nid if not pointer else path_to_nid.get(pointer)
+        if target_nid is None and any(part.isdigit() for part in pointer):
+            # Array-index pointer ("#/anyOf/0/x"). The walk deliberately gives
+            # array elements their array key's path — indices are positional
+            # noise — so resolve by dropping the numeric components to match the
+            # id scheme exactly. Only tried when the exact path missed.
+            target_nid = path_to_nid.get(
+                tuple(part for part in pointer if not part.isdigit())
+            )
         if target_nid:
             add_edge(parent_nid, target_nid, "references", line,
                      context="schema_ref")

--- a/tests/test_acceptance_policy.py
+++ b/tests/test_acceptance_policy.py
@@ -1,0 +1,116 @@
+"""The Graphify acceptance policy (#2311).
+
+The value of a gate is entirely in what it does NOT fail on. Expected external
+imports, intentionally non-graph-bearing files and deterministic edge
+consolidation are permanent properties of an honest graph over a real corpus; a
+gate that fails on those gets ignored, and then the real defects ride through.
+"""
+from graphify.diagnostics import (
+    evaluate_acceptance,
+    format_acceptance_report,
+)
+
+
+def _clean(**overrides):
+    summary = {
+        "non_object_edges": 0,
+        "missing_endpoint_edges": 0,
+        "dangling_endpoint_edges": 0,
+        "external_import_edges": 0,
+        "external_import_targets": [],
+        "unexpected_dangling_edges": 0,
+        "unverified_node_count": 0,
+        "self_loop_edges": 0,
+        "post_build_error": "",
+        "undirected_same_endpoint_collapsed_edges": 0,
+        "same_endpoint_group_count": 0,
+        "provenance_edge_count": 0,
+    }
+    summary.update(overrides)
+    return summary
+
+
+def test_clean_summary_passes():
+    verdict = evaluate_acceptance(_clean())
+    assert verdict["passed"]
+    assert verdict["failures"] == []
+
+
+def test_external_imports_and_collapses_report_without_failing():
+    verdict = evaluate_acceptance(_clean(
+        dangling_endpoint_edges=43,
+        external_import_edges=43,
+        external_import_targets=["json", "os", "pathlib"],
+        undirected_same_endpoint_collapsed_edges=1112,
+        same_endpoint_group_count=526,
+    ))
+    assert verdict["passed"], "expected externals must never fail the build"
+    assert any("43 verified external imports" in n for n in verdict["informational"])
+    assert any("1112 deterministic" in n for n in verdict["informational"])
+
+
+def test_unexpected_semantic_dangling_fails():
+    verdict = evaluate_acceptance(_clean(
+        dangling_endpoint_edges=74, external_import_edges=43,
+        unexpected_dangling_edges=31,
+    ))
+    assert not verdict["passed"]
+    assert any("31 unexpected dangling" in f for f in verdict["failures"])
+
+
+def test_malformed_and_missing_endpoints_fail():
+    verdict = evaluate_acceptance(_clean(non_object_edges=2, missing_endpoint_edges=3))
+    assert not verdict["passed"]
+    assert any("malformed" in f for f in verdict["failures"])
+    assert any("missing endpoint fields" in f for f in verdict["failures"])
+
+
+def test_unverified_code_nodes_fail():
+    verdict = evaluate_acceptance(_clean(unverified_node_count=7))
+    assert not verdict["passed"]
+    assert any("7 unverified code nodes" in f for f in verdict["failures"])
+
+
+def test_build_error_fails():
+    verdict = evaluate_acceptance(_clean(post_build_error="ValueError: boom"))
+    assert not verdict["passed"]
+    assert any("graph build error" in f for f in verdict["failures"])
+
+
+def test_self_loops_fail_unless_explicitly_allowed():
+    assert not evaluate_acceptance(_clean(self_loop_edges=4))["passed"]
+
+    allowed = evaluate_acceptance(_clean(self_loop_edges=4), allow_self_loops=True)
+    assert allowed["passed"]
+    assert any("explicitly allowed" in n for n in allowed["informational"])
+
+
+def test_provenance_loss_fails_only_when_pinned():
+    # Unpinned: provenance count is informational, not a gate.
+    assert evaluate_acceptance(_clean(provenance_edge_count=100))["passed"]
+
+    # Pinned and matching -> pass.
+    assert evaluate_acceptance(
+        _clean(provenance_edge_count=536), expected_provenance_edges=536
+    )["passed"]
+
+    # Pinned and drifted -> fail: provenance vanished between rebuilds.
+    drifted = evaluate_acceptance(
+        _clean(provenance_edge_count=12), expected_provenance_edges=536
+    )
+    assert not drifted["passed"]
+    assert any("nondeterministically" in f for f in drifted["failures"])
+
+
+def test_report_marks_failures_and_final_verdict():
+    failing = format_acceptance_report(
+        evaluate_acceptance(_clean(unexpected_dangling_edges=1))
+    )
+    assert "FAIL" in failing
+    assert failing.strip().endswith("FAIL")
+
+    passing = format_acceptance_report(
+        evaluate_acceptance(_clean(external_import_edges=43))
+    )
+    assert passing.strip().endswith("PASS")
+    assert "  info  " in passing

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -60,6 +60,53 @@ def test_surprising_connections_excludes_concept_nodes():
     assert "Abstract Concept" not in labels
 
 
+def test_architecture_analysis_excludes_saved_query_memory():
+    """Saved query-memory remains queryable but must not steer architecture advice."""
+    G = nx.Graph()
+    source_nodes = [
+        ("a", "SourceA", "src/a.py"),
+        ("b", "SourceB", "src/b.py"),
+        ("c", "SourceC", "src/c.py"),
+    ]
+    for nid, label, source_file in source_nodes:
+        G.add_node(nid, label=label, source_file=source_file, file_type="code")
+    G.add_edge("a", "b", relation="calls", confidence="AMBIGUOUS",
+               source_file="src/a.py", weight=1.0)
+    G.add_edge("b", "c", relation="calls", confidence="EXTRACTED",
+               source_file="src/b.py", weight=1.0)
+
+    memory_path = "graphify-out/memory/query-architecture.md"
+    G.add_node("memory", label="SavedQueryMemory", source_file=memory_path,
+               file_type="document")
+    for index in range(8):
+        nid = f"memory_{index}"
+        G.add_node(nid, label=f"MemoryConcept{index}", source_file=memory_path,
+                   file_type="document")
+        G.add_edge("memory", nid, relation="relates_to", confidence="AMBIGUOUS",
+                   source_file=memory_path, weight=1.0)
+    G.add_edge("memory", "a", relation="relates_to", confidence="AMBIGUOUS",
+               source_file=memory_path, weight=1.0)
+
+    communities = {0: ["a", "b"], 1: ["c"], 2: ["memory", *[f"memory_{i}" for i in range(8)]]}
+    labels = {0: "Application", 1: "Storage", 2: "Saved Queries"}
+
+    gods = god_nodes(G, top_n=10)
+    assert all(not item["label"].startswith(("SavedQuery", "MemoryConcept")) for item in gods)
+
+    surprises = surprising_connections(G, communities, top_n=10)
+    surprise_labels = {item["source"] for item in surprises} | {item["target"] for item in surprises}
+    assert "SavedQueryMemory" not in surprise_labels
+    assert {"SourceA", "SourceB"}.issubset(surprise_labels)
+
+    questions = suggest_questions(G, communities, labels, top_n=20)
+    rendered = " ".join(
+        f"{item.get('question') or ''} {item.get('why') or ''}" for item in questions
+    )
+    assert "SavedQueryMemory" not in rendered
+    assert "MemoryConcept" not in rendered
+    assert "SourceA" in rendered and "SourceB" in rendered
+
+
 def test_surprising_connections_single_file_uses_community_bridges():
     """Single-file graph: should return cross-community edges, not empty list."""
     G = nx.Graph()

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -107,6 +107,19 @@ def test_architecture_analysis_excludes_saved_query_memory():
     assert "SourceA" in rendered and "SourceB" in rendered
 
 
+def test_suggest_questions_tolerates_none_communities():
+    """communities=None must not crash (matches surprising_connections' contract).
+
+    No internal caller currently passes None here, but suggest_questions is a
+    public analyze.py function and its sibling surprising_connections already
+    accepts None with a default; the query-memory filter added to both must
+    not introduce an inconsistency between them.
+    """
+    G = make_graph()
+    questions = suggest_questions(G, None, {}, top_n=5)
+    assert isinstance(questions, list)
+
+
 def test_surprising_connections_single_file_uses_community_bridges():
     """Single-file graph: should return cross-community edges, not empty list."""
     G = nx.Graph()

--- a/tests/test_edge_collapse_provenance.py
+++ b/tests/test_edge_collapse_provenance.py
@@ -1,0 +1,167 @@
+"""Collapsed-edge provenance on the simple graph (#2311).
+
+The graph is deliberately a simple Graph/DiGraph: parallel edges are not needed
+for traversal. But repeated observations of the same node pair collapse onto one
+edge, and before this every attribute but the last was lost — 1,112 collapses in
+a real corpus left no trace of what produced them. The surviving edge must carry
+deterministic evidence of everything that merged into it.
+"""
+import networkx as nx
+
+from graphify.build import build_from_json
+
+
+def _extraction(edges, nodes=None):
+    node_ids = nodes or sorted({e["source"] for e in edges} | {e["target"] for e in edges})
+    return {
+        "nodes": [
+            {"id": n, "label": n, "file_type": "code", "source_file": "App/Sample.swift"}
+            for n in node_ids
+        ],
+        "edges": edges,
+    }
+
+
+def _edge(source, target, relation="references", location="L1",
+          source_file="App/Sample.swift", confidence="EXTRACTED"):
+    return {
+        "source": source, "target": target, "relation": relation,
+        "confidence": confidence, "source_file": source_file,
+        "source_location": location, "weight": 1.0,
+    }
+
+
+def test_repeated_swift_references_keep_every_source_location():
+    """A Swift type referencing another on 5 lines collapses to one edge."""
+    edges = [_edge("Record", "Bool", location=f"L{n}") for n in (152, 153, 154, 155, 156)]
+    G = build_from_json(_extraction(edges), directed=False)
+
+    assert G.number_of_edges() == 1
+    data = G.edges["Record", "Bool"]
+    assert data["evidence_count"] == 5
+    assert data["source_locations"] == ["L152", "L153", "L154", "L155", "L156"]
+    assert data["relations"] == ["references"]
+    # One direction only -> no `directions` noise on the edge.
+    assert "directions" not in data
+
+
+def test_differing_relations_are_all_preserved():
+    edges = [
+        _edge("View", "Protocol", relation="implements", location="L3"),
+        _edge("View", "Protocol", relation="references", location="L34"),
+        _edge("View", "Protocol", relation="references", location="L124"),
+    ]
+    G = build_from_json(_extraction(edges), directed=False)
+
+    data = G.edges["View", "Protocol"]
+    assert data["evidence_count"] == 3
+    assert data["relations"] == ["implements", "references"]
+    # Lexicographic, not numeric — the contract is determinism, not line order.
+    assert data["source_locations"] == ["L124", "L3", "L34"]
+
+
+def test_differing_source_files_are_preserved():
+    edges = [
+        _edge("Alpha", "Beta", location="L10", source_file="App/One.swift"),
+        _edge("Alpha", "Beta", location="L20", source_file="App/Two.swift"),
+    ]
+    G = build_from_json(_extraction(edges), directed=False)
+
+    data = G.edges["Alpha", "Beta"]
+    assert data["source_files"] == ["App/One.swift", "App/Two.swift"]
+    assert data["evidence_count"] == 2
+
+
+def test_reciprocal_directions_are_recorded_not_silently_dropped():
+    """a->b and b->a collapse on an undirected graph; both must stay visible."""
+    edges = [
+        _edge("Alpha", "Beta", relation="calls", location="L5"),
+        _edge("Beta", "Alpha", relation="calls", location="L9"),
+    ]
+    G = build_from_json(_extraction(edges), directed=False)
+
+    assert G.number_of_edges() == 1
+    data = G.edges["Alpha", "Beta"]
+    assert data["directions"] == ["Alpha->Beta", "Beta->Alpha"]
+    assert data["evidence_count"] == 2
+    assert data["source_locations"] == ["L5", "L9"]
+    # First-seen direction still wins for the primary attributes (#1061).
+    assert (data["_src"], data["_tgt"]) == ("Alpha", "Beta")
+
+
+def test_single_direction_records_no_directions_field():
+    edges = [_edge("Alpha", "Beta", location="L1"), _edge("Alpha", "Beta", location="L2")]
+    G = build_from_json(_extraction(edges), directed=False)
+    assert "directions" not in G.edges["Alpha", "Beta"]
+
+
+def test_semantic_edge_provenance_survives_collapse():
+    """Semantic (LLM) edges collapse too — 2 did in the real corpus."""
+    nodes = [
+        {"id": "concept_a", "label": "Concept A", "file_type": "document",
+         "source_file": "docs/one.md"},
+        {"id": "concept_b", "label": "Concept B", "file_type": "document",
+         "source_file": "docs/two.md"},
+    ]
+    edges = [
+        _edge("concept_a", "concept_b", relation="shares_data_with",
+              location="L12", source_file="docs/one.md", confidence="INFERRED"),
+        _edge("concept_a", "concept_b", relation="conceptually_related_to",
+              location="L40", source_file="docs/two.md", confidence="INFERRED"),
+    ]
+    G = build_from_json({"nodes": nodes, "edges": edges}, directed=False)
+
+    data = G.edges["concept_a", "concept_b"]
+    assert data["evidence_count"] == 2
+    assert data["relations"] == ["conceptually_related_to", "shares_data_with"]
+    assert data["source_files"] == ["docs/one.md", "docs/two.md"]
+    assert data["source_locations"] == ["L12", "L40"]
+
+
+def test_provenance_is_deterministic_across_rebuilds():
+    """Same extraction -> byte-identical provenance, regardless of input order."""
+    edges = [
+        _edge("Alpha", "Beta", relation="calls", location="L9"),
+        _edge("Beta", "Alpha", relation="calls", location="L5"),
+        _edge("Alpha", "Beta", relation="references", location="L1"),
+        _edge("Alpha", "Gamma", location="L7"),
+    ]
+
+    def provenance(edge_list):
+        G = build_from_json(_extraction(edge_list), directed=False)
+        return {
+            tuple(sorted((u, v))): (
+                d.get("evidence_count"), tuple(d.get("relations", ())),
+                tuple(d.get("source_files", ())), tuple(d.get("source_locations", ())),
+                tuple(d.get("directions", ())),
+            )
+            for u, v, d in G.edges(data=True)
+        }
+
+    baseline = provenance(edges)
+    assert provenance(edges) == baseline
+    assert provenance(list(reversed(edges))) == baseline
+    assert provenance([edges[2], edges[0], edges[3], edges[1]]) == baseline
+
+
+def test_directed_graph_keeps_opposite_directions_apart():
+    """A DiGraph does not collapse a->b with b->a, so each keeps its own count."""
+    edges = [
+        _edge("Alpha", "Beta", relation="calls", location="L1"),
+        _edge("Alpha", "Beta", relation="calls", location="L2"),
+        _edge("Beta", "Alpha", relation="calls", location="L3"),
+    ]
+    G = build_from_json(_extraction(edges), directed=True)
+
+    assert isinstance(G, nx.DiGraph)
+    assert G.number_of_edges() == 2
+    assert G.edges["Alpha", "Beta"]["evidence_count"] == 2
+    assert G.edges["Beta", "Alpha"]["evidence_count"] == 1
+
+
+def test_uncollapsed_edge_still_reports_single_evidence():
+    G = build_from_json(_extraction([_edge("Alpha", "Beta", location="L4")]), directed=False)
+    data = G.edges["Alpha", "Beta"]
+    assert data["evidence_count"] == 1
+    assert data["relations"] == ["references"]
+    assert data["source_locations"] == ["L4"]

--- a/tests/test_extract_zero_node_note.py
+++ b/tests/test_extract_zero_node_note.py
@@ -1,0 +1,45 @@
+"""Expected zero-node sources are a note, not a warning (#2311).
+
+Xcode asset-catalogue metadata and data-classified JSON produce zero nodes on
+every run forever. Warning about them each run trains the reader to ignore the
+zero-node warning — which does sometimes mean something. They must be reported
+separately as information, while a genuinely empty source still warns.
+"""
+import json
+
+from graphify.extract import extract
+
+
+def _run(tmp_path, capsys, files):
+    paths = []
+    for rel, payload in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(payload, encoding="utf-8")
+        paths.append(p)
+    result = extract(paths, cache_root=tmp_path, root=tmp_path, parallel=False)
+    return result, capsys.readouterr().err
+
+
+def test_asset_catalogue_contents_json_is_a_note_not_a_warning(tmp_path, capsys):
+    files = {
+        "Assets.xcassets/AppColor.colorset/Contents.json": json.dumps(
+            {"colors": [{"idiom": "universal"}], "info": {"version": 1}}
+        ),
+        "fixture_rows.json": json.dumps([{"row": 1}, {"row": 2}]),
+    }
+    _, err = _run(tmp_path, capsys, files)
+    assert "intentionally non-graph-bearing" in err
+    assert "Contents.json" in err
+    assert "fixture_rows.json" in err
+    assert "produced zero graph nodes" not in err.replace(
+        "intentionally non-graph-bearing", ""
+    ) or "warning" not in err.casefold()
+
+
+def test_unexplained_zero_node_source_still_warns(tmp_path, capsys):
+    # A config-probed JSON that yields a file node is NOT zero-node; use an
+    # empty Python file, which the extractor accepts but emits nothing for.
+    files = {"empty.py": ""}
+    _, err = _run(tmp_path, capsys, files)
+    assert "intentionally non-graph-bearing" not in err

--- a/tests/test_json_array_recursion.py
+++ b/tests/test_json_array_recursion.py
@@ -1,0 +1,136 @@
+"""Objects nested in JSON arrays are walked — inside the existing guardrails (#2311).
+
+The array-object recursion that makes Icon Composer descriptors extractable has
+the broadest potential blast radius of the #2311 work: lockfiles, generated
+JSON, fixtures and large arrays all funnel through the same walk. These tests
+pin the containment: the data-JSON gate, the 1 MiB read cap, the depth cap and
+the 500-pair cap all apply to array elements exactly as they do to objects, and
+arrays nested directly inside arrays are not descended into at all.
+"""
+import json
+
+from graphify.extractors.json_config import extract_json
+
+
+def _write(tmp_path, name, payload, parent=None):
+    directory = tmp_path if parent is None else tmp_path / parent
+    directory.mkdir(parents=True, exist_ok=True)
+    p = directory / name
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+def _icon_payload():
+    return {
+        "fill": {"solid": "srgb:0.2,0.2,0.2,1"},
+        "groups": [
+            {
+                "layers": [
+                    {"image-name": "lifted.svg", "name": "lifted"},
+                ],
+            },
+            {
+                "layers": [
+                    {"image-name": "set-front.svg", "name": "front"},
+                    {"image-name": "set-back.svg", "name": "back"},
+                ],
+            },
+        ],
+        "supported-platforms": {"circles": ["watchOS"], "squares": "shared"},
+    }
+
+
+def test_icon_composer_descriptor_produces_asset_edges(tmp_path):
+    """AppIcon.icon/icon.json -> nodes for the descriptor, edges to each asset."""
+    path = _write(tmp_path, "icon.json", _icon_payload(), parent="AppIcon.icon")
+    result = extract_json(path)
+
+    assert result.get("skipped") is None
+    assert result["nodes"], "the descriptor must produce nodes"
+
+    labels = {n["label"] for n in result["nodes"]}
+    assert {"lifted.svg", "set-front.svg", "set-back.svg"} <= labels
+
+    asset_edges = [e for e in result["edges"] if e.get("context") == "asset"]
+    ids = {n["id"] for n in result["nodes"]}
+    assert len(asset_edges) == 3
+    assert all(e["source"] in ids and e["target"] in ids for e in asset_edges)
+
+
+def test_icon_json_outside_an_icon_bundle_is_still_data(tmp_path):
+    """Only `<name>.icon/icon.json` is a descriptor; a stray icon.json is data."""
+    path = _write(tmp_path, "icon.json", _icon_payload())
+    result = extract_json(path)
+    assert result["nodes"] == []
+    assert str(result.get("skipped", "")).startswith("data json")
+
+
+def test_data_json_gate_still_blocks_arrays_of_objects(tmp_path):
+    """An API-response fixture full of objects is skipped before any walk."""
+    fixture = {"results": [{"id": i, "payload": {"deep": {"deeper": i}}} for i in range(200)]}
+    result = extract_json(_write(tmp_path, "api_fixture.json", fixture))
+    assert result["nodes"] == []
+    assert str(result.get("skipped", "")).startswith("data json")
+
+
+def test_top_level_array_is_never_walked(tmp_path):
+    result = extract_json(_write(tmp_path, "rows.json", [{"$ref": "#/x"}] * 50))
+    assert result["nodes"] == []
+    assert str(result.get("skipped", "")).startswith("data json")
+
+
+def test_pair_cap_bounds_a_config_with_a_huge_object_array(tmp_path):
+    """A config-shaped file with 10k array objects stops at the 500-pair cap."""
+    payload = {
+        "compilerOptions": {"strict": True},
+        "entries": [{f"k{i}": {"nested": i}} for i in range(10_000)],
+    }
+    result = extract_json(_write(tmp_path, "big.config.json", payload))
+    # file node + at most 500 key nodes (per-pair cap, J-3)
+    assert len(result["nodes"]) <= 501
+    assert len(result["edges"]) <= 501
+
+
+def test_depth_cap_applies_through_array_objects(tmp_path):
+    payload: dict = {"compilerOptions": {}}
+    cursor = payload
+    for i in range(12):
+        nxt: dict = {}
+        cursor["level"] = [nxt]  # alternate through an array at every level
+        cursor = nxt
+    cursor["bottom"] = "unreachable"
+    result = extract_json(_write(tmp_path, "deep.config.json", payload))
+    labels = {n["label"] for n in result["nodes"]}
+    assert "bottom" not in labels, "depth cap must hold through arrays"
+
+
+def test_arrays_nested_directly_in_arrays_are_not_descended(tmp_path):
+    payload = {
+        "compilerOptions": {},
+        "matrix": [[{"inner": {"$ref": "#/compilerOptions"}}]],
+    }
+    result = extract_json(_write(tmp_path, "matrix.config.json", payload))
+    labels = {n["label"] for n in result["nodes"]}
+    assert "inner" not in labels, "array-of-arrays must not be recursed"
+    # And nothing dangles because of it.
+    ids = {n["id"] for n in result["nodes"]}
+    assert all(e["source"] in ids and e["target"] in ids for e in result["edges"])
+
+
+def test_oversized_json_is_rejected_before_parsing(tmp_path):
+    p = tmp_path / "huge.config.json"
+    filler = "x" * 1_100_000
+    p.write_text('{"compilerOptions": {"pad": "%s"}}' % filler, encoding="utf-8")
+    result = extract_json(p)
+    assert result["nodes"] == []
+    assert "too large" in result.get("error", "")
+
+
+def test_asset_edges_resolve_endpoints(tmp_path):
+    """No dangling endpoints anywhere in an Icon Composer extraction."""
+    path = _write(tmp_path, "icon.json", _icon_payload(), parent="AppIcon.icon")
+    result = extract_json(path)
+    ids = {n["id"] for n in result["nodes"]}
+    for e in result["edges"]:
+        assert e["source"] in ids, e
+        assert e["target"] in ids, e

--- a/tests/test_json_schema_refs.py
+++ b/tests/test_json_schema_refs.py
@@ -1,0 +1,155 @@
+"""JSON Schema `$ref` resolution in the json_config extractor (#2311).
+
+Before this, the `$ref` branch emitted an edge but never a node, so EVERY
+`$ref` in a schema produced a dangling endpoint. Internal pointers must resolve
+to the `$defs` node the walk already emitted; external refs must emit their own
+namespaced concept node; anything unresolvable must be dropped, not dangled.
+"""
+import json
+
+from graphify.extractors.json_config import _json_pointer_parts, extract_json
+
+
+def _endpoints_resolve(result: dict) -> bool:
+    ids = {n["id"] for n in result["nodes"]}
+    return all(
+        e["source"] in ids and e["target"] in ids for e in result["edges"]
+    )
+
+
+def _write(tmp_path, name, payload):
+    p = tmp_path / name
+    p.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return p
+
+
+def test_json_pointer_parts_decodes_internal_pointers_only():
+    assert _json_pointer_parts("#/$defs/asset") == ["$defs", "asset"]
+    assert _json_pointer_parts("#") == []
+    # RFC 6901 escapes: ~1 -> "/", ~0 -> "~", and ~01 round-trips to "~1"
+    assert _json_pointer_parts("#/a~1b") == ["a/b"]
+    assert _json_pointer_parts("#/a~0b") == ["a~b"]
+    assert _json_pointer_parts("#/a~01b") == ["a~1b"]
+    # Not internal pointers
+    assert _json_pointer_parts("common.json#/$defs/asset") is None
+    assert _json_pointer_parts("https://example.com/s.json") is None
+    assert _json_pointer_parts("#namedAnchor") is None
+
+
+def test_internal_ref_resolves_to_the_defs_node(tmp_path):
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "assets": {"type": "array", "items": {"$ref": "#/$defs/asset"}},
+            "events": {"type": "array", "items": {"$ref": "#/$defs/event"}},
+        },
+        "$defs": {
+            "asset": {"type": "object", "properties": {"id": {"type": "string"}}},
+            "event": {"type": "object", "properties": {"id": {"type": "string"}}},
+        },
+    }
+    result = extract_json(_write(tmp_path, "export.schema.json", schema))
+
+    assert _endpoints_resolve(result), "internal $ref must not dangle"
+    assert "unresolved_internal_refs" not in result
+    assert "external_refs" not in result
+
+    schema_refs = [e for e in result["edges"] if e.get("context") == "schema_ref"]
+    assert len(schema_refs) == 2
+    targets = {e["target"] for e in schema_refs}
+    ids = {n["id"] for n in result["nodes"]}
+    assert targets <= ids
+    # The targets are the real $defs nodes, not minted "ref_*" placeholders.
+    assert all(t.endswith(("_defs_asset", "_defs_event")) for t in targets)
+    assert not any(t.startswith("ref_") for t in targets)
+
+
+def test_external_ref_emits_its_own_namespaced_node(tmp_path):
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+            "a": {"$ref": "common.json#/$defs/shared"},
+            "b": {"$ref": "https://example.com/other.schema.json"},
+        },
+    }
+    result = extract_json(_write(tmp_path, "ext.schema.json", schema))
+
+    assert _endpoints_resolve(result), "external $ref must emit its node"
+    assert result["external_refs"] == [
+        "common.json#/$defs/shared",
+        "https://example.com/other.schema.json",
+    ]
+    # Namespaced under ref_ so they cannot hijack real code node ids (J-4).
+    ext_nodes = [n for n in result["nodes"] if n["id"].startswith("ref_")]
+    assert {n["file_type"] for n in ext_nodes} == {"concept"}
+
+
+def test_unresolvable_internal_ref_is_dropped_not_dangled(tmp_path):
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {"a": {"$ref": "#/$defs/doesNotExist"}},
+        "$defs": {"real": {"type": "string"}},
+    }
+    result = extract_json(_write(tmp_path, "missing.schema.json", schema))
+
+    assert _endpoints_resolve(result), "a pointer at nothing must not dangle"
+    assert result["unresolved_internal_refs"] == ["#/$defs/doesNotExist"]
+    assert not [e for e in result["edges"] if e.get("context") == "schema_ref"]
+
+
+def test_root_pointer_targets_the_file_node(tmp_path):
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {"self": {"$ref": "#"}},
+    }
+    path = _write(tmp_path, "root.schema.json", schema)
+    result = extract_json(path)
+
+    assert _endpoints_resolve(result)
+    schema_refs = [e for e in result["edges"] if e.get("context") == "schema_ref"]
+    assert len(schema_refs) == 1
+    # The file node is the one whose label is the filename.
+    file_nid = next(n["id"] for n in result["nodes"] if n["label"] == path.name)
+    assert schema_refs[0]["target"] == file_nid
+
+
+def test_forward_and_backward_refs_both_resolve(tmp_path):
+    """Resolution is deferred, so document order must not matter."""
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "early": {"$ref": "#/$defs/late"},          # forward
+        "$defs": {"late": {"type": "string"}, "soon": {"type": "string"}},
+        "afterwards": {"$ref": "#/$defs/soon"},     # backward
+    }
+    result = extract_json(_write(tmp_path, "order2.schema.json", schema))
+    assert _endpoints_resolve(result)
+    assert "unresolved_internal_refs" not in result
+    assert len([e for e in result["edges"] if e.get("context") == "schema_ref"]) == 2
+
+
+def test_ref_resolution_is_deterministic_across_runs(tmp_path):
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+            "z": {"$ref": "#/$defs/zebra"},
+            "a": {"$ref": "#/$defs/apple"},
+            "m": {"$ref": "#/$defs/mango"},
+        },
+        "$defs": {
+            "zebra": {"type": "string"},
+            "apple": {"type": "string"},
+            "mango": {"type": "string"},
+        },
+    }
+    path = _write(tmp_path, "order.schema.json", schema)
+    runs = [
+        [
+            (e["source"], e["target"])
+            for e in extract_json(path)["edges"]
+            if e.get("context") == "schema_ref"
+        ]
+        for _ in range(3)
+    ]
+    assert runs[0] == runs[1] == runs[2]
+    assert len(runs[0]) == 3

--- a/tests/test_json_schema_refs.py
+++ b/tests/test_json_schema_refs.py
@@ -128,6 +128,34 @@ def test_forward_and_backward_refs_both_resolve(tmp_path):
     assert len([e for e in result["edges"] if e.get("context") == "schema_ref"]) == 2
 
 
+def test_array_index_pointer_resolves_via_the_array_key(tmp_path):
+    """"#/anyOf/0/x": array elements share the array key's path, so numeric
+    components are dropped to match the id scheme exactly."""
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "anyOf": [{"branch": {"type": "string"}}],
+        "properties": {"a": {"$ref": "#/anyOf/0/branch"}},
+    }
+    result = extract_json(_write(tmp_path, "arrayptr.schema.json", schema))
+    assert _endpoints_resolve(result)
+    assert "unresolved_internal_refs" not in result
+    refs = [e for e in result["edges"] if e.get("context") == "schema_ref"]
+    assert len(refs) == 1
+    branch_nid = next(n["id"] for n in result["nodes"] if n["label"] == "branch")
+    assert refs[0]["target"] == branch_nid
+
+
+def test_array_index_pointer_at_nothing_is_dropped_not_dangled(tmp_path):
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "anyOf": [{"branch": {"type": "string"}}],
+        "properties": {"a": {"$ref": "#/anyOf/0/absent"}},
+    }
+    result = extract_json(_write(tmp_path, "arrayptr2.schema.json", schema))
+    assert _endpoints_resolve(result)
+    assert result["unresolved_internal_refs"] == ["#/anyOf/0/absent"]
+
+
 def test_ref_resolution_is_deterministic_across_runs(tmp_path):
     schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -273,8 +273,12 @@ def test_label_communities_batches_when_over_batch_size(monkeypatch):
     monkeypatch.setattr("graphify.llm._call_llm", fake_call)
     labels = label_communities(G, communities, backend="gemini", batch_size=100)
 
-    # 250 communities / 100 per batch -> 3 batches (100, 100, 50)
-    assert calls == [100, 100, 50]
+    # 250 communities / 100 per batch -> 3 batches (100, 100, 50).
+    # Batches run concurrently in a ThreadPoolExecutor, so the order in which
+    # they append to `calls` is scheduling-dependent. Assert on the multiset of
+    # batch sizes — what this test is actually about; asserting the sequence
+    # made it fail whenever the 50-batch happened to finish first.
+    assert sorted(calls) == [50, 100, 100]
     # And every community got a real name, none left as a placeholder.
     assert all(name.startswith("Cluster ") for name in labels.values()), \
         f"some communities still have placeholders: {[k for k, v in labels.items() if not v.startswith('Cluster ')][:5]}"

--- a/tests/test_ollama_retry_cap.py
+++ b/tests/test_ollama_retry_cap.py
@@ -7,6 +7,13 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
+# The Ollama backend rides on the optional `openai` extra (pyproject
+# `ollama = ["openai"]`); these tests monkeypatch openai.OpenAI, so without
+# the package they fail on import resolution, not on the behaviour under test.
+openai = pytest.importorskip("openai")
+
 import graphify.llm as llm
 
 

--- a/tests/test_swift_cross_file_calls.py
+++ b/tests/test_swift_cross_file_calls.py
@@ -83,7 +83,9 @@ def test_swift_cross_file_member_calls_have_correct_confidence_and_resolve(tmp_p
     src_by_id = {n["id"]: n.get("source_file") for n in result["nodes"]}
 
     inferred_targets = {".update()", ".fetch()"}
-    extracted_targets = {".staticMethod()", ".method()"}
+    # A uniquely-resolved `TypeName(...)` constructor is explicit in source, even
+    # when Swift needs no import because the type is in the same module.
+    extracted_targets = {"SessionViewModel", ".staticMethod()", ".method()"}
     seen_inferred: set[str] = set()
     seen_extracted: set[str] = set()
     for e in result["edges"]:

--- a/uv.lock
+++ b/uv.lock
@@ -1090,7 +1090,7 @@ wheels = [
 
 [[package]]
 name = "graphifyy"
-version = "0.9.31"
+version = "0.9.32"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Nine commits hardening extraction and graph-build integrity, found while gating a real ~2,500-node Swift/docs corpus:

- **fix(analyze)**: exclude saved query-memory from god nodes, surprising connections, and suggested questions — remembered answers were outranking source-backed structure
- **fix(extract)**: promote uniquely-resolved Swift `TypeName(...)` constructor calls to EXTRACTED (same-module Swift needs no import edge)
- **fix(json)**: internal JSON Schema `$ref` now resolves through an exact JSON-Pointer path map (RFC 6901 `~0`/`~1`, forward refs, `#` root, array-index pointers); external refs emit their own namespaced node; unresolved pointers are dropped and reported, never dangled. Previously every `$ref` produced a dangling endpoint.
- **feat(build)**: simple-graph edge collapse now retains provenance (evidence_count, sorted relations/source_files/source_locations, bidirectional observation) — 1,112 collapses in the test corpus previously left no trace
- **feat(diagnostics)**: dangling endpoints classified into expected external imports vs unexpected semantic danglers (43 harmless import edges were hiding 31 real defects), plus `evaluate_acceptance` — a pass/fail policy that fails on real corruption and reports expected properties without failing
- **feat(json)**: Icon Composer `<AppIcon>.icon/icon.json` extraction and traversal of objects nested in JSON arrays, contained by the existing guardrails (data-JSON gate, 1 MiB cap, depth cap, 500-pair cap; arrays-in-arrays not descended), with tests pinning each guardrail
- **test(labeling)**: batch assertion made order-independent (ThreadPoolExecutor completion order)
- **test(ollama)**: importorskip on the optional `openai` extra
- **chore**: uv.lock sync

## Testing

- 3,946 passed, 36 skipped, 0 failed (`uv run pytest`)
- New suites: `test_json_schema_refs.py`, `test_edge_collapse_provenance.py`, `test_acceptance_policy.py`, `test_json_array_recursion.py`, `test_extract_zero_node_note.py`
- Deterministic rebuild verified: 3 identical graph hashes on a 2,536-node real corpus; acceptance gate PASS with 0 unexpected danglers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
