### PR TITLE
fix(wiki): count each incident edge once in the Audit Trail confidence split

### DIFF
--- a/graphify/wiki.py
+++ b/graphify/wiki.py
@@ -73,12 +73,23 @@ def _community_article(
     top_nodes = sorted(nodes, key=lambda n: G.degree(n), reverse=True)[:25]
     cross = _cross_community_links(G, nodes, cid, labels, node_community or {})
 
-    # Edge confidence breakdown
-    conf_counts: Counter = Counter()
-    for nid in nodes:
-        for neighbor in G.neighbors(nid):
-            ed = edge_data(G, nid, neighbor)
-            conf_counts[ed.get("confidence", "EXTRACTED")] += 1
+    # Edge confidence breakdown, over every edge INCIDENT to the community (the
+    # cross-community ones included — those are disproportionately the uncertain
+    # edges, and AMBIGUOUS is what ARCHITECTURE.md flags for human review).
+    #
+    # ``G.edges(nbunch)`` reports each incident edge exactly once. Walking
+    # ``nodes x G.neighbors`` instead visited an edge once per endpoint inside
+    # the community, so an intra-community edge was counted TWICE while a
+    # crossing one was counted once. Intra-community edges are overwhelmingly
+    # the high-confidence EXTRACTED ones — that is what makes a community — so
+    # the split was biased towards confidence and understated the review
+    # burden. On a MultiGraph this also counts parallel edges individually
+    # rather than collapsing them to the first (``edge_data``), which is the
+    # same understatement: an AMBIGUOUS edge parallel to an EXTRACTED one used
+    # to be invisible here.
+    conf_counts: Counter = Counter(
+        d.get("confidence", "EXTRACTED") for *_, d in G.edges(nodes, data=True)
+    )
     total_edges = sum(conf_counts.values()) or 1
 
     sources = sorted({G.nodes[n].get("source_file") or "" for n in nodes} - {""})

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -96,11 +96,42 @@ def test_community_article_shows_cohesion(tmp_path):
 
 
 def test_community_article_has_audit_trail(tmp_path):
+    """Each incident edge is counted exactly ONCE (#2633).
+
+    The Parsing Layer (n1, n2) touches two edges: n1-n2 (EXTRACTED, both
+    endpoints inside) and n1-n3 (INFERRED, crossing out). Counting
+    ``nodes x G.neighbors`` visited the intra-community edge from both ends and
+    the crossing one from only one, reporting EXTRACTED 2 (67%) / INFERRED 1
+    (33%) — biased towards confidence, which understates the AMBIGUOUS review
+    burden the section exists to surface.
+    """
     G = _make_graph()
     to_wiki(G, COMMUNITIES, tmp_path, community_labels=LABELS)
     parsing = (tmp_path / "Parsing_Layer.md").read_text()
-    assert "EXTRACTED" in parsing
-    assert "INFERRED" in parsing
+    audit = parsing[parsing.index("## Audit Trail"):]
+    assert "- EXTRACTED: 1 (50%)" in audit, audit
+    assert "- INFERRED: 1 (50%)" in audit, audit
+    assert "- AMBIGUOUS: 0 (0%)" in audit, audit
+
+
+def test_audit_trail_counts_parallel_edges_individually(tmp_path):
+    """On a MultiGraph each parallel edge is its own row in the split (#2633).
+
+    Collapsing them to the first (``edge_data``) hid an AMBIGUOUS edge behind an
+    EXTRACTED one running between the same pair — the same understatement as the
+    double-count above.
+    """
+    G = nx.MultiGraph()
+    G.add_node("n1", label="parse", file_type="code", source_file="parser.py")
+    G.add_node("n2", label="validate", file_type="code", source_file="parser.py")
+    G.add_edge("n1", "n2", relation="calls", confidence="EXTRACTED", weight=1.0)
+    G.add_edge("n1", "n2", relation="references", confidence="AMBIGUOUS", weight=1.0)
+
+    to_wiki(G, {0: ["n1", "n2"]}, tmp_path, community_labels={0: "Parsing Layer"})
+    audit = (tmp_path / "Parsing_Layer.md").read_text()
+    audit = audit[audit.index("## Audit Trail"):]
+    assert "- EXTRACTED: 1 (50%)" in audit, audit
+    assert "- AMBIGUOUS: 1 (50%)" in audit, audit
 
 
 def test_god_node_article_has_connections(tmp_path):


### PR DESCRIPTION
Fixes #2633.

## The bug

`_community_article` built the confidence breakdown by walking `nodes × G.neighbors`, which
visits the unordered pair `(a, b)` once as `a→b` and again as `b→a` when both endpoints are
community members. So:

- an edge with **both** endpoints inside the community was counted **twice**
- an edge crossing out of the community was counted **once**

Intra-community edges are overwhelmingly the high-confidence `EXTRACTED` ones — that is what
makes a community a community — while crossing edges are disproportionately the uncertain
ones. The reported split was therefore biased *towards* confidence, understating the
`AMBIGUOUS` share that `ARCHITECTURE.md` documents as "flagged for human review". The
section exists to size a reviewer's workload and was systematically shrinking it.

The reported repro (3 edges) printed `EXTRACTED: 4 (80%) / AMBIGUOUS: 1 (20%)` — a total of
5 for 3 edges.

## Fix

networkx already reports each incident edge exactly once, so no dedup bookkeeping is needed:

```python
conf_counts: Counter = Counter(
    d.get("confidence", "EXTRACTED") for *_, d in G.edges(nodes, data=True)
)
```

`G.edges(nbunch)` gives precisely the semantics this section wants — intra-community edges
once, crossing edges once, self-loops once — and tolerates duplicate or absent entries in
`nodes`. Net −5 lines, and it drops the `seen`-set the issue proposed along with the
per-pair `edge_data` lookup.

## On "belonging to" vs "touching" the community

The issue asks which is meant. The Expected output settles it: it keeps the crossing
`c→x` AMBIGUOUS edge in the denominator (`1/3`, not `0/2`). That also matches the issue's own
argument — crossing edges are the uncertain ones, so excluding them would understate the
review burden *further*. Cross-community edges stay in; only the double-count is removed.
Made explicit in a comment so the next reader doesn't have to re-derive it.

## One deliberate extra

On a `MultiGraph`, `edge_data` returns only the **first** parallel edge, so an `AMBIGUOUS`
edge running alongside an `EXTRACTED` one between the same pair was invisible in the split.
`G.edges(..., data=True)` counts each individually. This is the same class of understatement
as the double-count, but it is beyond what was reported and **will raise MultiGraph totals**
where parallel edges exist. Easy to revert to pair-collapsing if that is not wanted.

## Verification

| | before | after |
|---|---|---|
| issue repro (2 intra EXTRACTED + 1 cross AMBIGUOUS) | `EXTRACTED: 4 (80%)`, `AMBIGUOUS: 1 (20%)` | `EXTRACTED: 2 (67%)`, `AMBIGUOUS: 1 (33%)` |

Matches the Expected output exactly.

`test_community_article_has_audit_trail` existed but only asserted `"EXTRACTED" in parsing`
— substring checks, which is why arithmetic this far off went unnoticed. Replaced with the
actual counts and percentages (its fixture is already one intra + one cross edge, i.e. the
defect), plus a new `test_audit_trail_counts_parallel_edges_individually` for the MultiGraph
behavior. Both fail before the change and pass after.

Full suite: same 42 pre-existing failures as baseline (Windows/env), no new ones.

## Scope

`_cross_community_links` needs no change, as the issue notes — a crossing edge has one
endpoint in `nodes` and is naturally counted once. Swept the rest of the codebase for the
same `nodes × neighbors` pattern used as an edge counter; the neighbor loops in
`analyze.py`, `export.py`, `serve.py`, `cluster.py` and `benchmark.py` are traversals or
per-node listings, not edge tallies. This was the only affected site.