### PR TITLE
fix: preserve explicit scan roots when matching parent unanchored .gitignore patterns

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1169,7 +1169,14 @@ def _is_ignored(
             except ValueError:
                 continue  # target outside this pattern's anchor: cannot match
             if rel_anchor != ".":
-                matched = _matches(rel_anchor, p, path_relative=path_relative)
+                rel = rel_anchor
+                if not path_relative:
+                    try:
+                        if len(root.parts) > len(anchor.parts):
+                            rel = str(target.relative_to(root)).replace(os.sep, "/")
+                    except ValueError:
+                        pass
+                matched = _matches(rel, p, path_relative=path_relative)
                 if matched and directory_only and not target.is_dir():
                     matched = False
 

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1135,6 +1135,64 @@ def test_anchored_multi_segment_pattern(tmp_path):
     )
 
 
+def test_detect_does_not_ignore_scan_root_itself_via_parent_gitignore(tmp_path):
+    """If a parent `.gitignore` (at the repo root) ignores the directory being scanned
+    (the scan root itself), files inside the scan root must not be ignored (#2468)."""
+    (tmp_path / ".git").mkdir()
+
+    corpus_dir = tmp_path / "graphify-corpus"
+    corpus_dir.mkdir()
+
+    (corpus_dir / "keep.py").write_text("x = 1\n", encoding="utf-8")
+    
+    docs_dir = corpus_dir / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "intro.md").write_text("# Introduction\n", encoding="utf-8")
+
+    (tmp_path / ".gitignore").write_text("graphify-corpus/\n", encoding="utf-8")
+
+    result = detect(corpus_dir)
+
+    all_files = [Path(f) for files in result["files"].values() for f in files]
+    file_names = {f.name for f in all_files}
+
+    assert result["total_files"] == 2
+    assert "keep.py" in file_names
+    assert "intro.md" in file_names
+
+
+def test_detect_preserves_unrelated_parent_ignores_inside_scan_root(tmp_path):
+    """A parent `.gitignore` should still ignore unrelated directories (like `node_modules/`)
+    inside the scan root, even while the scan root itself is not ignored (#2468)."""
+    (tmp_path / ".git").mkdir()
+
+    corpus_dir = tmp_path / "graphify-corpus"
+    corpus_dir.mkdir()
+
+    (corpus_dir / "keep.py").write_text("x = 1\n", encoding="utf-8")
+    
+    docs_dir = corpus_dir / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "intro.md").write_text("# Introduction\n", encoding="utf-8")
+
+    node_modules_dir = corpus_dir / "node_modules"
+    node_modules_dir.mkdir()
+    (node_modules_dir / "lib.js").write_text("console.log(1);\n", encoding="utf-8")
+
+    # Parent .gitignore ignoring the scan root itself AND node_modules/
+    (tmp_path / ".gitignore").write_text("graphify-corpus/\nnode_modules/\n", encoding="utf-8")
+
+    result = detect(corpus_dir)
+
+    all_files = [Path(f) for files in result["files"].values() for f in files]
+    file_names = {f.name for f in all_files}
+
+    assert result["total_files"] == 2
+    assert "keep.py" in file_names
+    assert "intro.md" in file_names
+    assert "lib.js" not in file_names
+
+
 # Tests for #1235 - memoise _is_ignored/_eval results via a per-detect() cache
 
 def test_is_ignored_cache_matches_uncached_results(tmp_path):


### PR DESCRIPTION
## Summary

Fixes Issue #2468 by preventing unanchored parent `.gitignore` patterns from incorrectly matching the scan root itself when the user explicitly scans a subdirectory of a Git repository.

Previously, when a parent `.gitignore` contained an unanchored directory rule matching the scan root (for example, `graphify-corpus/`), Graphify evaluated the path relative to the parent ignore anchor. This allowed the scan root's own directory name to participate in unanchored basename matching, causing descendant directories to be incorrectly pruned during traversal.

The fix preserves existing ignore semantics while ensuring that unanchored parent patterns are evaluated relative to the scan root in this specific scenario, preventing the scan root itself from becoming a match candidate.

### Changes

* Adjust unanchored parent ignore matching in `_is_ignored()` to evaluate scan-root descendants using scan-root-relative paths when appropriate.
* Preserve existing behavior for:

  * anchored ignore patterns
  * nested `.gitignore` files
  * directory-only patterns
  * wildcard and basename matching
  * negation rules

### Tests

Added regression tests covering:

1. Scanning a directory whose name is excluded by an unanchored parent `.gitignore` rule no longer suppresses traversal of the explicitly requested scan root.
2. Parent `.gitignore` rules continue to ignore unrelated directories (for example, `node_modules/`) inside the scan root, ensuring existing ignore semantics are preserved.

### Validation

* New regression tests pass.
* Existing ignore-related tests continue to pass.
* Production change is limited to a small, localized modification in `graphify/detect.py`.
