### PR TITLE
test: skip the unreadable-dir detect test on non-POSIX platforms

### DIFF
--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -2518,14 +2518,24 @@ def test_detect_reports_walk_errors_key():
     assert res["walk_errors"] == []
 
 
+@pytest.mark.skipif(
+    not hasattr(os, "geteuid"),
+    reason="POSIX-only: needs geteuid() and chmod 000 to actually block scandir",
+)
 def test_detect_surfaces_unreadable_dir_instead_of_silent_skip(tmp_path, capsys):
     """os.walk silently skips a subtree whose scandir raises (permissions, or a
     dir deleted mid-walk); that under-enumeration used to be invisible and could
     yield a silently partial graph. detect() now records it in walk_errors and
-    warns, while still enumerating the rest of the tree."""
-    import os
+    warns, while still enumerating the rest of the tree.
+
+    Guarded on the capability, not the platform: `os.geteuid` is Unix-only, so on
+    Windows the root check below raises AttributeError before the test can decide
+    anything. Shimming geteuid would not help — Windows ignores POSIX mode bits,
+    so `chmod 000` leaves the directory readable and the test fails on its real
+    assertion instead. Both reasons say the same thing: this test cannot run here
+    (#2643).
+    """
     if os.geteuid() == 0:
-        import pytest
         pytest.skip("running as root: chmod 000 does not block scandir")
     (tmp_path / "a.py").write_text("def f(): pass\n")
     locked = tmp_path / "locked"


### PR DESCRIPTION
Fixes #2643.

## The bug

`test_detect_surfaces_unreadable_dir_instead_of_silent_skip` guards itself against running as
root — a `chmod 000` directory is still readable by root, so the test would assert nothing.
That guard calls `os.geteuid()`, which is Unix-only, so on Windows the guard raises before the
test can decide anything:

```
>       if os.geteuid() == 0:
E       AttributeError: module 'os' has no attribute 'geteuid'. Did you mean: 'getpid'?
```

## Fix

The capability guard from the issue:

```python
@pytest.mark.skipif(
    not hasattr(os, "geteuid"),
    reason="POSIX-only: needs geteuid() and chmod 000 to actually block scandir",
)
```

## Why not shim `geteuid`

The issue notes a shim would not help, and that holds up — I checked rather than assumed.
`chmod 000` is not enforced on Windows, so the directory stays readable and the test fails on
its real assertion instead:

```
scandir after chmod 000 -> SUCCEEDED, listed: ['b.py']
```

So both of the test's POSIX assumptions fail here, and skipping is the honest outcome rather
than a workaround. That reasoning is recorded in the docstring so nobody re-litigates it by
adding a shim later.

Guarding on `hasattr(os, "geteuid")` rather than `sys.platform` also keeps the check pointed at
what the test actually needs — the coverage is unaffected on POSIX, where the attribute exists
and the test runs exactly as before.

## Also

Dropped the function-local `import os` and `import pytest`; both are already module-level
imports in this file, and the local `import pytest` would have shadowed the decorator's need
for it at module scope.

## Verification

- The test now reports `SKIPPED [1] tests/test_detect.py:2521: POSIX-only: needs geteuid() and chmod 000 to actually block scandir`.
- Full suite on Windows: 42 pre-existing failures → 41. The set diff shows exactly this one test
  removed and **no new failures**.
- Test-only change; no product code touched.

As the issue says, a repo-wide grep confirms this was the only `geteuid` occurrence, so the fix
is self-contained.
