### PR TITLE
fix(typescript): avoid resolving namespace imports as workspace classes

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -492,6 +492,18 @@ def _import_js(node, source: bytes, file_nid: str, stem: str, edges: list, str_p
                                             "target_file": str(resolved_path),
                                         })
 
+    # Collect and return namespace import aliases for TS/JS resolver metadata
+    namespace_aliases = []
+    for child in node.children:
+        if child.type == "import_clause":
+            for sub in child.children:
+                if sub.type == "namespace_import":
+                    name_node = next((sc for sc in sub.children if sc.type == "identifier"), None)
+                    if name_node:
+                        namespace_aliases.append(_read_text(name_node, source))
+    return namespace_aliases
+
+
 
 def _import_java(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str, scope_stack: list[str] | None = None) -> None:
     def _walk_scoped(n) -> str:
@@ -2523,10 +2535,14 @@ def _resolve_typescript_member_calls(
     owning a method with the callee name, and emits an EXTRACTED ``calls`` edge.
     """
     type_table_by_file: dict[str, dict[str, str]] = {}
+    namespace_aliases_by_file: dict[str, set[str]] = {}
     for result in per_file:
         tt = result.get("ts_type_table")
         if tt and tt.get("path"):
             type_table_by_file[tt["path"]] = tt.get("table", {})
+        ns = result.get("ts_namespace_imports")
+        if ns and ns.get("path"):
+            namespace_aliases_by_file[ns["path"]] = set(ns.get("aliases", []))
     if not type_table_by_file:
         return
 
@@ -2565,6 +2581,8 @@ def _resolve_typescript_member_calls(
         if not receiver or not callee or not caller:
             continue
         if receiver[:1].isupper():
+            if receiver in namespace_aliases_by_file.get(rc.get("source_file", ""), set()):
+                continue
             type_name = receiver
         else:
             type_name = type_table_by_file.get(rc.get("source_file", ""), {}).get(receiver)

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2366,6 +2366,7 @@ def _extract_generic(
     # threaded out as `swift_type_table` so member calls (`vm.update()`) can be
     # resolved to the receiver's real definition in _resolve_swift_member_calls.
     type_table: dict[str, str] = {}
+    ts_namespace_imports: set[str] = set()
     # Java receiver typing is method-scoped: current-class fields are shared,
     # while parameters and locals belong only to their declaring method.
     java_field_types: dict[str, dict[str, str]] = {}
@@ -2461,7 +2462,7 @@ def _extract_generic(
         # Import types
         if t in config.import_types:
             if config.import_handler:
-                imported_modules = config.import_handler(node, source, file_nid, stem, edges, str_path, scope_stack)
+                import_result = config.import_handler(node, source, file_nid, stem, edges, str_path, scope_stack)
                 # Module-level import handlers (Swift) name a module, not a file
                 # path, so there is no pre-existing node to anchor the edge to.
                 # They return (id, label) pairs for which we materialize a
@@ -2470,19 +2471,22 @@ def _extract_generic(
                 # imported from N files shares one id (file_type=code keeps
                 # build.py validation happy; `type=module` exempts it from
                 # id-disambiguation) so it collapses to one shared node (#1327).
-                if imported_modules:
-                    line = node.start_point[0] + 1
-                    for mod_nid, mod_label in imported_modules:
-                        if mod_nid not in seen_ids:
-                            seen_ids.add(mod_nid)
-                            nodes.append({
-                                "id": mod_nid,
-                                "label": mod_label,
-                                "file_type": "code",
-                                "type": "module",
-                                "source_file": str_path,
-                                "source_location": f"L{line}",
-                            })
+                if import_result:
+                    if config.ts_module in ("tree_sitter_javascript", "tree_sitter_typescript"):
+                        ts_namespace_imports.update(import_result)
+                    elif config.ts_module == "tree_sitter_swift":
+                        line = node.start_point[0] + 1
+                        for mod_nid, mod_label in import_result:
+                            if mod_nid not in seen_ids:
+                                seen_ids.add(mod_nid)
+                                nodes.append({
+                                    "id": mod_nid,
+                                    "label": mod_label,
+                                    "file_type": "code",
+                                    "type": "module",
+                                    "source_file": str_path,
+                                    "source_location": f"L{line}",
+                                })
             # For export_statement: only return (skip children) if it's a re-export
             # (has a `from` source). Otherwise fall through to walk children which may
             # contain function_declaration, class_declaration, etc.
@@ -4878,6 +4882,8 @@ def _extract_generic(
             result["ts_type_table"] = {"path": str_path, "table": type_table}
         elif config.ts_module == "tree_sitter_cpp":
             result["cpp_type_table"] = {"path": str_path, "table": type_table}
+    if ts_namespace_imports:
+        result["ts_namespace_imports"] = {"path": str_path, "aliases": list(ts_namespace_imports)}
     return result
 
 def _python_decorator_name(deco_node, source: bytes) -> str | None:

--- a/tests/test_ts_receiver_member_calls.py
+++ b/tests/test_ts_receiver_member_calls.py
@@ -79,3 +79,38 @@ def test_array_typed_receiver_emits_no_edge(tmp_path):
                  "export function h(xs: Svc[]): number { return xs[0].doThing(); }\n"),
     })
     assert not any("h(" in s and "doThing" in t for s, t in calls)
+
+
+def test_namespace_import_does_not_bind_to_local_class(tmp_path):
+    calls, r = _calls(tmp_path, {
+        "mobile.ts": (
+            'import * as Notifications from "expo-notifications";\n\n'
+            'export function sendNotification() {\n'
+            '  Notifications.scheduleNotificationAsync();\n'
+            '}\n'
+        ),
+        "pages/Notifications.ts": (
+            'export class Notifications {\n'
+            '  scheduleNotificationAsync() {}\n'
+            '}\n'
+        ),
+        # Helper to populate the ts_type_table so the TS member call resolver runs
+        "dummy.ts": (
+            'export class Dummy { doThing() {} }\n'
+            'export function f(x: Dummy) { x.doThing(); }\n'
+        )
+    })
+    # Identify local nodes created from pages/Notifications.ts and mobile.ts
+    local_notifications_nodes = {
+        n["id"] for n in r["nodes"]
+        if n.get("source_file") and n["source_file"].replace("\\", "/").endswith("pages/Notifications.ts")
+    }
+    mobile_nodes = {
+        n["id"] for n in r["nodes"]
+        if n.get("source_file") and n["source_file"].replace("\\", "/").endswith("mobile.ts")
+    }
+    # Assert that no calls or references edge is created between mobile.ts and the local Notifications class
+    for e in r["edges"]:
+        if e.get("source") in mobile_nodes and e.get("target") in local_notifications_nodes:
+            assert e["relation"] not in ("calls", "references")
+


### PR DESCRIPTION
### Summary

This PR fixes a false cross-module resolution issue in the TypeScript member-call resolver.

Previously, namespace imports such as:

```ts
import * as Notifications from "expo-notifications";

Notifications.scheduleNotificationAsync();
```

could be incorrectly resolved to an unrelated workspace class with the same name (for example, `class Notifications` defined in another file). Because the resolver relied on the uppercase receiver heuristic and global name lookup, it could create incorrect `calls` or `references` edges, leading to phantom cross-module relationships.

### Root Cause

The TypeScript resolver did not distinguish namespace import aliases from workspace type names.

During extraction, the parser discarded namespace import alias information, so `_resolve_typescript_member_calls()` only saw the receiver name (`Notifications`) and treated it as a candidate workspace type.

### Solution

This change preserves namespace import aliases as **transient per-file extraction metadata** and uses that metadata during TypeScript member-call resolution.

When the receiver is identified as a namespace import alias for the current file, the resolver skips the existing uppercase receiver heuristic instead of attempting a global workspace type lookup.

The graph schema remains unchanged:

* No new graph node types
* No new graph edge relations
* No changes to graph serialization

The additional metadata exists only during extraction and resolution.

### Tests

Added a regression test covering the reported scenario:

* `import * as Notifications from "expo-notifications"`
* Local `class Notifications` defined in another module
* Verifies that no incorrect `calls` or `references` edge is created between them.

Verified with:

* `tests/test_ts_receiver_member_calls.py`
* `tests/test_js_import_resolution.py`
* `tests/test_phantom_external_import.py`

All related tests pass.
