### PR TITLE
fix(js): let `affected` traverse a dynamic import written inside a fu…

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1252,7 +1252,10 @@ def _rescue_js_dynamic_imports(path: Path, result: dict) -> None:
     as an ``imports_from`` edge marked ``deferred`` (``_dynamic_import_js``).
     Re-emitting it here as a second ``dynamic_import`` edge would state the
     same fact twice, so a match whose resolved target already has a deferred
-    edge is skipped.
+    edge FROM THIS FILE'S NODE is skipped. The source check matters: the AST
+    pass anchors the edge on the enclosing function when the ``import()`` is
+    written inside one, and that is a different fact from "this file depends on
+    that module" — the only one file-level traversal can use (#2584).
 
     Regex false positives in comments/strings are the precedented trade of
     the Svelte/Vue rescues; a ``//``-prefix guard covers the common case.
@@ -1268,8 +1271,28 @@ def _rescue_js_dynamic_imports(path: Path, result: dict) -> None:
         base_url = _load_tsconfig_base_url(path.parent)
         deferred_ids: set[str] = set()
         deferred_files: set[str] = set()
+        rescued_targets: set[str] = set()
         for e in result.get("edges", []):
-            if e.get("deferred") and e.get("relation") == "imports_from":
+            # Only a FILE-level deferred edge makes the rescue redundant (#2584).
+            #
+            # `_dynamic_import_js` emits `caller_nid -> target`, and `caller_nid` is this
+            # file's node only when the `import()` sits at module scope. Written inside a
+            # function it is that function's node — a different fact, at a granularity
+            # `affected` does not walk. Matching on target alone treated the two as one and
+            # skipped the rescue, so a dynamic import inside a function ended up with no
+            # file-level edge at all. The reverse walk then reached the enclosing function
+            # and stopped: the only edge pointing at it is `contains`, deliberately kept out
+            # of DEFAULT_AFFECTED_RELATIONS.
+            #
+            # Measured on a ~700-file TS repo: `affected --depth 3` returned 39 of 49 truly
+            # affected files (recall 0.80, precision 1.00) and deeper traversal did not help,
+            # which is a dead end rather than a depth limit. It stayed hidden because the
+            # usual case still resolves — when the next importer imports that exact symbol
+            # by name there IS an edge into the function. Switch that importer to
+            # `import * as ns` or a side-effect `import './dyn'` and the same graph goes
+            # silent.
+            if (e.get("deferred") and e.get("relation") == "imports_from"
+                    and e.get("source") == file_node_id):
                 deferred_ids.add(e.get("target"))
                 tf = e.get("target_file")
                 if tf:
@@ -1305,6 +1328,16 @@ def _rescue_js_dynamic_imports(path: Path, result: dict) -> None:
                         continue
                 except OSError:
                     pass
+            # One file depending on one module is one file-level fact, however many
+            # call sites defer it. Pre-existing (two module-scope `import('./x')` in one
+            # file already emitted two identical edges on v8), but #2584 routes every
+            # in-function dynamic import through here too, which would turn an edge case
+            # into the common one — a hub module deferred from eight functions of the same
+            # file would carry eight identical arrows.
+            emit_key = str(resolved_file.resolve()) if resolved_file is not None else raw
+            if emit_key in rescued_targets:
+                continue
+            rescued_targets.add(emit_key)
             _emit_rescued_import(
                 result, existing_ids, file_node_id, path, raw,
                 "dynamic_import", aliases, base_url,

--- a/tests/test_js_dynamic_import_affected.py
+++ b/tests/test_js_dynamic_import_affected.py
@@ -1,0 +1,154 @@
+"""`affected` must traverse a dynamic `import('…')` written inside a function — #2584.
+
+The edge was already emitted (#2575), so an edge-existence assertion passes while the
+answer users actually read is short. The reason is a granularity mismatch: a static import
+emits ``file -> target``, but ``_dynamic_import_js`` emitted ``caller_nid -> target``, and
+``caller_nid`` is the file node ONLY at module level. Written inside a function it is that
+function's node, so the graph held ``load() --imports_from--> target`` with no file-level
+edge, and the reverse walk stopped at ``load()`` — the one edge pointing at it is
+``contains``, which is deliberately not in DEFAULT_AFFECTED_RELATIONS.
+
+Measured on a ~700-file TS repo: recall 0.80 at depth 3, precision 1.00, and raising the
+depth did not help. It stayed hidden because the common case works — if the next importer
+imports that exact symbol by name, there IS an edge into ``load()``. So the tests below
+pin the cases where nothing points at the enclosing symbol: a namespace import and a
+side-effect import. Those are the ones that were silent.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+
+from graphify.affected import affected_nodes
+from graphify.extract import _file_node_id, extract
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+TARGET = "export const value = 1\n"
+
+# The dynamic import lives INSIDE a function — the case that regressed.
+DYN_IN_FUNCTION = (
+    "export async function load() {\n"
+    "    const m = await import('./target')\n"
+    "    return m.value\n"
+    "}\n"
+    "export const other = 2\n"
+)
+
+TOP = "import { run } from './mid'\nexport const go = () => run()\n"
+
+
+def _build(tmp_path: Path, mid_src: str, dyn_src: str = DYN_IN_FUNCTION):
+    files = [
+        _write(tmp_path / "src/target.ts", TARGET),
+        _write(tmp_path / "src/dyn.ts", dyn_src),
+        _write(tmp_path / "src/mid.ts", mid_src),
+        _write(tmp_path / "src/top.ts", TOP),
+    ]
+    result = extract(files, cache_root=tmp_path, root=tmp_path)
+    graph = nx.DiGraph()
+    for n in result["nodes"]:
+        graph.add_node(n["id"], **n)
+    for e in result["edges"]:
+        graph.add_edge(e["source"], e["target"], **e)
+    return result, graph
+
+
+def _fid(rel: str) -> str:
+    return _file_node_id(Path(rel))
+
+
+def _reaches(graph: nx.DiGraph, seed: str, wanted: str, depth: int = 3) -> bool:
+    hits = affected_nodes(graph, _fid(seed), depth=depth)
+    return _fid(wanted) in {h.node_id for h in hits}
+
+
+def _file_edges(result: dict, source: str, target: str) -> list[dict]:
+    return [
+        e for e in result["edges"]
+        if e["source"] == _fid(source) and e["target"] == _fid(target)
+    ]
+
+
+def test_dynamic_import_in_function_emits_a_file_level_edge(tmp_path: Path):
+    """The file owning the `import()` depends on the target, whoever wrote the call."""
+    result, _ = _build(tmp_path, "import './dyn'\nexport const run = () => 1\n")
+
+    edges = _file_edges(result, "src/dyn.ts", "src/target.ts")
+    assert edges, "no file-level edge for a dynamic import written inside a function"
+    # `dynamic_import`, not `imports_from`: it keeps the deferred nature legible, it is
+    # already in DEFAULT_AFFECTED_RELATIONS, and find_import_cycles reads only
+    # `imports_from`/`re_exports` — so the phantom file cycle of #1241 cannot come back
+    # through this edge the way a second `imports_from` might.
+    assert all(e["relation"] == "dynamic_import" for e in edges)
+
+
+def test_affected_reaches_through_a_side_effect_importer(tmp_path: Path):
+    """`import './dyn'` binds no symbol, so nothing points at the enclosing function."""
+    _, graph = _build(tmp_path, "import './dyn'\nexport const run = () => 1\n")
+
+    assert _reaches(graph, "src/target.ts", "src/dyn.ts", depth=1)
+    assert _reaches(graph, "src/target.ts", "src/top.ts", depth=3)
+
+
+def test_affected_reaches_through_a_namespace_importer(tmp_path: Path):
+    """`import * as ns` binds the module, not the function that defers the load."""
+    _, graph = _build(tmp_path, "import * as ns from './dyn'\nexport const run = () => ns.load()\n")
+
+    assert _reaches(graph, "src/target.ts", "src/top.ts", depth=3)
+
+
+def test_affected_reaches_when_importer_names_a_different_symbol(tmp_path: Path):
+    """`other` is a sibling export; the edge into `load()` that used to rescue this is absent."""
+    _, graph = _build(tmp_path, "import { other } from './dyn'\nexport const run = () => other\n")
+
+    assert _reaches(graph, "src/target.ts", "src/top.ts", depth=3)
+
+
+def test_call_site_precision_is_preserved(tmp_path: Path):
+    """The symbol-level edge must survive: `explain` still has to name the deferring function."""
+    result, _ = _build(tmp_path, "import { load } from './dyn'\nexport const run = () => load()\n")
+
+    tgt = _fid("src/target.ts")
+    symbol_edges = [
+        e for e in result["edges"]
+        if e["target"] == tgt and e["source"] != _fid("src/dyn.ts")
+        and e.get("deferred") is True
+    ]
+    assert symbol_edges, "the symbol-level dynamic-import edge was replaced instead of added"
+    assert symbol_edges[0]["relation"] == "imports_from"
+
+
+def test_module_level_dynamic_import_emits_no_duplicate(tmp_path: Path):
+    """At module level `caller_nid` IS the file node — emitting again would double-count."""
+    result, _ = _build(
+        tmp_path,
+        "import './dyn'\nexport const run = () => 1\n",
+        dyn_src="export const p = import('./target')\n",
+    )
+
+    assert len(_file_edges(result, "src/dyn.ts", "src/target.ts")) == 1
+
+
+def test_one_file_deferring_the_same_module_twice_emits_one_file_edge(tmp_path: Path):
+    """Two functions, one dependency. The file-level edge dedupes on its own key."""
+    result, _ = _build(
+        tmp_path,
+        "import './dyn'\nexport const run = () => 1\n",
+        dyn_src=(
+            "export async function a() {\n"
+            "    return (await import('./target')).value\n"
+            "}\n"
+            "export async function b() {\n"
+            "    return (await import('./target')).value\n"
+            "}\n"
+        ),
+    )
+
+    assert len(_file_edges(result, "src/dyn.ts", "src/target.ts")) == 1

--- a/tests/test_js_dynamic_imports.py
+++ b/tests/test_js_dynamic_imports.py
@@ -93,10 +93,26 @@ def test_module_scope_dynamic_import_edges(tmp_path: Path):
     assert any(e["relation"] == "dynamic_import" for e in edges)
 
 
-def test_ast_captured_dynamic_import_is_one_fact_not_two(tmp_path: Path):
-    """Dedupe: a dynamic import the AST pass already emitted (as a deferred
-    imports_from edge) must not be restated by the rescue as a second
-    dynamic_import edge to the same target."""
+def test_ast_captured_dynamic_import_still_gets_a_file_level_edge(tmp_path: Path):
+    """One import() inside a function, two granularities — #2584.
+
+    This test used to assert `len(edges) == 1`, on the reasoning that the rescue would be
+    restating what the AST pass had already said. The two edges are not the same statement:
+    the AST pass anchors on `caller_nid`, which is the enclosing FUNCTION when the import()
+    is written inside one, while the rescue anchors on the FILE. Only the second is a fact
+    `affected` can walk, since it traverses file to file.
+
+    Suppressing it cost real recall: on a ~700-file TS repo `affected --depth 3` returned 39
+    of 49 truly affected files, precision 1.00, and more depth did not help — a dead end, not
+    a depth limit. The reverse walk reached the enclosing function and stopped there, because
+    the only edge pointing at it is `contains`, deliberately not in
+    DEFAULT_AFFECTED_RELATIONS.
+
+    The dedupe is still right, just keyed wrong: it now matches on (source file, target)
+    rather than target alone, so the genuinely redundant case — a module-scope import(),
+    where `caller_nid` IS the file node — still collapses to one edge. That case is pinned
+    by `test_module_scope_dynamic_import_is_still_one_fact` below.
+    """
     _write(tmp_path / "src/dep.ts", "export const dep = 1\n")
     importer = _write(
         tmp_path / "src/page.ts",
@@ -109,9 +125,35 @@ def test_ast_captured_dynamic_import_is_one_fact_not_two(tmp_path: Path):
     result = extract([tmp_path / "src/dep.ts", importer], root=tmp_path)
 
     edges = _edges_to(result, "src/dep.ts")
-    assert len(edges) == 1, f"one import(), one edge — got {edges}"
-    assert edges[0]["relation"] == "imports_from"
-    assert edges[0].get("deferred") is True
+    page = _file_node_id(Path("src/page.ts"))
+
+    # The precise fact: which function defers the load. `explain` reads this one.
+    symbol_level = [e for e in edges if e["source"] != page]
+    assert symbol_level, f"lost the call-site edge — got {edges}"
+    assert symbol_level[0]["relation"] == "imports_from"
+    assert symbol_level[0].get("deferred") is True
+
+    # The traversable fact: this file depends on that module. `affected` reads this one.
+    file_level = [e for e in edges if e["source"] == page]
+    assert file_level, f"no file-level edge — `affected` cannot traverse this: {edges}"
+    assert file_level[0]["relation"] == "dynamic_import"
+
+
+def test_module_scope_dynamic_import_is_still_one_fact(tmp_path: Path):
+    """At module scope `caller_nid` IS the file node, so the rescue is genuinely redundant.
+
+    This is the half of the old dedupe that was always correct, kept as its own test so a
+    future change cannot quietly restore double-counting here while fixing #2584.
+    """
+    _write(tmp_path / "src/dep.ts", "export const dep = 1\n")
+    importer = _write(
+        tmp_path / "src/boot2.ts",
+        "const { dep } = await import('./dep')\nexport const booted = dep\n",
+    )
+
+    result = extract([tmp_path / "src/dep.ts", importer], root=tmp_path)
+
+    assert len(_edges_to(result, "src/dep.ts")) == 1
 
 
 def test_static_import_alongside_dynamic_is_untouched(tmp_path: Path):
@@ -130,7 +172,15 @@ def test_static_import_alongside_dynamic_is_untouched(tmp_path: Path):
 
     a_edges = _edges_to(result, "src/a.ts", "imports_from")
     assert a_edges and not any(e.get("deferred") for e in a_edges)
-    assert len(_edges_to(result, "src/b.ts")) == 1
+
+    # The point of this test is the STATIC edge above: the rescue must leave it alone, and
+    # in particular must not mark it deferred. The dynamic side is asserted only for the
+    # property that concerns this test — every edge to b.ts is flagged as deferred one way
+    # or another, so no arrow into b.ts can be mistaken for a static dependency. Its COUNT
+    # is #2584's subject, pinned in test_ast_captured_dynamic_import_still_gets_a_file_level_edge.
+    b_edges = _edges_to(result, "src/b.ts")
+    assert b_edges
+    assert all(e.get("deferred") or e["relation"] == "dynamic_import" for e in b_edges)
 
 
 def test_tsconfig_aliased_dynamic_import_edges(tmp_path: Path):


### PR DESCRIPTION
Issue #2584

`graphify affected` under-reports blast radius when `import('...')` sits inside a function. The edge exists -- this is not #2575, which 0.9.38 fixed -- but reverse traversal dead-ends on it.

The two passes emit at different granularities. `_dynamic_import_js` anchors on `caller_nid`, which is the file node only at module scope; inside a function it is that function's node. The rescue pass in `_rescue_js_dynamic_imports` emits the file-level `dynamic_import` edge -- but its dedupe matched on TARGET alone, saw the AST pass had already emitted a deferred edge to that target, and skipped. So an `import()` inside a function ended up with no file-level edge at all, and the reverse walk stopped at the enclosing function: the one edge pointing at it is `contains`, deliberately not in DEFAULT_AFFECTED_RELATIONS.

The dedupe was right, just keyed wrong. It now matches on (this file's node, target), so the genuinely redundant case -- a module-scope `import()`, where `caller_nid` IS the file node -- still collapses to one edge, while the in-function case gets the file-level edge it always needed.

Measured on a ~700-file TypeScript repo, `affected --depth 3` against three hub modules, ground truth built independently of graphify:

  before   39/49, 24/30, 84/84   recall 0.80 / 0.80 / 1.00
  after    49/49, 30/30, 84/84   recall 1.00 / 1.00 / 1.00

Precision stays 1.00 in both. Raising --depth to 4, 5 or 6 did not move the before numbers, which is what a dead end looks like as opposed to a depth limit.

It hid for so long because the common case still resolves: when the next importer imports that exact symbol by name there IS an edge into the function, and traversal continues. Change that importer to `import * as ns` or a side-effect `import './x'` and the same graph goes silent. The new tests pin exactly those cases.

Also dedupes the rescue's own emissions per file. Two `import('./x')` in one file already produced two identical file-level edges before this change; that was rare while only module-scope imports reached the rescue, but every in-function dynamic import now does, so a hub deferred from eight functions of one file would have carried eight identical arrows.

`test_ast_captured_dynamic_import_is_one_fact_not_two` asserted the invariant that was the bug, so it is rewritten rather than deleted -- the docstring explains why one edge is not enough -- and the half of it that was always correct is now pinned on its own in `test_module_scope_dynamic_import_is_still_one_fact`.

No new relation, no schema change. `find_import_cycles` reads only `imports_from` and `re_exports` and skips `deferred`, so the file cycle of #1241 cannot return through a `dynamic_import` edge.

Full suite: 3929 passed, 13 failed -- the same 13 that fail on an unmodified v8 checkout here (terraform, ollama, manifest, install_references), none touched by this change.

Fixes #2584