### PR TITLE
fix(ids): casefold before the non-word filter so normalize_id is idempotent

### DIFF
--- a/graphify/ids.py
+++ b/graphify/ids.py
@@ -16,10 +16,19 @@ module exists so the recipe lives in one place and the two callers can no longer
 diverge.
 
 The recipe: NFKC-normalize (so composed/decomposed Unicode forms collapse),
-replace runs of non-word characters with a single underscore (``re.UNICODE`` so
-CJK/Cyrillic/Arabic/accented-Latin letters survive instead of collapsing to a
-per-file node), collapse repeated underscores, strip leading/trailing
-underscores, and casefold.
+casefold, NFKC-normalize again (casefold can *expand* a character into a base
+letter plus a combining mark — ``İ`` -> ``i`` + U+0307 — and the second pass
+recomposes what can be recomposed), replace runs of non-word characters with a
+single underscore (``re.UNICODE`` so CJK/Cyrillic/Arabic/accented-Latin letters
+survive instead of collapsing to a per-file node), collapse repeated
+underscores, then strip leading/trailing underscores.
+
+Casefolding runs BEFORE the non-word filter, not after. With it last, the
+combining marks casefold introduces were never filtered: ``İslemYap`` produced
+``i̇slemyap`` — an id containing U+0307, which is not a ``\\w`` character — and a
+second pass collapsed it to ``i_slemyap``, so the function was not idempotent
+and the builder's re-normalization disagreed with the extractor's ``make_id``
+for any Turkish identifier.
 """
 from __future__ import annotations
 
@@ -32,12 +41,21 @@ __all__ = ["normalize_id", "make_id"]
 def normalize_id(s: str) -> str:
     r"""Normalize a single ID string to its canonical form.
 
-    Idempotent: ``normalize_id(normalize_id(s)) == normalize_id(s)``.
+    Guarantees, both enforced by tests:
+
+    - Idempotent: ``normalize_id(normalize_id(s)) == normalize_id(s)``.
+    - The result contains only ``\w`` characters and ``_``.
+
+    Casefolding before the ``[^\w]+`` filter is what makes both hold — see the
+    module docstring for why the reverse order silently broke them.
     """
     s = unicodedata.normalize("NFKC", s)
+    # casefold can expand one character into a letter + combining mark, so it
+    # must run while the non-word filter can still see the result.
+    s = unicodedata.normalize("NFKC", s.casefold())
     s = re.sub(r"[^\w]+", "_", s, flags=re.UNICODE)
     s = re.sub(r"_+", "_", s)
-    return s.strip("_").casefold()
+    return s.strip("_")
 
 
 def make_id(*parts: str) -> str:

--- a/graphify/ids.py
+++ b/graphify/ids.py
@@ -28,7 +28,7 @@ combining marks casefold introduces were never filtered: ``İslemYap`` produced
 ``i̇slemyap`` — an id containing U+0307, which is not a ``\\w`` character — and a
 second pass collapsed it to ``i_slemyap``, so the function was not idempotent
 and the builder's re-normalization disagreed with the extractor's ``make_id``
-for any Turkish identifier.
+for any Turkish identifier (#2614).
 """
 from __future__ import annotations
 
@@ -47,7 +47,7 @@ def normalize_id(s: str) -> str:
     - The result contains only ``\w`` characters and ``_``.
 
     Casefolding before the ``[^\w]+`` filter is what makes both hold — see the
-    module docstring for why the reverse order silently broke them.
+    module docstring for why the reverse order silently broke them (#2614).
     """
     s = unicodedata.normalize("NFKC", s)
     # casefold can expand one character into a letter + combining mark, so it

--- a/tests/test_id_normalization_contract.py
+++ b/tests/test_id_normalization_contract.py
@@ -39,7 +39,7 @@ CONTRACT_CASES = [
     "x_c1",                       # must NOT be treated as a chunk suffix here
     "__dunder__",                 # leading/trailing underscores stripped
     "tab\tnewline\nspace ",       # whitespace runs -> single underscore
-    # Casefolding these EXPANDS them into a base letter plus a combining
+    # #2614: casefolding these EXPANDS them into a base letter plus a combining
     # mark. With casefold last, the mark landed in the id after the [^\w] filter
     # had already run, so the id carried a non-word character and a second pass
     # changed it. Turkish identifiers are the common real-world case.
@@ -52,7 +52,7 @@ CONTRACT_CASES = [
 ]
 
 # Characters whose casefold expands or recomposes — the exact class that broke
-# the contract. Kept separate from CONTRACT_CASES because a few of them
+# the contract in #2614. Kept separate from CONTRACT_CASES because a few of them
 # (e.g. U+01F0) legitimately normalize to a precomposed character that is not
 # equal to its own casefold, which the lowercase assertion below would reject.
 CASE_EXPANDING_CHARS = [
@@ -110,7 +110,7 @@ def test_normalized_ids_are_safe_node_ids():
 
 @pytest.mark.parametrize("ch", CASE_EXPANDING_CHARS)
 def test_case_expanding_chars_yield_word_only_ids(ch):
-    """The postcondition the old recipe silently broke.
+    """#2614: the postcondition the old recipe silently broke.
 
     ``normalize_id`` must emit only ``\\w`` characters and ``_``. Casefolding
     last let the combining mark that ``İ``.casefold() produces slip past the
@@ -145,7 +145,7 @@ def test_case_expanding_chars_normalize_case_insensitively(ch):
 
 
 def test_turkish_identifier_ids_match_between_extractor_and_builder():
-    """End to end: the drift that split a Turkish symbol into ghost nodes.
+    """#2614 end to end: the drift that split a Turkish symbol into ghost nodes.
 
     ``make_id`` minted ``islem_i̇slemyap`` (with U+0307) while the builder's
     re-normalization produced ``islem_i_slemyap``, so ``_semantic_id_remap``'s
@@ -195,7 +195,7 @@ def test_property_normalize_id_idempotent(s):
     assert normalize_id(once) == once
 
 
-# The plain st.text() property above already existed when this bug shipped, and did
+# The plain st.text() property above already existed when #2614 shipped, and did
 # not catch it: the bug needs one specific codepoint (U+0130) out of ~1.1M, which
 # a uniform draw essentially never produces. These strategies bias the search
 # toward the characters that actually stress the recipe — case-expanding letters
@@ -216,7 +216,7 @@ def test_property_normalize_id_idempotent_under_case_stress(s):
 
 @given(_stress_text)
 def test_property_normalize_id_emits_only_word_chars(s):
-    """The postcondition the old recipe violated: only \\w and _ may survive."""
+    """The postcondition #2614 violated: only \\w and _ may survive."""
     out = normalize_id(s)
     assert not re.search(r"[^\w]", out.replace("_", "")), (
         f"normalize_id({s!r}) -> {out!r} leaked a non-word character"

--- a/tests/test_id_normalization_contract.py
+++ b/tests/test_id_normalization_contract.py
@@ -39,6 +39,30 @@ CONTRACT_CASES = [
     "x_c1",                       # must NOT be treated as a chunk suffix here
     "__dunder__",                 # leading/trailing underscores stripped
     "tab\tnewline\nspace ",       # whitespace runs -> single underscore
+    # Casefolding these EXPANDS them into a base letter plus a combining
+    # mark. With casefold last, the mark landed in the id after the [^\w] filter
+    # had already run, so the id carried a non-word character and a second pass
+    # changed it. Turkish identifiers are the common real-world case.
+    "İ",                     # İ  -> i + U+0307
+    "İslemYap",              # İslemYap
+    "fileİname",             # İ mid-identifier
+    "İı_Mixed",         # İ with dotless ı
+    "Große",                 # ß -> ss (length-changing casefold)
+    "ẞ",                     # ẞ capital sharp s -> ss
+]
+
+# Characters whose casefold expands or recomposes — the exact class that broke
+# the contract. Kept separate from CONTRACT_CASES because a few of them
+# (e.g. U+01F0) legitimately normalize to a precomposed character that is not
+# equal to its own casefold, which the lowercase assertion below would reject.
+CASE_EXPANDING_CHARS = [
+    "İ",  # İ  LATIN CAPITAL LETTER I WITH DOT ABOVE -> i + U+0307
+    "ǰ",  # ǰ  casefold expands, NFKC then recomposes it
+    "ͅ",  # ͅ   COMBINING GREEK YPOGEGRAMMENI -> ι
+    "ͺ",  # ͺ   GREEK YPOGEGRAMMENI -> space + ι
+    "ẞ",  # ẞ  -> ss
+    "ῗ",  # ῗ   iota with dialytika and perispomeni
+    "ὒ",  # ὒ   upsilon with psili and varia
 ]
 
 
@@ -84,6 +108,58 @@ def test_normalized_ids_are_safe_node_ids():
         assert not out.startswith("_") and not out.endswith("_")
 
 
+@pytest.mark.parametrize("ch", CASE_EXPANDING_CHARS)
+def test_case_expanding_chars_yield_word_only_ids(ch):
+    """The postcondition the old recipe silently broke.
+
+    ``normalize_id`` must emit only ``\\w`` characters and ``_``. Casefolding
+    last let the combining mark that ``İ``.casefold() produces slip past the
+    ``[^\\w]+`` filter, so ids carried U+0307 — invisible in most terminals, and
+    a second normalization pass then rewrote it to ``_``.
+    """
+    out = normalize_id(f"a{ch}b")
+    assert not re.search(r"[^\w]", out.replace("_", "")), (
+        f"normalize_id({ch!r}) -> {out!r} contains a non-word character "
+        f"({[hex(ord(c)) for c in out]})"
+    )
+
+
+@pytest.mark.parametrize("ch", CASE_EXPANDING_CHARS)
+def test_case_expanding_chars_are_idempotent(ch):
+    once = normalize_id(f"a{ch}b")
+    assert normalize_id(once) == once, (
+        f"normalize_id not idempotent for {ch!r}: {once!r} -> {normalize_id(once)!r}"
+    )
+
+
+@pytest.mark.parametrize("ch", CASE_EXPANDING_CHARS)
+def test_case_expanding_chars_normalize_case_insensitively(ch):
+    """The point of casefolding: upper and lower spellings must land on one id.
+
+    Asserted instead of ``out == out.casefold()`` because casefold and NFKC do
+    not commute — ``ǰ`` normalizes to the precomposed U+01F0, which is lowercase
+    but is not equal to its own casefold. Case-insensitivity is the property the
+    graph actually depends on.
+    """
+    assert normalize_id(f"a{ch.upper()}b") == normalize_id(f"a{ch.lower()}b")
+
+
+def test_turkish_identifier_ids_match_between_extractor_and_builder():
+    """End to end: the drift that split a Turkish symbol into ghost nodes.
+
+    ``make_id`` minted ``islem_i̇slemyap`` (with U+0307) while the builder's
+    re-normalization produced ``islem_i_slemyap``, so ``_semantic_id_remap``'s
+    ``startswith(new_stem)`` check missed and the re-key silently no-opped.
+    """
+    stem, symbol = "islem", "İslemYap"
+    minted = make_id(stem, symbol)
+    assert _normalize_id(minted) == minted, "builder re-normalization drifts from make_id"
+    assert minted.startswith(make_id(stem) + "_"), (
+        "symbol id lost its file stem prefix, so the re-key cannot relate them"
+    )
+    assert minted == "islem_i_slemyap"
+
+
 def test_both_callers_share_one_implementation():
     """Guard against re-forking: the two public callers must resolve to the same
     underlying function object as graphify.ids.normalize_id."""
@@ -117,3 +193,44 @@ def test_property_make_id_equals_normalize_id(s):
 def test_property_normalize_id_idempotent(s):
     once = normalize_id(s)
     assert normalize_id(once) == once
+
+
+# The plain st.text() property above already existed when this bug shipped, and did
+# not catch it: the bug needs one specific codepoint (U+0130) out of ~1.1M, which
+# a uniform draw essentially never produces. These strategies bias the search
+# toward the characters that actually stress the recipe — case-expanding letters
+# and combining marks — so the class stays covered rather than relying on luck.
+_stress_alphabet = st.one_of(
+    st.sampled_from(CASE_EXPANDING_CHARS),
+    st.sampled_from("Iıİi_.-/aZ0"),        # Turkish dotted/dotless pairs + separators
+    st.characters(categories=["Lu", "Ll", "Lt", "Mn", "Nd", "Pc"]),
+)
+_stress_text = st.text(alphabet=_stress_alphabet, max_size=12)
+
+
+@given(_stress_text)
+def test_property_normalize_id_idempotent_under_case_stress(s):
+    once = normalize_id(s)
+    assert normalize_id(once) == once, f"not idempotent for {s!r} -> {once!r}"
+
+
+@given(_stress_text)
+def test_property_normalize_id_emits_only_word_chars(s):
+    """The postcondition the old recipe violated: only \\w and _ may survive."""
+    out = normalize_id(s)
+    assert not re.search(r"[^\w]", out.replace("_", "")), (
+        f"normalize_id({s!r}) -> {out!r} leaked a non-word character"
+    )
+
+
+@given(_stress_text)
+def test_property_normalize_id_agrees_with_its_own_caseless_form(s):
+    """Feeding an already-caseless string must not change the answer.
+
+    Deliberately NOT ``normalize_id(s.upper()) == normalize_id(s.lower())``:
+    ``str.upper()`` is locale-independent and lossy, so Turkish dotless ``ı``
+    uppercases to ``I`` and then casefolds to ``i`` — the two spellings are
+    genuinely different characters, not a normalization failure. Caseless
+    equivalence via ``casefold`` is the invariant the graph relies on.
+    """
+    assert normalize_id(s) == normalize_id(s.casefold())


### PR DESCRIPTION
Fixes #2614.

## Problem

`normalize_id()` casefolded **after** the `[^\w]+` filter:

```python
s = unicodedata.normalize("NFKC", s)
s = re.sub(r"[^\w]+", "_", s, flags=re.UNICODE)
s = re.sub(r"_+", "_", s)
return s.strip("_").casefold()      # <-- last
```

Casefolding can *expand* a character into a base letter plus a combining mark:
`"İ".casefold()` is `"i" + U+0307`. With the filter already spent, that mark
survived into the id — so `normalize_id` broke both of its contracts:

- **Not idempotent**, though the docstring promises it: `İstanbul` → `i̇stanbul` → `i_stanbul`.
- **Emitted non-`\w` characters**, though `cache.py` documents that "normalize_id drops every
  non-word character".

Turkish identifiers (`İslemYap`, `İçerik`) hit this on every run, and U+0307 is invisible in
most terminals, so the resulting ids look correct.

The concrete damage is the ghost-node class `ids.py` was created to prevent. `build.py`
re-normalizes ids that `make_id()` already produced, and at `build.py:1057` compares
`_normalize_id(nid).startswith(new_stem)` where `new_stem` comes from `make_id()` and is *not*
re-normalized. For a Turkish symbol the two sides disagreed (`i_slemyap` vs `i̇slemyap`), so
`_semantic_id_remap`'s re-key silently no-opped.

## Fix

Move casefold ahead of the filter, and NFKC again to recompose what it expanded:

```python
s = unicodedata.normalize("NFKC", s)
s = unicodedata.normalize("NFKC", s.casefold())
s = re.sub(r"[^\w]+", "_", s, flags=re.UNICODE)
s = re.sub(r"_+", "_", s)
return s.strip("_")
```

## Blast radius (measured, not assumed)

Scanned all 1.1M codepoints, and diffed ids across the 369-file graphify tree:

| | |
|---|---|
| ASCII codepoints that change | **0** — no churn for ordinary code |
| Codepoints where old emitted non-`\w` | 27 → **0** |
| Codepoints where old was non-idempotent | 1 (U+0130) → **0** |
| Codepoints whose id changes at all | 29 |
| Real tokens in the graphify tree whose id changes | **0** (the 14 hits are the Turkish/Greek fixtures added by this PR) |

The 29 affected codepoints are U+0130, Greek ypogegrammeni, and precomposed
Latin/Greek letters whose casefold expands. For those, the new output is the **composed**
NFKC form — which is what the module docstring already specified.

## No migration needed — and I verified rather than assumed

The issue expected this to need #1504/#1917-style legacy-form handling. It does not, because
**the new output is exactly the old recipe's fixed point**: `normalize_id(old_id) == new_id`.
`build.py:1008` keys its reconciliation map on `_normalize_id(nid)`, so old-form and new-form
ids already collapse to the same key.

Tested end to end rather than argued: built a Turkish corpus with the unfixed code
(`islem_i̇slemyap`), applied the fix, added a symbol, ran `graphify update`:

```
islem
islem_caller
islem_i_kinci      <- new symbol
islem_i_slemyap    <- re-keyed from islem_i̇slemyap
main
main_main
dangling edges: 0
GHOST PAIR PRESENT: False
```

So no legacy-form code was added.

## Tests

**A property test for exactly this already existed and did not catch it.**
`test_property_normalize_id_idempotent` with `@given(st.text())` has been in the suite since
the contract file was written — a uniform draw essentially never produces U+0130 out of ~1.1M
codepoints. Fixing only the implementation would leave that gap open, so this PR also
strengthens the guard:

- deterministic Turkish/case-expanding entries in `CONTRACT_CASES`
- a new `CASE_EXPANDING_CHARS` set covering each distinct failure shape (expansion,
  recomposition, combining marks, `ẞ` → `ss`)
- the missing `\w`-only postcondition, asserted directly
- hypothesis strategies biased toward case-expanding letters and combining marks, so the
  class is covered by construction rather than by luck

New tests produce **18 failures on the unfixed code, 0 with the fix.**

### One assertion hypothesis rejected, worth knowing

I first asserted `normalize_id(s.upper()) == normalize_id(s.lower())`. Hypothesis
immediately found `ı` (U+0131 dotless i): `'ı'.upper()` is `'I'`, which casefolds to `'i'`.
`str.upper()` is locale-independent and lossy, so that property is false regardless of this
fix. Replaced with caseless equivalence via `casefold`, which is the invariant the graph
actually relies on. Noted in the test docstring so nobody "fixes" it back.

## Verification

- Issue repro: all four cases now idempotent
- `tests/test_id_normalization_contract.py`: **71 passed**
- Full suite: **41 failures, identical to the pre-existing baseline on this platform**, zero
  new, **+37 tests**

```
graphify/ids.py                         |  30 ++++++--
tests/test_id_normalization_contract.py | 117 +++++++++++++++++++++++++++++
```
