### PR TITLE
fix(cache): a same-size rewrite in one filesystem tick reused a stale digest

### DIFF
--- a/graphify/cache.py
+++ b/graphify/cache.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import tempfile
+import time
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
@@ -74,6 +75,14 @@ def _cleanup_stale_ast_entries(ast_base: Path, current_dir: Path) -> None:
 # actually changed. Entries live under cache/semantic/p{fingerprint}/ when the
 # caller supplies its prompt; callers that don't keep the historical flat layout.
 _PROMPT_FP_LEN = 12
+
+#: How close a memo's own timestamp may sit to the file's mtime before the
+#: (size, mtime_ns) fastpath stops proving content identity. The coarse value
+#: covers filesystems that round mtime to whole seconds (HFS+, some network
+#: mounts); the sub-second value applies when real nanosecond precision is
+#: reported, where only writes a few milliseconds apart can share a tick.
+_MTIME_GRANULARITY_NS = 2_000_000_000
+_MTIME_SUBSECOND_NS = 50_000_000
 
 # Count of pre-fingerprint (flat-layout) entries served this process, so
 # check_semantic_cache can report N to the user (#1939).
@@ -257,6 +266,13 @@ def _ensure_stat_index(root: Path, cache_root: "Path | None" = None) -> None:
                 for k, v in raw.items():
                     if not isinstance(k, str):
                         continue
+                    # Entries read back from disk were written by a COMPLETED
+                    # run, so the same-tick ambiguity that makes an in-process
+                    # memo untrustworthy cannot apply: any later write would
+                    # have to move size or mtime. Clearing seen_ns marks them
+                    # safe and keeps a moved/cloned corpus 100% warm.
+                    if isinstance(v, dict):
+                        v.pop("seen_ns", None)
                     if Path(k).is_absolute():
                         # Legacy/out-of-anchor key: pass through, but never
                         # clobber a re-anchored relative (new-format) entry
@@ -321,6 +337,41 @@ def _normalize_path(path: Path) -> Path:
     return Path(os.path.normcase(s))
 
 
+def _mtime_collision_risk(entry: dict, mtime_ns: int) -> bool:
+    """Could a same-size rewrite be hiding behind this unchanged mtime?
+
+    The stat fastpath assumes a content change moves size or mtime. Filesystem
+    timestamp granularity breaks that: an edit that keeps the file the same
+    length and lands inside one timestamp tick is invisible to stat, so a stale
+    digest is served and the graph keeps the old content. It is easy to hit
+    under ``watch``, in a fast edit loop, and in tests.
+
+    The risky window is the one the memo itself was taken in. ``seen_ns``
+    records that moment; when the file's mtime sits inside the same tick, a
+    later same-size write could have landed in that tick without moving mtime,
+    so the memo cannot prove content identity and the file is re-read.
+
+    Granularity is derived from the timestamp rather than assumed: a whole-second
+    mtime means the filesystem cannot distinguish writes inside that second and
+    the window is widened; genuine nanosecond precision keeps it at a few
+    milliseconds, so ordinary work still takes the fastpath.
+
+    Memos restored from disk have ``seen_ns`` cleared at load time — they come
+    from a completed run, so this ambiguity cannot apply to them.
+    """
+    seen = entry.get("seen_ns")
+    if not isinstance(seen, int):
+        return False
+    try:
+        delta = int(seen) - int(mtime_ns)
+    except (TypeError, ValueError):
+        return True  # unparseable: never trust the memo
+    if delta < 0:
+        return False  # file is newer than the memo; size/mtime already differ
+    coarse = int(mtime_ns) % 1_000_000_000 == 0
+    return delta < (_MTIME_GRANULARITY_NS if coarse else _MTIME_SUBSECOND_NS)
+
+
 def file_hash(path: Path, root: Path = Path("."), cache_root: "Path | None" = None) -> str:
     """SHA256 of file contents + path relative to root.
 
@@ -366,7 +417,8 @@ def file_hash(path: Path, root: Path = Path("."), cache_root: "Path | None" = No
         entry = _stat_index.get(abs_key)
         if (isinstance(entry, dict)
                 and entry.get("size") == st.st_size
-                and entry.get("mtime_ns") == st.st_mtime_ns):
+                and entry.get("mtime_ns") == st.st_mtime_ns
+                and not _mtime_collision_risk(entry, st.st_mtime_ns)):
             hashes = entry.get("hashes")
             if isinstance(hashes, dict):
                 cached = hashes.get(salt)
@@ -396,9 +448,15 @@ def file_hash(path: Path, root: Path = Path("."), cache_root: "Path | None" = No
                 entry["hashes"] = hashes
             hashes[salt] = digest       # preserve a co-located word_count / other salts
             entry.pop("hash", None)     # retire the un-salted legacy digest
+            entry["seen_ns"] = time.time_ns()
         else:
+            # seen_ns records WHEN this digest was observed, so a later read can
+            # tell "written by an earlier, completed run" from "taken in this
+            # process moments after the file was written", where a same-size
+            # rewrite can hide behind an unchanged mtime.
             _stat_index[abs_key] = {"size": st.st_size, "mtime_ns": st.st_mtime_ns,
-                                    "hashes": {salt: digest}}
+                                    "hashes": {salt: digest},
+                                    "seen_ns": time.time_ns()}
         _stat_index_dirty = True
 
     return digest

--- a/tests/test_stat_fastpath_collision.py
+++ b/tests/test_stat_fastpath_collision.py
@@ -1,0 +1,109 @@
+"""A same-size edit inside one filesystem tick must not reuse a stale digest.
+
+``file_hash`` memoises on ``(size, mtime_ns)`` to skip re-reading unchanged
+files. That assumes a content change always moves one of the two, which is
+false: an edit keeping the file the same length and landing inside a single
+timestamp tick is invisible to stat, so the old digest is served and every
+consumer — the semantic cache, incremental extraction, ``prune_semantic_cache``
+— keeps treating the new content as the old.
+
+The fastpath itself must survive: a corpus copied with ``copy2`` (mtimes
+preserved) has to stay 100% warm, or every relocated checkout re-bills a full
+extraction.
+"""
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from graphify import cache
+
+
+@pytest.fixture(autouse=True)
+def _fresh_index():
+    cache._stat_index = {}
+    cache._stat_index_root = None
+    yield
+    cache._stat_index = {}
+    cache._stat_index_root = None
+
+
+def _count_reads(monkeypatch, name):
+    hits = {"n": 0}
+    real = Path.read_bytes
+
+    def counting(self, *a, **k):
+        if self.name == name:
+            hits["n"] += 1
+        return real(self, *a, **k)
+
+    monkeypatch.setattr(Path, "read_bytes", counting)
+    return hits
+
+
+def test_same_size_rewrite_in_one_tick_changes_the_digest(tmp_path):
+    """The bug: two different documents, same length, one timestamp tick."""
+    f = tmp_path / "doc.md"
+    f.write_text("# A\n\nContent A.\n", encoding="utf-8")
+    first = cache.file_hash(f, tmp_path)
+
+    f.write_text("# B\n\nContent B.\n", encoding="utf-8")
+    second = cache.file_hash(f, tmp_path)
+
+    assert len("# A\n\nContent A.\n") == len("# B\n\nContent B.\n")
+    assert first != second, "a same-size rewrite must not reuse the old digest"
+
+
+def test_semantic_prune_sees_the_orphaned_entry(tmp_path):
+    """Downstream consequence: an orphan is unprunable if the hash never moves."""
+    f = tmp_path / "doc.md"
+    f.write_text("# A\n\nContent A.\n", encoding="utf-8")
+    cache.save_cached(f, {"nodes": [{"id": "a"}], "edges": []},
+                      root=tmp_path, kind="semantic")
+
+    f.write_text("# B\n\nContent B.\n", encoding="utf-8")
+    live = cache.file_hash(f, tmp_path)
+    cache.save_cached(f, {"nodes": [{"id": "b"}], "edges": []},
+                      root=tmp_path, kind="semantic")
+
+    assert cache.prune_semantic_cache(tmp_path, {live}) == 1
+
+
+def test_an_untouched_older_file_still_uses_the_fastpath(tmp_path, monkeypatch):
+    """The fastpath must survive: no re-read for a file that has not moved."""
+    f = tmp_path / "settled.md"
+    f.write_text("# Old\n\nSettled content.\n", encoding="utf-8")
+    cache.file_hash(f, tmp_path)
+
+    old = time.time() - 3600
+    os.utime(f, (old, old))
+    cache.file_hash(f, tmp_path)          # re-prime after the utime change
+
+    hits = _count_reads(monkeypatch, "settled.md")
+    cache.file_hash(f, tmp_path)
+    assert hits["n"] == 0, "an unchanged, aged file must not be re-read"
+
+
+def test_a_memo_restored_from_disk_is_trusted(tmp_path, monkeypatch):
+    """An index flushed by a completed run keeps a moved corpus warm."""
+    f = tmp_path / "f1.py"
+    f.write_text("x = 1\n", encoding="utf-8")
+    digest = cache.file_hash(f, tmp_path)
+    cache._flush_stat_index()
+
+    cache._stat_index = {}
+    cache._stat_index_root = None
+
+    hits = _count_reads(monkeypatch, "f1.py")
+    assert cache.file_hash(f, tmp_path) == digest
+    assert hits["n"] == 0, "a persisted memo must serve a warm hit"
+
+
+def test_a_growing_file_still_invalidates(tmp_path):
+    """Control: the ordinary size-change path is untouched."""
+    f = tmp_path / "grow.md"
+    f.write_text("# A\n\nShort.\n", encoding="utf-8")
+    first = cache.file_hash(f, tmp_path)
+    f.write_text("# A\n\nA considerably longer body than before.\n", encoding="utf-8")
+    assert cache.file_hash(f, tmp_path) != first


### PR DESCRIPTION
`file_hash` memoises on `(size, mtime_ns)` to skip re-reading unchanged files.
That assumes a content change always moves one of the two. It doesn't — an
edit that keeps the file the same length and lands inside a single filesystem
timestamp tick is invisible to `stat`, so the previous digest is served:

```python
f.write_text("# A\n\nContent A.\n"); h1 = file_hash(f, root)
f.write_text("# B\n\nContent B.\n"); h2 = file_hash(f, root)
h1 == h2   # different documents, identical digest
```

Everything keyed on that digest then treats the new content as the old: the
semantic cache serves stale nodes, incremental extraction skips the file, and
`prune_semantic_cache` cannot see the orphan it should collect.

## How it surfaced

`tests/test_cache.py::test_semantic_prune_removes_orphan_entries` and
`::test_semantic_prune_sweeps_both_namespaces_against_same_live_set` fail on
`v8` today — `prune_semantic_cache` returns 0 where 1 is expected. The prune
logic is correct; there was only ever one cache entry, because the two writes
produced the same hash.

The realistic trigger is `watch` mode and any fast edit loop, and it gets
worse on filesystems that round mtime to whole seconds (HFS+, some network
mounts, containers with reduced clock resolution) where the collision window is
a full second rather than a few milliseconds.

## The fix

The memo now records the moment it was taken (`seen_ns`) and is distrusted only
while the file's mtime sits inside that same tick — precisely the window where a
later same-size write can hide behind an unchanged mtime.

Granularity is derived from the timestamp rather than assumed: a whole-second
mtime means the filesystem cannot separate writes within that second, so the
window widens; genuine nanosecond precision keeps it at a few milliseconds and
ordinary work keeps the fastpath.

Entries restored from disk have `seen_ns` cleared at load time. They come from a
completed run, so the ambiguity cannot apply to them — which is what keeps a
corpus relocated with `copy2` 100% warm, with no extra reads and no re-billed
extraction.

## Verification

| case | before | after |
|---|---|---|
| same-size rewrite in one tick | same digest | digest changes |
| `prune_semantic_cache` orphan | 0 pruned | 1 pruned |
| aged, untouched file | fastpath | fastpath (0 reads) |
| corpus moved with `copy2` | warm | warm (0 reads) |
| file grows | invalidates | invalidates |

Full suite on this branch: **3908 passed**, 33 skipped. On a pristine `v8`
worktree with the same interpreter and extras installed: **5 failed**. The
stat-index portability tests (`test_cache_hits_survive_corpus_move`,
`test_out_of_root_key_round_trips_absolute`) pass unchanged — those were the
constraint that ruled out the simpler "distrust any recent mtime" approach.

The 5 new tests fail on `v8` without the fix.

## Note on a related flake

While verifying this I found
`test_extract_cli.py::test_incremental_partial_run_preserves_untouched_semantic_hash`
fails **non-deterministically on `v8` itself** (about 2 runs in 6, unpatched) —
the manifest shows two files sharing one `mtime` with `ast_hash == semantic_hash`.
Same underlying class of problem, different code path. Not addressed here; happy
to open it separately if useful.
