### PR TITLE
fix(install): copy skill on opencode always-on install

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -638,13 +638,13 @@ def _run_cli() -> None:
         print("  claude uninstall        remove graphify section from CLAUDE.md + PreToolUse hook")
         print("  codebuddy install       write graphify section to CODEBUDDY.md + PreToolUse hook (CodeBuddy)")
         print("  codebuddy uninstall     remove graphify section from CODEBUDDY.md + PreToolUse hook")
-        print("  codex install           write graphify section to AGENTS.md (Codex)")
-        print("  codex uninstall         remove graphify section from AGENTS.md")
+        print("  codex install           copy skill + write graphify section to AGENTS.md (Codex)")
+        print("  codex uninstall         remove skill + graphify section from AGENTS.md")
         print(
-            "  opencode install        write graphify section to AGENTS.md + tool.execute.before plugin (OpenCode)"
+            "  opencode install        copy skill + write AGENTS.md + tool.execute.before plugin (OpenCode)"
         )
         print(
-            "  opencode uninstall      remove graphify section from AGENTS.md + plugin"
+            "  opencode uninstall      remove skill + AGENTS.md section + plugin"
         )
         print(
             "  kilo install            install native Kilo skill + command + AGENTS.md + .kilo plugin"

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -2262,11 +2262,22 @@ def dispatch_install_cli(cmd: str) -> bool:
             if "--project" in sys.argv[3:]:
                 _project_install(cmd, Path("."))
             else:
+                # Mirror amp/agents user-scope install: skill file first, then
+                # AGENTS.md (+ platform plugin). Without this, `graphify
+                # opencode install` only wrote the AGENTS section/plugin and
+                # never copied skill-opencode.md to
+                # ~/.config/opencode/skills/graphify/SKILL.md, so /graphify
+                # was never discoverable (#2670). Same gap for the other
+                # always-on platforms in this branch.
+                _copy_skill_file(cmd)
                 _agents_install(Path("."), cmd)
         elif subcmd == "uninstall":
             if "--project" in sys.argv[3:]:
                 _project_uninstall(cmd, Path("."))
             else:
+                removed = _remove_skill_file(cmd)
+                if removed:
+                    print("skill removed")
                 _agents_uninstall(Path("."), platform=cmd)
                 if cmd == "codex":
                     _uninstall_codex_hook(Path("."))

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -765,6 +765,68 @@ def test_opencode_agents_uninstall_removes_plugin(tmp_path):
         assert not any("graphify.js" in p for p in config.get("plugin", []))
 
 
+def test_opencode_cli_install_copies_skill_file(tmp_path, monkeypatch):
+    """#2670: `graphify opencode install` must copy skill-opencode.md to the
+    user skill path, not only write AGENTS.md + the tool.execute.before plugin.
+    """
+    from graphify.__main__ import main
+
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(sys, "argv", ["graphify", "opencode", "install"])
+    with patch("graphify.install.Path.home", return_value=home):
+        main()
+
+    skill = home / ".config" / "opencode" / "skills" / "graphify" / "SKILL.md"
+    assert skill.exists(), "user-scope OpenCode skill was not installed (#2670)"
+    assert skill.stat().st_size > 0
+    assert (project / "AGENTS.md").exists()
+    assert (project / ".opencode" / "plugins" / "graphify.js").exists()
+
+
+def test_opencode_cli_uninstall_removes_skill_file(tmp_path, monkeypatch):
+    """#2670: `graphify opencode uninstall` removes the user-scope skill too."""
+    from graphify.__main__ import main
+
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    monkeypatch.setattr(sys, "argv", ["graphify", "opencode", "install"])
+    with patch("graphify.install.Path.home", return_value=home):
+        main()
+    skill = home / ".config" / "opencode" / "skills" / "graphify" / "SKILL.md"
+    assert skill.exists()
+
+    monkeypatch.setattr(sys, "argv", ["graphify", "opencode", "uninstall"])
+    with patch("graphify.install.Path.home", return_value=home):
+        main()
+    assert not skill.exists()
+
+
+def test_codex_cli_install_copies_skill_file(tmp_path, monkeypatch):
+    """Same always-on install branch as opencode: codex must also get its skill."""
+    from graphify.__main__ import main
+
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(sys, "argv", ["graphify", "codex", "install"])
+    with patch("graphify.install.Path.home", return_value=home):
+        main()
+
+    skill = home / ".codex" / "skills" / "graphify" / "SKILL.md"
+    assert skill.exists()
+    assert (project / "AGENTS.md").exists()
+
+
 def test_kilo_agents_install_writes_agents_md(tmp_path):
     _agents_install(tmp_path, "kilo")
     assert (tmp_path / "AGENTS.md").exists()


### PR DESCRIPTION
## Summary
`graphify opencode install` wrote AGENTS.md and the OpenCode plugin, but never copied `skill-opencode.md` to `~/.config/opencode/skills/graphify/SKILL.md`, so `/graphify` was not discoverable.

## Linked Issue
Fixes #2670

## What Changed
- User-scope install for the always-on branch (`aider` / `codex` / `opencode` / `claw` / `droid` / `trae` / `trae-cn` / `hermes`) now calls `_copy_skill_file(cmd)` before `_agents_install`, matching `amp` / `agents`.
- Matching uninstall removes the skill via `_remove_skill_file`.
- Help text for `opencode` / `codex` install mentions the skill copy.
- Regression tests cover `graphify opencode install` / `uninstall` and `graphify codex install` end-to-end through `main()`.

## Testing
```bash
python -m pytest tests/test_install.py -q
# 98 passed

python -m pytest \
  tests/test_install.py::test_opencode_cli_install_copies_skill_file \
  tests/test_install.py::test_opencode_cli_uninstall_removes_skill_file \
  tests/test_install.py::test_codex_cli_install_copies_skill_file \
  -q
# 3 passed
```

Manual check before the fix: `graphify opencode install` left no `~/.config/opencode/skills/graphify/SKILL.md`. After the fix, that path is created and uninstall removes it.

## Notes
- Project-scope `graphify opencode install --project` already went through `_project_install`, which copied the skill. Only the bare user-scope path was missing it.
- I did not run a live OpenCode binary end-to-end; verification is the install path + unit tests above.