### PR TITLE
fix: skip Obsidian vault metadata directories

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -807,6 +807,7 @@ _SKIP_DIRS = {
     ".next", ".nuxt", ".turbo", ".angular",
     ".idea", ".cache", ".parcel-cache", ".svelte-kit", ".terraform", ".serverless",
     ".graphify",  # graphify's own extraction cache — never index self-generated data
+    ".obsidian", ".smart-env",  # Obsidian vault metadata and plugin caches (#2493)
     ".worktrees",  # git worktree convention (#947) — sibling checkouts, always redundant
 }
 

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -76,6 +76,25 @@ def test_detect_skips_noise_dot_dirs():
                 assert noise not in f
 
 
+def test_detect_skips_obsidian_vault_metadata_dirs(tmp_path):
+    """Obsidian metadata and plugin caches are not part of the source corpus (#2493)."""
+    for directory in (".obsidian", ".smart-env"):
+        metadata_dir = tmp_path / directory
+        metadata_dir.mkdir()
+        (metadata_dir / "state.json").write_text("{}")
+    trash_dir = tmp_path / ".trash"
+    trash_dir.mkdir()
+    (trash_dir / "state.json").write_text("{}")
+    (tmp_path / "project.json").write_text("{}")
+
+    result = detect(tmp_path)
+
+    assert result["files"]["code"] == [
+        str(trash_dir / "state.json"),
+        str(tmp_path / "project.json"),
+    ]
+
+
 def test_classify_md_paper_by_signals(tmp_path):
     """A .md file with enough paper signals should classify as PAPER."""
     paper = tmp_path / "paper.md"


### PR DESCRIPTION
## Summary

This fixes vault scans where Obsidian workspace state was treated as source code.

- Add `.obsidian` and `.smart-env` to the existing unconditional generated/noise-directory set.
- Add a regression test that verifies those two Obsidian-specific directories are skipped.
- Keep generic `.trash` directories discoverable: the test asserts that both `.trash/state.json` and root `project.json` remain code inputs.

## Why this belongs in `_SKIP_DIRS`

`.obsidian` and `.smart-env` contain Obsidian application metadata and plugin-generated cache data, not user-authored corpus files. A scan previously classified files such as `.obsidian/graph.json` and `.obsidian/workspace.json` as code, producing misleading graph input.

`.trash` is intentionally not excluded because it is a generic directory name and may contain real user files outside an Obsidian vault.

## Reproduction

Create a vault root containing `.obsidian/graph.json`, `.obsidian/workspace.json`, `.smart-env/state.json`, `.trash/state.json`, and a real `project.json`, then call `detect(root)`.

Before: the `.obsidian` JSON files appeared in `files["code"]`.

After: `.obsidian` and `.smart-env` are excluded, while `.trash/state.json` and `project.json` remain in `files["code"]`.

## Scope

This deliberately changes only the directory-pruning list and detector coverage. It does not modify `.graphifyignore` behavior or user-defined exclusions.

## Validation

- `uv run --no-sync pytest tests/test_detect.py -q -k obsidian`
- `uv run --no-sync pytest tests/test_detect.py -q`: 232 passed; 4 unrelated Windows baseline failures
- `uv run --no-sync ruff check graphify/detect.py tests/test_detect.py`
- `uv run graphify update .`

Fixes #2493