### PR TITLE
docs: document CI parity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,28 @@ uv run pytest tests/test_extract.py -q # one module
 uv run pytest tests/ -q -k "python"    # filter by name
 ```
 
+### CI parity checks
+
+The authoritative CI commands live in [`.github/workflows/`](.github/workflows/).
+For local CI-style verification, use Python 3.10 or 3.12 and run:
+
+```bash
+uv sync --all-extras --frozen
+uv run --frozen pytest tests/ -q --tb=short
+uv run --frozen python -m tools.skillgen --check
+uv run --frozen python -m tools.skillgen --audit-coverage
+uv run --frozen python -m tools.skillgen --schema-singleton
+uv run --frozen python -m tools.skillgen --monolith-roundtrip
+uv run --frozen python -m tools.skillgen --always-on-roundtrip
+uv run --frozen graphify --help
+uv run --frozen graphify install
+```
+
+Ruff is useful as an additional local check (`uv run --frozen ruff check .`),
+but is not currently a blocking CI job. Pyright is also local/advisory unless it
+is added to CI later. The Bandit and pip-audit CI steps currently use
+`continue-on-error`, so their findings are advisory rather than blocking.
+
 > macOS note: the test suite includes both `sample.f90` and `sample.F90` fixtures. These collide on case-insensitive HFS+ / APFS file systems. Run on Linux or in a Docker container if you need to test both Fortran variants simultaneously.
 
 ### Git workflow


### PR DESCRIPTION
## Summary
- document the authoritative location of CI commands
- list the local CI-style dependency, pytest, skillgen, and CLI smoke commands
- clarify the Python 3.10/3.12 matrix and advisory status of Ruff, Pyright, Bandit, and pip-audit

## Verification
- `uv run --frozen ruff check .` — passed
- all five `tools.skillgen` consistency guards — passed
- `git diff --check` — passed

## Scope
Docs-only: `README.md`. No source, test, workflow, AGENTS, generated artifact, hook, or skill changes.

The full pytest suite was not used as a native-Windows blocker because the repository's Ubuntu CI matrix is authoritative and known Windows parity failures remain in symlink, long-path, POSIX, separator, and encoding behavior.