### PR TITLE
fix(callflow): load graph directed — caller/callee columns are swapped on 43% of edges

### DIFF
--- a/graphify/callflow_html.py
+++ b/graphify/callflow_html.py
@@ -233,7 +233,14 @@ def _node_link_payload(data: dict) -> tuple[list, list] | None:
         # though the shape check above accepts "edges" (#2212).
         from graphify.paths import load_node_link_graph
 
-        graph = load_node_link_graph(data)
+        # Force directed/multigraph so the stored caller->callee direction and
+        # parallel edges survive the round-trip; mirrors affected.py:263,
+        # serve.py:42 and cli.py:1229 (#1174). graph.json is written with
+        # "directed": false for backward compatibility (build.py:658), so
+        # without this networkx returns an undirected Graph and edge
+        # orientation becomes arbitrary -- which silently swaps the Caller and
+        # Callee columns of the call table and drops parallel edges.
+        graph = load_node_link_graph({**data, "directed": True, "multigraph": True})
     except Exception:
         return None
 

--- a/graphify/callflow_html.py
+++ b/graphify/callflow_html.py
@@ -1214,16 +1214,35 @@ def format_node_refs(node_ids: set, node_by_id: dict, lang: str, empty_text: str
     return "<br>".join(parts)
 
 
-def generate_call_table_rows(nodes: list, section_edges: list, lang: str) -> str:
-    """Generate call table row scaffolding for a section's nodes."""
+def generate_call_table_rows(
+    nodes: list,
+    section_edges: list,
+    lang: str,
+    all_edges: list | None = None,
+    all_nodes: list | None = None,
+) -> str:
+    """Generate call table row scaffolding for a section's nodes.
+
+    The Caller/Callee columns make a claim about the whole graph ("External
+    entry / no inbound edge"), so they must be computed from the whole graph.
+    Built from ``section_edges`` alone they only see edges whose *both*
+    endpoints sit in this section, so a node called from anywhere else is
+    mislabelled an entry point. Section coverage makes that the common case
+    rather than a corner case: only ``max_sections`` communities are rendered,
+    so most callers are not in any rendered section at all.
+
+    ``all_edges``/``all_nodes`` are the full graph; ``all_nodes`` also lets
+    out-of-section callers render as labels instead of raw node ids. Both
+    default to None, preserving the previous behaviour for other callers.
+    """
     if not nodes:
         return ""
 
     # Build source/target lookup from edges
-    node_by_id = {n.get("id"): n for n in nodes}
+    node_by_id = {n.get("id"): n for n in (all_nodes or nodes)}
     callers = defaultdict(set)
     callees = defaultdict(set)
-    for e in section_edges:
+    for e in (all_edges if all_edges is not None else section_edges):
         src = e.get("source", "")
         tgt = e.get("target", "")
         if e.get("relation") in ("calls", "imports", "imports_from", "uses", "method"):
@@ -1750,7 +1769,7 @@ def write_callflow_html(
   <th style="width:20%">{callee_header}</th>
   <th style="width:20%">{desc_header}</th>
 </tr>
-{generate_call_table_rows(sec_nodes, sec_edges, lang)}
+{generate_call_table_rows(sec_nodes, sec_edges, lang, edges, nodes)}
 </table>
 
 {generate_section_cards(sec, sec_nodes, sec_edges, lang)}

--- a/tests/test_callflow_html.py
+++ b/tests/test_callflow_html.py
@@ -185,3 +185,17 @@ def test_load_graph_rejects_oversized_file(monkeypatch, tmp_path):
     with pytest.raises(SystemExit) as excinfo:
         load_graph(graph_path)
     assert "exceeds" in str(excinfo.value)
+
+
+def test_load_graph_preserves_edge_direction(tmp_path):
+    """#1174: graph.json is written with "directed": false, so the node-link
+    parser must be told otherwise or networkx returns an undirected Graph and
+    caller->callee orientation becomes arbitrary."""
+    from graphify.callflow_html import load_graph
+
+    out = _make_graphify_out(tmp_path)
+    _nodes, edges, _hyper, _meta = load_graph(out / "graph.json")
+
+    directed = {(e["source"], e["target"]) for e in edges}
+    assert ("run", "api") in directed
+    assert ("api", "run") not in directed, "edge direction was lost (undirected load)"

--- a/tests/test_callflow_html.py
+++ b/tests/test_callflow_html.py
@@ -199,3 +199,21 @@ def test_load_graph_preserves_edge_direction(tmp_path):
     directed = {(e["source"], e["target"]) for e in edges}
     assert ("run", "api") in directed
     assert ("api", "run") not in directed, "edge direction was lost (undirected load)"
+
+
+def test_call_table_caller_column_sees_other_sections(tmp_path):
+    """A node called from a different section is not an "External entry".
+
+    ``export`` is used by ``api``, which lives in another community. Computing
+    the Caller column from section-local edges alone mislabels it an entry
+    point -- a whole-graph claim made from partial data.
+    """
+    from graphify.callflow_html import generate_call_table_rows, load_graph
+
+    out = _make_graphify_out(tmp_path)
+    nodes, edges, _hyper, _meta = load_graph(out / "graph.json")
+    export_node = [n for n in nodes if n["id"] == "export"]
+
+    rows = generate_call_table_rows(export_node, [], "en", edges, nodes)
+    assert "External entry" not in rows
+    assert "ApiClient" in rows, "cross-section caller should render as a label"


### PR DESCRIPTION
## Problem

`export callflow-html` loads `graph.json` through NetworkX **undirected**, so the Caller and Callee columns of the call table are populated from arbitrary edge orientation.

`graph.json` is written with `"directed": false` for backward compatibility (`build.py:658`). `_node_link_payload` passes that straight to `node_link_graph`, which therefore returns a plain `Graph` — and `Graph.edges()` does not promise to give back the orientation that was stored.

Measured on a 4,990-node / 10,135-edge graph of a real project:

| | |
|---|---|
| edges whose direction survived the round-trip | **5,785 / 10,132 (57%)** |
| edges returned **reversed** | **4,347 (43%)** |
| edges dropped entirely (parallel edges collapsed by simple `Graph`) | **3** |

The user-visible symptom is that a function's caller is printed in its **Callee** column and vice versa, on a ~43% subset that looks random. Concrete case from that graph — `scrape_domain() --calls--> matches_keyword()` in the source, and in `graph.json`:

```
 | matches_keyword() | Function | External entry / no inbound edge | scrape_domain() |
                                  ^ wrong: it has a caller             ^ wrong column: this IS the caller
```

Every other loader in the codebase already guards against exactly this — `affected.py:263`, `serve.py:42`, `cli.py:1229`, all referencing #1174. `callflow_html.py` looks like the one that was missed.

## Second, related defect

`"External entry / no inbound edge"` is a claim about the **whole graph**, but `callers`/`callees` were built from `section_edges` — edges with *both* endpoints inside the current section. Any node called from another section is therefore mislabelled an entry point.

Section coverage makes this the common case rather than a corner case: only `max_sections` communities are rendered (15 by default), so most callers are in no rendered section at all and their edges are never consulted.

## Fix

Two commits, each independently reviewable and testable:

1. **`load the graph directed`** — pass `{"directed": True, "multigraph": True}` into `load_node_link_graph`, mirroring the existing idiom in `affected.py` / `serve.py` / `cli.py`.
2. **`compute the Caller column from the whole graph`** — thread the full node/edge lists into `generate_call_table_rows`. Both new parameters default to `None`, so behaviour is unchanged for any other caller.

## Result

Rows claiming `External entry / no inbound edge` where the node demonstrably *does* have inbound call edges in `graph.json`:

| | claims | false |
|---|---|---|
| before | 327 | 45 |
| + directed load | 280 | 10 |
| + whole-graph caller column | 263 | **0** |

Direction preserved goes 57% → **100%**, and all 10,135 edges load instead of 10,132.

## Notes

- `format_node_refs` already caps each cell at 3 entries with `+N more`, so passing wider caller sets does not widen the table.
- Two regression tests added. Both **fail on `v8` as-is** and pass with the fix.
- Full suite: 3,795 passing, and the set of failing tests is byte-identical before and after this branch (27 pre-existing failures in `test_terraform.py`, `test_skillgen.py`, `test_cli_export.py`; `test_labeling.py::test_label_communities_batches_when_over_batch_size` appears to be flaky and fails intermittently on unpatched `v8` too).

Happy to split this into two PRs if you'd prefer the directed-load fix on its own — it is the root cause and the larger of the two.
