### PR TITLE
fix(manifest): apm.yml fallback parser dropped the package version

### DIFF
--- a/graphify/manifest_ingest.py
+++ b/graphify/manifest_ingest.py
@@ -143,8 +143,10 @@ def _parse_apm(text: str) -> dict | None:
 
 def _parse_apm_fallback(text: str) -> dict | None:
     """Minimal line parser for apm.yml when PyYAML is unavailable: a top-level
-    ``name:`` plus a simple ``dependencies:`` block (list items or a name map)."""
+    ``name:``/``version:`` plus a simple ``dependencies:`` block (list items or
+    a name map)."""
     name = None
+    version = None
     deps: list[str] = []
     in_deps = False
     for line in text.splitlines():
@@ -152,6 +154,13 @@ def _parse_apm_fallback(text: str) -> dict | None:
             m = re.match(r'^name:\s*["\']?([^"\'\s#]+)', line)
             if m:
                 name = m.group(1)
+                continue
+            # `version` is part of the manifest contract the YAML path already
+            # returns; dropping it here made a package node lose its version
+            # on every machine without PyYAML installed.
+            m = re.match(r'^version:\s*["\']?([^"\'\s#]+)', line)
+            if m:
+                version = m.group(1)
                 continue
         if re.match(r'^dependencies:\s*$', line):
             in_deps = True
@@ -163,7 +172,7 @@ def _parse_apm_fallback(text: str) -> dict | None:
                 deps.append(dm.group(1))
             elif re.match(r'^\S', line):  # next top-level key ends the block
                 in_deps = False
-    return {"name": name, "version": None, "deps": deps} if name else None
+    return {"name": name, "version": version, "deps": deps} if name else None
 
 
 def _pep508_name(spec: str) -> str:

--- a/tests/test_apm_fallback_version.py
+++ b/tests/test_apm_fallback_version.py
@@ -1,0 +1,47 @@
+"""The apm.yml fallback parser must return the manifest's version.
+
+``_parse_apm`` uses PyYAML when it is installed and returns name, version and
+dependencies. PyYAML is not a hard dependency, so on any machine without it the
+line-based fallback runs instead — and it hardcoded ``"version": None``, so the
+package node lost its version entirely. The two parsers must agree.
+"""
+from graphify.manifest_ingest import _parse_apm_fallback
+
+APM = "name: my-pkg\nversion: 1.2.3\ndependencies:\n  - dep-a\n  - dep-b\n"
+
+
+def test_fallback_returns_the_version():
+    assert _parse_apm_fallback(APM)["version"] == "1.2.3"
+
+
+def test_fallback_still_returns_name_and_deps():
+    parsed = _parse_apm_fallback(APM)
+    assert parsed["name"] == "my-pkg"
+    assert parsed["deps"] == ["dep-a", "dep-b"]
+
+
+def test_quoted_version_is_unwrapped():
+    parsed = _parse_apm_fallback('name: p\nversion: "2.0.0"\n')
+    assert parsed["version"] == "2.0.0"
+
+
+def test_version_with_a_trailing_comment():
+    parsed = _parse_apm_fallback("name: p\nversion: 3.1.0  # pinned\n")
+    assert parsed["version"] == "3.1.0"
+
+
+def test_a_manifest_without_a_version_still_parses():
+    parsed = _parse_apm_fallback("name: p\ndependencies:\n  - d\n")
+    assert parsed["version"] is None
+    assert parsed["name"] == "p"
+
+
+def test_a_version_inside_the_dependencies_block_is_not_the_package_version():
+    """`version:` nested under dependencies belongs to a dep, not the package."""
+    parsed = _parse_apm_fallback(
+        "name: p\ndependencies:\n  dep-a:\n    version: 9.9.9\n")
+    assert parsed["version"] is None
+
+
+def test_a_manifest_with_no_name_is_rejected():
+    assert _parse_apm_fallback("version: 1.0.0\n") is None


### PR DESCRIPTION
`_parse_apm` returns `name`, `version` and `deps` when PyYAML is installed.
PyYAML is not a hard dependency, so on any machine without it the line-based
fallback runs instead — and it hardcoded `"version": None`, so the package node
silently lost its version.

```python
>>> _parse_apm_fallback("name: my-pkg\nversion: 1.2.3\ndependencies:\n  - dep-a\n")
{'name': 'my-pkg', 'version': None, 'deps': ['dep-a']}
```

The two parsers are meant to agree; only this field diverged.

This is what makes
`tests/test_manifest_ingest.py::test_apm_parses_name_and_deps` fail with
`KeyError: 'version'` on a PyYAML-less install — the node builder drops the key
entirely when the value is `None`, so the failure surfaces one layer away from
the cause.

## The fix

The fallback reads a top-level `version:` exactly the way it already reads
`name:`, unwrapping quotes and stopping at a trailing comment. A `version:`
nested inside the `dependencies:` block still belongs to a dependency and is
not mistaken for the package version.

## Verification

7 new tests covering: version returned, name and deps unaffected, quoted
version unwrapped, trailing comment stripped, manifest without a version still
parses, a dependency's nested version not picked up, and a manifest with no
name still rejected.

3 of them fail on `v8` without the fix. `tests/test_manifest_ingest.py` goes
from 1 failed / 7 passed to **8 passed**.
