### PR TITLE
fix(tests,paths): skip the POSIX-mode assertion on Windows, and stop leaking a temp file on failed atomic writes

### DIFF
--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -76,7 +76,15 @@ def _atomic_replace(path: "str | Path", write_fn) -> None:
         try:
             os.unlink(tmp)
         except OSError:
-            pass
+            # The temp was chmod'd to match the destination above, so when the
+            # destination is read-only the temp is too — and Windows refuses to
+            # unlink a read-only file. Clear the bit and retry, or every failed
+            # write leaks a `.graph.json.*.tmp` into the output directory.
+            try:
+                os.chmod(tmp, stat.S_IWRITE)
+                os.unlink(tmp)
+            except OSError:
+                pass
         raise
 
 

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -36,6 +36,12 @@ def test_write_text_atomic_preserves_existing_on_failure(tmp_path, monkeypatch):
     assert sorted(x.name for x in tmp_path.iterdir()) == ["graph.json"]
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows has no POSIX mode bits: chmod only toggles the read-only "
+           "attribute, and st_mode reports 0o666 for any writable file, so "
+           "chmod(0o644) followed by an equality check can never hold",
+)
 def test_write_text_atomic_preserves_existing_mode(tmp_path):
     # An atomic replace must not tighten a 0644 file to mkstemp's 0600 default.
     p = tmp_path / "graph.json"
@@ -43,6 +49,44 @@ def test_write_text_atomic_preserves_existing_mode(tmp_path):
     os.chmod(p, 0o644)
     write_text_atomic(p, '{"x": 1}')
     assert (os.stat(p).st_mode & 0o777) == 0o644
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows read-only attribute semantics")
+def test_write_text_atomic_refuses_a_readonly_destination_without_leaking_a_temp(
+    tmp_path,
+):
+    """The Windows analogue of the mode-preservation contract.
+
+    There is no POSIX mode to preserve here, so the property worth pinning is
+    the one Windows actually has: a read-only destination is NOT silently
+    overwritten, the original survives intact, and — the part that used to be
+    wrong — no temp file is left behind.
+
+    `_atomic_replace` chmods the temp to match the destination, so against a
+    read-only target the temp is read-only too; Windows then refuses to unlink
+    it and the cleanup swallowed the error, dropping a `.graph.json.*.tmp` into
+    the output directory on every failed write.
+
+    Note this diverges from POSIX, where `os.replace` needs only directory write
+    permission and so happily replaces a read-only file. Documented rather than
+    "fixed": refusing to overwrite a file the user marked read-only is the
+    defensible behaviour.
+    """
+    import stat as _stat
+
+    p = tmp_path / "graph.json"
+    p.write_text("original", encoding="utf-8")
+    os.chmod(p, _stat.S_IREAD)
+    try:
+        with pytest.raises(PermissionError):
+            write_text_atomic(p, "replaced")
+
+        assert p.read_text(encoding="utf-8") == "original", "read-only file was clobbered"
+        assert [x.name for x in tmp_path.iterdir()] == ["graph.json"], (
+            f"failed write leaked a temp file: {[x.name for x in tmp_path.iterdir()]}"
+        )
+    finally:
+        os.chmod(p, _stat.S_IWRITE)  # let tmp_path cleanup remove it
 
 
 def test_write_text_atomic_new_file_respects_umask(tmp_path):


### PR DESCRIPTION
Fixes #2622.

## Problem

`test_write_text_atomic_preserves_existing_mode` sets `0o644` and asserts the atomic write
preserves it. Windows does not implement POSIX permission bits, so the assertion can never
hold:

```
E       AssertionError: assert (33206 & 511) == 420
```

`33206` is `0o100666`. Confirmed on this platform — `chmod` only toggles the read-only
attribute, and **any** writable file reports `0o666`:

```
chmod(0o644) -> st_mode & 0o777 = 0o666
chmod(0o600) -> st_mode & 0o777 = 0o666
```

So the `os.chmod(p, 0o644)` on line 4 is a no-op and the test fails on a completely healthy
`write_text_atomic`.

## Fix

Skip it on Windows. The property under test — "an atomic replace must not tighten a 0644 file
to mkstemp's 0600 default" — is POSIX-only and has no Windows equivalent.

## The issue's open question, answered

The issue asked whether the suggested Windows analogue (read-only attribute survives a
replace) is actually desired behaviour, flagging it as *"possibly its own papercut"*. I
checked, and it is worse than a papercut:

```
before: writable=False mode=0o444
write_text_atomic: RAISED PermissionError: [Errno 13] Permission denied: ...\ro.json
  content preserved = 'original'

files in dir: ['.ro.json.uqew9or4.tmp', 'ro.json']     <-- leaked temp
```

Two findings:

1. **A read-only destination is refused, not silently overwritten.** The existing
   `PermissionError` → `shutil.copy2` fallback does not help, because copying onto a
   read-only file fails the same way. This diverges from POSIX, where `os.replace` needs only
   directory write permission and so happily replaces a read-only file. Left as-is and
   documented: refusing to overwrite a file the user marked read-only is the defensible
   behaviour, and changing it is out of scope for a test fix.

2. **The failed write leaks a temp file — a real bug, fixed here.** `_atomic_replace` chmods
   the temp to match the destination, so against a read-only target the temp is read-only
   too. Windows then refuses to unlink it, and the cleanup's `except OSError: pass` swallowed
   the failure — dropping a `.graph.json.*.tmp` into `graphify-out/` on **every** failed
   write, accumulating silently. The cleanup now clears the read-only bit and retries.

## Changes

- `tests/test_atomic_writes.py` — `skipif(os.name == "nt")` on the POSIX-mode test, with the
  reason spelling out *why* it can never hold rather than just "Windows".
- `tests/test_atomic_writes.py` — new `test_write_text_atomic_refuses_a_readonly_destination_without_leaking_a_temp`,
  the Windows analogue: pins that the original survives, the write raises rather than
  clobbering, and no temp is left behind.
- `graphify/paths.py` — the temp-file leak fix (9 lines).

## Verification

- The POSIX-mode test now **skips** on Windows instead of failing; its body is unchanged, so
  POSIX coverage is untouched.
- The new Windows test **fails without the `paths.py` fix**, with the leak visible:
  ```
  E   AssertionError: failed write leaked a temp file:
      ['.graph.json.57kqk4yl.tmp', 'graph.json']
  ```
  and passes with it — so it is guarding the fix, not just describing it.

```
graphify/paths.py           | 10 +++++++++-
tests/test_atomic_writes.py | 44 ++++++++++++++++++++++++++++++++++++++++++++
```