### PR TITLE
fix(extract): shadow a single unparenthesised arrow parameter from indirect_call args

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -1164,6 +1164,13 @@ def _js_local_bound_names(func_node, source: bytes) -> set[str]:
     params = func_node.child_by_field_name("parameters")
     if params is not None:
         _js_collect_pattern_idents(params, source, bound)
+    # An arrow with ONE unparenthesised parameter exposes it as `parameter`
+    # (singular) — there is no `parameters` list node — so `x => f(x)` bound
+    # nothing at all and `x` read as a by-name reference to any same-named
+    # callable in the corpus. Same singular/plural trap as `catch_clause`.
+    solo = func_node.child_by_field_name("parameter")
+    if solo is not None:
+        _js_collect_pattern_idents(solo, source, bound)
 
     def walk(n) -> None:
         for c in n.children:

--- a/tests/test_indirect_call_arrow_single_param_shadow.py
+++ b/tests/test_indirect_call_arrow_single_param_shadow.py
@@ -1,0 +1,91 @@
+"""A single unparenthesised arrow parameter must shadow indirect_call args.
+
+`_js_local_bound_names` read only the `parameters` field. tree-sitter gives an
+arrow with ONE unparenthesised parameter a `parameter` field (singular) and no
+`parameters` list node at all, so `x => sink(x)` contributed nothing to the shadow
+set: `x` read as an unresolved by-name reference, resolved against the corpus-wide
+label index, and fabricated an `indirect_call` edge (INFERRED, 0.8) to an
+unrelated same-named callable. Minified bundles name nearly every private
+function with a single letter and use this arrow form heavily, so the two collide
+constantly.
+
+This is the same singular/plural trap as `catch_clause.parameter`. The
+parenthesised form was always handled, which is what makes the bug easy to miss:
+`(x) => …` and `x => …` behaved differently.
+"""
+import os
+from pathlib import Path
+
+from graphify.extract import extract
+
+
+def _extract_js_dir(tmp_path, files: dict[str, str]):
+    base = tmp_path / "src"
+    base.mkdir()
+    for name, body in files.items():
+        (base / name).write_text(body)
+    old = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        r = extract(
+            [Path("src") / name for name in files],
+            cache_root=Path(".cache"), parallel=False,
+        )
+    finally:
+        os.chdir(old)
+    nid = {n["label"].rstrip("()"): n["id"] for n in r["nodes"]}
+    return r, nid
+
+
+def _indirect(r):
+    return {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "indirect_call"}
+
+
+def test_single_unparenthesised_arrow_param_emits_no_indirect_call(tmp_path):
+    """The reported shape: a minified bundle's private `k` must not become a
+    fabricated target because an arrow names its only parameter `k`."""
+    r, nid = _extract_js_dir(tmp_path, {
+        "vendor.min.js": "var Lib=function(){function k(a){return a}return{k:k}}();\n",
+        "a.js": "function sink(f){ return f; }\nexport const run = k => sink(k);\n",
+    })
+    assert all(t != nid["k"] for _s, t in _indirect(r))
+
+
+def test_parenthesised_arrow_param_still_shadows(tmp_path):
+    """Control: the `parameters` path was already correct and must stay correct."""
+    r, nid = _extract_js_dir(tmp_path, {
+        "vendor.min.js": "var Lib=function(){function k(a){return a}return{k:k}}();\n",
+        "a.js": "function sink(f){ return f; }\nexport const run = (k) => sink(k);\n",
+    })
+    assert all(t != nid["k"] for _s, t in _indirect(r))
+
+
+def test_async_single_param_arrow_shadows(tmp_path):
+    """`async x => …` is the same node with the same singular field."""
+    r, nid = _extract_js_dir(tmp_path, {
+        "vendor.min.js": "var Lib=function(){function k(a){return a}return{k:k}}();\n",
+        "a.js": "function sink(f){ return f; }\nexport const run = async k => sink(k);\n",
+    })
+    assert all(t != nid["k"] for _s, t in _indirect(r))
+
+
+def test_arrow_param_does_not_shadow_a_genuine_reference(tmp_path):
+    """The parameter is scoped to its arrow: a same-named module callable
+    referenced from a DIFFERENT function must still resolve."""
+    r, nid = _extract_js_dir(tmp_path, {"a.js": (
+        "function k(x){ return x; }\n"
+        "function sink(f){ return f; }\n"
+        "export const shadowed = k => sink(k);\n"
+        "export function elsewhere(pool) { pool.submit(k); }\n"
+    )})
+    assert (nid["elsewhere"], nid["k"]) in _indirect(r)
+
+
+def test_genuine_reference_inside_the_arrow_still_emits(tmp_path):
+    """Widening the shadow set must not blanket-suppress inside arrows: an
+    unshadowed callable referenced in the body still emits."""
+    r, nid = _extract_js_dir(tmp_path, {"a.js": (
+        "function handler(x){ return x; }\n"
+        "export const run = pool => pool.submit(handler);\n"
+    )})
+    assert (nid["run"], nid["handler"]) in _indirect(r)


### PR DESCRIPTION
## Summary

`_js_local_bound_names` reads only the `parameters` field. tree-sitter gives an arrow with
**one unparenthesised parameter** a `parameter` field (singular) and no `parameters` list node
at all, so that parameter never entered the shadow set: `x => sink(x)` bound nothing, and `x`
read as an unresolved by-name reference, resolved against the corpus-wide label index, and
fabricated an `indirect_call` edge (INFERRED, 0.8) to an unrelated same-named callable.

This is the same singular/plural trap as `catch_clause.parameter` (#2517). The parenthesised
form was always handled, which is what makes it easy to miss — `(x) => …` and `x => …` behaved
differently.

Minified bundles name nearly every private function with a single letter and use this arrow
form heavily, so the two collide constantly.

## Reproduction

On `v8` @ `09a34ad` (v0.9.37):

```js
// src/vendor.min.js
var Lib=function(){function k(a){return a}return{k:k}}();
```

```js
// src/a.js
function sink(f){ return f; }
export const run = k => sink(k);      // `k` is this arrow's parameter
```

```python
from graphify.extract import extract
from pathlib import Path
r = extract([Path('src/a.js'), Path('src/vendor.min.js')], cache_root=Path('.c'), parallel=False)
print([e for e in r['edges'] if e['relation'] == 'indirect_call'])
```

| form | `v8` | this PR |
|---|---|---|
| `k => sink(k)` | **fabricates** `run -> vendor_min_k` | none |
| `async k => sink(k)` | **fabricates** | none |
| `(k) => sink(k)` (control) | none | none |

Grammar check, so the field names are not taken on trust:

```
const f = x => g(x);         -> fields present: ['parameter']
const f = async x => g(x);   -> fields present: ['parameter']
const f = (x) => g(x);       -> fields present: ['parameters']
const f = ({a}) => g(a);     -> fields present: ['parameters']
```

## Change

Seven lines in `_js_local_bound_names`, next to the existing `parameters` read:

```python
    # An arrow with ONE unparenthesised parameter exposes it as `parameter`
    # (singular) — there is no `parameters` list node — so `x => f(x)` bound
    # nothing at all and `x` read as a by-name reference to any same-named
    # callable in the corpus. Same singular/plural trap as `catch_clause`.
    solo = func_node.child_by_field_name("parameter")
    if solo is not None:
        _js_collect_pattern_idents(solo, source, bound)
```

`_js_collect_pattern_idents` already handles the pattern forms, and `async x => …` is the same
node with the same field, so both are covered by the one read.

Scope note: the parameter is scoped to its arrow, and `_js_local_bound_names` is called per
function, so this does not widen anything beyond that arrow — a same-named module callable
referenced from a different function still resolves. There is a test for exactly that.

## Tests

New `tests/test_indirect_call_arrow_single_param_shadow.py`, modelled on
`test_indirect_call_nested_closure_shadow.py`:

| test | pins |
|---|---|
| `test_single_unparenthesised_arrow_param_emits_no_indirect_call` | the reported shape |
| `test_parenthesised_arrow_param_still_shadows` | control — the `parameters` path stays correct |
| `test_async_single_param_arrow_shadows` | `async x => …`, same singular field |
| `test_arrow_param_does_not_shadow_a_genuine_reference` | a same-named module callable used in **another** function still resolves |
| `test_genuine_reference_inside_the_arrow_still_emits` | no blanket suppression inside arrows |

Against the same test file:

| engine | result |
|---|---|
| `v8` @ `09a34ad` | **2 failed**, 3 passed — the two singular-parameter cases, i.e. the bug |
| this PR | **5 passed** |

Regression: `227 passed, 2 skipped` across `test_indirect_call_*`, `test_indirect_dispatch*`,
`test_extract`, `test_cross_language_call_resolution`, `test_node_id_canonical`.

## Effect on real code

Strictly subtractive — it removes fabricated edges and adds none:

| corpus | `v8` | this PR | delta |
|---|---|---|---|
| `node_modules`, 5,402 JS/TS files | 2,572 `indirect_call` | 2,484 | **+0 / -88** |
| 6,000-file mixed project tree | 3,030 | 2,932 | **+0 / -98** |

Those are my own measurements on my machine; the per-case tables and the grammar check above
are the parts you can reproduce directly from this description.

## Scope

Touches only `_js_local_bound_names`, and only by adding a second field read. It does not
overlap #1985 (`for_in_statement`, same function but a different branch) or #2517
(`catch_clause`, in `walk_calls`) — though all three are the same underlying class of bug: a
binding form that never reaches the shadow set.
