### PR TITLE
fix(extract): skip files that are not regular files (a FIFO hangs the run forever)

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import shlex
+import stat
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from functools import lru_cache
@@ -779,10 +780,35 @@ def count_words(path: Path) -> int:
             return len(docx_to_markdown(path).split())
         if ext == ".xlsx":
             return len(xlsx_to_markdown(path).split())
+        # Only regular files may be opened. A repository can contain named
+        # pipes, sockets and device nodes, and `clone <github-url>` exists to
+        # point the scan at trees the operator did not write. open() on a FIFO
+        # with no writer BLOCKS FOREVER — it never raises, so the except below
+        # cannot help, and `graphify update` hangs with no output. os.stat
+        # follows symlinks on purpose: a link pointing at a FIFO blocks exactly
+        # like the FIFO itself.
+        if not stat.S_ISREG(os.stat(_os_path(path)).st_mode):
+            return 0
         with open(_os_path(path), encoding="utf-8", errors="ignore") as f:
             return len(f.read().split())
     except Exception:
         return 0
+
+
+def _is_regular_file(path: Path) -> bool:
+    """True only for regular files (symlinks followed).
+
+    Named pipes, sockets and device nodes must never reach a reader:
+    ``open()`` on a FIFO with no writer blocks forever and never raises, so a
+    single ``pipe.py`` in a scanned repository hangs the run with no output.
+    A symlink is resolved deliberately — a link pointing at a FIFO blocks
+    exactly like the FIFO itself. A path that cannot be stat'ed is treated as
+    not readable rather than raising.
+    """
+    try:
+        return stat.S_ISREG(os.stat(path).st_mode)
+    except OSError:
+        return False
 
 
 # Directory names to always skip - venvs, caches, build artifacts, deps
@@ -1397,6 +1423,18 @@ def detect(root: Path, *, follow_symlinks: bool | None = None, google_workspace:
             continue
         if not _resolves_under_root(p, root):
             skipped_sensitive.append(str(p) + " [symlink target outside scan root]")
+            continue
+        if not _is_regular_file(p):
+            # A repository may contain named pipes, sockets and device nodes,
+            # and `clone <github-url>` exists precisely to point the scan at
+            # trees the operator did not write.
+            #
+            # This has to be caught HERE, at the one place where a path is
+            # admitted to the corpus, rather than at each read: the readers
+            # number in the hundreds across the extractors, and open() on a
+            # FIFO with no writer BLOCKS FOREVER — it never raises, so their
+            # try/except cannot help and the whole run hangs with no output.
+            skipped_sensitive.append(str(p) + " [not a regular file]")
             continue
         if _is_sensitive(p):
             skipped_sensitive.append(str(p))

--- a/tests/test_non_regular_files.py
+++ b/tests/test_non_regular_files.py
@@ -1,0 +1,91 @@
+"""A repository may contain files that are not regular files.
+
+``clone <github-url>`` exists to point the extractor at trees the operator did
+not write, and ``watch`` re-runs the scan silently, so the corpus walk has to
+survive whatever a repository happens to contain.
+
+The decisive case is a FIFO carrying a source suffix: ``open()`` on a named
+pipe with no writer blocks forever and never raises, so the ``try``/``except``
+around every reader cannot help — ``graphify update`` simply never returns and
+prints nothing. A unix socket fails differently (``ENXIO``) but for the same
+reason: it is not a regular file.
+"""
+import os
+import socket
+import stat
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from graphify.detect import _is_regular_file
+
+
+@pytest.fixture()
+def tree():
+    d = tempfile.mkdtemp(prefix="nonregular-")
+    src = Path(d, "src")
+    src.mkdir()
+    (src / "module.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    yield Path(d)
+
+
+def test_regular_source_file_is_accepted(tree):
+    assert _is_regular_file(tree / "src" / "module.py") is True
+
+
+def test_fifo_is_rejected(tree):
+    """The shape that hangs the whole run."""
+    fifo = tree / "src" / "pipe.py"
+    os.mkfifo(fifo)
+    assert stat.S_ISFIFO(os.stat(fifo).st_mode)
+    assert _is_regular_file(fifo) is False
+
+
+def test_unix_socket_is_rejected(tree):
+    sock_path = tree / "src" / "sock.py"
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.bind(str(sock_path))
+        assert _is_regular_file(sock_path) is False
+    finally:
+        sock.close()
+
+
+def test_directory_named_like_a_source_file_is_rejected(tree):
+    d = tree / "src" / "package.py"
+    d.mkdir()
+    assert _is_regular_file(d) is False
+
+
+def test_symlink_to_a_regular_file_is_accepted(tree):
+    target = tree / "src" / "module.py"
+    link = tree / "src" / "alias.py"
+    link.symlink_to(target)
+    assert _is_regular_file(link) is True
+
+
+def test_symlink_pointing_at_a_fifo_is_rejected(tree):
+    """A link to a FIFO blocks exactly like the FIFO, so stat must follow it."""
+    fifo = tree / "src" / "real.py"
+    os.mkfifo(fifo)
+    link = tree / "src" / "link.py"
+    link.symlink_to(fifo)
+    assert _is_regular_file(link) is False
+
+
+def test_broken_symlink_is_rejected_without_raising(tree):
+    link = tree / "src" / "dangling.py"
+    link.symlink_to(tree / "src" / "does-not-exist.py")
+    assert _is_regular_file(link) is False
+
+
+def test_missing_path_is_rejected_without_raising(tree):
+    assert _is_regular_file(tree / "src" / "absent.py") is False
+
+
+def test_char_device_is_rejected():
+    dev = Path("/dev/null")
+    if not dev.exists():
+        pytest.skip("/dev/null unavailable")
+    assert _is_regular_file(dev) is False


### PR DESCRIPTION
A repository can contain named pipes, sockets and device nodes, and
`graphify clone <github-url>` exists to point the extractor at trees the
operator did not write. Any of those carrying a source suffix is currently
admitted to the corpus and handed to a reader.

## The bug

A FIFO named `pipe.py` hangs the entire run:

```
$ graphify update <repo> --no-cluster
(no output; killed at 180s)
```

`open()` on a named pipe with no writer **blocks forever and never raises**,
so the `try`/`except` around every reader cannot help. Confirmed at kernel
level on the stuck worker process:

```
/proc/<pid>/wchan   -> wait_for_partner
/proc/<pid>/syscall -> 257  (openat)
```

`watch` mode re-runs the same walk, so the hang is silent and permanent.

Bisected against six other hostile shapes — only this one hangs:

| shape in the scanned repo | result |
|---|---|
| **FIFO named `.py`** | **hangs (>180s, no output)** |
| symlink to `/etc/passwd` | ok |
| self-referential symlink loop | ok |
| 5000-deep nested expression | ok |
| invalid syntax | ok |
| newline in filename | ok |

A unix socket fails differently — `ENXIO` on open — for the same underlying
reason: it is not a regular file.

## Why the check goes here

I first patched the reader I found, re-ran, still hung; found a second reader,
patched it, still hung; found a third, patched it, **still hung**. Four
independent readers surfaced in sequence (`collect_files`, `detect.count_words`,
`extractors/engine.py`, `extractors/resolution.py`), and a sweep counts 500+
file-read call sites across the extractors. Point-patching cannot converge.

So the predicate sits at the one place where a path is admitted to the corpus,
alongside the existing `_resolves_under_root` and `_is_sensitive` rules, and
records the skip in `skipped_sensitive` like every other rejection.

`os.stat` follows symlinks on purpose: a link *pointing at* a FIFO blocks
exactly like the FIFO does. A path that cannot be stat'ed is skipped rather
than raising.

## Verification

End to end, same repo, 60s budget:

| tree | exit | artefacts |
|---|---|---|
| v8 (`00efd6e`) | **124 — hang** | 0 |
| with this change | 0 (<1s) | graph.json + manifest.json |

A normal repository produces a byte-identical graph — 5 nodes / 5 edges on
both trees, so this is not filtering anything that used to be indexed.

Full suite on this branch: **18 failed, 3758 passed**. Baseline on a pristine
`v8` worktree: **19 failed, 3748 passed**. Diffing the FAILED lists shows
**zero new failures** (the pre-existing ones are in `test_terraform.py`,
`test_ollama_retry_cap.py`, `test_cache.py` and friends, unrelated to this
change).

The 9 new tests fail on `v8` without the fix — collection errors on the
missing symbol — so they are not vacuous. They cover: regular file accepted,
FIFO rejected, unix socket rejected, directory named `.py` rejected, symlink
to a regular file accepted, symlink to a FIFO rejected, broken symlink and
missing path rejected without raising, char device rejected.

## Note

I could not find a working private channel for this. `SECURITY.md` says to use
GitHub private vulnerability reporting, but #2011 (open since 18 July, no
response) reports it returns HTTP 500 on submit, and `GET /security-advisories`
is empty. Since the impact is availability-only, needs a hostile or unusual
repository, and the fix is public anyway, a normal PR seemed right — happy to
move it if you would prefer otherwise.
