### PR TITLE
fix(python): emit nodes for nested function definitions

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -729,6 +729,7 @@ _PYTHON_CONFIG = LanguageConfig(
     call_accessor_field="attribute",
     call_accessor_object_field="object",
     function_boundary_types=frozenset({"function_definition"}),
+    extract_nested_functions=True,
     import_handler=_import_python,
 )
 

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2455,7 +2455,11 @@ def _extract_generic(
     file_nid = _make_id(str(path))
     add_node(file_nid, path.name, 1)
 
-    def walk(node, parent_class_nid: str | None = None) -> None:
+    def walk(
+        node,
+        parent_class_nid: str | None = None,
+        parent_func_nid: str | None = None,
+    ) -> None:
         t = node.type
 
         # Import types
@@ -3408,6 +3412,13 @@ def _extract_generic(
                 func_nid = _make_id(parent_class_nid, func_name)
                 add_node(func_nid, f".{func_name}()", line)
                 add_edge(parent_class_nid, func_nid, "method", line)
+            elif parent_func_nid:
+                # A nested def is owned by the function it lives in, not the
+                # file: qualifying the id keeps `outer.helper` distinct from a
+                # module-level `helper` of the same name.
+                func_nid = _make_id(parent_func_nid, func_name)
+                add_node(func_nid, f"{func_name}()", line)
+                add_edge(parent_func_nid, func_nid, "contains", line)
             else:
                 func_nid = _make_id(stem, func_name)
                 add_node(func_nid, f"{func_name}()", line)
@@ -3761,6 +3772,27 @@ def _extract_generic(
                 if config.ts_module == "tree_sitter_c_sharp" and parent_class_nid:
                     csharp_method_scopes[id(body)] = (node, parent_class_nid)
                 function_bodies.append((func_nid, body))
+                if config.extract_nested_functions:
+                    # This branch returns without recursing, so a `def` inside
+                    # another function's body got no node at all — and because
+                    # walk_calls stops at function_boundary_types, every call in
+                    # that body was dropped rather than attributed to the outer
+                    # function. A FastAPI endpoint whose whole implementation
+                    # lives in an inner `async def generate()` therefore showed
+                    # up in the graph as a near-leaf. Scan this body for the
+                    # next level of definitions and walk each one owned by this
+                    # function; deeper nesting is handled by that walk in turn.
+                    # Class bodies are skipped — a nested class's members are
+                    # already the class branch's job.
+                    nested_stack = list(body.children)
+                    while nested_stack:
+                        cand = nested_stack.pop()
+                        if cand.type in config.class_types:
+                            continue
+                        if cand.type in config.function_types:
+                            walk(cand, parent_func_nid=func_nid)
+                            continue
+                        nested_stack.extend(cand.children)
                 if config.ts_module == "tree_sitter_kotlin":
                     # #2347: Kotlin anonymous objects (`object : Foo { … }`,
                     # node type `object_literal`). The function branch never

--- a/graphify/extractors/models.py
+++ b/graphify/extractors/models.py
@@ -50,6 +50,13 @@ class LanguageConfig:
     # Extra label formatting for functions: if True, functions get "name()" label
     function_label_parens: bool = True
 
+    # Emit nodes for function definitions nested inside another function's body.
+    # Off by default: languages whose idiom is inline callbacks (JS/TS arrow
+    # functions) already have their own handling and would gain a large number
+    # of low-signal nodes. On where a named inner def carries real structure
+    # (Python closures, streaming generators, decorator wrappers).
+    extract_nested_functions: bool = False
+
     # Extra walk hook called after generic dispatch (for JS arrow functions, C# namespaces, etc.)
     extra_walk_fn: Callable | None = None
 

--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -1768,16 +1768,54 @@ def _resolve_python_module_path(module_name: str, current_path: Path, root: Path
             return cand
     return None
 
-def _python_top_level_function_bodies(path: Path, root_node, source: bytes) -> list[tuple[str, object]]:
-    bodies: list[tuple[str, object]] = []
-    stem = _file_stem(path)
-    for node in root_node.children:
-        if node.type != "function_definition":
+def _python_walk_to_function_boundary(body, *, yield_functions: bool):
+    """Walk ``body`` but never cross into a nested ``def``.
+
+    With ``yield_functions`` the nested definitions themselves are yielded (and
+    not descended into) — the next level of nesting. Without it they are skipped
+    and everything else is yielded: the nodes that genuinely belong to this
+    function. Calls inside an inner ``def`` belong to that def, which gets its
+    own entry from :func:`_python_top_level_function_bodies`; walking through the
+    boundary would attribute them to the outer function as well.
+    """
+    stack = list(body.children)
+    while stack:
+        node = stack.pop()
+        if node.type == "function_definition":
+            if yield_functions:
+                yield node
             continue
-        name_node = node.child_by_field_name("name")
-        body = node.child_by_field_name("body")
-        if name_node is not None and body is not None:
-            bodies.append((_make_id(stem, _read_text(name_node, source)), body))
+        if not yield_functions:
+            yield node
+        stack.extend(node.children)
+
+def _python_top_level_function_bodies(path: Path, root_node, source: bytes) -> list[tuple[str, object]]:
+    """(node_id, body) for every function definition in the file, nested included.
+
+    Ids mirror the ones the extractor mints: a module-level ``def`` is keyed on
+    the file stem, a nested one on its owning function, so a use fact collected
+    here lands on the node the graph already holds instead of dangling.
+    """
+    bodies: list[tuple[str, object]] = []
+
+    def collect(scope_children, owner_id: str) -> None:
+        for node in scope_children:
+            if node.type != "function_definition":
+                continue
+            name_node = node.child_by_field_name("name")
+            body = node.child_by_field_name("body")
+            if name_node is None or body is None:
+                continue
+            nid = _make_id(owner_id, _read_text(name_node, source))
+            bodies.append((nid, body))
+            # A nested def can sit under an if/try inside the body, so scan the
+            # whole body rather than just its direct children.
+            collect(
+                _python_walk_to_function_boundary(body, yield_functions=True),
+                nid,
+            )
+
+    collect(root_node.children, _file_stem(path))
     return bodies
 
 def _python_call_identifier(node, source: bytes) -> str | None:
@@ -1849,7 +1887,7 @@ def _collect_python_symbol_resolution_facts(
             continue
         source, root_node = parsed
         for source_id, body in _python_top_level_function_bodies(path, root_node, source):
-            for node in _walk_python_tree(body):
+            for node in _python_walk_to_function_boundary(body, yield_functions=False):
                 imported_name = _python_call_identifier(node, source)
                 if imported_name is None:
                     continue

--- a/tests/test_python_nested_functions.py
+++ b/tests/test_python_nested_functions.py
@@ -1,0 +1,182 @@
+"""Regression tests: Python functions nested inside another function.
+
+The generic walk's function branch returns without recursing into the body, so a
+`def` inside another `def` got no node at all. Because walk_calls also stops at
+`function_boundary_types`, every call in that inner body was dropped rather than
+attributed to the outer function — a FastAPI endpoint whose whole implementation
+lives in `async def generate()` showed up in the graph as a near-leaf with two or
+three edges.
+
+Python now emits a node per nested definition, owned by the function it lives in
+(`contains`, id qualified by the owner so `outer.helper` stays distinct from a
+module-level `helper`), and its calls are attributed to it. Languages whose idiom
+is inline callbacks stay opt-out via `LanguageConfig.extract_nested_functions`.
+"""
+from pathlib import Path
+
+from graphify.extract import _file_stem, _make_id, extract_python
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "mod.py"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _nid(path: Path, *parts: str) -> str:
+    nid = _file_stem(path)
+    for part in parts:
+        nid = _make_id(nid, part)
+    return nid
+
+
+def _labels(result: dict) -> set[str]:
+    return {n["label"] for n in result["nodes"]}
+
+
+def _calls(result: dict, source: str) -> set[str]:
+    by_id = {n["id"]: n for n in result["nodes"]}
+    return {
+        by_id.get(e["target"], {}).get("label", e["target"])
+        for e in result["edges"]
+        if e["source"] == source and e["relation"] == "calls"
+    }
+
+
+def test_nested_def_gets_a_node(tmp_path):
+    path = _write(tmp_path, """
+def outer():
+    def inner():
+        pass
+    return inner
+""")
+    result = extract_python(path)
+    assert "inner()" in _labels(result)
+
+
+def test_nested_def_is_contained_by_its_owner_not_the_file(tmp_path):
+    path = _write(tmp_path, """
+def outer():
+    def inner():
+        pass
+""")
+    result = extract_python(path)
+    outer = _nid(path, "outer")
+    inner = _nid(path, "outer", "inner")
+    contains = {
+        (e["source"], e["target"])
+        for e in result["edges"]
+        if e["relation"] == "contains"
+    }
+    assert (outer, inner) in contains
+    assert (_make_id(str(path)), inner) not in contains
+
+
+def test_nested_id_does_not_collide_with_module_level_same_name(tmp_path):
+    path = _write(tmp_path, """
+def helper():
+    pass
+
+def outer():
+    def helper():
+        pass
+""")
+    result = extract_python(path)
+    ids = {n["id"] for n in result["nodes"]}
+    assert _nid(path, "helper") in ids
+    assert _nid(path, "outer", "helper") in ids
+
+
+def test_calls_in_a_nested_body_are_attributed_to_the_nested_def(tmp_path):
+    path = _write(tmp_path, """
+def target():
+    pass
+
+def outer():
+    def inner():
+        target()
+""")
+    result = extract_python(path)
+    assert _calls(result, _nid(path, "outer", "inner")) == {"target()"}
+    # ...and not to the enclosing function, which calls nothing itself.
+    assert _calls(result, _nid(path, "outer")) == set()
+
+
+def test_nesting_recurses_past_one_level(tmp_path):
+    path = _write(tmp_path, """
+def target():
+    pass
+
+def outer():
+    def middle():
+        def inner():
+            target()
+""")
+    result = extract_python(path)
+    assert _calls(result, _nid(path, "outer", "middle", "inner")) == {"target()"}
+
+
+def test_def_nested_under_a_control_block_is_found(tmp_path):
+    """The inner def sits under `if`/`try`, not directly in the body block."""
+    path = _write(tmp_path, """
+def target():
+    pass
+
+def outer(flag):
+    if flag:
+        def inner():
+            target()
+    return inner
+""")
+    result = extract_python(path)
+    assert _calls(result, _nid(path, "outer", "inner")) == {"target()"}
+
+
+def test_async_generator_inside_endpoint_keeps_its_calls(tmp_path):
+    """The shape this fixes: a streaming endpoint delegating to an inner async def."""
+    path = _write(tmp_path, """
+def build_context():
+    pass
+
+def render(chunk):
+    pass
+
+async def chat_stream(request):
+    async def generate():
+        ctx = build_context()
+        for chunk in ctx:
+            render(chunk)
+    return generate
+""")
+    result = extract_python(path)
+    assert _calls(result, _nid(path, "chat_stream", "generate")) == {
+        "build_context()", "render()",
+    }
+
+
+def test_method_local_def_is_owned_by_the_method(tmp_path):
+    path = _write(tmp_path, """
+def target():
+    pass
+
+class Service:
+    def run(self):
+        def step():
+            target()
+""")
+    result = extract_python(path)
+    run_nid = _make_id(_nid(path, "Service"), "run")
+    assert _calls(result, _make_id(run_nid, "step")) == {"target()"}
+
+
+def test_js_still_skips_nested_function_declarations(tmp_path):
+    """extract_nested_functions is opt-in; JS/TS keeps its arrow-function handling."""
+    from graphify.extract import extract_js
+
+    path = tmp_path / "mod.js"
+    path.write_text(
+        "function outer() {\n  function inner() {}\n  return inner;\n}\n",
+        encoding="utf-8",
+    )
+    result = extract_js(path)
+    assert "inner()" not in _labels(result)


### PR DESCRIPTION
## Summary

Python functions defined inside other functions were never emitted as graph nodes, and every call made from inside them was dropped instead of being attributed to the enclosing function.

The generic AST walk's function branch returned without recursing into the body, so a `def` nested in another `def` produced nothing. `walk_calls` independently stops at `function_boundary_types`, so the inner body's call sites were not attributed to the outer function either — they simply vanished.

## Impact

The shape this hurts most is a streaming endpoint that delegates its entire implementation to an inner `async def generate()`. On a real FastAPI codebase the endpoint node appeared in the graph with 4 edges, while **692 lines and 317 call sites** inside the generator were absent entirely.

Downstream commands degraded accordingly:

- `affected <helper>` answered with the helper's test callers only, missing the production endpoint that actually drives it.
- `explain <endpoint>` showed nothing of what the endpoint does, because everything it does lives in the nested function.

## Change

Python now emits one node per nested definition:

- The node is owned by the function it lives in, via a `contains` edge.
- Its id is qualified by the owner, so `outer.helper` stays distinct from a module-level `helper`.
- Calls made inside the nested body are attributed to the nested function.

Cross-file resolution follows the same model: `_python_top_level_function_bodies` now yields every nesting level with ids matching the extractor's, and both it and its consumer stop at function boundaries, so each call is attributed exactly once and no double-counting is introduced.

## Scope

Gated behind `LanguageConfig.extract_nested_functions`, which defaults to `False` and is enabled for Python only (`graphify/extract.py`).

This is deliberate. Languages whose idiom is inline callbacks — JS/TS arrow functions in particular — would gain a large number of low-signal nodes from the same treatment, so their existing handling is untouched. Any other language can opt in later by flipping the flag once its node-quality tradeoff has been evaluated.

## Tests

`tests/test_python_nested_functions.py` adds 9 tests covering:

- a node is emitted for a nested `def` and for a nested `async def`
- the `contains` edge points from the enclosing function to the nested one
- ids are qualified, so a nested `helper` does not collide with a module-level `helper`
- calls inside the nested body are attributed to the nested function, not the parent and not dropped
- multiple nesting levels each produce a node
- cross-file resolution reaches a nested definition
- each call is attributed once, with no duplicates
- JS/TS is unaffected — arrow functions keep their current handling and gain no extra nodes

## Verification on a real codebase

Run against a 74-file FastAPI + Vue project (1675 nodes, 3306 edges). Nested definitions that were previously missing now appear with the enclosing function encoded in the id:

```
"label": "split_row()",   "id": "agent_api_main_parse_md_table_split_row"
"label": "_split_row()",  "id": "agent_api_database_migrate_selection_to_split_tables_split_row"
```

## Files changed

| File | +/- |
|---|---|
| `graphify/extract.py` | +1 |
| `graphify/extractors/engine.py` | +34 |
| `graphify/extractors/models.py` | +7 |
| `graphify/extractors/resolution.py` | +56 -10 |
| `tests/test_python_nested_functions.py` | +182 |

Base is `v8` at `4e7e6b1`, so the branch merges cleanly.
