### PR TITLE
fix(cluster-only): report a refused graph.json write instead of "updated" (#2436)

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -1875,6 +1875,21 @@ def dispatch_command(cmd: str) -> None:
             })
         stages.mark("label")
         questions = suggest_questions(G, communities, labels)
+        # Snapshot BEFORE any artifact is replaced: GRAPH_REPORT.md was written
+        # first, so the dated folder held the NEW report, not the previous (#2402).
+        from graphify.export import backup_if_protected as _backup
+        _backup(out)
+        # The #479 guard can refuse this write, so it goes before the sidecars —
+        # a report and labels describing a clustering graph.json does not contain
+        # are worse than no run at all (#2436).
+        if not to_json(G, communities, str(out / "graph.json"), community_labels=labels):
+            print(
+                "graph.json NOT written: refusing to overwrite (see warning above). "
+                "GRAPH_REPORT.md, .graphify_labels.json and .graphify_analysis.json "
+                "left untouched.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         tokens = label_token_usage
         from graphify.export import _git_head as _gh
         _commit = _gh()
@@ -1886,8 +1901,6 @@ def dispatch_command(cmd: str) -> None:
                           learning=_llfr(out / "graph.json"))
         (out / "GRAPH_REPORT.md").write_text(report, encoding="utf-8")
         stages.mark("report")
-        from graphify.export import backup_if_protected as _backup
-        _backup(out)
         analysis = {
             "communities": {str(k): v for k, v in communities.items()},
             "cohesion": {str(k): v for k, v in cohesion.items()},
@@ -1899,7 +1912,6 @@ def dispatch_command(cmd: str) -> None:
             json.dumps(analysis, indent=2, ensure_ascii=False),
             encoding="utf-8",
         )
-        to_json(G, communities, str(out / "graph.json"), community_labels=labels)
         # Don't persist placeholder-only labels (or their .sig): leaving the
         # sidecar absent lets a later run generate real labels instead of reading
         # back "Community N" as authoritative (#2073).

--- a/tests/test_cli_export.py
+++ b/tests/test_cli_export.py
@@ -650,3 +650,29 @@ def test_graph_json_node_ids_are_portable_across_checkout_paths(tmp_path):
     leak = {"alice_home", "bob_elsewhere", "checkout", "tmp", "private", "users", "home", "var"}
     assert not any(part in leak for ident in a for part in ident.split("_")), \
         f"node id embeds an absolute-path component: {a}"
+
+
+def test_cluster_only_reports_failure_when_write_is_refused(tmp_path):
+    """The #479 shrink guard can refuse to overwrite graph.json. cluster-only
+    still printed "graph.json updated" and exited 0, and it had already written
+    GRAPH_REPORT.md and the labels for the clustering it then discarded (#2436)."""
+    out = _make_graph(tmp_path)
+    graph_json = out / "graph.json"
+
+    # Duplicate node ids make the file look larger than the graph it loads into,
+    # which is what trips the guard on a real re-cluster.
+    data = json.loads(graph_json.read_text(encoding="utf-8"))
+    data["nodes"] = data["nodes"] + data["nodes"][:3]
+    graph_json.write_text(json.dumps(data), encoding="utf-8")
+
+    report = out / "GRAPH_REPORT.md"
+    report.write_text("PREVIOUS REPORT\n", encoding="utf-8")
+    before = graph_json.read_text(encoding="utf-8")
+
+    r = _run(["cluster-only", ".", "--no-viz", "--no-label"], tmp_path)
+
+    assert r.returncode != 0, r.stdout
+    assert "graph.json NOT written" in r.stderr, r.stderr
+    assert "graph.json updated" not in r.stdout, r.stdout
+    assert graph_json.read_text(encoding="utf-8") == before
+    assert report.read_text(encoding="utf-8") == "PREVIOUS REPORT\n"


### PR DESCRIPTION
Fixes #2436. Also fixes the ordering half of #2402.

## Problem

`to_json()` returns `False` when the #479 shrink guard refuses to overwrite `graph.json`. `cluster-only` ignored it, and wrote in this order:

```
GRAPH_REPORT.md -> backup_if_protected -> analysis.json -> graph.json -> labels + .sig
```

So a refused write had already written the report and labels for the clustering it then discarded, and still exited **0** printing `Done - N communities. GRAPH_REPORT.md and graph.json updated.` The sidecars then describe a clustering the graph does not contain, which is silently wrong for anything keyed on community ids.

## Fix

- Move `to_json()` ahead of the report, analysis and labels writes, check its return value, and on a refusal name the untouched artifacts and `sys.exit(1)`. The guard already explains the cause on stderr; the new line only reports the consequence.
- That forced `backup_if_protected()` above the write too — otherwise the snapshot captures the *new* graph. Which fixes the ordering half of **#2402**: the snapshot ran after `GRAPH_REPORT.md` was overwritten, so the dated folder held the new report and the previous one was unrecoverable.

This makes the three `to_json()` call sites consistent — `extract` (`cli.py:3769`) and `watch.py:1574` already checked the return; `cluster-only` was the one that did not. `label` shares this branch and is fixed by the same change, which #2402 also asks for.

Not included: the `graph.html` half of #2402 (#2512 covers it, and also fixes the skill path that never called `backup_if_protected` at all), and the report's separate unexplained -119 node reduction — this only makes the refusal visible.

## Tests

`test_cluster_only_reports_failure_when_write_is_refused` in `tests/test_cli_export.py` — trips the guard with duplicate node ids, then asserts non-zero exit, `graph.json NOT written` on stderr, no `graph.json updated`, and that `graph.json` and a sentinel `GRAPH_REPORT.md` are byte-identical afterwards.

## Validation

- `uv run pytest -q` — 4007 passed (4006 on clean `v8`; +1 is the new test)
- `uv run ruff check graphify/cli.py tests/test_cli_export.py`
- `uv run python -m tools.skillgen --check`
- `git diff --check`
- Manually, on a real graph: success path exits 0 with full community coverage; refusal path exits 1 leaving `graph.json`, `GRAPH_REPORT.md` and `.graphify_labels.json` byte-identical; same for `graphify label`.

The 4 failures in `tests/test_ollama_retry_cap.py` are pre-existing — it monkeypatches `openai`, an optional extra, so it errors instead of skipping when absent. Identical on clean `v8`. Happy to send the one-line `pytest.importorskip` fix separately.
