### PR TITLE
fix(serve): suppress query truncation banner when no nodes were cut (#2601)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 ## 0.9.40 (unreleased)
 
+- Fix: `query` no longer prints the truncation banner when zero whole nodes were cut (#2601); an over-budget answer that only trims trailing edges renders as complete instead of falsely warning "showing N of N nodes … among the 0 cut nodes", which used to push agents into pointless narrowing calls.
 - Fix: the 0.9.37 partial-parse warning no longer fires on valid TypeScript/TSX (#2610, #2599, thanks @Sid-AutoWisdom and @atlasplatformu-ai). tree-sitter-typescript sets an error flag on tiny fully-recovered constructs (a `&` in a JSX string attribute, a semicolon-less `in_*` interface member) that still extract completely; the warning now fires only when recovery plausibly cost symbols (the file yielded at most the file node, or an error region spans multiple lines), so the genuine Kotlin one-line-body and Luau cases still warn.
 - Fix: `file_hash()`'s stat fastpath no longer serves a stale digest when a file is rewritten to the same size within one mtime tick (#2612, thanks @rajarshidattapy); a racily-clean guard falls back to a content hash for recently-modified files.
 - Fix: stored-path absoluteness is now detected cross-platform, so a POSIX-absolute `source_file` from a Linux/CI-built graph no longer leaks into node ids on Windows (#2618, thanks @rajarshidattapy).

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -1082,6 +1082,16 @@ def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_bu
         total_nodes = sum(1 for l in lines if l.startswith("NODE "))
         shown_nodes = output[:cut_at].count("\nNODE ") + (1 if output.startswith("NODE ") else 0)
         cut_count = total_nodes - shown_nodes
+        # Nodes render before edges, so a char-budget overflow whose cut lands
+        # past the last NODE line drops only trailing edges — no whole node is
+        # lost. Announcing "showing N of N nodes … among the 0 cut nodes" then
+        # reads as a false truncation warning that teaches an agent to distrust a
+        # complete answer and burn follow-up narrowing calls for nodes that were
+        # never cut (#2601). When every node is shown the answer is complete:
+        # return the full output with no banner rather than silently dropping
+        # edges under a misleading notice.
+        if cut_count == 0:
+            return output
         # Prominent notice at the TOP so a truncated answer can never be mistaken
         # for a complete one — silence used to read as absence (#BUG2). The
         # notice + end marker sit OUTSIDE char_budget by design (two bounded

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1496,6 +1496,33 @@ def test_subgraph_to_text_no_notice_when_under_budget():
     assert "TRUNCATED" not in text and "truncated" not in text
 
 
+def test_subgraph_to_text_no_banner_when_only_edges_overflow():
+    """#2601: nodes render before edges, so a budget overflow that only trims
+    trailing edges cuts zero whole nodes. The banner must not fire with a
+    misleading "showing N of N nodes … among the 0 cut nodes" — that pushes an
+    agent to distrust a complete answer and issue pointless narrowing calls."""
+    import itertools
+
+    G = nx.Graph()
+    labels = [f"n{i}" for i in range(4)]
+    for lbl in labels:
+        G.add_node(lbl, label=lbl, source_file="f.py", source_location="L1", community="c")
+    edges = list(itertools.combinations(labels, 2))
+    for u, v in edges:
+        G.add_edge(u, v, relation="calls", confidence="high")
+    # Budget large enough for every NODE line but not the trailing EDGE lines.
+    text = _subgraph_to_text(G, set(G.nodes), edges, token_budget=60)
+    node_lines = [l for l in text.splitlines() if l.startswith("NODE ")]
+    edge_lines = [l for l in text.splitlines() if l.startswith("EDGE ")]
+    assert len(node_lines) == len(labels), "every node must still be shown"
+    assert "TRUNCATED" not in text and "truncated" not in text
+    assert "cut nodes" not in text
+    # A complete answer renders the whole subgraph: suppressing the banner must
+    # not silently truncate the trailing edges either (a `return output[:cut_at]`
+    # would drop them and still pass the assertions above).
+    assert len(edge_lines) == len(edges), "all edges must survive a complete answer"
+
+
 def test_subgraph_to_text_order_is_deterministic():
     """Equal-degree nodes render in a stable order regardless of set iteration."""
     G = nx.Graph()


### PR DESCRIPTION
## Why

Fix #2601

`query` printed the truncation banner even when **zero whole nodes were cut**. `_subgraph_to_text` renders every `NODE` line before any `EDGE` line, so a char-budget overflow whose cut lands past the last node drops only trailing edges — `cut_count` is `0`, yet the banner still fired:

```
[!] TRUNCATED: showing 91 of 91 nodes (~6000-token budget). The answer may be among the 0 cut nodes ...
```

The banner's audience is usually an agent, and this false warning is actively harmful: "the answer may be among the 0 cut nodes" teaches the reader to distrust a **complete** answer, and an agent that follows the banner's own advice issues follow-up `context_filter` / `get_node` calls to recover nodes that were never cut — pure wasted round-trips.

## What changed

`graphify/serve.py` — in `_subgraph_to_text`, when `cut_count == 0` return the full `output` (the complete node set plus all its edges) with no banner. All nodes are shown and every edge connects shown nodes, so it is a complete answer and renders as one — no misleading notice, and no silently-dropped edges (which would repeat the #BUG2 "silence reads as absence" mistake). When a whole node is genuinely cut (`cut_count > 0`) the banner still fires exactly as before.

The sibling `_cut_lines_to_budget` is line-oriented and cannot produce `cut_count == 0` (an over-budget cut always drops at least one line), so it is intentionally left untouched.

## Test verification (RED → GREEN)

New test `test_subgraph_to_text_no_banner_when_only_edges_overflow` builds a 4-node K4 and picks `token_budget=60` so every `NODE` line fits but the trailing `EDGE` lines overflow. It asserts all 4 nodes are shown, no `TRUNCATED`/`cut nodes` banner, **and** all 6 edges survive (so a banner-suppressed-but-edge-truncated implementation would still fail).

RED — unmodified `v8`, new test only:
```
>       assert "TRUNCATED" not in text and "truncated" not in text
E       AssertionError: assert ('TRUNCATED' not in '[!] TRUNCAT...ific symbol)'
E         'TRUNCATED' is contained here:
E           [!] TRUNCATED: showing 4 of 4 nodes (~60-token budget). The answer may be among the 0 cut nodes ...
FAILED tests/test_serve.py::test_subgraph_to_text_no_banner_when_only_edges_overflow
1 failed
```

GREEN — with the fix:
```
tests/test_serve.py::test_subgraph_to_text_no_banner_when_only_edges_overflow PASSED
1 passed
```

## Full local suite

- `pytest tests/` (Python 3.12 & 3.10): 4306 passed, 3 skipped. Two failures are pre-existing on unmodified `v8` and unrelated to this change (`test_collect_files_skips_hidden` picks up local `.venv`/hidden dirs in the checkout; `test_property_normalize_id_agrees_with_its_own_caseless_form` is a hypothesis Unicode combining-mark falsifying example). Both reproduce identically on `v8` with this diff stashed — iso-baseline, no new failures.
- `tests/test_serve.py`: 140 passed. The existing truncation guards (`test_subgraph_to_text_truncates`, `test_subgraph_to_text_seed_survives_truncation`, `test_subgraph_to_text_truncation_notice_at_top`) still pass — the banner is unchanged whenever a node is actually cut.
- `ruff check graphify tests` clean; `skillgen --check` OK (no generated files touched).
- Minimal diff: one guard in `serve.py`, one new test, one CHANGELOG entry.
