### PR TITLE
fix(extract): canonicalize source_file to POSIX on every node and edge

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -10,7 +10,7 @@ import sys
 import textwrap
 from collections import Counter
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, Callable
 
 from .cache import load_cached, save_cached
@@ -6436,6 +6436,31 @@ def extract(
         n["_origin"] = "ast"
     for e in all_edges:
         e["_origin"] = "ast"
+
+    # Canonicalize source_file to POSIX on every node AND edge (#2625).
+    #
+    # Extractors build source_file from the Path they were handed, so a run
+    # given RELATIVE inputs keeps the native separator on Windows. Only the
+    # relativizing branch of _sf_entry above ever calls as_posix(), so a single
+    # extraction could emit `src\lib\content.ts` and `src/pages/index.astro`
+    # side by side. source_file is compared as a STRING downstream
+    # (build._norm_source_file keying, _derive_prune_root, dedup, and
+    # analyze.find_import_cycles, which matches an edge's source_file against a
+    # node's by equality), so two spellings are two different files — the
+    # fragmentation of #683, and the reason the CLI path (which passes an
+    # explicit root) looked correct while the library entry point did not.
+    #
+    # Safe as a final pass: ids are minted through make_id, which collapses
+    # every non-word character — `\` and `/` alike — to `_`, so canonicalizing
+    # the separator here cannot desync an id from its source_file.
+    #
+    # PurePath is the NATIVE flavour on purpose: on POSIX a backslash is a legal
+    # filename character and must be left alone, so this only rewrites paths on
+    # the platform where `\` is actually a separator.
+    for _item in (*all_nodes, *all_edges):
+        _sf = _item.get("source_file")
+        if _sf and "\\" in str(_sf):
+            _item["source_file"] = PurePath(_sf).as_posix()
 
     return {
         "nodes": all_nodes,

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -3200,3 +3200,54 @@ def test_rewire_does_not_bind_supertype_stub_to_function():
               "source_file": "store.py", "weight": 1.0}]
     _rewire_unique_stub_nodes(nodes, edges)
     assert edges[0]["target"] == "BookStore"  # inherits stub not bound to function
+
+
+def test_extract_emits_posix_source_file_for_relative_inputs(tmp_path):
+    r"""source_file must be canonical POSIX on every node AND edge, whatever
+    separator the caller's input paths used.
+
+    Extractors build source_file from the Path handed to them, and only the
+    relativizing branch of extract()'s remap calls as_posix(), so a run given
+    relative inputs used to keep the native separator on Windows — mixing
+    `src\lib\content.ts` and `src/pages/index.astro` in one extraction.
+    source_file is compared as a string downstream (build keying, prune-root
+    derivation, dedup, analyze.find_import_cycles), so two spellings are two
+    different files (#683 / #2625).
+
+    Uses the relative-input form deliberately: passing an explicit ``root``
+    takes the branch that already normalized, and would make this vacuous.
+    """
+    (tmp_path / "src" / "lib").mkdir(parents=True)
+    (tmp_path / "src" / "pages").mkdir(parents=True)
+    (tmp_path / "src" / "lib" / "content.ts").write_text(
+        "export function getPosts() { return []; }\n", encoding="utf-8"
+    )
+    (tmp_path / "src" / "pages" / "index.astro").write_text(
+        "---\nimport { getPosts } from '../lib/content';\n"
+        "const posts = getPosts();\n---\n<h1>{posts.length}</h1>\n",
+        encoding="utf-8",
+    )
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        result = extract([Path("src/lib/content.ts"), Path("src/pages/index.astro")])
+    finally:
+        os.chdir(cwd)
+
+    carriers = [
+        (kind, item.get("source_file"))
+        for kind, items in (("node", result["nodes"]), ("edge", result["edges"]))
+        for item in items
+        if item.get("source_file")
+    ]
+    assert carriers, "fixture produced nothing with a source_file; test would be vacuous"
+
+    offenders = [(kind, sf) for kind, sf in carriers if "\\" in sf]
+    assert not offenders, f"native separator survived into source_file: {offenders}"
+
+    # ...and both files are present under one spelling each, so the graph sees
+    # two files rather than four.
+    assert {sf for _, sf in carriers} == {
+        "src/lib/content.ts", "src/pages/index.astro",
+    }

--- a/tests/test_js_import_resolution.py
+++ b/tests/test_js_import_resolution.py
@@ -1407,8 +1407,11 @@ def test_alias_import_does_not_remap_an_owned_symbol_id(tmp_path, monkeypatch):
     }
     target_symbol = _make_id(_file_stem(target), "formatDate")
     mirror_symbol = _make_id(_file_stem(mirror), "formatDate")
-    assert symbols[str(target)] == target_symbol
-    assert symbols[str(mirror)] == mirror_symbol
+    # as_posix, not str: source_file is canonical POSIX in extract() output
+    # (#2625), while str(Path(...)) is the native spelling and so only matched
+    # on POSIX hosts.
+    assert symbols[target.as_posix()] == target_symbol
+    assert symbols[mirror.as_posix()] == mirror_symbol
 
     imports = [
         edge
@@ -1418,8 +1421,8 @@ def test_alias_import_does_not_remap_an_owned_symbol_id(tmp_path, monkeypatch):
     by_source: dict[str, list[str]] = {}
     for edge in imports:
         by_source.setdefault(edge["source_file"], []).append(edge["target"])
-    assert by_source[str(button)] == [target_symbol]
-    assert by_source[str(mirror_user)] == [mirror_symbol]
+    assert by_source[button.as_posix()] == [target_symbol]
+    assert by_source[mirror_user.as_posix()] == [mirror_symbol]
     assert all(edge["source"] in node_ids and edge["target"] in node_ids for edge in imports)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1090,7 +1090,7 @@ wheels = [
 
 [[package]]
 name = "graphifyy"
-version = "0.9.38"
+version = "0.9.40"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1090,7 +1090,7 @@ wheels = [
 
 [[package]]
 name = "graphifyy"
-version = "0.9.31"
+version = "0.9.38"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Fixes #2625.

## Problem

`source_file` is built from whatever `Path` an extractor was handed, and only the
relativizing branch of `extract()`'s remap (`_sf_entry`) ever calls `as_posix()`. A run given
**relative** inputs therefore keeps the native separator on Windows — and because different
extractors reach that branch differently, a single extraction emits two conventions at once:

```
$ python -m graphify.extract src/lib/content.ts src/pages/index.astro

"source_file": "src\\lib\\content.ts"      <- native
"source_file": "src/pages/index.astro"     <- posix
```

`source_file` is compared as a **string** downstream — `build._norm_source_file` keying,
`_derive_prune_root`, dedup, the semantic-cache key path, and `analyze.find_import_cycles`,
which matches an edge's `source_file` against a node's by equality. Two spellings are two
different files: the fragmentation of #683, resurfaced on a different code path.

The primary `graphify extract` CLI passes an explicit `root` and takes the already-correct
branch, which is why this stayed invisible. It is reachable from the documented
`python -m graphify.extract <file> …` entry point and from any library caller.

## Fix

One pass at the end of `extract()`, where all nodes and edges are already being walked:

```python
for _item in (*all_nodes, *all_edges):
    _sf = _item.get("source_file")
    if _sf and "\\" in str(_sf):
        _item["source_file"] = PurePath(_sf).as_posix()
```

Three deliberate choices, each verified rather than assumed:

- **Edges, not just nodes.** #2625 suggests a node-only loop; edges carry `source_file` too.
  Without the fix the new test reports **5 node + 3 edge** violations, and
  `find_import_cycles` compares an edge's `source_file` to a node's by equality — so a
  node-only fix would have left cycle detection broken on exactly this input. (`target_file`
  is popped earlier and never reaches the output, so it needs nothing.)
- **Running last is safe.** IDs are minted through `make_id`, which collapses every non-word
  character — `\` and `/` alike — to `_`. Confirmed:
  `make_id("src\lib\content.ts") == make_id("src/lib/content.ts") == "src_lib_content_ts"`.
  Canonicalizing the separator after IDs exist cannot desync an id from its `source_file`.
- **`PurePath` is the native flavour on purpose.** On POSIX a backslash is a legal filename
  character and must be left alone, so this only rewrites paths on the platform where `\` is
  actually a separator.

## Warm cache entries are healed, no version bump needed

The pass runs *after* the AST cache merge, so an entry written by a pre-fix version is
corrected on read:

```
cold: ['src/lib/content.ts', 'src/pages/index.astro']   native-separator entries: 0
warm: ['src/lib/content.ts', 'src/pages/index.astro']   native-separator entries: 0
```

No cache invalidation and no re-extraction cost for existing users.

## Changes

- `graphify/extract.py` — the normalization pass.
- `tests/test_extract.py` — new `test_extract_emits_posix_source_file_for_relative_inputs`,
  covering nodes *and* edges. Uses relative inputs deliberately: passing an explicit `root`
  takes the branch that already normalized and would make the test vacuous.
- `tests/test_js_import_resolution.py` —
  `test_alias_import_does_not_remap_an_owned_symbol_id` looked `source_file` up with
  `str(Path(...))`, the native spelling. It passed on Windows only because the product emitted
  backslashes too; with `source_file` now canonical, the four lookups need `as_posix()`. This
  is the mirror image of #2620 — a test coupled to a separator convention rather than to the
  property it means to assert.

  I checked for siblings: `test_extract.py:84-91` keys both sides of its comparison from the
  same output, so it is self-consistent and unaffected (not silently vacuous).

## Verification

| Check | Result |
|---|---|
| Issue repro via `python -m graphify.extract …` | mixed → **all POSIX** |
| `test_astro_import_ids::test_astro_relative_inputs_keep_canonical_ids` (collateral evidence in #2625) | now **passes** |
| `graphify extract .` (CLI path) | unregressed, still POSIX |
| New test without the fix | **fails**, listing 5 node + 3 edge offenders |
| Warm AST-cache replay | healed |
| **Full suite** | **41 → 40 failures, zero new**; 4122 → 4123 passed |

The single removed failure is the astro test above. The remaining 40 are the pre-existing
Windows baseline (symlink privilege, `os.geteuid`, POSIX mode bits), untouched here.

```
graphify/extract.py                | 27 ++++++++++++++++++++++++++-
tests/test_extract.py              | 51 +++++++++++++++++++++++++++++++++++++
tests/test_js_import_resolution.py |  9 ++++++---
```

## Migration note

Any Windows-built graph currently holding backslash spellings will re-key those nodes on the
next rebuild — the same one-time churn as #683's fix, moving them onto the canonical form the
rest of the pipeline already expects.