### PR TITLE
fix(cli): derive the --platform list from the dispatch so --help can't omit accepted platforms

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -97,6 +97,7 @@ from graphify.install import (  # noqa: E402,F401
     vscode_install,
     vscode_uninstall,
     _PLATFORM_ALIASES,
+    ACCEPTED_PLATFORMS,
     _CLAUDE_MD_MARKER,
     _CODEBUDDY_MD_MARKER,
     _AGENTS_MD_MARKER,
@@ -507,7 +508,7 @@ def _run_cli() -> None:
         print("Usage: graphify <command>")
         print()
         print("Commands:")
-        print("  install [--platform P]  copy skill to platform config dir (claude|windows|codebuddy|codex|opencode|aider|amp|agents|claw|droid|trae|trae-cn|gemini|cursor|antigravity|hermes|kiro|pi|devin)")
+        print(f"  install [--platform P]  copy skill to platform config dir ({'|'.join(ACCEPTED_PLATFORMS)})")
         print("  uninstall               remove graphify from all detected platforms in one shot")
         print("    --purge                 also delete graphify-out/ directory")
         print("  path \"A\" \"B\"            shortest path between two nodes in graph.json")

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -468,6 +468,18 @@ _PLATFORM_CONFIG: dict[str, dict] = {
 # dispatch. `skills` is the friendly alias for the generic `agents` platform
 # (the Agent-Skills ecosystem calls them "skills").
 _PLATFORM_ALIASES: dict[str, str] = {"skills": "agents"}
+# The platforms `install()` dispatches BEFORE its _PLATFORM_CONFIG membership
+# check, so they are accepted despite having no config entry of their own.
+_SPECIAL_PLATFORMS: tuple[str, ...] = ("cursor", "gemini")
+# Every value `--platform` accepts. Single source of truth for the three places
+# that advertise it — the top-level `--help` line, `graphify install`'s own
+# usage, and the unknown-platform error below. All three used to hand-maintain
+# a copy, and the `--help` one had drifted to omit `antigravity-windows`,
+# `copilot`, `kilo` and `kimi`; the other two omit the `skills` alias (#2638).
+# Derived, so the advertised list cannot fall behind the dispatch again.
+ACCEPTED_PLATFORMS: tuple[str, ...] = tuple(sorted(
+    set(_PLATFORM_CONFIG) | set(_SPECIAL_PLATFORMS) | set(_PLATFORM_ALIASES)
+))
 def _canonical_platform(platform_name: str) -> str:
     """Resolve a CLI platform alias to its real _PLATFORM_CONFIG key."""
     return _PLATFORM_ALIASES.get(platform_name, platform_name)
@@ -601,7 +613,7 @@ def install(platform: str = "claude", *, project: bool = False, project_dir: Pat
         platform = "antigravity-windows"
     if platform not in _PLATFORM_CONFIG:
         print(
-            f"error: unknown platform '{platform}'. Choose from: {', '.join(_PLATFORM_CONFIG)}, gemini, cursor",
+            f"error: unknown platform '{platform}'. Choose from: {', '.join(ACCEPTED_PLATFORMS)}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -675,7 +687,7 @@ def install(platform: str = "claude", *, project: bool = False, project_dir: Pat
     print("open free before the public v1 launch: https://app.graphify.com")
     print()
 def _print_install_usage() -> None:
-    platforms = ", ".join([*_PLATFORM_CONFIG, "gemini", "cursor"])
+    platforms = ", ".join(ACCEPTED_PLATFORMS)
     print("Usage: graphify install [--project] [--strict] [--platform P|P]")
     print(f"Platforms: {platforms}")
     print("  --strict  block the first raw file read per session until one "

--- a/tests/test_install_strings.py
+++ b/tests/test_install_strings.py
@@ -141,6 +141,79 @@ def test_skill_registration_uses_host_generic_instruction():
     assert "use the installed graphify skill or instructions" in reg
 
 
+# --- the advertised --platform list vs what install() actually accepts (#2638) ---
+# Three surfaces advertise this list (top-level --help, `graphify install`'s own
+# usage, and install()'s unknown-platform error). Each used to hand-maintain its
+# own copy, and --help had drifted to omit four accepted values. These lock the
+# advertised list to the dispatch in BOTH directions, so neither a new platform
+# that nobody documents nor a stale/typo'd entry that nothing accepts survives.
+
+def _documented_platforms() -> set[str]:
+    """The `--platform` values the top-level --help advertises."""
+    import re
+    import sys as _sys
+    import io
+    from contextlib import redirect_stdout
+
+    from graphify.__main__ import _run_cli
+
+    argv = _sys.argv
+    _sys.argv = ["graphify", "--help"]
+    buf = io.StringIO()
+    try:
+        with redirect_stdout(buf):
+            _run_cli()
+    finally:
+        _sys.argv = argv
+    line = next(
+        l for l in buf.getvalue().split("\n") if "install [--platform P]" in l
+    )
+    m = re.search(r"\(([^()]*)\)\s*$", line)
+    assert m, f"no parenthesised platform list in: {line!r}"
+    return set(m.group(1).split("|"))
+
+
+def test_help_lists_every_accepted_platform():
+    """Every value install() dispatches must be discoverable from --help."""
+    from graphify.install import _PLATFORM_ALIASES, _PLATFORM_CONFIG
+
+    documented = _documented_platforms()
+    accepted = set(_PLATFORM_CONFIG) | set(_PLATFORM_ALIASES)
+    missing = sorted(accepted - documented)
+    assert not missing, f"accepted but undocumented in --help: {missing}"
+
+
+def test_help_advertises_no_platform_install_rejects():
+    """...and nothing advertised may be rejected. `cursor`/`gemini` have no
+    _PLATFORM_CONFIG entry — install() branches on them before the membership
+    check — so they are accepted despite not being config keys."""
+    from graphify.install import _PLATFORM_CONFIG, _canonical_platform
+
+    phantom = sorted(
+        p for p in _documented_platforms()
+        if _canonical_platform(p) not in _PLATFORM_CONFIG
+        and p not in ("cursor", "gemini")
+    )
+    assert not phantom, f"advertised in --help but install() rejects: {phantom}"
+
+
+def test_all_three_platform_surfaces_agree():
+    """--help, `graphify install` usage and the unknown-platform error must not
+    drift apart — they are three renderings of one list."""
+    import io
+    from contextlib import redirect_stdout
+
+    from graphify.install import ACCEPTED_PLATFORMS, _print_install_usage
+
+    assert _documented_platforms() == set(ACCEPTED_PLATFORMS)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _print_install_usage()
+    usage = next(l for l in buf.getvalue().split("\n") if l.startswith("Platforms:"))
+    assert set(usage.split(":", 1)[1].strip().split(", ")) == set(ACCEPTED_PLATFORMS)
+
+
 def test_how_it_works_clarifies_code_only_semantic_extraction():
     from pathlib import Path
     doc = (Path(__file__).parent.parent / "docs" / "how-it-works.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes #2638.

## The bug

The `--platform` value list in `graphify --help` was a hand-written literal and had drifted
from `install._PLATFORM_CONFIG`, advertising 19 values where 21+ are accepted. Confirmed the
four reported gaps: `antigravity-windows`, `copilot`, `kilo`, `kimi`. `kimi` and
`antigravity-windows` appear nowhere in `--help` at all.

## Wider than the help line

Three surfaces advertise this list, each maintaining its own copy:

| surface | was | missing |
|---|---|---|
| `--help` (`__main__.py:510`) | 19 literal values | `antigravity-windows`, `copilot`, `kilo`, `kimi`, `skills` |
| `install()` error (`install.py:604`) | `_PLATFORM_CONFIG` + `", gemini, cursor"` | `skills` |
| `_print_install_usage()` | `[*_PLATFORM_CONFIG, "gemini", "cursor"]` | `skills` |

Regenerating only the `--help` string would have left the other two able to drift, so this
adds one derived constant in `install.py` and points all three at it:

```python
# The platforms install() dispatches BEFORE its _PLATFORM_CONFIG membership check.
_SPECIAL_PLATFORMS: tuple[str, ...] = ("cursor", "gemini")

ACCEPTED_PLATFORMS: tuple[str, ...] = tuple(sorted(
    set(_PLATFORM_CONFIG) | set(_SPECIAL_PLATFORMS) | set(_PLATFORM_ALIASES)
))
```

All three now render the same 24 values.

## One value beyond the four reported

`skills` — the friendly alias for `agents` (`_PLATFORM_ALIASES`) — is accepted by
`--platform` via `_canonical_platform`, but was advertised on **none** of the three surfaces,
including the two the issue's repro doesn't inspect. Since the stated goal is "the advertised
list matches what the command accepts", aliases are folded in.

## Tests

In `tests/test_install_strings.py`, locking the list in **both** directions rather than only
the reported one:

- `test_help_lists_every_accepted_platform` — the issue's suggested assertion. Catches a newly
  registered platform that nobody documents.
- `test_help_advertises_no_platform_install_rejects` — the reverse: a stale or typo'd entry
  that `install()` would actually reject. A one-directional test would let that through.
- `test_all_three_platform_surfaces_agree` — keeps the three renderings from splitting again.

Verified by reverting just the help line to the old literal: tests 1 and 3 fail. A synthetic
phantom entry trips test 2.

Full suite: same 42 pre-existing failures as baseline (Windows/env), none new.

## Notes for reviewers

**`vscode` is intentionally not in the list.** Test 2 flagged it, and the asymmetry is real:
`graphify vscode install` works (`vscode` is in `_CLI_INSTALL_COMMANDS`, and `vscode_install`
exists), but `--platform vscode` errors, since it has no `_PLATFORM_CONFIG` entry and no
special-case branch. Left as-is — deciding whether `--platform vscode` *should* work is a
behavior change, not a docs fix. Happy to open a follow-up.

**Two small corrections to the issue**, neither affecting the fix:

1. The repro's `line.rindex(')')` lands on the closing paren of the `print(...)` call rather
   than the list, so against the current file it also reports `devin` as undocumented. The
   real gap is the four named plus `skills`.
2. `cursor` / `gemini` work because `install()` branches on them at `install.py:593-598`,
   ahead of the `_PLATFORM_CONFIG` membership check — matching what the issue verified
   empirically. That branch is now named by `_SPECIAL_PLATFORMS` so the reason they're
   accepted is recorded in one place.