### PR TITLE
fix(extract,affected): edge `import('…')` in plain JS/TS, and travers…

### DIFF
--- a/graphify/affected.py
+++ b/graphify/affected.py
@@ -15,6 +15,12 @@ DEFAULT_AFFECTED_RELATIONS = (
     "references",
     "imports",
     "imports_from",
+    # `import('…')`. Emitted by the Svelte/Astro/Vue rescue passes and (since the
+    # companion fix in extract.py) by plain JS/TS too. Omitting it made every
+    # dynamic import invisible to blast-radius traversal even where the edge WAS
+    # in the graph — and dynamic import is precisely how codebases break require
+    # cycles, so the missing edges sit under the most load-bearing modules.
+    "dynamic_import",
     "re_exports",
     "inherits",
     "extends",

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1231,7 +1231,49 @@ def extract_js(path: Path) -> dict:
     result = _extract_generic(path, config)
     if "error" not in result:
         _extract_js_rationale(path, result)
+        _rescue_js_dynamic_imports(path, result)
     return result
+
+
+def _rescue_js_dynamic_imports(path: Path, result: dict) -> None:
+    """Recover ``import('…')`` edges the AST pass does not emit for plain JS/TS.
+
+    tree-sitter models ``await import('x')`` as a ``call_expression``, not an
+    ``import_statement``, so the specifier never reaches the import walk. This is
+    the same gap :func:`extract_svelte`, :func:`extract_astro` and
+    :func:`extract_vue` already patch by regex — those file types only got the
+    rescue because their AST pass fails wholesale, while plain ``.ts``/``.js``
+    were left out on the reasoning that their AST pass "works". It works for
+    STATIC imports; the dynamic ones fall through silently.
+
+    Measured on a 546-file TypeScript app (2026-08-09): 31 real
+    ``import('…')`` edges were missing from graph.json. Because they cluster
+    under hub modules, the loss compounds with traversal depth — one such app's
+    ``affected --depth 3`` returned 8 of 30 truly-affected files (recall 0.27,
+    precision still 1.00: the graph under-reports, it never invents). Codebases
+    that use dynamic import deliberately to break require cycles are hit hardest,
+    since those edges are exactly the load-bearing ones.
+    """
+    try:
+        import re as _re
+        src = path.read_text(encoding="utf-8", errors="replace")
+        if "import(" not in src:  # cheap bail — most files have none
+            return
+        existing_ids = {n["id"] for n in result.get("nodes", [])}
+        file_node_id = _make_id(str(path))
+        aliases = _load_tsconfig_aliases(path.parent)
+        base_url = _load_tsconfig_base_url(path.parent)
+        # `(?<!\w)` so `fooimport('x')` and `_import('x')` do not match.
+        for m in _re.finditer(r"""(?<!\w)import\(\s*['"]([^'"]+)['"]\s*\)""", src):
+            raw = m.group(1)
+            if not raw:
+                continue
+            _emit_rescued_import(
+                result, existing_ids, file_node_id, path, raw,
+                "dynamic_import", aliases, base_url,
+            )
+    except Exception:
+        pass
 
 
 # ── JS/TS rationale + doc-reference extraction ────────────────────────────────

--- a/tests/test_js_dynamic_imports.py
+++ b/tests/test_js_dynamic_imports.py
@@ -1,0 +1,123 @@
+"""`import('…')` in plain .ts/.js must produce an edge.
+
+tree-sitter models ``await import('x')`` as a ``call_expression``, not an
+``import_statement``, so the specifier never reaches the import walk. The
+Svelte/Astro/Vue extractors already compensate with a regex pass; plain JS/TS
+did not, because its AST pass "works" — for STATIC imports. The dynamic ones
+fell through silently, which matters most in codebases that use dynamic import
+deliberately to break require cycles: those edges sit under the hub modules, so
+the loss compounds with traversal depth in ``graphify affected``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from graphify.affected import DEFAULT_AFFECTED_RELATIONS
+from graphify.extract import _file_node_id, extract
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _has_edge(result: dict, source: str, target: str, relation: str) -> bool:
+    expected = (_file_node_id(Path(source)), _file_node_id(Path(target)), relation)
+    return expected in {
+        (e["source"], e["target"], e["relation"]) for e in result["edges"]
+    }
+
+
+def test_relative_dynamic_import_edges(tmp_path: Path):
+    target = _write(tmp_path / "src/lib/foo.ts", "export const foo = 1\n")
+    importer = _write(
+        tmp_path / "src/lib/page.ts",
+        "export async function load() {\n"
+        "    const { foo } = await import('./foo')\n"
+        "    return foo\n"
+        "}\n",
+    )
+
+    result = extract([target, importer], cache_root=tmp_path)
+
+    assert _has_edge(result, "src/lib/page.ts", "src/lib/foo.ts", "dynamic_import")
+
+
+def test_multi_level_relative_dynamic_import_edges(tmp_path: Path):
+    target = _write(tmp_path / "src/runner.ts", "export const run = () => 1\n")
+    importer = _write(
+        tmp_path / "src/tools/impl/delegate.ts",
+        "export async function go() {\n"
+        "    const { run } = await import('../../runner')\n"
+        "    return run()\n"
+        "}\n",
+    )
+
+    result = extract([target, importer], cache_root=tmp_path)
+
+    assert _has_edge(result, "src/tools/impl/delegate.ts", "src/runner.ts", "dynamic_import")
+
+
+def test_tsconfig_aliased_dynamic_import_edges(tmp_path: Path):
+    _write(
+        tmp_path / "tsconfig.json",
+        json.dumps({"compilerOptions": {"baseUrl": ".", "paths": {"@/*": ["./src/*"]}}}),
+    )
+    target = _write(tmp_path / "src/agent/runner.ts", "export const run = () => 1\n")
+    importer = _write(
+        tmp_path / "src/stores/store.ts",
+        "export async function send() {\n"
+        "    const { run } = await import('@/agent/runner')\n"
+        "    return run()\n"
+        "}\n",
+    )
+
+    result = extract([target, importer], cache_root=tmp_path)
+
+    assert _has_edge(result, "src/stores/store.ts", "src/agent/runner.ts", "dynamic_import")
+
+
+def test_static_import_still_edges_alongside_a_dynamic_one(tmp_path: Path):
+    """The rescue pass must not disturb the AST pass it runs beside."""
+    a = _write(tmp_path / "src/a.ts", "export const a = 1\n")
+    b = _write(tmp_path / "src/b.ts", "export const b = 2\n")
+    importer = _write(
+        tmp_path / "src/main.ts",
+        "import { a } from './a'\n"
+        "export async function later() {\n"
+        "    const { b } = await import('./b')\n"
+        "    return a + b\n"
+        "}\n",
+    )
+
+    result = extract([a, b, importer], cache_root=tmp_path)
+
+    assert _has_edge(result, "src/main.ts", "src/a.ts", "imports_from")
+    assert _has_edge(result, "src/main.ts", "src/b.ts", "dynamic_import")
+
+
+def test_identifier_ending_in_import_is_not_matched(tmp_path: Path):
+    """`fooimport('./x')` is a call to `fooimport`, not a dynamic import."""
+    target = _write(tmp_path / "src/x.ts", "export const x = 1\n")
+    importer = _write(
+        tmp_path / "src/caller.ts",
+        "declare function fooimport(s: string): unknown\n"
+        "export const r = fooimport('./x')\n",
+    )
+
+    result = extract([target, importer], cache_root=tmp_path)
+
+    assert not _has_edge(result, "src/caller.ts", "src/x.ts", "dynamic_import")
+
+
+def test_dynamic_import_is_traversed_by_affected():
+    """Emitting the edge is only half the fix.
+
+    ``graphify affected`` walks ``DEFAULT_AFFECTED_RELATIONS``; while
+    ``dynamic_import`` was absent from it, every dynamic edge stayed invisible to
+    blast-radius traversal — including the ones the Svelte/Astro/Vue rescue
+    passes had been emitting all along.
+    """
+    assert "dynamic_import" in DEFAULT_AFFECTED_RELATIONS


### PR DESCRIPTION
Fixes #2575

tree-sitter models `await import('x')` as a `call_expression`, not an `import_statement`, so the specifier never reaches the import walk. The Svelte/Astro/Vue extractors already compensate with a regex pass — the docstring in `extract_vue` says so outright ("A regex pass then recovers `import('…')` dynamic imports the AST does not edge"). Plain .ts/.js was left out, on the reasonable-sounding basis that its AST pass works. It works for STATIC imports; the dynamic ones fall through silently.

Two independent gaps, and fixing either alone changes nothing:

1. extract.py — no dynamic-import edge is produced for plain JS/TS at all.
2. affected.py — `dynamic_import` was missing from DEFAULT_AFFECTED_RELATIONS, so even the dynamic edges the Svelte/Astro/Vue passes DO emit were invisible to `graphify affected`.

Measured on a 546-file TypeScript app (graphify 0.9.36/0.9.37, 2026-08-09): 31 real `import('…')` edges missing from graph.json. The loss compounds with depth because dynamic imports cluster under hub modules — codebases use them precisely to break require cycles, so the missing edges are the load-bearing ones. On that app, `affected <file> --depth 3` returned 10 of 30 truly-affected files (recall 0.27); ground truth came from an independently written import resolver, not from graphify. Precision stayed 1.00 throughout: the graph under-reports, it never invents.

With this change, on the same corpus: 31 missing edges -> 0, and recall goes to 1.00 at every depth on all three targets tested, precision still 1.00.

Implementation reuses what already exists — `_emit_rescued_import`, `_load_tsconfig_aliases`, `_load_tsconfig_base_url` — so aliased specifiers (`@/agent/runner`) resolve through the same path as static ones. The regex is guarded with `(?<!\w)` so `fooimport('x')` does not match, and the pass bails early when the file contains no `import(` at all.

tests/test_js_dynamic_imports.py covers relative, multi-level relative and tsconfig-aliased dynamic imports, asserts a static import still edges alongside a dynamic one, guards the `(?<!\w)` boundary, and asserts `dynamic_import` is traversable by `affected`. Verified to fail without this change: 5 of the 6 fail on v8, all 6 pass with it.

Suite: 6 failed / 3931 passed, byte-identical with and without this change — those 6 are pre-existing in my environment (missing `ollama`, a wheel-build test, an apm manifest dependency).