### PR TITLE
 fix(python): avoid crash resolving overdeep relative imports ( #2605 )

### DIFF
--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -1724,6 +1724,8 @@ def _probe_python_module_candidate(candidate: Path) -> Path | None:
             return init_path
     if candidate.is_file():
         return candidate
+    if not candidate.name:
+        return None
     py_candidate = candidate.with_suffix(".py")
     if py_candidate.is_file():
         return py_candidate

--- a/tests/test_python_import_resolution.py
+++ b/tests/test_python_import_resolution.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from graphify.extract import extract
+from graphify.extractors.resolution import _resolve_python_module_path
 
 
 def _write(path: Path, text: str) -> Path:
@@ -28,6 +29,35 @@ def _has_edge(result: dict, source: str, target: str, relation: str) -> bool:
         and edge["relation"] == relation
         for edge in result["edges"]
     )
+
+
+def test_overdeep_relative_import_is_unresolved_not_fatal(tmp_path: Path):
+    source = _write(
+        tmp_path / "pkg" / "mod.py",
+        "from ........................... import missing\n\n"
+        "def ok():\n"
+        "    return 1\n",
+    )
+
+    assert _resolve_python_module_path("", source, tmp_path, level=27) is None
+
+    result = extract([source], cache_root=tmp_path)
+
+    assert _node_id(result, "mod.py", "pkg/mod.py")
+    assert _node_id(result, "ok()", "pkg/mod.py")
+
+
+def test_ordinary_relative_import_still_resolves(tmp_path: Path):
+    target = _write(tmp_path / "pkg" / "sibling.py", "def helper():\n    return 1\n")
+    source = _write(tmp_path / "pkg" / "mod.py", "from .sibling import helper\n")
+
+    assert _resolve_python_module_path("sibling", source, tmp_path, level=1) == target
+
+    result = extract([source, target], cache_root=tmp_path)
+    source_file = _node_id(result, "mod.py", "pkg/mod.py")
+    target_symbol = _node_id(result, "helper()", "pkg/sibling.py")
+
+    assert _has_edge(result, source_file, target_symbol, "imports")
 
 
 def test_python_package_reexport_resolves_import_and_call_to_origin_symbol(tmp_path: Path):


### PR DESCRIPTION
 Changed `graphify/extractors/resolution.py:1727` so `_probe_python_module_candidate()` returns `None`  when the candidate path has no name before calling `with_suffix(".py")` . That
  makes an over-deep relative import unresolved instead of crashing extraction.

  Added regression coverage in `tests/test_python_import_resolution.py:34:`

  - 27-dot relative import does not crash and still extracts the file/function.
  - normal `from .sibling import helper` still resolves.

  Validation run:

  - `uv run pytest tests/test_python_import_resolution.py tests/test_src_layout_import_resolution.py tests/
    test_extract.py::test_python_relative_import_out_of_root_target_id_is_portable tests/test_incremental.py::test_incremental_python_relative_import_target_canonicalizes -q`

  - Result: 10 passed
  - Reduced CLI repro: graphify extract /tmp/graphify-overdeep-relative --code-only --force ... completed and wrote graph.json.
  - Ran uv run graphify update . as required.

fixes #2605 