### PR TITLE
fix(serve): treat `_` as a token separator so underscore queries match hyphenated labels

### DIFF
--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -164,8 +164,17 @@ def _strip_diacritics(text: str | None) -> str:
 
 
 def _search_tokens(text: str) -> list[str]:
-    """Split text into word tokens, stripping punctuation and diacritics."""
-    return re.findall(r"\w+", _strip_diacritics(str(text)).lower())
+    """Split text into word tokens, stripping punctuation and diacritics.
+
+    `_` is a separator, exactly like `-`. `\\w` counts underscore as a word
+    character but not hyphen, so `graph_first_guard` stayed one token while the
+    label `graph-first-guard.py` split into three — and the query matched
+    nothing. Both the query and the node label pass through here, so splitting
+    on `_` keeps the two sides consistent and snake_case lookups still resolve
+    (their tokens simply match the same way). Found 2026-07-29: the graph could
+    not find the underscore spelling of its own `local_id`.
+    """
+    return re.findall(r"[^\W_]+", _strip_diacritics(str(text)).lower())
 
 
 def _has_chinese(text: str) -> bool:

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1386,3 +1386,35 @@ def test_subgraph_to_text_honors_valid_src_tgt_direction():
     out = _subgraph_to_text(G, {"caller", "callee"}, [("callee", "caller")])
     edge_line = next(l for l in out.splitlines() if l.startswith("EDGE"))
     assert "caller --calls" in edge_line and "--> callee" in edge_line
+
+def test_underscore_query_matches_hyphenated_label():
+    r"""Separator-blind seeding: `_` must split like `-` does.
+
+    `\w` counts `_` as a word character but not `-`, so a query written with
+    underscores stayed one un-matchable token while the label tokenized into
+    parts. Both sides run through _search_tokens, so normalising there keeps
+    query and label consistent. Regression for the 2026-07-29 finding: the
+    graph could not find its own `local_id` spelling of a node.
+    """
+    G = nx.Graph()
+    G.add_node("n1", label="graph-first-guard.py", source_file="bin/graph-first-guard.py",
+               source_location="L1", community=0)
+    G.add_node("n2", label="unrelated", source_file="other.py", source_location="L1", community=1)
+
+    hyphen = _score_nodes(G, _query_terms("graph-first-guard"))
+    underscore = _score_nodes(G, _query_terms("graph_first_guard"))
+
+    assert hyphen, "hyphenated query must match (this already worked)"
+    assert underscore, "underscored query must match the same node"
+    assert hyphen[0][1] == underscore[0][1] == "n1"
+
+
+def test_snake_case_identifier_still_matches_itself():
+    """Splitting on `_` must not break plain snake_case lookups."""
+    G = nx.Graph()
+    G.add_node("n1", label="_query_terms", source_file="graphify/serve.py",
+               source_location="L128", community=0)
+    G.add_node("n2", label="unrelated", source_file="other.py", source_location="L1", community=1)
+
+    scored = _score_nodes(G, _query_terms("_query_terms"))
+    assert scored and scored[0][1] == "n1"


### PR DESCRIPTION
### The bug

`_search_tokens` splits on `\w+`. Python's `\w` counts `_` as a *word character* but not `-`,
so the two spellings tokenize inconsistently:

| input | tokens |
|---|---|
| `graph-first-guard.py` | `graph`, `first`, `guard`, `py` |
| `graph_first_guard`    | `graph_first_guard` |

Both the query and the node label pass through this same function, so the two sides can never
meet: searching for the underscore spelling of a hyphenated label returns nothing.

Found while querying a graph for a file it had itself indexed — the graph could not find the
underscore spelling of its own `local_id`.

### The fix

One character class: `\w+` → `[^\W_]+`. `_` becomes a separator, exactly like `-`.

Because *both* sides pass through `_search_tokens`, plain snake_case lookups still resolve —
query and label simply split the same way. The second test below pins that.

### Tests

- `test_underscore_query_matches_hyphenated_label` — the reported case; asserts the hyphenated
  query still matches (it always did) **and** that the underscored query now resolves to the
  same node.
- `test_snake_case_identifier_still_matches_itself` — guards the obvious regression risk: that
  splitting on `_` breaks snake_case search.

`pytest tests/test_serve.py` → **128 passed** on this branch.

Verified red-green against this branch's base: with `\w+` the first test fails; with the fix
both pass. The snake_case guard passes in *both* states — which is what a regression guard
should do.

### Scope

Deliberately minimal — one function, one character class, no behaviour change to ranking,
Chinese handling, or diacritics stripping.

### Related

Same family as #920 (`\b` boundary missing underscore-separated names) and #1522
(`normalize_id` collapsing non-word sequences to `_`) — both closed. This is the query-side
instance of that class: `\w` and `\b` disagree with `-` about what a word is.
