### PR TITLE
fix(serve): resolve node ids containing punctuation in _find_node (#2467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: `graphify merge-graphs` no longer drops hyperedges (#2484, thanks @sortakool, and @oleksii-tumanov for the approach in #1691). Hyperedge member ids and ids are now relabeled with the per-repo prefix, both inputs' hyperedges are unioned instead of one clobbering the other, and they are written to both the top-level and nested slots.
 - Fix: `build_from_json` now reads hyperedges from both the top-level and nested `graph` slots, so label and re-cluster runs no longer silently empty a graph's hyperedge set (#2485, thanks @sortakool); a full validation wipeout is now reported loudly.
 - Fix: the skill flow now passes the curated community labels to `to_json`, so `graph.json` ships with `community_name` on nodes instead of dropping it (#2490, thanks @PapiScholz).
+- Fix: `graphify explain` (and `_find_node`) can now resolve a node by an exactly-typed id that contains punctuation, e.g. `concept:domain:x` (#2467, thanks @sean-soomgo). `term` tokenizes punctuation into spaces, so it never matched the punctuation-preserving node id; the punctuation-preserving `norm_query` is now also compared against the id, mirroring the `norm_query == norm_label` label path from #1704. Id lookups without punctuation and label lookups are unchanged.
 
 ## 0.9.33 (2026-08-05)
 

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -1143,7 +1143,9 @@ def _find_node_tiers(
     # stored `norm_label` keeps punctuation ("blockstream.ts"). Matching only via
     # `term`/`label_tokens` works when the node label tokenizes the same way, but is
     # fragile if `label` and `norm_label` diverge. `norm_query` matches `norm_label`
-    # symmetrically so an exactly-typed punctuated label always resolves (#1704).
+    # symmetrically so an exactly-typed punctuated label always resolves (#1704),
+    # and against `nid_lower` so an exactly-typed node ID whose punctuation `term`
+    # tokenizes away (e.g. `concept:domain:x`) still resolves by id (#2467).
     norm_query = _strip_diacritics(str(label)).lower().strip()
     source_exact: list[str] = []
     exact: list[str] = []
@@ -1166,7 +1168,7 @@ def _find_node_tiers(
             source_exact.append(nid)
         elif (
             term == norm_label or term == bare_label or term == label_tokens or term == nid_lower
-            or norm_query == norm_label or norm_query == bare_label
+            or norm_query == norm_label or norm_query == bare_label or norm_query == nid_lower
         ):
             exact.append(nid)
         elif (

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -225,6 +225,23 @@ def test_find_node_resolves_when_label_and_norm_label_diverge():
     assert _find_node(G, "blockStream.ts") == ["n1"]
 
 
+def test_find_node_resolves_id_with_punctuation():
+    # #2467: an exactly-typed node ID containing punctuation (e.g. a
+    # `concept:domain:x` overlay id) must resolve. `term` tokenizes the ':'
+    # into spaces ("concept domain gosu"), so it can never equal the
+    # punctuation-preserving `nid_lower`; only the symmetric
+    # `norm_query == nid_lower` match reaches it. Without that path the node
+    # is unreachable by its own id, even though the docstring promises id
+    # lookup.
+    G = nx.Graph()
+    G.add_node("concept:domain:gosu", label="Gosu")
+    G.add_node("plain_node_id", label="Plain")
+    assert _find_node(G, "concept:domain:gosu") == ["concept:domain:gosu"]
+    # regression: punctuation-free ids and label lookups still resolve.
+    assert _find_node(G, "plain_node_id") == ["plain_node_id"]
+    assert _find_node(G, "Gosu") == ["concept:domain:gosu"]
+
+
 # --- trigram candidate prefilter (the trigram index that shrinks the O(N) scan) ---
 
 


### PR DESCRIPTION
## Why

| | |
| --- | --- |
| Issues | Fix #2467 |
| Branch | v8 |
| Bug fix? | yes |

`graphify explain` (and `_find_node`) cannot resolve **any** node ID that contains punctuation — e.g. `concept:domain:gosu`, `entity:*`, `commit:*`. The reporter measured 2,327 of 2,327 concept/overlay nodes silently unresolvable by id, while punctuation-free ids resolved. The docstring promises id lookup ("Return node IDs whose label **or ID** matches …"), and `find_node_ambiguity`'s own hint tells users to "retry with the full node id" — so this is an oversight, not a design choice.

## Root cause

In `graphify/serve.py` `_find_node_tiers`, the query is normalized two ways:

```python
term       = " ".join(_search_tokens(label))          # \w+ tokens -> punctuation becomes a space
norm_query = _strip_diacritics(str(label)).lower().strip()   # punctuation preserved
```

The exact-match tier compared the node id (`nid_lower`, which **keeps** punctuation) only against `term` (which **replaces** punctuation with spaces). For `concept:domain:gosu`, `term` is `"concept domain gosu"` — it can never equal `nid_lower` `"concept:domain:gosu"`. The punctuation-preserving `norm_query` was already compared against `norm_label`/`bare_label`, but not against `nid_lower`.

## What changed

Add the symmetric comparison `norm_query == nid_lower` to the exact-match tier — the exact counterpart of the `norm_query == norm_label` clause that was added for punctuated *labels* in #1704. One production line, plus a clarifying comment and a CHANGELOG entry.

## Why it's safe

- **Purely additive, zero false-positive risk.** A node newly enters the `exact` tier only when the whole diacritic-stripped, lowercased query byte-equals that node's id — the definition of an exact id match. It can only promote a currently-unresolvable id into `exact`; it cannot pull in a different node or reorder resolution for any existing query.
- **Correct tier.** The docstring states node-ID exact matches are grouped with label exact matches, and the existing `term == nid_lower` clause already lives in `exact`.
- **Siblings untouched.** `shortest_path` / `_score_nodes` use a separate scoring path and are not affected; `explain` and `find_node_ambiguity` route through `_find_node_tiers` and only benefit.
- Scope is the exact-id case reported in #2467; partial-prefix punctuated-id lookup (the `prefix` tier) is intentionally left as a separate concern to avoid speculative false-prefix matches.

## Test verification (RED → GREEN)

New test `tests/test_serve.py::test_find_node_resolves_id_with_punctuation`.

RED — on unmodified `v8`, with only the new test applied:

```
tests/test_serve.py:239: in test_find_node_resolves_id_with_punctuation
    assert _find_node(G, "concept:domain:gosu") == ["concept:domain:gosu"]
E   AssertionError: assert [] == ['concept:domain:gosu']
FAILED tests/test_serve.py::test_find_node_resolves_id_with_punctuation
1 failed
```

GREEN — with the fix:

```
tests/test_serve.py::test_find_node_resolves_id_with_punctuation PASSED
1 passed
```

The test also guards the regressions (punctuation-free ids and label lookups still resolve).

Full suite: `4044 passed` on clean `v8` → `4045 passed, 3 skipped` on this branch (the one added test). `ruff check graphify tests` clean; `python -m tools.skillgen --check` OK; `graphify --help` install smoke OK.
