### PR TITLE
fix(callflow): mark compacted labels — non_ai_ silently renders as "ai"

### DIFF
--- a/graphify/callflow_html.py
+++ b/graphify/callflow_html.py
@@ -478,8 +478,14 @@ def truncate_text(text: str, limit: int) -> str:
     return text[: max(0, limit - 3)].rstrip() + "..."
 
 
-def humanize_label(label: str, source_file: str = "") -> str:
-    """Convert graph labels into short labels people can scan in a diagram."""
+def humanize_label(label: str, source_file: str = "", compact_over: int = 28) -> str:
+    """Convert graph labels into short labels people can scan in a diagram.
+
+    ``compact_over`` is the length past which a snake_case name is reduced to
+    its last three words. It defaults to the historical 28 so Mermaid node
+    boxes keep their current width; callers that render into flowing HTML,
+    where width is not scarce, pass the full render width instead.
+    """
     label = str(label or "").strip()
     if not label:
         return Path(source_file).name if source_file else "Unknown"
@@ -487,10 +493,18 @@ def humanize_label(label: str, source_file: str = "") -> str:
         return label[1:]
     if label.endswith((".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java", ".rb")):
         return Path(label).name
-    if "_" in label and " " not in label and len(label) > 28:
+    # Compaction drops *leading* words, which silently reverses meaning when the
+    # head carries a negation, and left no ellipsis to signal that anything had
+    # been removed:
+    #   api_list_non_ai_email_templates -> "ai email templates"
+    #   skip_company_content_too_short  -> "content too short"
+    # Both read as complete, correct identifiers of a different function. The
+    # leading ellipsis marks the result as truncated, matching what
+    # truncate_text already does at the other end.
+    if "_" in label and " " not in label and len(label) > compact_over:
         parts = [p for p in label.split("_") if p]
         if parts:
-            label = " ".join(parts[-3:])
+            label = "..." + " ".join(parts[-3:])
     return truncate_text(label, 42)
 
 
@@ -1195,7 +1209,9 @@ def node_display_name(node: dict | None, fallback: str = "") -> str:
     if not node:
         return str(fallback or "")
     label = str(node.get("label") or node.get("id") or fallback or "")
-    return humanize_label(label, node.get("source_file", ""))
+    # Table cells are flowing HTML, not fixed-width Mermaid boxes, so compact
+    # only what the 42-char render width will actually cut.
+    return humanize_label(label, node.get("source_file", ""), compact_over=42)
 
 
 def format_node_refs(node_ids: set, node_by_id: dict, lang: str, empty_text: str, limit: int = 3) -> str:

--- a/tests/test_callflow_html.py
+++ b/tests/test_callflow_html.py
@@ -345,3 +345,31 @@ def test_call_table_rows_without_whole_graph_params_unchanged(tmp_path):
     # semantics other call sites may rely on).
     export_node = [n for n in nodes if n["id"] == "export"]
     assert "External entry" in generate_call_table_rows(export_node, section_edges, "en")
+
+
+def test_table_cells_keep_labels_that_fit_the_render_width():
+    """Table cells are flowing HTML, not fixed-width Mermaid boxes, so a name
+    that fits the 42-char render width must not lose its leading words."""
+    from graphify.callflow_html import node_display_name
+
+    label = "api_list_non_ai_email_templates()"
+    assert len(label) <= 42
+    assert node_display_name({"label": label, "source_file": "api.py"}) == label
+
+
+def test_humanize_label_marks_compaction_as_truncated():
+    """Compaction drops leading words, which reverses meaning (non_ai -> ai),
+    so the result must not read as a complete identifier."""
+    from graphify.callflow_html import humanize_label
+
+    out = humanize_label("api_list_non_ai_email_templates()")
+    assert out.startswith("..."), out
+
+
+def test_humanize_label_keeps_diagram_width_unchanged():
+    """Mermaid node boxes keep the historical 28-char compaction threshold;
+    only the ellipsis is added."""
+    from graphify.callflow_html import humanize_label
+
+    out = humanize_label("skip_company_content_too_short()")
+    assert out == "...content too short()", out


### PR DESCRIPTION
## Problem

`humanize_label` reduces a snake_case name to its **last three words** past 28 characters. It drops **leading** words — where negations live — and leaves no ellipsis to signal that anything was removed:

| stored label | rendered as |
|---|---|
| `api_list_non_ai_email_templates` | **`ai email templates`** |
| `api_update_non_ai_email_template` | **`ai email template`** |
| `generate_non_ai_template_email` | **`ai template email`** |
| `skip_company_content_too_short` | **`content too short`** |

The first three drop `non_`, inverting the meaning. The fourth turns a skip *condition* into what reads as an assertion. Each reads as a complete, correct identifier — of a function that does the opposite. `truncate_text` appends `...` when it cuts; this path does not.

Separately, the threshold is **28** while the render width applied on the next line is **42**, so names of 29–42 characters are shortened even though they fit.

## Fix

Two changes, deliberately narrow:

1. **Prefix compacted labels with an ellipsis**, so they cannot be mistaken for whole names.
2. **Make the threshold a parameter**, defaulting to the historical 28.

`humanize_label` feeds two surfaces with different constraints, which is why a single threshold cannot be right for both:

- **Mermaid node boxes** (`node_label`) — width is scarce. **Unchanged at 28.** Measured on a 4,990-node graph: mean label width 24.3 → 25.6 chars, entirely from the ellipsis. No layout change.
- **Table cells** (`node_display_name` → `format_node_refs`) — flowing HTML, width is not scarce. These now pass the 42-char render width, so **87 of 96 affected labels show their real name** instead of a rewritten one.

The main table label column already uses the raw label, so it is unaffected.

## Result

| | diagram box | table cell |
|---|---|---|
| `api_list_non_ai_email_templates()` | `...ai email templates()` | `api_list_non_ai_email_templates()` |
| `skip_company_content_too_short()` | `...content too short()` | `skip_company_content_too_short()` |

Meaning is no longer silently inverted on either surface, and diagram width is preserved.

## Notes

- Three regression tests; all three **fail on `v8` as-is** (verified against a clean checkout, not a working-tree revert).
- Full suite: 3,867 passing, failure set matches `v8` (31 pre-existing, mostly `test_terraform.py`/`test_skillgen.py`). `test_labeling.py::test_label_communities_batches_when_over_batch_size` is flaky and fails intermittently on unpatched `v8` too.
- Rebased on 0.9.35.
- Ellipsis written as `...` to match `truncate_text` rather than `…`.
- Tail-preserving compaction is kept; this changes only *when* it fires and makes it visible. If you would rather keep the head (`api_list_non_ai...`), that is a one-line change.
