### PR TITLE
fix(opencode): install user-scope skill

### DIFF
--- a/graphify/install.py
+++ b/graphify/install.py
@@ -1526,6 +1526,22 @@ def _amp_uninstall(project_dir: Path | None = None) -> None:
     if removed:
         print("skill removed")
     _agents_uninstall(project_dir or Path("."), platform="amp")
+
+
+def _opencode_install(project_dir: Path | None = None) -> None:
+    """User-scope OpenCode install: skill into config + AGENTS.md and plugin."""
+    _copy_skill_file("opencode")
+    _agents_install(project_dir or Path("."), "opencode")
+
+
+def _opencode_uninstall(project_dir: Path | None = None) -> None:
+    """User-scope OpenCode uninstall: remove the skill, AGENTS.md section, and plugin."""
+    removed = _remove_skill_file("opencode")
+    if removed:
+        print("skill removed")
+    _agents_uninstall(project_dir or Path("."), platform="opencode")
+
+
 def _agents_platform_install(project_dir: Path | None = None) -> None:
     """`graphify agents install`: skill into ~/.agents/skills + AGENTS.md.
 
@@ -2256,7 +2272,22 @@ def dispatch_install_cli(cmd: str) -> bool:
         else:
             print(f"Usage: graphify {cmd} [install|uninstall]", file=sys.stderr)
             sys.exit(1)
-    elif cmd in ("aider", "codex", "opencode", "claw", "droid", "trae", "trae-cn", "hermes"):
+    elif cmd == "opencode":
+        subcmd = sys.argv[2] if len(sys.argv) > 2 else ""
+        if subcmd == "install":
+            if "--project" in sys.argv[3:]:
+                _project_install("opencode", Path("."))
+            else:
+                _opencode_install(Path("."))
+        elif subcmd == "uninstall":
+            if "--project" in sys.argv[3:]:
+                _project_uninstall("opencode", Path("."))
+            else:
+                _opencode_uninstall(Path("."))
+        else:
+            print("Usage: graphify opencode [install|uninstall]", file=sys.stderr)
+            sys.exit(1)
+    elif cmd in ("aider", "codex", "claw", "droid", "trae", "trae-cn", "hermes"):
         subcmd = sys.argv[2] if len(sys.argv) > 2 else ""
         if subcmd == "install":
             if "--project" in sys.argv[3:]:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -67,6 +67,39 @@ def test_install_positional_platform_opencode(tmp_path, monkeypatch):
     assert not (tmp_path / ".claude" / "skills" / "graphify" / "SKILL.md").exists()
 
 
+def test_opencode_subcommand_installs_user_scope_skill(tmp_path, monkeypatch):
+    from graphify.__main__ import main
+
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(sys, "argv", ["graphify", "opencode", "install"])
+
+    with patch("graphify.__main__.Path.home", return_value=home):
+        main()
+
+    skill_dir = home / ".config" / "opencode" / "skills" / "graphify"
+    assert (skill_dir / "SKILL.md").exists()
+    assert (skill_dir / "references").is_dir()
+
+
+def test_opencode_subcommand_uninstalls_user_scope_skill(tmp_path, monkeypatch):
+    from graphify.__main__ import _copy_skill_file, main
+
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    with patch("graphify.__main__.Path.home", return_value=home):
+        _copy_skill_file("opencode")
+        monkeypatch.setattr(sys, "argv", ["graphify", "opencode", "uninstall"])
+        main()
+
+    assert not (home / ".config" / "opencode" / "skills" / "graphify" / "SKILL.md").exists()
+
+
 def test_install_project_claude_writes_project_scope(tmp_path, monkeypatch, capsys):
     from graphify.__main__ import main
     home = tmp_path / "home"


### PR DESCRIPTION
Fixes #2670

## What
Make the `graphify opencode install` subcommand install Graphify's OpenCode skill at the user-scope location:
`~/.config/opencode/skills/graphify/SKILL.md`.

## Why
The command previously configured the project integration (`AGENTS.md`, plugin, and OpenCode config) but did not copy the skill itself. That left the documented OpenCode user-scope installation incomplete.

## How
- Route the OpenCode subcommand through dedicated install and uninstall handlers.
- Reuse the existing skill-copy and skill-removal helpers so progressive `references/` content is installed and cleaned up consistently.
- Preserve the existing `--project` behavior.

## Testing
- `uv run pytest tests/test_install.py::test_opencode_subcommand_installs_user_scope_skill tests/test_install.py::test_opencode_subcommand_uninstalls_user_scope_skill -q`
- `uv run ruff check graphify/install.py tests/test_install.py`
- `uv run graphify update .`

The focused regression tests cover both user-scope installation and cleanup. The complete installer test file reports 89 passing tests; one untouched Windows-only Hermes assertion still expects POSIX path separators.