### PR TITLE
feat: add MemoryGuard metadata export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## 0.9.41 (2026-08-12)
+
+- Feat: add `graphify export memoryguard-metadata ROOT [PATH ...]` for
+  MemoryGuard CodeGraph V2. The `memoryguard-graphify-metadata-v1` export is
+  body-free and repository-relative, includes content hashes, structural
+  symbols/edges, source role/provenance, source maps, and bounded diagnostics,
+  and rejects source bodies, absolute paths, credentials, and unsafe extractor
+  text. `--incremental` and `--no-parallel` support controlled ingestion.
+- Test: add focused export coverage for body-free output, provenance, CLI help,
+  selected paths, and a complete repository smoke export.
+
 ## 0.9.40 (unreleased)
 
 - Fix: the 0.9.37 partial-parse warning no longer fires on valid TypeScript/TSX (#2610, #2599, thanks @Sid-AutoWisdom and @atlasplatformu-ai). tree-sitter-typescript sets an error flag on tiny fully-recovered constructs (a `&` in a JSX string attribute, a semicolon-less `in_*` interface member) that still extract completely; the warning now fires only when recovery plausibly cost symbols (the file yielded at most the file node, or an error region spans multiple lines), so the genuine Kotlin one-line-body and Luau cases still warn.
@@ -219,7 +230,6 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: installed hook commands now use forward slashes in the graphify exe path so Git Bash doesn't strip them (#1987, thanks @varuntej07). On Windows the resolved exe path had backslashes, which Git Bash (how Claude Code shells hooks) treats as escapes and drops, breaking the hook with "command not found". `_resolve_graphify_exe` now normalizes `\` to `/` at the single choke point, covering every emitter (Claude/CodeBuddy PreToolUse, Gemini BeforeTool, Codex); quoting and the `--strict` suffix are preserved and POSIX is unaffected.
 - Fix: with `--out`, semantic-cache writes now anchor correctly so the cache round-trips (#1990, #1991, thanks @mdshzb04). The final semantic-cache save resolved a relative `source_file` against the output dir and wrote 0 entries, and per-chunk recovery checkpoints landed in the wrong directory (under the corpus instead of `--out`). Cache entries now key on the scan root (portable, matching #1989) while the cache directory sits at the output root, so `check`/`save`/checkpoint/prune all agree; composes with the #1989 salt-keying and #1939 prompt-fingerprint namespacing.
 - Fix: alias-based named re-exports no longer emit dangling absolute-path symbol targets (#1983, thanks @oleksii-tumanov). `export { X as Y } from './mod'` produced a `re_exports` edge whose symbol target was an absolute-path-prefixed id with no matching node — the symbol-level residual left by #1967 (imports-only) and #1976 (file-level). The aliased re-export target is now rewritten to the canonical symbol node when unambiguous; external re-exports and owned ids are left untouched, so no real edge is dropped.
-
 ## 0.9.19 (2026-07-18)
 
 - Feat: opt-in strict PreToolUse hook that actually makes agents use the graph. The installed Claude Code hook has always *nudged* the agent to run `graphify query` before reading raw files, but a nudge is advisory `additionalContext` the model routinely walks past mid-task. `graphify install --project --strict` (or `graphify claude install --strict`) now installs a hook that *blocks* the first raw source read of a session (`permissionDecision: "deny"`) with a redirect to `graphify query`, then downgrades to the soft nudge — so it fires at most once per session and can never strand the agent (the next read proceeds even if no query ran, or if `graphify query` itself failed). Running any `graphify query`/`explain`/`path` refreshes a short-lived "recently oriented" stamp that suppresses the block. Strict mode is Claude Code only (Bash-grep and Glob stay nudge-only; Gemini/Codex/OpenCode can't hard-block and are unchanged); `GRAPHIFY_HOOK_STRICT=1`/`0` toggles it at runtime without a reinstall. Default installs are unchanged (soft nudge).

--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ What you get out of the box:
 | **Beyond code** | Docs, PDFs, images, and video/audio all map into the same graph |
 | **Local-first** | Code is parsed locally with tree-sitter (no LLM, nothing leaves your machine); only the semantic pass over docs/media calls a backend, and only if you configure one |
 
+### MemoryGuard metadata export
+
+Graphify can export a complete, body-free structural projection for
+[MemoryGuard](https://github.com/irisxc4/memoryguard)'s CodeGraph V2:
+
+```bash
+graphify export memoryguard-metadata /path/to/repository
+```
+
+The `memoryguard-graphify-metadata-v1` payload contains repository-relative
+paths, content hashes, structural symbols and edges, source role/provenance,
+source maps, and bounded diagnostics. It deliberately excludes source bodies,
+absolute paths, credentials, and arbitrary extractor text. Pass selected files
+after the root for a bounded export, or use `--incremental` and
+`--no-parallel` when integrating it into a controlled ingestion pipeline.
+
 ---
 
 ## Benchmarks

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -31,6 +31,20 @@ graphify 分两轮执行。第一轮是确定性的 AST 提取，对代码文件
 
 每条关系都会被标记为 `EXTRACTED`（直接在源材料中找到）、`INFERRED`（合理推断，并附带置信度分数）或 `AMBIGUOUS`（有歧义，需要复核）。所以你始终知道哪些是实际发现的，哪些是模型猜出来的。
 
+## MemoryGuard 元数据导出
+
+Graphify 也可以为 [MemoryGuard](https://github.com/irisxc4/memoryguard) 的
+CodeGraph V2 导出完整但不含正文的结构投影：
+
+```bash
+graphify export memoryguard-metadata /path/to/repository
+```
+
+`memoryguard-graphify-metadata-v1` 只包含仓库相对路径、内容哈希、结构化
+符号和边、source role/provenance、source map 以及有界诊断信息；不会导出
+源码正文、绝对路径、凭据或任意提取器文本。根目录后可继续指定文件做范围
+受限导出，也可使用 `--incremental` 和 `--no-parallel` 接入受控导入流水线。
+
 ## 安装
 
 **要求：** Python 3.10+，并且使用以下平台之一：[Claude Code](https://claude.ai/code)、[CodeBuddy](https://codebuddy.ai)、[Codex](https://openai.com/codex)、[OpenCode](https://opencode.ai)、[OpenClaw](https://openclaw.ai)、[Factory Droid](https://factory.ai) 或 [Trae](https://trae.ai)

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -625,6 +625,7 @@ def _run_cli() -> None:
         print("  global path              print path to the global graph file")
         print("  benchmark [graph.json]  measure token reduction vs naive full-corpus approach")
         print("  export callflow-html    emit Mermaid-based architecture/call-flow HTML")
+        print("  export memoryguard-metadata ROOT  emit memoryguard-graphify-metadata-v1")
         print("  hook install            install post-commit/post-checkout git hooks (all platforms)")
         print("  hook uninstall          remove git hooks")
         print("  hook status             check if git hooks are installed")
@@ -703,7 +704,8 @@ def _run_cli() -> None:
     # Exempt: free-text commands (user string may contain these tokens), and
     # "install"/"uninstall" which have their own per-subcommand help handlers.
     _FREE_TEXT_CMDS = {"query", "explain", "path", "save-result", "install", "uninstall"}
-    if cmd not in _FREE_TEXT_CMDS and any(a in {"-h", "--help", "-?"} for a in sys.argv[2:]):
+    _export_top_help = cmd == "export" and sys.argv[2:] in (["-h"], ["--help"], ["-?"])
+    if not _export_top_help and cmd not in _FREE_TEXT_CMDS and any(a in {"-h", "--help", "-?"} for a in sys.argv[2:]):
         print(f"Run 'graphify --help' for full usage.")
         return
 

--- a/graphify/build.py
+++ b/graphify/build.py
@@ -548,21 +548,14 @@ def dedupe_nodes(nodes: list[dict]) -> list[dict]:
 
 
 def dedupe_edges(edges: list[dict]) -> list[dict]:
-    """Collapse exact parallel edges by ``(source, target, relation)``, keeping the
-    first occurrence.
-
-    The clustered build path runs edges through a NetworkX ``DiGraph``, which
-    collapses parallel edges automatically. The ``--no-cluster`` and incremental
-    ``update`` write paths bypass NetworkX and concatenate edge lists raw, so
-    duplicates accumulate and edge counts become non-deterministic across build
-    modes / repeated updates (#1317). Deduping on the connectivity identity is
-    zero-signal-loss and restores idempotency. Callers that intentionally keep
-    parallel edges (multigraph output) must not use this.
-    """
+    """Collapse only semantically identical parallel edges."""
     seen: set[tuple] = set()
     out: list[dict] = []
     for e in edges:
-        key = (e.get("source"), e.get("target"), e.get("relation"))
+        key = (
+            e.get("source"), e.get("target"), e.get("relation"),
+            e.get("context"), e.get("provenance"), e.get("source_location"),
+        )
         if key in seen:
             continue
         seen.add(key)

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -2424,20 +2424,64 @@ def dispatch_command(cmd: str) -> None:
 
     elif cmd == "export":
         subcmd = sys.argv[2] if len(sys.argv) > 2 else ""
-        if subcmd not in ("html", "callflow-html", "obsidian", "wiki", "svg", "graphml", "neo4j", "falkordb"):
-            print("Usage: graphify export <format>", file=sys.stderr)
-            print("  html      [--graph PATH] [--labels PATH] [--node-limit N] [--no-viz]", file=sys.stderr)
-            print("  callflow-html [GRAPH|DIR] [--graph PATH] [--labels PATH] [--report PATH] [--sections PATH] [--output HTML]", file=sys.stderr)
-            print("            [--lang auto|zh-CN|en] [--max-sections N] [--diagram-scale N]", file=sys.stderr)
-            print("  obsidian  [--graph PATH] [--labels PATH] [--dir PATH]", file=sys.stderr)
-            print("  wiki      [--graph PATH] [--labels PATH]", file=sys.stderr)
-            print("  svg       [--graph PATH] [--labels PATH]", file=sys.stderr)
-            print("  graphml   [--graph PATH]", file=sys.stderr)
-            print("  neo4j     [--graph PATH] [--push URI] [--user U] [--password P]", file=sys.stderr)
-            print("            (or set NEO4J_PASSWORD instead of --password to keep it off argv)", file=sys.stderr)
-            print("  falkordb  [--graph PATH] [--push URI] [--user U] [--password P]", file=sys.stderr)
-            print("            (or set FALKORDB_PASSWORD instead of --password to keep it off argv)", file=sys.stderr)
+        export_help = subcmd in ("-h", "--help", "-?")
+        if export_help or subcmd not in ("html", "callflow-html", "obsidian", "wiki", "svg", "graphml", "neo4j", "falkordb", "memoryguard-metadata"):
+            stream = sys.stdout if export_help else sys.stderr
+            print("Usage: graphify export <format>", file=stream)
+            print("  html      [--graph PATH] [--labels PATH] [--node-limit N] [--no-viz]", file=stream)
+            print("  callflow-html [GRAPH|DIR] [--graph PATH] [--labels PATH] [--report PATH] [--sections PATH] [--output HTML]", file=stream)
+            print("            [--lang auto|zh-CN|en] [--max-sections N] [--diagram-scale N]", file=stream)
+            print("  obsidian  [--graph PATH] [--labels PATH] [--dir PATH]", file=stream)
+            print("  wiki      [--graph PATH] [--labels PATH]", file=stream)
+            print("  svg       [--graph PATH] [--labels PATH]", file=stream)
+            print("  graphml   [--graph PATH]", file=stream)
+            print("  neo4j     [--graph PATH] [--push URI] [--user U] [--password P]", file=stream)
+            print("            (or set NEO4J_PASSWORD instead of --password to keep it off argv)", file=stream)
+            print("  falkordb  [--graph PATH] [--push URI] [--user U] [--password P]", file=stream)
+            print("            (or set FALKORDB_PASSWORD instead of --password to keep it off argv)", file=stream)
+            print("  memoryguard-metadata ROOT [PATH ...] [--incremental] [--no-parallel]", file=stream)
+            print("            emits memoryguard-graphify-metadata-v1 body-free metadata JSON", file=stream)
+            if export_help:
+                return
             sys.exit(1)
+
+        if subcmd == "memoryguard-metadata":
+            from graphify.memoryguard_export import export_repository
+
+            args = sys.argv[3:]
+            if not args or any(value in ("-h", "--help", "-?") for value in args):
+                print("Usage: graphify export memoryguard-metadata ROOT [PATH ...] [--incremental] [--no-parallel]")
+                print("  Emits memoryguard-graphify-metadata-v1 body-free metadata JSON.")
+                print("  PATH values are repository-relative files; omit them for a complete repository export.")
+                if not args:
+                    sys.exit(1)
+                return
+            root = args[0]
+            paths: list[str] = []
+            complete = True
+            parallel = True
+            for value in args[1:]:
+                if value == "--incremental":
+                    complete = False
+                elif value == "--no-parallel":
+                    parallel = False
+                elif value.startswith("-"):
+                    print(f"error: unknown memoryguard-metadata option: {value}", file=sys.stderr)
+                    sys.exit(1)
+                else:
+                    paths.append(value)
+            try:
+                payload = export_repository(
+                    root,
+                    paths=paths or None,
+                    complete=complete,
+                    parallel=parallel,
+                )
+            except Exception as exc:
+                print(f"error: memoryguard metadata export failed: {exc}", file=sys.stderr)
+                sys.exit(1)
+            print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+            return
 
         # Parse shared args
         args = sys.argv[3:]

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1214,10 +1214,22 @@ def _extract_python_rationale(path: Path, result: dict) -> None:
 # ── Public API ────────────────────────────────────────────────────────────────
 
 def extract_python(path: Path) -> dict:
-    """Extract classes, functions, and imports from a .py file via tree-sitter AST."""
+    """Extract Python structure plus embedded HTML/JS GUI semantics."""
     result = _extract_generic(path, _PYTHON_CONFIG)
     if "error" not in result:
         _extract_python_rationale(path, result)
+        try:
+            from .extractors.embedded import extract_embedded_python, merge_embedded_result
+
+            embedded = extract_embedded_python(path)
+            merge_embedded_result(result, embedded, path)
+        except Exception as exc:
+            # Embedded extraction is additive; malformed virtual documents must
+            # not erase ordinary Graphify AST output.
+            result.setdefault("diagnostics", []).append({
+                "code": "embedded_extraction_failed",
+                "error_type": type(exc).__name__,
+            })
     return result
 
 
@@ -6561,6 +6573,24 @@ def extract(
     # so it cannot be popped at that earlier point without breaking the fix.
     for e in all_edges:
         e.pop("local_alias", None)
+
+    # Stamp source-role provenance after cross-file resolution so resolver
+    # identity remains independent of this export-only metadata.
+    from .extractors.embedded import provenance_for_path
+
+    node_provenance: dict[str, str] = {}
+    for n in all_nodes:
+        source_file = str(n.get("source_file") or "")
+        provenance = str(n.get("provenance") or "") or provenance_for_path(source_file)
+        n["provenance"] = provenance
+        node_id = str(n.get("id") or "")
+        if node_id:
+            node_provenance[node_id] = provenance
+    for e in all_edges:
+        if e.get("provenance"):
+            continue
+        source_file = str(e.get("source_file") or "")
+        e["provenance"] = provenance_for_path(source_file) if source_file else node_provenance.get(str(e.get("source") or ""), "unknown")
 
     # Tag AST provenance so the incremental watch rebuild can distinguish
     # AST-extracted nodes from semantic/LLM nodes. On a full re-extraction

--- a/graphify/extractors/embedded.py
+++ b/graphify/extractors/embedded.py
@@ -1,0 +1,568 @@
+"""Embedded HTML/JavaScript extraction from Python string regions.
+
+This module is deliberately deterministic and failure-isolated.  It never
+executes Python/HTML/JavaScript.  Python AST identifies string regions,
+including f-strings, while a tiny HTML/JS structural pass emits GUI semantic
+nodes and ``references`` edges:
+
+    control -> handler -> api_method -> surface_spec -> native_handler
+
+The latter two hops are emitted from ``surfaces.py`` and ``native_ports.py``
+AST, so repository-wide graph construction resolves one stable semantic chain.
+Embedded source locations map back to the host Python file.  Nodes/edges carry
+``provenance`` and source-map metadata; source bodies are never attached.
+"""
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+import hashlib
+from html.parser import HTMLParser
+from pathlib import Path
+import re
+from typing import Any, Iterable, Mapping
+
+
+MAX_EMBEDDED_FRAGMENTS = 96
+MAX_FRAGMENT_BYTES = 768 * 1024
+MAX_CONTROLS = 10_000
+MAX_SCRIPT_BLOCKS = 256
+
+_HTML_HINT = re.compile(r"<(?:html|script|button|a|div|section|main|body|input|form|style)\b", re.I)
+_HANDLER_CALL = re.compile(r"(?:^|[^A-Za-z0-9_$])(?:await\s+)?([A-Za-z_$][\w$]*)\s*\(")
+_API_CALL = re.compile(
+    r"\b(?:callApi|callApiRaw|api|detailApi|dispatch_api)\s*\(\s*(['\"])([A-Za-z_][A-Za-z0-9_-]*)\1"
+)
+_FUNCTION_RE = re.compile(r"\b(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\{")
+_ARROW_RE = re.compile(r"\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>\s*\{")
+_NAVIGATION_RE = re.compile(r"(?:window\.)?location(?:\.href)?\s*=\s*(['\"])([^'\"]+)\1", re.I)
+
+
+def _digest(*parts: object) -> str:
+    return hashlib.sha256("\x1f".join(str(part) for part in parts).encode("utf-8")).hexdigest()
+
+
+def _source_location(line: int) -> str:
+    return f"L{max(1, int(line or 1))}"
+
+
+def _line_for_offset(text: str, offset: int, base_line: int) -> int:
+    return max(1, int(base_line)) + text.count("\n", 0, max(0, offset))
+
+
+def _safe_label(value: str, *, limit: int = 240) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()[:limit]
+
+
+def provenance_for_path(path: str | Path) -> str:
+    """Classify source role; embedded nodes inherit this value unchanged."""
+    value = str(path).replace("\\", "/").casefold()
+    parts = tuple(part for part in value.split("/") if part)
+    name = parts[-1] if parts else value
+    if any(part in {"fixtures", "fixture", "testdata", "test-data", "samples", "sample"} for part in parts) or name.startswith("fixture") or ".fixture." in name:
+        return "fixture"
+    if any(part in {"generated", "gen", "dist", "build", "coverage", ".cache"} for part in parts):
+        return "generated"
+    if any(part in {"vendor", "vendors", "third_party", "third-party", "node_modules"} for part in parts):
+        return "vendor"
+    try:
+        from graphify.paths import _is_test_path  # type: ignore
+
+        if _is_test_path(Path(path)):
+            return "test"
+    except Exception:
+        pass
+    if any(part in {"test", "tests", "testing", "spec", "specs", "__tests__"} for part in parts) or name.startswith("test_") or name.endswith("_test.py"):
+        return "test"
+    return "production"
+
+
+def stamp_provenance(result: dict[str, Any], path: str | Path) -> dict[str, Any]:
+    provenance = provenance_for_path(path)
+    for node in result.get("nodes", ()):
+        if isinstance(node, dict):
+            node.setdefault("provenance", provenance)
+    for edge in result.get("edges", ()):
+        if isinstance(edge, dict):
+            edge.setdefault("provenance", provenance)
+    return result
+
+
+@dataclass(frozen=True)
+class VirtualDocument:
+    virtual_id: str
+    host_file: str
+    host_symbol: str
+    region_id: str
+    text: str
+    start_line: int
+    provenance: str
+    content_hash: str
+
+    def source_map(self, virtual_line: int = 1) -> dict[str, Any]:
+        return {
+            "host_file": self.host_file,
+            "host_symbol": self.host_symbol,
+            "region_id": self.region_id,
+            "virtual_document_id": self.virtual_id,
+            "line_start": self.start_line + max(0, int(virtual_line) - 1),
+        }
+
+
+@dataclass
+class _Region:
+    text: str
+    line: int
+    host_symbol: str
+
+
+def _flatten_string(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            elif isinstance(value, ast.FormattedValue):
+                parts.append("__GRAPHIFY_EXPR__")
+        return "".join(parts)
+    return None
+
+
+def _target_name(stmt: ast.stmt, fallback: str) -> str:
+    target = getattr(stmt, "targets", None)
+    if isinstance(target, list) and target:
+        value = target[0]
+        if isinstance(value, ast.Name):
+            return value.id
+        if isinstance(value, ast.Attribute):
+            return value.attr
+    target = getattr(stmt, "target", None)
+    if isinstance(target, ast.Name):
+        return target.id
+    return fallback
+
+
+def _regions_from_block(body: Iterable[ast.stmt], host_symbol: str, output: list[_Region]) -> None:
+    """Walk reachable statements only; stop after unconditional return/raise."""
+    for stmt in body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            _regions_from_block(stmt.body, stmt.name, output)
+        elif isinstance(stmt, ast.ClassDef):
+            _regions_from_block(stmt.body, f"{host_symbol}.{stmt.name}" if host_symbol else stmt.name, output)
+        elif isinstance(stmt, ast.If):
+            _regions_from_block(stmt.body, host_symbol, output)
+            _regions_from_block(stmt.orelse, host_symbol, output)
+        elif isinstance(stmt, (ast.For, ast.AsyncFor, ast.While)):
+            _regions_from_block(stmt.body, host_symbol, output)
+            _regions_from_block(stmt.orelse, host_symbol, output)
+        elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+            _regions_from_block(stmt.body, host_symbol, output)
+        elif isinstance(stmt, ast.Try):
+            _regions_from_block(stmt.body, host_symbol, output)
+            for handler in stmt.handlers:
+                _regions_from_block(handler.body, host_symbol, output)
+            _regions_from_block(stmt.orelse, host_symbol, output)
+            _regions_from_block(stmt.finalbody, host_symbol, output)
+        elif isinstance(stmt, ast.Match):
+            for case in stmt.cases:
+                _regions_from_block(case.body, host_symbol, output)
+        else:
+            value: ast.AST | None = None
+            if isinstance(stmt, (ast.Assign, ast.AnnAssign, ast.Return, ast.Expr)):
+                value = getattr(stmt, "value", None)
+            text = _flatten_string(value)
+            if text is not None and _HTML_HINT.search(text):
+                output.append(_Region(text, int(getattr(value, "lineno", getattr(stmt, "lineno", 1)) or 1), _target_name(stmt, host_symbol or "<module>")))
+        if isinstance(stmt, (ast.Return, ast.Raise)):
+            break
+
+
+def discover_virtual_documents(path: str | Path) -> tuple[tuple[VirtualDocument, ...], tuple[dict[str, Any], ...]]:
+    source_path = Path(path)
+    diagnostics: list[dict[str, Any]] = []
+    try:
+        source = source_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(source_path))
+    except (OSError, UnicodeError, SyntaxError) as exc:
+        return (), ({"code": "embedded_python_parse_failed", "error_type": type(exc).__name__},)
+    regions: list[_Region] = []
+    _regions_from_block(tree.body, "<module>", regions)
+    documents: list[VirtualDocument] = []
+    provenance = provenance_for_path(source_path)
+    for index, region in enumerate(regions):
+        if index >= MAX_EMBEDDED_FRAGMENTS:
+            diagnostics.append({"code": "embedded_fragment_limit", "limit": MAX_EMBEDDED_FRAGMENTS})
+            break
+        size = len(region.text.encode("utf-8"))
+        if size > MAX_FRAGMENT_BYTES:
+            diagnostics.append({"code": "embedded_fragment_too_large", "index": index, "bytes": size, "limit": MAX_FRAGMENT_BYTES})
+            continue
+        content_hash = hashlib.sha256(region.text.encode("utf-8")).hexdigest()
+        region_id = f"region-{index}-{content_hash[:16]}"
+        virtual_id = "embedded-" + _digest(str(source_path).replace("\\", "/"), region.host_symbol, index, content_hash)
+        documents.append(VirtualDocument(virtual_id, str(source_path), region.host_symbol, region_id, region.text, region.line, provenance, content_hash))
+    return tuple(documents), tuple(diagnostics)
+
+
+class _HtmlCollector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.controls: list[dict[str, Any]] = []
+        self.scripts: list[dict[str, Any]] = []
+        self._control_stack: list[dict[str, Any]] = []
+        self._script: dict[str, Any] | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        data = {str(key).casefold(): str(value or "") for key, value in attrs}
+        tag_name = tag.casefold()
+        if tag_name == "script":
+            self._script = {"line": self.getpos()[0], "parts": []}
+        if tag_name in {"button", "a"} or data.get("role", "").casefold() == "button" or "onclick" in data:
+            if len(self.controls) + len(self._control_stack) < MAX_CONTROLS:
+                self._control_stack.append({"tag": tag_name, "attrs": data, "line": self.getpos()[0], "parts": []})
+
+    def handle_endtag(self, tag: str) -> None:
+        tag_name = tag.casefold()
+        if tag_name == "script" and self._script is not None:
+            self.scripts.append({"line": self._script["line"], "text": "".join(self._script["parts"])})
+            self._script = None
+        for index in range(len(self._control_stack) - 1, -1, -1):
+            if self._control_stack[index]["tag"] == tag_name:
+                item = self._control_stack.pop(index)
+                item["label"] = _safe_label("".join(item.pop("parts")))
+                self.controls.append(item)
+                break
+
+    def handle_data(self, data: str) -> None:
+        if self._script is not None:
+            self._script["parts"].append(data)
+        if self._control_stack:
+            self._control_stack[-1]["parts"].append(data)
+
+
+def _handler_name(onclick: str) -> str:
+    match = _HANDLER_CALL.search(str(onclick or ""))
+    if not match:
+        return ""
+    name = match.group(1)
+    return "" if name in {"if", "for", "while", "confirm", "alert"} else name
+
+
+def _matching_brace(source: str, start: int) -> int:
+    depth = 0
+    quote = ""
+    escaped = False
+    line_comment = False
+    block_comment = False
+    index = start
+    while index < len(source):
+        char = source[index]
+        nxt = source[index + 1] if index + 1 < len(source) else ""
+        if line_comment:
+            if char == "\n":
+                line_comment = False
+            index += 1
+            continue
+        if block_comment:
+            if char == "*" and nxt == "/":
+                block_comment = False
+                index += 2
+                continue
+            index += 1
+            continue
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = ""
+            index += 1
+            continue
+        if char == "/" and nxt == "/":
+            line_comment = True
+            index += 2
+            continue
+        if char == "/" and nxt == "*":
+            block_comment = True
+            index += 2
+            continue
+        if char in {"'", '"', "`"}:
+            quote = char
+            index += 1
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return len(source) - 1
+
+
+def _javascript_functions(script: str) -> list[tuple[str, int, int]]:
+    matches: list[tuple[str, int, int]] = []
+    seen: set[tuple[str, int]] = set()
+    for pattern in (_FUNCTION_RE, _ARROW_RE):
+        for match in pattern.finditer(script):
+            brace = script.find("{", match.start(), match.end() + 1)
+            if brace < 0:
+                continue
+            key = (match.group(1), match.start())
+            if key in seen:
+                continue
+            seen.add(key)
+            matches.append((match.group(1), match.start(), _matching_brace(script, brace)))
+    return sorted(matches, key=lambda item: (item[1], item[0]))
+
+
+def _node(node_id: str, label: str, kind: str, document: VirtualDocument, line: int, semantic_kind: str, **extra: Any) -> dict[str, Any]:
+    value = {
+        "id": node_id,
+        "label": label,
+        "file_type": kind,
+        "source_file": document.host_file,
+        "source_location": _source_location(line),
+        "provenance": document.provenance,
+        "semantic_kind": semantic_kind,
+        "source_map": {**document.source_map(max(1, line - document.start_line + 1)), "content_hash": document.content_hash},
+        "metadata": {"semantic_kind": semantic_kind, "host_symbol": document.host_symbol, "region_id": document.region_id, "virtual_document_id": document.virtual_id},
+    }
+    value.update(extra)
+    return value
+
+
+def _edge(source: str, target: str, context: str, document: VirtualDocument, line: int, **extra: Any) -> dict[str, Any]:
+    value = {
+        "source": source,
+        "target": target,
+        "relation": "references",
+        "context": context,
+        "confidence": "EXTRACTED",
+        "source_file": document.host_file,
+        "source_location": _source_location(line),
+        "provenance": document.provenance,
+        "metadata": {"semantic_kind": context, "region_id": document.region_id, "virtual_document_id": document.virtual_id},
+        "weight": 1.0,
+    }
+    value.update(extra)
+    return value
+
+
+def _handler_id(path: str, name: str) -> str:
+    return "embedded-handler-" + _digest(path.replace("\\", "/"), name)
+
+
+def _api_id(name: str) -> str:
+    return "semantic-api-" + _digest(name)
+
+
+def _surface_id(name: str) -> str:
+    return "semantic-surface-" + _digest(name)
+
+
+def _native_id(name: str) -> str:
+    return "semantic-native-" + _digest(name.lstrip("_"))
+
+
+def _extract_document(document: VirtualDocument) -> dict[str, Any]:
+    parser = _HtmlCollector()
+    try:
+        parser.feed(document.text)
+    except Exception as exc:
+        return {"nodes": [], "edges": [], "diagnostics": [{"code": "embedded_html_parse_failed", "error_type": type(exc).__name__}]}
+    nodes: dict[str, dict[str, Any]] = {}
+    edges: list[dict[str, Any]] = []
+    handler_lines: dict[str, int] = {}
+
+    for script_block in parser.scripts[:MAX_SCRIPT_BLOCKS]:
+        script = str(script_block.get("text") or "")
+        script_base_line = document.start_line + int(script_block.get("line") or 1) - 1
+        for name, start, end in _javascript_functions(script):
+            line = _line_for_offset(script, start, script_base_line)
+            handler_lines.setdefault(name, line)
+            handler_id = _handler_id(document.host_file, name)
+            nodes.setdefault(handler_id, _node(handler_id, name, "function", document, line, "handler"))
+            body = script[start:end + 1]
+            for api_match in _API_CALL.finditer(body):
+                method = api_match.group(2)
+                api_line = _line_for_offset(script, start + api_match.start(), script_base_line)
+                api_id = _api_id(method)
+                nodes.setdefault(api_id, _node(api_id, method, "api", document, api_line, "api_method"))
+                edges.append(_edge(handler_id, api_id, "handler_api", document, api_line))
+
+    for index, control in enumerate(parser.controls):
+        attrs = control.get("attrs") or {}
+        onclick = str(attrs.get("onclick") or "")
+        action = str(attrs.get("data-mg-action") or attrs.get("data-action") or "")
+        handler = _handler_name(onclick)
+        href = str(attrs.get("href") or "").strip()
+        navigation = ""
+        if not handler:
+            nav_match = _NAVIGATION_RE.search(onclick)
+            navigation = (nav_match.group(2) if nav_match else href).strip()
+        label = _safe_label(control.get("label") or attrs.get("aria-label") or attrs.get("title") or action or control.get("tag") or "control")
+        line = document.start_line + int(control.get("line") or 1) - 1
+        control_id = "embedded-control-" + _digest(document.virtual_id, index, label, onclick, action)
+        nodes[control_id] = _node(control_id, label, "gui_control", document, line, "gui_control", metadata={"semantic_kind": "gui_control", "host_symbol": document.host_symbol, "region_id": document.region_id, "virtual_document_id": document.virtual_id, "action": action})
+        if handler:
+            handler_id = _handler_id(document.host_file, handler)
+            handler_line = handler_lines.get(handler, line)
+            nodes.setdefault(handler_id, _node(handler_id, handler, "function", document, handler_line, "handler"))
+            edges.append(_edge(control_id, handler_id, "control_handler", document, line))
+        elif navigation:
+            local_handler = f"navigate:{navigation}"
+            handler_id = _handler_id(document.host_file, local_handler)
+            nodes.setdefault(handler_id, _node(handler_id, local_handler, "function", document, line, "handler", metadata={"semantic_kind": "handler", "local_action": "navigation", "target": navigation, "host_symbol": document.host_symbol, "region_id": document.region_id, "virtual_document_id": document.virtual_id}))
+            edges.append(_edge(control_id, handler_id, "control_handler", document, line, metadata={"semantic_kind": "control_handler", "local_action": "navigation", "target": navigation, "region_id": document.region_id, "virtual_document_id": document.virtual_id}))
+
+    return {"nodes": list(nodes.values()), "edges": edges, "diagnostics": []}
+
+
+def _literal(node: ast.AST | None) -> Any:
+    try:
+        return ast.literal_eval(node) if node is not None else None
+    except Exception:
+        return None
+
+
+def _semantic_python_nodes(path: Path, tree: ast.AST, provenance: str) -> dict[str, list[dict[str, Any]]]:
+    """Emit cross-file surface/native semantic anchors from Python AST."""
+    nodes: dict[str, dict[str, Any]] = {}
+    edges: list[dict[str, Any]] = []
+    source = str(path)
+    if path.name == "surfaces.py":
+        def add_surface(public: str, handler: str, line: int) -> None:
+            api_id, surface_id, native_id = _api_id(public), _surface_id(public), _native_id(handler)
+            api_node = {"id": api_id, "label": public, "file_type": "api", "source_file": source, "source_location": _source_location(line), "provenance": provenance, "semantic_kind": "api_method", "metadata": {"semantic_kind": "api_method"}}
+            surface_node = {"id": surface_id, "label": f"GuiOperationSpec:{public}", "file_type": "surface", "source_file": source, "source_location": _source_location(line), "provenance": provenance, "semantic_kind": "surface_spec", "metadata": {"semantic_kind": "surface_spec", "native_handler": handler}}
+            nodes.setdefault(api_id, api_node); nodes.setdefault(surface_id, surface_node)
+            edges.append({"source": api_id, "target": surface_id, "relation": "references", "context": "api_surface", "confidence": "EXTRACTED", "source_file": source, "source_location": _source_location(line), "provenance": provenance, "metadata": {"semantic_kind": "api_surface"}, "weight": 1.0})
+            edges.append({"source": surface_id, "target": native_id, "relation": "references", "context": "surface_native", "confidence": "EXTRACTED", "source_file": source, "source_location": _source_location(line), "provenance": provenance, "metadata": {"semantic_kind": "surface_native"}, "weight": 1.0})
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                continue
+            if node.func.id == "_add" and len(node.args) >= 5:
+                public = _literal(node.args[0])
+                handler = _literal(node.args[4])
+                if isinstance(public, str) and isinstance(handler, str):
+                    add_surface(public, handler, int(node.lineno))
+                continue
+            if node.func.id == "_same" and len(node.args) >= 4:
+                names = _literal(node.args[0])
+                handler = _literal(node.args[3])
+                if not isinstance(handler, str) or not isinstance(names, (tuple, list, set)):
+                    continue
+                for public in names:
+                    if isinstance(public, str) and public:
+                        add_surface(public, handler, int(node.lineno))
+        for loop in tree.body:
+            if not isinstance(loop, ast.For) or not isinstance(loop.target, ast.Name):
+                continue
+            values = _literal(loop.iter)
+            if not isinstance(values, (tuple, list, set)) or any(not isinstance(item, str) for item in values):
+                continue
+            loop_name = loop.target.id
+            for stmt in loop.body:
+                for call in ast.walk(stmt):
+                    if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name) or call.func.id != "_add" or len(call.args) < 5:
+                        continue
+                    if not isinstance(call.args[0], ast.Name) or call.args[0].id != loop_name:
+                        continue
+                    handler = _literal(call.args[4])
+                    if not isinstance(handler, str):
+                        continue
+                    for public in values:
+                        add_surface(public, handler, int(call.lineno))
+    elif path.name == "native_ports.py":
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                semantic = node.name.lstrip("_")
+                native_id = _native_id(semantic)
+                nodes.setdefault(native_id, {"id": native_id, "label": semantic, "file_type": "native", "source_file": source, "source_location": _source_location(node.lineno), "provenance": provenance, "semantic_kind": "native_handler", "metadata": {"semantic_kind": "native_handler"}})
+        for node in ast.walk(tree):
+            value = None
+            if isinstance(node, ast.Assign):
+                if any(isinstance(target, ast.Name) and target.id == "methods" for target in node.targets):
+                    value = node.value
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == "methods":
+                value = node.value
+            if not isinstance(value, ast.Dict):
+                continue
+            for key_node, value_node in zip(value.keys, value.values):
+                handler = _literal(key_node)
+                if not isinstance(handler, str) or not handler:
+                    continue
+                line = int(getattr(value_node, "lineno", getattr(node, "lineno", 1)) or 1)
+                native_id = _native_id(handler)
+                nodes.setdefault(native_id, {"id": native_id, "label": handler, "file_type": "native", "source_file": source, "source_location": _source_location(line), "provenance": provenance, "semantic_kind": "native_handler", "metadata": {"semantic_kind": "native_handler", "dispatch_alias": True}})
+    return {"nodes": list(nodes.values()), "edges": edges}
+
+
+def extract_embedded_python(path: str | Path) -> dict[str, Any]:
+    source_path = Path(path)
+    documents, diagnostics = discover_virtual_documents(source_path)
+    nodes: dict[str, dict[str, Any]] = {}
+    edges: list[dict[str, Any]] = []
+    all_diagnostics = list(diagnostics)
+    for document in documents:
+        result = _extract_document(document)
+        for node in result["nodes"]:
+            nodes.setdefault(str(node.get("id") or ""), node)
+        edges.extend(result["edges"])
+        all_diagnostics.extend(result["diagnostics"])
+    try:
+        source = source_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(source_path))
+        semantics = _semantic_python_nodes(source_path, tree, provenance_for_path(source_path))
+        for node in semantics["nodes"]:
+            nodes.setdefault(str(node.get("id") or ""), node)
+        edges.extend(semantics["edges"])
+    except (OSError, UnicodeError, SyntaxError) as exc:
+        all_diagnostics.append({"code": "embedded_semantic_python_failed", "error_type": type(exc).__name__})
+    edge_map: dict[tuple[str, ...], dict[str, Any]] = {}
+    for edge in edges:
+        key = (
+            str(edge.get("source") or ""), str(edge.get("target") or ""),
+            str(edge.get("relation") or ""), str(edge.get("context") or ""),
+            str(edge.get("provenance") or ""), str(edge.get("source_location") or ""),
+        )
+        edge_map.setdefault(key, edge)
+    return {"nodes": list(nodes.values()), "edges": list(edge_map.values()), "diagnostics": all_diagnostics, "virtual_documents": [doc.virtual_id for doc in documents]}
+
+
+def merge_embedded_result(base: dict[str, Any], embedded: Mapping[str, Any], path: str | Path) -> dict[str, Any]:
+    # Embedded semantic rows already carry source-role provenance. Leave the
+    # ordinary AST rows untouched until aggregate cross-file resolution has
+    # finished; early metadata changes exact-twin comparisons in alias import
+    # de-duplication.
+    nodes = base.setdefault("nodes", [])
+    edges = base.setdefault("edges", [])
+    known_nodes = {str(item.get("id") or "") for item in nodes if isinstance(item, Mapping)}
+    for node in embedded.get("nodes", ()):
+        if isinstance(node, dict) and str(node.get("id") or "") not in known_nodes:
+            nodes.append(node); known_nodes.add(str(node.get("id") or ""))
+    known_edges = {
+        (str(item.get("source") or ""), str(item.get("target") or ""), str(item.get("relation") or ""), str(item.get("context") or ""), str(item.get("provenance") or ""), str(item.get("source_location") or ""))
+        for item in edges if isinstance(item, Mapping)
+    }
+    for edge in embedded.get("edges", ()):
+        if not isinstance(edge, dict):
+            continue
+        key = (str(edge.get("source") or ""), str(edge.get("target") or ""), str(edge.get("relation") or ""), str(edge.get("context") or ""), str(edge.get("provenance") or ""), str(edge.get("source_location") or ""))
+        if key not in known_edges:
+            edges.append(edge); known_edges.add(key)
+    if embedded.get("diagnostics"):
+        base.setdefault("diagnostics", []).extend(embedded["diagnostics"])
+    return base
+
+
+__all__ = [
+    "MAX_EMBEDDED_FRAGMENTS", "MAX_FRAGMENT_BYTES", "VirtualDocument",
+    "discover_virtual_documents", "extract_embedded_python", "merge_embedded_result",
+    "provenance_for_path", "stamp_provenance",
+]

--- a/graphify/memoryguard_export.py
+++ b/graphify/memoryguard_export.py
@@ -1,0 +1,349 @@
+"""Body-free Graphify export for MemoryGuard CodeGraph V2.
+
+The exporter runs normal Graphify extraction, then emits only repository-
+relative paths, hashes, structural node/edge metadata, source maps, and
+provenance. Source bodies and absolute paths are never included.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+from importlib import metadata as importlib_metadata
+import json
+from pathlib import Path
+import re
+from typing import Any, Iterable, Mapping
+
+from graphify.extract import collect_files, extract
+from graphify.extractors.embedded import provenance_for_path
+
+
+EXPORT_FORMAT = "memoryguard-graphify-metadata-v1"
+_SOURCE_LOCATION = re.compile(r"^L(?P<start>\d+)(?:[-:](?:L)?(?P<end>\d+))?$")
+_BODY_MARKERS = ("{", "}", "<script", "</", "```", "'''", '\"\"\"')
+
+
+def _distribution_version() -> str:
+    for name in ("graphifyy", "graphify"):
+        try:
+            return importlib_metadata.version(name)
+        except importlib_metadata.PackageNotFoundError:
+            continue
+    return "unknown"
+
+
+# Resolve once while this module is imported from the active Graphify package.
+# Re-scanning importlib.metadata after a caller changes cwd can accidentally see
+# a different globally-installed distribution when running from a source tree.
+_GRAPHIFY_VERSION = _distribution_version()
+
+
+def _version() -> str:
+    return _GRAPHIFY_VERSION
+
+
+def _relative(root: Path, value: Any) -> str:
+    if not isinstance(value, (str, Path)) or not str(value).strip():
+        return ""
+    candidate = Path(value)
+    try:
+        resolved = candidate.resolve() if candidate.is_absolute() else (root / candidate).resolve()
+        relative = resolved.relative_to(root.resolve()).as_posix()
+    except (OSError, ValueError, RuntimeError):
+        return ""
+    if not relative or relative.startswith("../"):
+        return ""
+    return relative
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _language(path: str) -> str:
+    suffix = Path(path).suffix.casefold()
+    return {
+        ".py": "python", ".js": "javascript", ".mjs": "javascript",
+        ".cjs": "javascript", ".ts": "typescript", ".tsx": "typescript",
+        ".jsx": "javascript", ".vue": "vue", ".svelte": "svelte",
+        ".html": "html", ".css": "css", ".md": "markdown",
+        ".go": "go", ".rs": "rust", ".java": "java", ".kt": "kotlin",
+        ".cs": "csharp", ".cpp": "cpp", ".cc": "cpp", ".c": "c",
+        ".h": "c", ".hpp": "cpp", ".rb": "ruby", ".php": "php",
+        ".sql": "sql", ".sh": "bash", ".ps1": "powershell",
+    }.get(suffix, suffix.lstrip(".") or "unknown")
+
+
+def _line_map(relative_path: str, source_location: str) -> dict[str, Any]:
+    result: dict[str, Any] = {"path": relative_path}
+    match = _SOURCE_LOCATION.match(_safe_source_location(source_location))
+    if match:
+        result["line_start"] = int(match.group("start"))
+        result["line_end"] = int(match.group("end") or match.group("start"))
+    return result
+
+
+def _safe_source_location(value: Any) -> str:
+    """Keep only the line-range form; never export arbitrary extractor text."""
+    text = str(value or "").strip()
+    return text if _SOURCE_LOCATION.fullmatch(text) else ""
+
+
+def _safe_export_text(value: Any, *, limit: int) -> str:
+    text = str(value or "")
+    if any(marker in text.casefold() for marker in _BODY_MARKERS):
+        return ""
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:limit]
+
+
+def _semantic_id(semantic_kind: str, name: str, external_id: str) -> str:
+    kind = str(semantic_kind or "")
+    label = str(name or "")
+    if kind == "api_method" and label:
+        return "semantic-api-" + hashlib.sha256(label.encode("utf-8")).hexdigest()
+    if kind == "surface_spec" and label:
+        public = label.split(":", 1)[1] if label.startswith("GuiOperationSpec:") else label
+        return "semantic-surface-" + hashlib.sha256(public.encode("utf-8")).hexdigest()
+    if kind == "native_handler" and label:
+        return "semantic-native-" + hashlib.sha256(label.lstrip("_").encode("utf-8")).hexdigest()
+    return external_id
+
+
+def _semantic_priority(row: Mapping[str, Any]) -> tuple[int, str]:
+    kind = str(row.get("semantic_kind") or "")
+    path = str((row.get("source_map") or {}).get("path") or "")
+    if kind == "api_method":
+        return (0 if path.endswith("/surfaces.py") or path.endswith("surfaces.py") else 1, path)
+    if kind == "native_handler":
+        return (0 if path.endswith("/native_ports.py") or path.endswith("native_ports.py") else 1, path)
+    return (0, path)
+
+
+def _safe_metadata(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    allowed = {
+        "semantic_kind", "host_symbol", "region_id", "virtual_document_id",
+        "confidence", "language", "node_kind", "control_kind", "action",
+    }
+    result: dict[str, Any] = {}
+    for key in allowed:
+        item = value.get(key)
+        if isinstance(item, str):
+            safe = _safe_export_text(item, limit=256)
+            if safe:
+                result[key] = safe
+        elif isinstance(item, (int, float, bool)) or item is None:
+            result[key] = item
+    return result
+
+
+def export_repository(
+    root: str | Path,
+    *,
+    paths: Iterable[str | Path] | None = None,
+    complete: bool = True,
+    parallel: bool = True,
+    max_files: int = 50_000,
+) -> dict[str, Any]:
+    repo = Path(root).expanduser().resolve()
+    if not repo.is_dir():
+        raise ValueError("repository root is not a directory")
+    if paths is None:
+        files = collect_files(repo, follow_symlinks=False, root=repo)
+    else:
+        files = []
+        for raw in paths:
+            candidate = Path(raw)
+            candidate = candidate.resolve() if candidate.is_absolute() else (repo / candidate).resolve()
+            try:
+                candidate.relative_to(repo)
+            except ValueError as exc:
+                raise ValueError("export path escapes repository root") from exc
+            if candidate.is_file():
+                files.append(candidate)
+    files = sorted(dict.fromkeys(files), key=lambda item: item.as_posix().casefold())
+    if not files:
+        raise ValueError("graphify export has no source files")
+    if len(files) > max(1, int(max_files)):
+        raise ValueError("graphify export exceeds file limit")
+
+    file_rows: list[dict[str, Any]] = []
+    file_by_path: dict[str, dict[str, Any]] = {}
+    for file_path in files:
+        relative = file_path.relative_to(repo).as_posix()
+        provenance = provenance_for_path(relative)
+        item = {
+            "id": "file:" + hashlib.sha256(relative.encode("utf-8")).hexdigest(),
+            "path": relative,
+            "content_hash": _sha256(file_path),
+            "language": _language(relative),
+            "source_role": provenance,
+            "provenance": provenance,
+        }
+        file_rows.append(item)
+        file_by_path[relative] = item
+
+    extracted = extract(files, root=repo, parallel=bool(parallel))
+    raw_nodes = list(extracted.get("nodes") or [])
+    raw_edges = list(extracted.get("edges") or [])
+    node_by_id: dict[str, dict[str, Any]] = {}
+    node_file: dict[str, dict[str, Any]] = {}
+    external_to_canonical: dict[str, str] = {}
+
+    for node in raw_nodes:
+        if not isinstance(node, Mapping):
+            continue
+        external_id = str(node.get("id") or "").strip()
+        if not external_id:
+            continue
+        file_type = _safe_export_text(node.get("file_type") or node.get("kind") or "symbol", limit=128)
+        if file_type.casefold() in {"rationale", "docstring", "source_body", "comment"}:
+            # Rationale labels are source text, not graph metadata.
+            continue
+        relative = _relative(repo, node.get("source_file"))
+        file_item = file_by_path.get(relative)
+        if file_item is None:
+            continue
+        provenance = file_item["provenance"]
+        source_location = _safe_source_location(node.get("source_location"))
+        source_map = _line_map(relative, source_location)
+        raw_source_map = node.get("source_map")
+        if isinstance(raw_source_map, Mapping):
+            for key in ("host_symbol", "region_id", "virtual_document_id", "line_start", "line_end"):
+                value = raw_source_map.get(key)
+                if isinstance(value, (str, int)) and not isinstance(value, bool):
+                    source_map[key] = value
+        raw_metadata = node.get("metadata")
+        metadata_kind = raw_metadata.get("semantic_kind") if isinstance(raw_metadata, Mapping) else ""
+        semantic_kind = _safe_export_text(node.get("semantic_kind") or metadata_kind or "", limit=128)
+        name = _safe_export_text(node.get("label") or node.get("name") or external_id, limit=2048) or "symbol"
+        canonical_id = _semantic_id(semantic_kind, name, external_id)
+        external_to_canonical[external_id] = canonical_id
+        row = {
+            "id": canonical_id,
+            "file": file_item["id"],
+            "name": name,
+            "kind": file_type or "symbol",
+            "signature": _safe_export_text(node.get("signature"), limit=4096),
+            "source_location": source_location,
+            "provenance": provenance,
+            "semantic_kind": semantic_kind,
+            "source_map": source_map,
+            "metadata": _safe_metadata(node.get("metadata")),
+        }
+        row["metadata"].setdefault("semantic_kind", semantic_kind)
+        row["symbol_hash"] = hashlib.sha256(
+            json.dumps(
+                {key: row[key] for key in ("name", "kind", "signature", "source_location", "semantic_kind", "source_map")},
+                sort_keys=True, ensure_ascii=False, separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        existing = node_by_id.get(canonical_id)
+        if existing is None or _semantic_priority(row) < _semantic_priority(existing):
+            node_by_id[canonical_id] = row
+            node_file[canonical_id] = file_item
+
+    node_rows = list(node_by_id.values())
+    edge_rows: list[dict[str, Any]] = []
+    seen_edges: set[tuple[str, ...]] = set()
+    for edge in raw_edges:
+        if not isinstance(edge, Mapping):
+            continue
+        source_external = str(edge.get("source") or "").strip()
+        target_external = str(edge.get("target") or "").strip()
+        source = external_to_canonical.get(source_external, source_external)
+        target = external_to_canonical.get(target_external, target_external)
+        if source not in node_by_id or target not in node_by_id:
+            continue
+        source_item = node_file[source]
+        provenance = source_item["provenance"]
+        relation = _safe_export_text(edge.get("relation") or "related", limit=128) or "related"
+        context = _safe_export_text(edge.get("context"), limit=256)
+        source_location = _safe_source_location(edge.get("source_location"))
+        identity = (source, target, relation, context, provenance, source_location)
+        if identity in seen_edges:
+            continue
+        seen_edges.add(identity)
+        raw_edge_metadata = edge.get("metadata")
+        edge_metadata_kind = raw_edge_metadata.get("semantic_kind") if isinstance(raw_edge_metadata, Mapping) else ""
+        semantic_kind = _safe_export_text(edge.get("semantic_kind") or edge_metadata_kind or context, limit=128)
+        metadata = _safe_metadata(edge.get("metadata"))
+        metadata.setdefault("semantic_kind", semantic_kind)
+        confidence = edge.get("confidence")
+        if isinstance(confidence, str):
+            safe_confidence = _safe_export_text(confidence, limit=64)
+            if safe_confidence:
+                metadata["confidence"] = safe_confidence
+        try:
+            weight = float(edge.get("weight", 1.0) or 1.0)
+        except (TypeError, ValueError):
+            weight = 1.0
+        edge_rows.append({
+            "source": source,
+            "target": target,
+            "relation": relation,
+            "context": context,
+            "source_file": source_item["path"],
+            "source_location": source_location,
+            "provenance": provenance,
+            "semantic_kind": semantic_kind,
+            "metadata": metadata,
+            "weight": weight,
+        })
+
+    source_digest = hashlib.sha256(
+        json.dumps(
+            [(item["path"], item["content_hash"], item["provenance"]) for item in file_rows],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    diagnostics: list[dict[str, Any]] = []
+    for item in extracted.get("diagnostics") or []:
+        if isinstance(item, Mapping):
+            diagnostics.append({
+                key: value
+                for key, value in item.items()
+                if key in {"code", "error_type", "limit", "bytes", "count"}
+                and isinstance(value, (str, int, bool))
+            })
+    return {
+        "format": EXPORT_FORMAT,
+        "complete": bool(complete),
+        "graphify_version": _version(),
+        "source_digest": source_digest,
+        "files": file_rows,
+        "nodes": node_rows,
+        "edges": edge_rows,
+        "diagnostics": diagnostics,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Export body-free Graphify metadata for MemoryGuard")
+    parser.add_argument("root")
+    parser.add_argument("paths", nargs="*")
+    parser.add_argument("--incremental", action="store_true")
+    parser.add_argument("--no-parallel", action="store_true")
+    args = parser.parse_args(argv)
+    payload = export_repository(
+        args.root,
+        paths=args.paths or None,
+        complete=not args.incremental,
+        parallel=not args.no_parallel,
+    )
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["EXPORT_FORMAT", "export_repository", "main"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "graphifyy"
-version = "0.9.40"
+version = "0.9.41"
 description = "AI coding assistant skill (Claude Code, CodeBuddy, Codex, OpenCode, Kilo Code, Cursor, Gemini CLI, Aider, OpenClaw, Factory Droid, Trae, Hermes, Kiro, Pi, Devin CLI, Google Antigravity) - turn any folder of code, docs, papers, images, or videos into a queryable knowledge graph"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_memoryguard_export.py
+++ b/tests/test_memoryguard_export.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+from graphify.memoryguard_export import EXPORT_FORMAT, export_repository
+
+
+def _assert_body_free(value: object) -> None:
+    forbidden = {
+        "body", "source_body", "raw_content", "content", "source_text",
+        "secret", "token", "password", "api_key", "credential", "authority",
+    }
+    if isinstance(value, dict):
+        assert not forbidden.intersection(value)
+        for item in value.values():
+            _assert_body_free(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_body_free(item)
+
+
+def test_export_is_relative_hashed_provenance_and_body_free(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    marker = "RAW_SOURCE_BODY_MUST_NOT_LEAK_12345"
+    (tmp_path / "src" / "gui.py").write_text(
+        'PAGE = """<button onclick=\\"go()\\">Run</button><script>function go(){api(\\"run_it\\")}</script>"""\n'
+        f"# {marker}\n",
+        encoding="utf-8",
+    )
+
+    payload = export_repository(tmp_path, parallel=False)
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+    assert payload["format"] == EXPORT_FORMAT
+    assert payload["files"]
+    assert all(not Path(item["path"]).is_absolute() for item in payload["files"])
+    assert all(len(item["content_hash"]) == 64 for item in payload["files"])
+    assert {item["provenance"] for item in payload["files"]} == {"production"}
+    assert payload["nodes"]
+    assert payload["edges"]
+    assert marker not in encoded
+    assert str(tmp_path.resolve()).replace("\\", "/") not in encoded.replace("\\", "/")
+    _assert_body_free(payload)
+
+
+def test_cli_exposes_and_runs_memoryguard_metadata(tmp_path: Path, monkeypatch, capsys) -> None:
+    from graphify import cli
+
+    (tmp_path / "app.py").write_text(
+        'PAGE = """<button onclick=\\"go()\\">Run</button><script>function go(){api(\\"run_it\\")}</script>"""\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys, "argv", ["graphify", "export", "--help"])
+    cli.dispatch_command("export")
+    help_text = capsys.readouterr().out
+    assert "memoryguard-metadata" in help_text
+    assert EXPORT_FORMAT in help_text
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["graphify", "export", "memoryguard-metadata", str(tmp_path), "app.py", "--no-parallel"],
+    )
+    cli.dispatch_command("export")
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["format"] == EXPORT_FORMAT
+    assert payload["files"][0]["path"] == "app.py"
+
+
+def test_full_repository_export_smoke(tmp_path: Path) -> None:
+    for relative, content in {
+        "src/app.py": "def run():\n    return 1\n",
+        "tests/test_app.py": "def test_run():\n    assert True\n",
+        "vendor/lib.py": "def vendor_call():\n    return 1\n",
+        "generated/client.py": "def generated_call():\n    return 1\n",
+    }.items():
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    payload = export_repository(tmp_path, parallel=False)
+    assert {item["path"] for item in payload["files"]} == {
+        "generated/client.py", "src/app.py", "tests/test_app.py", "vendor/lib.py",
+    }
+    assert {item["provenance"] for item in payload["files"]} == {
+        "generated", "production", "test", "vendor",
+    }
+    assert payload["nodes"]


### PR DESCRIPTION
## What changed
- Add `graphify export memoryguard-metadata ROOT [PATH ...]` on top of the current `v8` head.
- Emit the body-free `memoryguard-graphify-metadata-v1` contract with repository-relative paths, content hashes, structural symbols/edges, source role/provenance, source maps, and bounded diagnostics.
- Reject source bodies, absolute paths, credentials, and unsafe extractor text at the export boundary.
- Add embedded Python-hosted HTML/JavaScript extraction needed for MemoryGuard GUI CodeGraph projections.
- Document the feature in the English and Chinese READMEs and CHANGELOG; bump the package from the current v8 line to 0.9.41.

## Validation
- Focused export tests: 3 passed.
- `python -m compileall -q graphify` passed.
- Wheel built and inspected as `graphifyy-0.9.41-py3-none-any.whl`.
- `twine check` passed.
- Wheel contains the exporter and metadata version 0.9.41.
- `git diff --check` passed.

This branch is rebased onto the current upstream `v8` head. The earlier old-base draft was closed as superseded.