### PR TITLE
fix(hooks): probe interpreters with a multi-line -c, like the rebuild does

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -28,7 +28,15 @@ _PYTHON_DETECT = """\
 # detached launch even started. find_spec locates the package without executing
 # it, so each probe costs interpreter startup only. The detached rebuild still
 # fails loudly in the log if the package is broken under that interpreter.
-_GFY_PROBE="import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
+# The probe MUST stay multi-line, because the rebuild body it stands in for is
+# multi-line. On Windows a pyenv-win `python3` is a .bat shim: it accepts a
+# single-line -c and mangles a multi-line one, leaking its own `|| goto :error`
+# into the Python source. A single-line probe therefore passes on that shim, the
+# hook selects it, and every rebuild afterwards dies with IndentationError in the
+# log where nobody looks. Probing with the shape actually used rejects the shim
+# and falls through to the next candidate.
+_GFY_PROBE="import importlib.util, sys
+sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
 GRAPHIFY_PYTHON=""
 _PINNED='__PINNED_PYTHON__'
 if [ -n "$_PINNED" ] && [ -x "$_PINNED" ] && "$_PINNED" -c "$_GFY_PROBE" 2>/dev/null; then


### PR DESCRIPTION
## The bug

On Windows, when `python3` resolves to a **pyenv-win shim**, the hook selects an interpreter that cannot run the rebuild, and every rebuild afterwards dies silently.

A pyenv-win shim is a `.bat` file. It forwards a single-line `-c` argument fine, but mangles a multi-line one: the batch file's own `|| goto :error` leaks into the Python source.

`_GFY_PROBE` is a single-line program. `_REBUILD_BODY_COMMIT` and `_REBUILD_BODY_CHECKOUT` are multi-line. So the probe passes on the shim, `GRAPHIFY_PYTHON` is set to it, and the detached rebuild then fails with `IndentationError` into `~/.cache/graphify-rebuild.log`, which nobody reads because the hook prints its cheerful "launching background rebuild" line either way.

Symptom, on every commit, for an unknown length of time:

```
  File "<string>", line 1
    ||  goto :error
IndentationError: unexpected indent
```

## Reproduction

```console
$ command -v python3
/c/Users/me/.pyenv/pyenv-win/shims/python3

$ python3 -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
$ echo $?
0                      # the current probe ACCEPTS the shim

$ python3 -c "
import graphify
"
  File "<string>", line 1
    ||  goto :error
IndentationError: unexpected indent     # but a multi-line -c is mangled
```

## Why the existing Windows probes do not catch it

`v8` already tries a pinned interpreter, `graphify-out/.graphify_python`, and the pip-layout siblings `$_GFY_BINDIR/../python.exe` and `$_GFY_BINDIR/python.exe` before falling through. Those cover a venv or a standard pip install. They do not cover a **user-site** install, where the launcher sits in `%APPDATA%\Roaming\Python\PythonXY\Scripts` and there is no `python.exe` beside or above it:

```console
$ command -v graphify
/c/Users/me/AppData/Roaming/Python/Python313/Scripts/graphify
$ ls ../python.exe ./python.exe
(absent, both)
$ ls graphify-out/.graphify_python
(absent)
```

Every earlier probe misses, execution reaches the `python3` fallback, and the shim is accepted.

## The fix

Make the probe multi-line, so it exercises the same shape as the body it stands in for. One definition, and all six probe sites inherit it since they already share `$_GFY_PROBE`.

```console
$ M="import importlib.util, sys
sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
$ python3 -c "$M"; echo $?
1                      # shim now correctly rejected
$ python -c "$M"; echo $?
0                      # real interpreter still accepted, falls through to it
```

Verified afterwards on a real commit: `Rebuilt: 0 nodes, 0 edges` instead of `IndentationError`, and a full AST extraction on a subsequent checkout.

## Notes

- **The `find_spec` rationale is preserved.** The probe still avoids importing the package; the statement is only split across two lines, so probe cost stays interpreter startup.
- **Valid POSIX sh.** A double-quoted assignment spanning lines is standard; checked with `sh -n`, and `"$_GFY_PROBE"` preserves the newline when expanded.
- The general point is the one the comment now records: a probe that does not exercise the capability it gates will pass on interpreters that cannot do the real work.