### PR TITLE
fix(python): stop unresolved member calls binding by bare name

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -4482,6 +4482,21 @@ def _extract_generic(
                             obj = func_node.child_by_field_name(config.call_accessor_object_field)
                             if obj is not None and obj.type == "identifier":
                                 member_receiver = _read_text(obj, source)
+                            elif (
+                                config.ts_module == "tree_sitter_python"
+                                and obj is not None
+                                and obj.type == "call"
+                            ):
+                                # ``super().method()`` has a call node as its
+                                # receiver. Preserve it as a known intra-class
+                                # receiver instead of treating it as unresolved.
+                                receiver_func = obj.child_by_field_name("function")
+                                if (
+                                    receiver_func is not None
+                                    and receiver_func.type == "identifier"
+                                    and _read_text(receiver_func, source) == "super"
+                                ):
+                                    member_receiver = "super"
                             elif (obj is not None
                                   and obj.type in config.call_accessor_node_types
                                   and config.call_accessor_object_field):
@@ -4496,12 +4511,13 @@ def _extract_generic(
                         callee_name = _read_text(func_node, source)
 
             if callee_name and callee_name not in _LANGUAGE_BUILTIN_GLOBALS:
-                # A capitalized-receiver member call (`ClassName.method()`) must defer
-                # to receiver-based cross-file resolution: the bare method name can
-                # collide with an in-file node — even the calling method itself, when a
-                # viewset action delegates to a same-named service action — which would
-                # match `tgt_nid == caller_nid` and silently drop the call (#1446). The
-                # captured receiver is resolved later in _resolve_python_member_calls.
+                # Python member calls defer to receiver-based resolution unless the
+                # receiver is known to stay in the current class. Falling back to a
+                # bare method name for an unresolved/lowercase receiver (`d.get()` or
+                # `self.store.get()`) can bind to an unrelated module function and
+                # inflate it into a god node (#2417). Qualified class/module calls are
+                # recovered later by _resolve_python_member_calls when the receiver
+                # supplies enough evidence (#1446/#1883).
                 # C#: ANY member call with a captured receiver defers to the
                 # receiver-typed resolver — a bare method-name match ignores the
                 # receiver's declared type and mis-binds to an unrelated same-named
@@ -4511,10 +4527,15 @@ def _extract_generic(
                     config.ts_module == "tree_sitter_c_sharp"
                     and is_member_call and member_receiver
                 )
+                _python_defer = (
+                    config.ts_module == "tree_sitter_python"
+                    and is_member_call
+                    and member_receiver not in {"self", "cls", "super"}
+                )
                 _java_defer = (
                     config.ts_module == "tree_sitter_java" and is_member_call
                 )
-                if _java_defer or (
+                if _python_defer or _java_defer or (
                     is_member_call
                     and member_receiver
                     and (

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1136,13 +1136,15 @@ def test_python_relative_import_out_of_root_target_id_is_portable(tmp_path):
 
 def test_python_module_qualified_call_resolves_extracted(tmp_path):
     """`module.func()` where `module` is imported resolves to the callable that
-    module contains, with an EXTRACTED `calls` edge (#1883). A lowercase module
-    receiver was previously dropped alongside instance calls."""
+    module contains, with an EXTRACTED `calls` edge (#1883), even when the caller
+    file contains a same-named function that bare-name lookup could select."""
     mathlib = tmp_path / "mathlib.py"
     caller = tmp_path / "caller.py"
     mathlib.write_text("def compute(x):\n    return x * 2\n")
     caller.write_text(
         "import mathlib\n\n"
+        "def compute(x):\n"
+        "    return x + 1\n\n"
         "def use_qualified(n):\n"
         "    return mathlib.compute(n)\n"
     )
@@ -1153,9 +1155,9 @@ def test_python_module_qualified_call_resolves_extracted(tmp_path):
         if e["relation"] == "calls"
         and "use_qualified" in nodes[e["source"]]["label"]
         and "compute" in nodes[e["target"]]["label"]
-        and "mathlib.py" in (nodes[e["target"]].get("source_file") or "")
     ]
     assert len(edges) == 1, f"expected one use_qualified->compute edge, got {edges}"
+    assert "mathlib.py" in (nodes[edges[0]["target"]].get("source_file") or "")
     assert edges[0]["confidence"] == "EXTRACTED"
 
 
@@ -1462,6 +1464,94 @@ def test_python_instance_member_call_not_overconnected(tmp_path):
         and "run" in nodes[e["target"]]["label"]
     ]
     assert bad == [], f"instance member call must not connect cross-file: {bad}"
+
+
+def test_python_unresolved_member_calls_do_not_bind_to_bare_function(tmp_path):
+    """#2417: unresolved attribute calls must not bind by bare method name.
+
+    ``d.get()`` and ``self.store.get()`` do not identify the module-level
+    ``get()`` definition, so only the direct ``get()`` call is a real edge.
+    The result must also survive a warm cache extraction.
+    """
+    fixture = tmp_path / "fixture.py"
+    fixture.write_text(
+        "def get(k):\n"
+        "    return k\n\n"
+        "class Store:\n"
+        "    def __init__(self):\n"
+        "        self.store = {}\n\n"
+        "    def read(self, k):\n"
+        "        return self.store.get(k)\n\n"
+        "def other(d):\n"
+        "    return d.get('x')\n\n"
+        "def real():\n"
+        "    return get('real')\n",
+        encoding="utf-8",
+    )
+
+    def _get_callers(result):
+        nodes = {node["id"]: node for node in result["nodes"]}
+        target_ids = {
+            node["id"] for node in result["nodes"]
+            if node.get("label") == "get()" and node.get("source_file")
+        }
+        return sorted(
+            nodes[edge["source"]]["label"]
+            for edge in result["edges"]
+            if edge.get("relation") == "calls" and edge.get("target") in target_ids
+        )
+
+    cold = extract([fixture], cache_root=tmp_path, root=tmp_path)
+    assert _get_callers(cold) == ["real()"]
+    warm = extract([fixture], cache_root=tmp_path, root=tmp_path)
+    assert _get_callers(warm) == ["real()"]
+
+
+def test_python_known_member_receivers_keep_local_call_edges(tmp_path):
+    """Preserve self/cls/super calls while deferring other call receivers."""
+    fixture = tmp_path / "known_receivers.py"
+    fixture.write_text(
+        "class Base:\n"
+        "    def inherited(self):\n"
+        "        return 1\n\n"
+        "class Worker(Base):\n"
+        "    def local(self):\n"
+        "        return 2\n\n"
+        "    @classmethod\n"
+        "    def class_local(cls):\n"
+        "        return 3\n\n"
+        "    def via_self(self):\n"
+        "        return self.local()\n\n"
+        "    @classmethod\n"
+        "    def via_cls(cls):\n"
+        "        return cls.class_local()\n\n"
+        "    def via_super(self):\n"
+        "        return super().inherited()\n\n"
+        "def via_factory(factory):\n"
+        "    return factory().local()\n",
+        encoding="utf-8",
+    )
+    result = extract([fixture], cache_root=tmp_path, root=tmp_path)
+    nodes = {node["id"]: node for node in result["nodes"]}
+    call_pairs = {
+        (nodes[edge["source"]]["label"], nodes[edge["target"]]["label"])
+        for edge in result["edges"]
+        if edge.get("relation") == "calls"
+    }
+
+    for caller, callee in (
+        ("via_self", "local"),
+        ("via_cls", "class_local"),
+        ("via_super", "inherited"),
+    ):
+        assert any(
+            caller in source_label and callee in target_label
+            for source_label, target_label in call_pairs
+        ), f"missing {caller} -> {callee} call edge: {call_pairs}"
+    assert not any(
+        "via_factory" in source_label and "local" in target_label
+        for source_label, target_label in call_pairs
+    ), f"unresolved factory() receiver must not bind by bare name: {call_pairs}"
 
 
 def test_python_qualified_call_ambiguous_class_bails(tmp_path):


### PR DESCRIPTION
## Summary

- Stop unresolved Python attribute calls such as `d.get()` and `self.store.get()` from falling back to a same-named module-level function.
- Preserve local `self` / `cls` / `super()` calls and evidence-backed class- or module-qualified member resolution.
- Add cold- and warm-cache regression coverage for the exact issue fixture, plus receiver and name-collision cases.

## Scope

This intentionally favors precision: when a Python member receiver cannot be resolved, Graphify leaves the call unconnected instead of guessing from the bare method name. This does not add receiver type inference or address #2315. There are no public API, schema, version, or dependency-lock changes.

## Test plan

- [x] `.venv/bin/python -m pytest tests/ -q --tb=short` — 4009 passed, 37 skipped
- [x] `.venv/bin/python -m pytest tests/test_extract.py -q --tb=short` — 167 passed, 1 skipped
- [x] `.venv/bin/ruff check graphify/extractors/engine.py tests/test_extract.py`
- [x] `.venv/bin/python -m tools.skillgen --check`
- [x] `git diff --check`
- [x] `graphify update .`

Test coverage audit: 100% of changed behavior paths covered. Pre-landing review: no issues found.

Fixes #2417
