### PR TITLE
Fixed src file path in the output for accessibility

### DIFF
--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -984,9 +984,9 @@ def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_bu
                 learning_suffix = f" learning={status}{':stale' if entry.get('stale') else ''}"
         line = (
             f"NODE {sanitize_label(d.get('label', nid))} "
-            f"[src={sanitize_label(str(d.get('source_file', '')))} "
-            f"loc={sanitize_label(str(d.get('source_location', '')))} "
-            f"community={sanitize_label(str(d.get('community_name') or d.get('community', '')))}"
+            f"[src: {sanitize_label(str(d.get('source_file', '')))} "
+            f"loc: {sanitize_label(str(d.get('source_location', '')))} "
+            f"community: {sanitize_label(str(d.get('community_name') or d.get('community', '')))}"
             f"{learning_suffix}]"
         )
         lines.append(line)


### PR DESCRIPTION
This PR updates the terminal output formatting for the graphify query command to improve developer experience (DX) and IDE compatibility.

## Motivation and Context
Currently, the CLI output formats file paths without proper delimiters (e.g., src=apps/...). This causes VS Code's terminal link detector to include the src= prefix as part of the file path, breaking the standard Cmd/Ctrl + Click functionality to open files directly from the terminal.

## Before:
Terminal output fails to parse the exact file path correctly:
<img width="724" height="38" alt="image" src="https://github.com/user-attachments/assets/9438ae75-77d1-429e-bce6-59d52ed7adf0" />

Clicking the link results in an error because the IDE searches for a file explicitly named src=...:
<img width="739" height="96" alt="image" src="https://github.com/user-attachments/assets/f8f9fcbb-9980-4706-8b60-fc48dbb5cdcd" />

## Changes Made

- Adjusted the string formatting of the node output to ensure file paths are cleanly separated from their labels.
- This allows modern IDE terminals (like VS Code) to correctly identify and hyperlink the exact file path, improving overall CLI usability.