### PR TITLE
fix(dedup): prefer active path segments over archived in collision rank

### DIFF
--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -225,22 +225,69 @@ def _defines_id(node: dict) -> bool:
                for prefix in _id_prefixes(source_file))
 
 
+# Path-segment lifecycle markers used by _collision_rank. Lower penalty wins.
+# Without this, pure lexical source_file order makes ``plans/_done/…`` beat
+# ``plans/in-progress/…`` because "_" < "i" in ASCII (#2532).
+_ACTIVE_PATH_SEGMENTS = frozenset({
+    "in-progress",
+    "in_progress",
+    "wip",
+    "active",
+    "current",
+    "ongoing",
+})
+_ARCHIVED_PATH_SEGMENTS = frozenset({
+    "_done",
+    "done",
+    "archive",
+    "archived",
+    "_archive",
+    "deprecated",
+    "retired",
+    "trash",
+    "obsolete",
+})
+
+
+def _lifecycle_penalty(source_file: str) -> int:
+    """Prefer live path segments over archived ones when ranking collisions.
+
+    Returns 0 for active/in-progress paths, 2 for archived/done paths, and 1
+    when no lifecycle marker is present. Among mixed markers the best (lowest)
+    score wins so an active segment is not drowned out by an unrelated archive
+    directory higher in the tree.
+    """
+    parts = [p for p in source_file.replace("\\", "/").casefold().split("/") if p]
+    marked: list[int] = []
+    for part in parts:
+        if part in _ARCHIVED_PATH_SEGMENTS:
+            marked.append(2)
+        elif part in _ACTIVE_PATH_SEGMENTS:
+            marked.append(0)
+    if not marked:
+        return 1
+    return min(marked)
+
+
 def _collision_rank(node: dict) -> tuple:
     """A total order for choosing the survivor of an ID collision, independent of
     the order the colliding nodes arrive in.
 
     The winner is the node with the SMALLEST rank. A node whose ``source_file``
     defines the ID always outranks a mere reference; among equally-(non-)defining
-    nodes it prefers the shorter, more canonical label over a longer qualified
+    nodes an active/in-progress path outranks an archived/done path (#2532), then
+    it prefers the shorter, more canonical label over a longer qualified
     variant, then breaks any remaining tie lexically on label and then source_file
     (so the lexically-first path wins) — fully deterministic regardless of order.
     """
     label = node.get("label") or ""
+    source_file = node.get("source_file") or ""
     return (
         not _defines_id(node),  # definers (False) sort before references (True)
+        _lifecycle_penalty(source_file),  # live paths beat archived ones (#2532)
         len(label),             # shorter, more canonical label first
         label,                  # lexical tiebreak
-        node.get("source_file") or "",  # lexically-first source path wins
+        source_file,            # lexically-first source path wins
     )
 
 

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,7 +1,14 @@
 """Tests for graphify/dedup.py entity deduplication pipeline."""
 from __future__ import annotations
 import pytest
-from graphify.dedup import deduplicate_entities, _defines_id, _entropy, _shingles
+from graphify.dedup import (
+    deduplicate_entities,
+    _collision_rank,
+    _defines_id,
+    _entropy,
+    _lifecycle_penalty,
+    _shingles,
+)
 
 
 # ── entropy gate ─────────────────────────────────────────────────────────────
@@ -626,6 +633,61 @@ def test_defines_id_helper():
     # A path that is merely a string-prefix of the ID's path does not define it.
     assert not _defines_id({"id": "agents_foo", "source_file": "agent/foo.md"})
     assert not _defines_id({"id": "docs_intro_foo", "source_file": ""})
+
+
+# ── #2532: lifecycle-aware collision ranking ──────────────────────────────────
+
+def test_lifecycle_penalty_prefers_active_over_archived():
+    assert _lifecycle_penalty("plans/in-progress/binding.md") == 0
+    assert _lifecycle_penalty("plans/_done/binding.md") == 2
+    assert _lifecycle_penalty("docs/binding.md") == 1
+    # Mixed markers: best (active) segment wins.
+    assert _lifecycle_penalty("archive/in-progress/note.md") == 0
+
+
+def test_archived_path_does_not_beat_active_path_by_ascii_order():
+    """#2532: plans/_done sorts before plans/in-progress in ASCII, but the live
+    copy must still win when both mint the same node id."""
+    nid = "plans_binding_doctrine"
+    done = {
+        "id": nid,
+        "label": "binding doctrine",
+        "file_type": "concept",
+        "source_file": "plans/_done/binding-doctrine.md",
+    }
+    active = {
+        "id": nid,
+        "label": "binding doctrine",
+        "file_type": "concept",
+        "source_file": "plans/in-progress/binding-doctrine.md",
+    }
+    assert _collision_rank(active) < _collision_rank(done)
+    assert done["source_file"] < active["source_file"]  # pure lexical trap
+
+
+def test_active_plan_survives_over_archived_copy_order_independent(capsys):
+    """#2532 reproduction: archived copy must not win just because '_' < 'i'."""
+    import itertools
+
+    nid = "plans_binding_doctrine"
+    done = {
+        "id": nid,
+        "label": "binding doctrine",
+        "file_type": "concept",
+        "source_file": "plans/_done/binding-doctrine.md",
+    }
+    active = {
+        "id": nid,
+        "label": "binding doctrine",
+        "file_type": "concept",
+        "source_file": "plans/in-progress/binding-doctrine.md",
+    }
+    survivors = set()
+    for perm in itertools.permutations([done, active]):
+        out, _ = deduplicate_entities([dict(n) for n in perm], [], communities={})
+        assert len(out) == 1
+        survivors.add(out[0]["source_file"])
+    assert survivors == {"plans/in-progress/binding-doctrine.md"}
 
 
 # ── #2091 review: attribute-merge correctness (fixes A-D) ─────────────────────


### PR DESCRIPTION
## Problem
When two nodes share an ID, `_collision_rank` broke ties with pure lexical `source_file` order. That makes `plans/_done/...` win over `plans/in-progress/...` because `_` sorts before `i` in ASCII, so an archived plan can beat the live one.

Fixes #2532

## Change
- Add a small lifecycle penalty on path segments before the existing label/path lexical tiebreaks
- Active markers (`in-progress`, `wip`, `active`, ...) rank better than archived markers (`_done`, `archive`, `deprecated`, ...)
- Paths with no lifecycle marker stay neutral
- Definer-vs-reference ranking is unchanged

## Verification
Reproduced the reported case before the change: both insertion orders kept `plans/_done/binding-doctrine.md`.

After the change, both orders keep `plans/in-progress/binding-doctrine.md`.

```bash
uv run pytest tests/test_dedup.py -q
# 68 passed
```

Focused new coverage:
- `test_lifecycle_penalty_prefers_active_over_archived`
- `test_archived_path_does_not_beat_active_path_by_ascii_order`
- `test_active_plan_survives_over_archived_copy_order_independent`

## Notes
This only affects same-ID collision ranking. It does not change fuzzy/label dedup. Lifecycle markers are matched as whole path segments only, so ordinary filenames like `done.md` are not treated as archive markers.