### PR TITLE
fix(llm): surface claude-cli envelope errors on both exit paths (#2554)

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -1373,6 +1373,30 @@ def _claude_cli_envelope(stdout: str) -> dict:
     return envelope
 
 
+def _claude_cli_error(stdout: str) -> str:
+    """Return the CLI's own error text when the envelope flags `is_error`.
+
+    `claude -p` reports API failures (rate limits, auth) in the stdout JSON
+    envelope with `is_error: true` and leaves stderr EMPTY — and on a rate limit
+    it still exits 0. So the two obvious checks both miss it: a non-zero exit
+    printed a bare "exited 1: " with no cause, and a zero exit fed the error
+    string to the JSON parser, producing an empty graph that `_response_is_hollow`
+    misread as truncation and adaptive retry then bisected, re-issuing requests
+    that were still being refused (#2554). Best-effort: unparseable stdout is not
+    this function's problem, the caller's `_claude_cli_envelope` reports that.
+    """
+    try:
+        envelope = _claude_cli_envelope(stdout)
+    except RuntimeError:
+        return ""
+    if not envelope.get("is_error"):
+        return ""
+    detail = envelope.get("result")
+    if isinstance(detail, str) and detail.strip():
+        return detail.strip()
+    return "unspecified error"
+
+
 # A JSON Schema pinning the top-level shape graphify consumes. Passed to
 # `claude -p --json-schema` (structured output) so the CLI CONSTRAINS the model
 # to emit the object directly instead of relying on it CHOOSING to honour a
@@ -1538,10 +1562,12 @@ def _call_claude_cli(user_message: str, max_tokens: int = 8192, *, deep_mode: bo
         check=False,
         **_no_window_kwargs(),
     )
+    cli_error = _claude_cli_error(proc.stdout)
     if proc.returncode != 0:
-        raise RuntimeError(
-            f"claude -p exited {proc.returncode}: {proc.stderr.strip()[:500]}"
-        )
+        detail = proc.stderr.strip() or cli_error or "(no stderr, no error envelope)"
+        raise RuntimeError(f"claude -p exited {proc.returncode}: {detail[:500]}")
+    if cli_error:
+        raise RuntimeError(f"claude -p reported an error: {cli_error[:500]}")
 
     envelope = _claude_cli_envelope(proc.stdout)
 
@@ -2597,8 +2623,14 @@ def _call_llm(
             check=False,
             **_no_window_kwargs(),
         )
+        cli_error = _claude_cli_error(proc.stdout)
         if proc.returncode != 0:
-            raise RuntimeError(f"claude -p exited {proc.returncode}: {proc.stderr.strip()[:500]}")
+            detail = proc.stderr.strip() or cli_error or "(no stderr, no error envelope)"
+            raise RuntimeError(f"claude -p exited {proc.returncode}: {detail[:500]}")
+        if cli_error:
+            # Without this the error text is returned as the model's reply and
+            # the caller writes it into the graph as a community label (#2554).
+            raise RuntimeError(f"claude -p reported an error: {cli_error[:500]}")
         envelope = _claude_cli_envelope(proc.stdout)
         cli_usage = envelope.get("usage") or {}
         if cli_usage:

--- a/tests/test_claude_cli_backend.py
+++ b/tests/test_claude_cli_backend.py
@@ -87,6 +87,67 @@ def test_raises_on_nonzero_exit():
             llm._call_claude_cli("dummy", max_tokens=8192)
 
 
+_ERROR_ENVELOPE = {
+    "type": "result",
+    "subtype": "success",
+    "is_error": True,
+    "result": "API Error: Rate limit reached",
+    "stop_reason": "stop_sequence",
+    "usage": {"input_tokens": 0, "output_tokens": 0},
+    "modelUsage": {},
+}
+
+
+def test_nonzero_exit_surfaces_envelope_error_when_stderr_empty():
+    # The CLI reports API failures in the stdout JSON envelope, not on stderr.
+    # Without reading it the user gets a bare "exited 1: " and no cause (#2554).
+    completed = MagicMock(
+        returncode=1, stdout=json.dumps(_ERROR_ENVELOPE), stderr="",
+    )
+    with patch("shutil.which", return_value="/fake/bin/claude"), \
+         patch("subprocess.run", return_value=completed):
+        with pytest.raises(RuntimeError, match="Rate limit reached"):
+            llm._call_claude_cli("dummy", max_tokens=8192)
+
+
+def test_raises_on_error_envelope_with_zero_exit():
+    # `claude -p` exits 0 on a rate limit and flags it as is_error in the
+    # envelope. Parsing `result` as model output yields an empty graph that
+    # _response_is_hollow then misreads as truncation, so adaptive retry
+    # bisects the chunk while every request is still being refused (#2554).
+    completed = MagicMock(
+        returncode=0, stdout=json.dumps(_ERROR_ENVELOPE), stderr="",
+    )
+    with patch("shutil.which", return_value="/fake/bin/claude"), \
+         patch("subprocess.run", return_value=completed):
+        with pytest.raises(RuntimeError, match="Rate limit reached"):
+            llm._call_claude_cli("dummy", max_tokens=8192)
+
+
+def test_call_llm_raises_on_error_envelope():
+    # _call_llm returns envelope["result"] verbatim, so a rate-limited call
+    # hands "API Error: Rate limit reached" back to its callers as if it were
+    # model output — the dedup tiebreaker and community labeling then write
+    # that string into the graph as a label (#2554).
+    completed = MagicMock(
+        returncode=0, stdout=json.dumps(_ERROR_ENVELOPE), stderr="",
+    )
+    with patch("shutil.which", return_value="/fake/bin/claude"), \
+         patch("subprocess.run", return_value=completed):
+        with pytest.raises(RuntimeError, match="Rate limit reached"):
+            llm._call_llm("dummy", backend="claude-cli")
+
+
+def test_call_llm_nonzero_exit_surfaces_envelope_error():
+    completed = MagicMock(
+        returncode=1, stdout=json.dumps(_ERROR_ENVELOPE), stderr="",
+    )
+    with patch("shutil.which", return_value="/fake/bin/claude"), \
+         patch("subprocess.run", return_value=completed):
+        with pytest.raises(RuntimeError, match="Rate limit reached"):
+            llm._call_llm("dummy", backend="claude-cli")
+
+
 def test_raises_on_garbage_envelope():
     completed = MagicMock(returncode=0, stdout="not json", stderr="")
     with patch("shutil.which", return_value="/fake/bin/claude"), \


### PR DESCRIPTION
Fixes #2554

## Problem

`claude -p` reports API failures in the stdout JSON envelope (`is_error: true`) with an empty stderr, and on a rate limit it may exit **0**. Both call sites in `llm.py` decide success from `returncode` and read the cause from `stderr` only, so three failures go unreported:

- **A.** Non-zero exit prints `claude -p exited 1:` with nothing after the colon.
- **B.** Zero exit feeds `"API Error: Rate limit reached"` to `_parse_llm_json`; the empty parse reads as truncation and adaptive retry bisects the chunk, re-issuing requests that are still being refused.
- **C.** `_call_llm` returns that same string as the model's reply, so community labeling and the dedup tiebreaker can write `API Error: Rate limit reached` into `graph.json` as a label.

## Change

`_claude_cli_error(stdout)` returns the envelope's `result` text when `is_error` is set, and `""` otherwise, including when stdout will not parse, so the existing "unparseable JSON envelope" error still takes precedence.

Both call sites (`_call_claude_cli`, `_call_llm`) then:

- prefer `stderr` on a non-zero exit and fall back to the envelope text, so a genuine CLI crash or spawn failure still reports its own diagnostics;
- raise on a zero exit when the flag is set, which fixes B and C together since both stem from that string flowing downstream.

Failing fast is intended here: `extract_corpus_parallel` already catches per-chunk exceptions and continues, so each chunk now reports the real cause instead of silently bisecting during an outage.

## Relationship to #1864

#1864 found the same root cause and fixes **A** via `proc.stdout.strip()[-500:]`. It has not landed; `llm.py:1541` on `v8` still reads stderr only.

This PR is a superset: it also covers B and C, which occur on a **zero** exit that #1864's non-zero branch never reaches, and it surfaces the envelope's `result` field rather than a 500-character tail of raw JSON. Happy to rebase onto #1864 instead if the author would rather extend that PR.

## Verification

Four tests added to `tests/test_claude_cli_backend.py`, following the file's existing `MagicMock` + `patch("subprocess.run")` convention, so CI needs no `claude` binary:

- `test_nonzero_exit_surfaces_envelope_error_when_stderr_empty`
- `test_raises_on_error_envelope_with_zero_exit`
- `test_call_llm_raises_on_error_envelope`
- `test_call_llm_nonzero_exit_surfaces_envelope_error`

Each was written and observed failing before the implementation.

```
tests/test_claude_cli_backend.py tests/test_llm_backends.py
tests/test_llm_parser.py tests/test_backend_extras.py     136 passed

full suite                                               4041 passed, 36 skipped
```

Four unrelated failures in `tests/test_ollama_retry_cap.py` are pre-existing on my machine and come from the optional `openai` package not being installed (`ModuleNotFoundError: No module named 'openai'` raised by `monkeypatch`), not from this change.

Against a live rate-limited account:

```
before  [graphify] chunk 1/11 failed: claude -p exited 1:
after   [graphify] chunk 1/11 failed: claude -p exited 1: API Error: Rate limit reached
```
