### PR TITLE
fix(extract): resolve prefixed PHP imports (#2659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 ## 0.9.40 (unreleased)
 
+- Fix: PHP `use` imports now resolve to the intended class when its name prefixes sibling class names (#2659).
 - Fix: the 0.9.37 partial-parse warning no longer fires on valid TypeScript/TSX (#2610, #2599, thanks @Sid-AutoWisdom and @atlasplatformu-ai). tree-sitter-typescript sets an error flag on tiny fully-recovered constructs (a `&` in a JSX string attribute, a semicolon-less `in_*` interface member) that still extract completely; the warning now fires only when recovery plausibly cost symbols (the file yielded at most the file node, or an error region spans multiple lines), so the genuine Kotlin one-line-body and Luau cases still warn.
 - Fix: `file_hash()`'s stat fastpath no longer serves a stale digest when a file is rewritten to the same size within one mtime tick (#2612, thanks @rajarshidattapy); a racily-clean guard falls back to a content hash for recently-modified files.
 - Fix: stored-path absoluteness is now detected cross-platform, so a POSIX-absolute `source_file` from a Linux/CI-built graph no longer leaks into node ids on Windows (#2618, thanks @rajarshidattapy).

--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -2871,11 +2871,13 @@ def _resolve_php_type_references(
             continue
         tgt = edge.get("target")
         label = stub_label.get(tgt)
+        uses = uses_by_file.get(ref_file, {})
+        if not label and relation == "imports":
+            label = next((alias for alias in uses if _make_id(alias) == tgt), "")
         if not label:
             continue
         bare = label.strip().lower()
         ns = ns_by_file[ref_file]
-        uses = uses_by_file.get(ref_file, {})
 
         raw = None
         if relation in _PHP_SUPERTYPE_RELATIONS:

--- a/tests/test_php_type_resolution.py
+++ b/tests/test_php_type_resolution.py
@@ -156,3 +156,35 @@ def test_php_plain_no_namespace_inheritance_preserved(tmp_path: Path):
         "no-namespace inheritance must still resolve to the real Base def"
     )
     assert tgt.get("label") == "Base"
+
+
+def test_php_import_resolves_when_target_name_prefixes_sibling_classes(tmp_path: Path):
+    pivot = _write(
+        tmp_path / "src/Pivot.php",
+        "<?php\nnamespace App\\Entities;\nclass Pivot {}\n",
+    )
+    importer = _write(
+        tmp_path / "src/ModelWithRelation.php",
+        "<?php\nnamespace App\\Models;\n"
+        "use App\\Entities\\Pivot;\n"
+        "class ModelWithRelation {}\n",
+    )
+    siblings = [
+        _write(
+            tmp_path / f"src/{name}.php",
+            f"<?php\nnamespace App\\Repositories;\nclass {name} {{}}\n",
+        )
+        for name in ("PivotRepository", "PivotRepositoryEloquent", "PivotValidator")
+    ]
+
+    result = extract([pivot, importer, *siblings], cache_root=tmp_path)
+    pivot_id = _class_defs(result, "Pivot")[0]["id"]
+    imports = [
+        edge
+        for edge in result["edges"]
+        if edge["relation"] == "imports"
+        and "modelwithrelation" in edge.get("source", "").lower()
+    ]
+
+    assert len(imports) == 1
+    assert imports[0]["target"] == pivot_id


### PR DESCRIPTION
## Why

PHP `use` imports target a bare ID before namespace-aware resolution. When that ID has no sourceless stub node, the resolver cannot recover its label and leaves the import dangling instead of resolving the imported class.

Fixes #2659.

## What changed

- recover a missing PHP import label from the importing file's parsed `use` aliases
- keep matching exact through the existing normalized target ID and FQN resolver
- add a regression test with `Pivot` and three sibling classes whose names begin with `Pivot`
- add the unreleased changelog entry

## Why it is safe

The fallback runs only for `imports` edges without an existing stub label. Other PHP reference relations and non-namespaced legacy resolution are unchanged. External imports continue through the existing FQN stub path.

## Test verification (RED → GREEN)

Upstream `v8` without the production fix:

```text
FAILED tests/test_php_type_resolution.py::test_php_import_resolves_when_target_name_prefixes_sibling_classes
E   AssertionError: assert 'pivot' == 'src_pivot_pivot'
1 failed in 0.23s
```

Patched branch:

```text
tests/test_php_type_resolution.py ...... [100%]
6 passed in 0.27s
changed lines: [2874, 2875, 2876]
executed changed lines: [2874, 2875, 2876]
changed-line coverage: 100%
```

Full local CI replay:

- Python 3.12: 4306 passed, 3 skipped; two pre-existing failures reproduced on unmodified `v8`
- Python 3.10: 4306 passed, 3 skipped; same two pre-existing failures as baseline, with one additional passing regression test
- generated skill checks, install smoke, and `ruff check graphify tests`: passed
