### PR TITLE
fix(csharp): extract members in preprocessor blocks

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2162,7 +2162,7 @@ def _csharp_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: 
                        nodes: list, edges: list, seen_ids: set, function_bodies: list,
                        parent_class_nid: str | None, add_node_fn, add_edge_fn,
                        walk_fn, namespace_stack: list[str], scope_stack: list[str]) -> bool:
-    """Handle namespace declarations for C#. Returns True if handled."""
+    """Handle C# namespaces and transparent class-member wrappers."""
     if node.type == "namespace_declaration":
         ns_name = _csharp_namespace_name(node, source)
         pushed = False
@@ -2198,6 +2198,13 @@ def _csharp_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: 
             line = node.start_point[0] + 1
             add_node_fn(ns_nid, ns_label, line, node_type="namespace", metadata={"kind": "csharp_namespace"})
             add_edge_fn(file_nid, ns_nid, "contains", line)
+        return True
+    if parent_class_nid and node.type.startswith("preproc_"):
+        # tree-sitter wraps members in #if/#else/#elif directives in preproc_*
+        # nodes. They are conditional containers, not ownership scopes: dropping
+        # parent_class_nid here makes guarded methods look file-level (#2631).
+        for child in node.children:
+            walk_fn(child, parent_class_nid)
         return True
     return False
 

--- a/tests/test_dotnet.py
+++ b/tests/test_dotnet.py
@@ -519,6 +519,56 @@ def test_xaml_viewmodel_with_non_utf8_codebehind_does_not_crash(tmp_path):
     assert nodes[edges[0]["target"]]["label"] == "SettingsViewModel"
 
 
+def test_csharp_members_in_preprocessor_blocks_are_extracted_and_resolved(tmp_path):
+    """C# preprocessor wrappers must preserve class ownership for members (#2631)."""
+    helper = tmp_path / "Helper.cs"
+    helper.write_text(
+        """namespace Probe.Lib;
+public static class Gated
+{
+    public static void Outside(string a) { }
+#if NET8_0_OR_GREATER
+    public static void InsideIf(string a) { }
+#else
+    public static void InsideElse(string a) { }
+#endif
+#if DEBUG
+    public static void InsideDebug(string a) { }
+#endif
+}
+"""
+    )
+    caller = tmp_path / "Caller.cs"
+    caller.write_text(
+        """namespace Probe.Lib;
+public static class Caller
+{
+    public static void Drive()
+    {
+        Gated.Outside(\"x\");
+        Gated.InsideIf(\"x\");
+        Gated.InsideDebug(\"x\");
+    }
+}
+"""
+    )
+
+    result = extract([helper, caller], cache_root=tmp_path)
+    by_label = {node["label"]: node["id"] for node in result["nodes"]}
+
+    for label in (".Outside()", ".InsideIf()", ".InsideElse()", ".InsideDebug()"):
+        assert label in by_label
+
+    calls = {
+        (edge["source"], edge["target"])
+        for edge in result["edges"]
+        if edge["relation"] == "calls"
+    }
+    assert (by_label[".Drive()"], by_label[".Outside()"]) in calls
+    assert (by_label[".Drive()"], by_label[".InsideIf()"]) in calls
+    assert (by_label[".Drive()"], by_label[".InsideDebug()"]) in calls
+
+
 # ── .razor ───────────────────────────────────────────────────────────────────
 
 def test_razor_using_and_inject():


### PR DESCRIPTION
## Summary

Fixes #2631.

C# members declared inside `#if`, `#elif`, and `#else` blocks were skipped because the generic extractor treated tree-sitter's `preproc_*` nodes as scope boundaries. This removed the enclosing class context, so guarded members were not emitted as class methods and call resolution could not target them.

## Changes

- Treat C# preprocessor nodes as transparent while walking a class body.
- Preserve the enclosing class ID for methods nested in conditional compilation blocks.
- Add a regression test with two C# files covering guarded methods in `#if` / `#else` blocks and calls to the active methods.

Both conditional branches are represented in the graph. Choosing a build configuration remains outside the extractor's scope.

## Validation

- `uv run pytest tests/test_dotnet.py -q -k preprocessor` — passed.
- `uv run pytest tests/test_dotnet.py -q` — 42 passed.
- `uv run pytest tests/test_languages.py -q -k csharp` — 14 passed.
- `uv run ruff check graphify/extractors/engine.py tests/test_dotnet.py` — passed.
- `uv run graphify update .` — completed successfully.

I also ran `uv run pytest tests/ -q`: 4,271 passed and 20 skipped. The 20 failures are unrelated Windows/platform-sensitive tests in Astro IDs, filesystem permissions, gitignore, hooks, image handling, install paths, and watch-path separators; none exercise the C# extractor or this regression.