### PR TITLE
fix: benchmark crashes on nodes with a None label

### DIFF
--- a/graphify/benchmark.py
+++ b/graphify/benchmark.py
@@ -39,7 +39,7 @@ def _query_subgraph_tokens(G: nx.Graph, question: str, depth: int = 3) -> int:
     terms = _query_terms(question)
     scored = []
     for nid, data in G.nodes(data=True):
-        label = data.get("label", "").lower()
+        label = (data.get("label") or "").lower()
         score = sum(1 for t in terms if t in label)
         if score > 0:
             scored.append((score, nid))

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -54,6 +54,21 @@ def test_query_keeps_short_non_english_terms():
     assert tokens > 0
 
 
+def test_query_handles_node_with_none_label():
+    """A node can carry `label` with a None VALUE, not just a missing key.
+
+    `.get("label", "")` only substitutes when the key is absent, so a stored
+    None reached `.lower()` and raised
+    `AttributeError: 'NoneType' object has no attribute 'lower'`. The loop
+    scans every node before returning, so one such node broke the whole
+    benchmark rather than just its own score.
+    """
+    G = _make_graph()
+    G.add_node("n6", label=None, source_file="orphan.py", source_location="L1", community=0)
+    G.add_edge("n6", "n1", relation="calls", confidence="INFERRED")
+    assert _query_subgraph_tokens(G, "how does authentication work") > 0
+
+
 # --- run_benchmark ---
 
 def test_run_benchmark_returns_reduction(tmp_path):


### PR DESCRIPTION
## What

`graphify/benchmark.py:42` guards a node label with `data.get("label", "")`. That default only applies when the key is **missing** — a node that carries `label` with a stored value of `None` returns `None`, which then hits `.lower()`:

```
AttributeError: 'NoneType' object has no attribute 'lower'
```

`_query_subgraph_tokens` iterates every node before returning, so a single such node takes down the whole benchmark rather than just scoring itself as zero.

## Why it's still here

This exact guard was already rolled out elsewhere:

- `serve.py` — all `.get("label", "")` calls guarded with `or ""` (#323)
- wiki `source_file` path (#1016)

`benchmark.py` was missed by both passes. On `v8` it is the last remaining occurrence of the unguarded pattern in the query path.

## How it shows up

Nodes with `source_file: null` / `label: null` are produced by entity extraction when no source file resolves. Hit in the wild on a 6028-node graph where 6 nodes had a null attribute — enough to break every query against it.

## Change

```diff
-        label = data.get("label", "").lower()
+        label = (data.get("label") or "").lower()
```

Plus a regression test in `tests/test_benchmark.py` that adds a `label=None` node to the existing fixture graph.

## Verification

- `pytest tests/test_benchmark.py` → **17 passed**
- Reverting the one-line guard makes the new test fail with the exact `AttributeError` at `benchmark.py:42` — confirmed red before green
- Full suite not run locally (`tests/test_dedup.py` needs `rapidfuzz`, not installed in my environment); leaving that to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)