### PR TITLE
fix(build): report nodes dropped by replace-on-re-extract

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -1486,6 +1486,10 @@ def build_merge(
     if directed is None:
         directed = existing_directed if had_graph else False
 
+    # Pre-replace count for the replace-on-re-extract report (#2497). Captured
+    # before the rebind below drops replaced-file nodes from ``existing_nodes``.
+    loaded_node_count = len(existing_nodes)
+
     # Effective root for relativizing absolute source_file / prune paths back to the
     # stored relative source_file keys. When the caller passes root we use it;
     # otherwise fall back to the graph's recorded scan root, so absolute
@@ -1535,6 +1539,24 @@ def build_merge(
             return sf not in own and _norm_source_file(sf, _replace_root) not in own
         existing_nodes = [n for n in existing_nodes if _kept(n)]
         existing_edges = [e for e in existing_edges if _kept(e)]
+        # Surface replace-on-re-extract the same way prune reports its effect
+        # (#2497). Without this, a bare-basename source_file collision can drop
+        # an unrelated project's nodes with no log line at all.
+        replaced = loaded_node_count - len(existing_nodes)
+        if replaced:
+            # Count distinct source_file keys from the new chunks (raw form only;
+            # norm aliases are extra entries in new_sources for matching).
+            n_files = len({
+                n.get("source_file")
+                for ch in new_chunks
+                for n in ch.get("nodes", [])
+                if n.get("source_file")
+            })
+            print(
+                f"[graphify] Replaced {replaced} node(s) from {n_files} "
+                f"re-extracted source file(s).",
+                file=sys.stderr,
+            )
 
     base = [{"nodes": existing_nodes, "edges": existing_edges}] if had_graph else []
 
@@ -1647,7 +1669,11 @@ def build_merge(
                 file=sys.stderr,
             )
 
-    # Safety check: refuse to shrink the graph silently (#479)
+    # Safety check: refuse to shrink the graph silently (#479).
+    # Uses the post-replace ``existing_nodes`` length: nodes dropped by
+    # re-extract replacement are intentional (and reported above, #2497).
+    # Comparing against the pre-replace loaded count would refuse every
+    # legitimate same-file shrink (a re-extract that emits fewer nodes).
     # Skip when dedup or prune_sources is active — shrinkage is intentional there.
     if graph_path.exists() and not dedup and not prune_sources:
         existing_n = len(existing_nodes)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1427,3 +1427,66 @@ def test_build_from_json_prunes_dangling_hyperedge_members(capsys):
     assert set(hes) == {"he_partial"}, "an all-dangling hyperedge must be dropped"
     assert hes["he_partial"]["nodes"] == ["alpha", "beta"]
     assert "he_all_ghost" in capsys.readouterr().err
+
+
+def test_build_merge_replace_collision_reports_dropped_nodes(tmp_path, capsys):
+    """#2497: bare-basename source_file collision replaces another input's
+    nodes. The #479 shrink guard intentionally ignores replacement (same-file
+    re-extract that emits fewer nodes is legitimate), so the loss must be
+    visible on stderr the same way prune reports deleted sources.
+    """
+    import networkx as nx
+
+    graph_path = tmp_path / "graph.json"
+
+    # Project A contributed 10 nodes under the bare basename CHANGELOG.md.
+    chunk_a = {"nodes": [
+        {"id": f"a{i}", "label": f"A{i}", "file_type": "document",
+         "source_file": "CHANGELOG.md"}
+        for i in range(10)
+    ], "edges": []}
+    G0 = build([chunk_a], dedup=False)
+    graph_path.write_text(
+        json.dumps(nx.node_link_data(G0, edges="edges")), encoding="utf-8"
+    )
+    assert G0.number_of_nodes() == 10
+
+    # Unrelated project B re-extracts the same bare source_file with 1 node.
+    # Replacement drops A's 10; B adds 1. Net 10 → 1 — must be reported.
+    chunk_b = {"nodes": [
+        {"id": "b0", "label": "B0", "file_type": "document",
+         "source_file": "CHANGELOG.md"},
+    ], "edges": []}
+    G1 = build_merge([chunk_b], graph_path, dedup=False)
+    assert G1.number_of_nodes() == 1
+    err = capsys.readouterr().err
+    assert "Replaced 10 node(s) from 1 re-extracted source file(s)." in err
+
+
+def test_build_merge_replace_reports_replaced_count(tmp_path, capsys):
+    """#2497: replace-on-re-extract should log how many nodes it dropped,
+    matching the existing prune report for deleted sources.
+    """
+    import networkx as nx
+
+    graph_path = tmp_path / "graph.json"
+    # Keep.md stays; changed.md shrinks 2 → 2 so the shrink guard does not fire.
+    chunk0 = {"nodes": [
+        {"id": "A", "label": "A", "file_type": "document", "source_file": "changed.md"},
+        {"id": "B", "label": "B", "file_type": "document", "source_file": "changed.md"},
+        {"id": "K", "label": "K", "file_type": "document", "source_file": "keep.md"},
+    ], "edges": []}
+    G0 = build([chunk0], dedup=False)
+    graph_path.write_text(
+        json.dumps(nx.node_link_data(G0, edges="edges")), encoding="utf-8"
+    )
+
+    new_chunk = {"nodes": [
+        {"id": "A", "label": "A", "file_type": "document", "source_file": "changed.md"},
+        {"id": "C", "label": "C", "file_type": "document", "source_file": "changed.md"},
+    ], "edges": []}
+    G1 = build_merge([new_chunk], graph_path, dedup=False)
+    err = capsys.readouterr().err
+    assert "Replaced 2 node(s) from 1 re-extracted source file(s)." in err
+    labels = {d["label"] for _, d in G1.nodes(data=True)}
+    assert labels == {"A", "C", "K"}


### PR DESCRIPTION
## Problem

`build_merge` rebinds `existing_nodes` to drop a re-extracted file's prior contribution **before** the `#479` shrink guard runs. That rebind is correct for same-file replace, but it also means:

1. Nodes lost to replace-on-re-extract never show up in the shrink comparison (post-rebind `len(existing_nodes)` under-counts by exactly those nodes).
2. A bare `source_file` collision across unrelated inputs (e.g. two projects both using `CHANGELOG.md`) can drop another project's nodes with **no log line at all**.

Prune already prints `Pruned N node(s) from ... deleted or excluded source file(s).` Replacement of comparable size was silent.

Tracked in #2497.

## Solution

- Capture the pre-replace loaded node count.
- After the re-extract rebind, if any nodes were dropped, print:
  `[graphify] Replaced N node(s) from M re-extracted source file(s).`
  (same style as the existing prune report).
- Leave the `#479` shrink guard on the **post-replace** length so a legitimate same-file re-extract that emits fewer nodes still succeeds (raising on the pre-replace count would refuse every real shrink).

## Verification

```bash
python3 -m pytest \
  tests/test_build.py::test_build_merge_replace_collision_reports_dropped_nodes \
  tests/test_build.py::test_build_merge_replace_reports_replaced_count \
  tests/test_build.py::test_build_merge_replaces_changed_file_stale_edges \
  tests/test_build.py::test_build_merge_root_collapses_convention_drift \
  -q
# 4 passed
```

Also re-ran `tests/test_build.py` + `tests/test_build_merge_hyperedges_and_prune.py` (78 passed; 2 pre-existing failures need `tree_sitter_javascript`, unrelated).

## Notes / limitations

- This makes replace-on-re-extract **visible**; it does not refuse bare-basename collisions. Refusing those would break intentional same-file shrinks. A follow-up could warn harder when the replaced `source_file` only matches as a bare basename across roots.
- Draft while CI runs.