### PR TITLE
fix(report): portable basename in GRAPH_REPORT.md header, not the host absolute path (#2628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: a PHP `use` import written with a leading-backslash / fully-qualified prefix now resolves to its target definition instead of being dropped (#2661, thanks @ousamabenyounes).
 - Fix: an unresolved local JS/TS import (to a file absent from the scan) now emits a stable, portable `ref` target id instead of leaking a per-checkout absolute-path slug (#2457, thanks @rohit-jsfreaky).
 - Fix: `graphify benchmark` no longer crashes on a node whose label is `None` (#2674, thanks @Arthuro0103).
+- Fix: `GRAPH_REPORT.md`'s header no longer embeds the generator's absolute host path (#2628, thanks @AirRocker); it labels the report with the project directory basename, so the same graph produces the same bytes on any machine (same class as the 0.9.40 `graph.html` title fix, #2598).
 
 ## 0.9.40 (2026-08-11)
 

--- a/graphify/report.py
+++ b/graphify/report.py
@@ -2,7 +2,32 @@
 from __future__ import annotations
 import re
 from datetime import date
+from pathlib import Path
 import networkx as nx
+
+
+def _portable_root_label(root: str) -> str:
+    """Portable label for the report header — the project directory basename.
+
+    GRAPH_REPORT.md is a tracked artifact in practice, so its header must not
+    bake the generator host's absolute path into the file: the same graph would
+    otherwise produce different bytes on different machines and leak the build
+    machine's directory layout into git history (#2628, same class as #2598).
+
+    Taking the basename strips any leading absolute path without touching the
+    filesystem, and makes `graphify update .`, `graphify update ./proj`, and
+    `graphify update /abs/path/proj` all label the header `proj`. Only the
+    degenerate `.`/``/`..` cases need a cwd resolve to recover the real name;
+    if even that fails, fall back to the raw value.
+    """
+    raw = str(root).replace("\\", "/")
+    name = Path(raw).name
+    if name in ("", ".", ".."):
+        try:
+            name = Path(raw).resolve().name
+        except (OSError, RuntimeError):
+            name = ""
+    return name or raw
 
 
 def _safe_community_name(label: str) -> str:
@@ -101,7 +126,7 @@ def generate(
     inf_avg = round(sum(inf_scores) / len(inf_scores), 2) if inf_scores else None
 
     lines = [
-        f"# Graph Report - {root}  ({today})",
+        f"# Graph Report - {_portable_root_label(root)}  ({today})",
         "",
         "## Corpus Check",
     ]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -63,6 +63,30 @@ def test_report_shows_raw_cohesion_scores():
     assert "⚠" not in report
 
 
+def test_report_header_does_not_embed_host_absolute_path():
+    """#2628 / #2598: the header must not bake the generator host absolute path
+    into GRAPH_REPORT.md — it labels with the project directory basename so the
+    same graph produces the same bytes on any machine."""
+    G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
+    report = generate(G, communities, cohesion, labels, gods, surprises, detection,
+                      tokens, "/Users/mike/dev/apps/secretproj")
+    header = report.splitlines()[0]
+    assert "/Users/mike" not in header
+    assert "secretproj" in header
+
+
+def test_portable_root_label():
+    from graphify.report import _portable_root_label
+    # Absolute paths collapse to the basename on both POSIX and Windows.
+    assert _portable_root_label("/Users/mike/dev/apps/proj") == "proj"
+    assert _portable_root_label(r"C:\Users\mike\dev\proj") == "proj"
+    # A trailing slash still yields the directory name, not an empty label.
+    assert _portable_root_label("/Users/mike/dev/proj/") == "proj"
+    # Relative names pass through unchanged.
+    assert _portable_root_label("./project") == "project"
+    assert _portable_root_label("project") == "project"
+
+
 # --- work-memory lessons section ----------------------------------------------
 
 def test_report_work_memory_section_present_with_overlay_and_dead_ends():


### PR DESCRIPTION
## Summary

Fix #2628

`GRAPH_REPORT.md`'s header interpolated the scan `root` verbatim
(`report.py:104`), so passing an absolute root baked the build machine's full
path into a **tracked** artifact:

```
# Graph Report - /Users/<user>/dev/apps/<project>  (2026-08-03)
```

The same graph then produces different bytes on different machines and the host
directory layout ends up in git history. This is the same class of defect as
#2598 (fixed for `graph.html`'s `<title>` in 0.9.40).

The fix labels the header with the **project directory basename** via a small
`_portable_root_label()` helper, so `graphify update .`, `graphify update ./proj`,
and `graphify update /abs/path/proj` all render `proj` — portable and stable
across machines, no filesystem access for absolute inputs.

## Reproduces with

On unmodified `v8`, `report.generate(..., root="/Users/mike/dev/apps/secretproj")`
yields:

```
# Graph Report - /Users/mike/dev/apps/secretproj  (2026-08-12)
```

## Test verification (RED → GREEN)

Two new tests in `tests/test_report.py`
(`test_report_header_does_not_embed_host_absolute_path`, `test_portable_root_label`).

RED — new tests on `v8` with the fix reverted (`report.py` only):

```
FAILED tests/test_report.py::test_report_header_does_not_embed_host_absolute_path
FAILED tests/test_report.py::test_portable_root_label - ImportError: cannot import name '_portable_root_label'
2 failed
```

GREEN — with the fix:

```
tests/test_report.py::test_report_header_does_not_embed_host_absolute_path PASSED
tests/test_report.py::test_portable_root_label PASSED
2 passed
```

Full suite (Python 3.13, local): `4330 passed, 3 skipped`; the only failures are
3 pre-existing, environment-dependent `test_ollama.py` backend-detection tests
that also fail on unmodified `v8` (local ollama present) — no new failures, no
regressions. skillgen `--check`/`--audit-coverage`/`--schema-singleton`/
`--monolith-roundtrip`/`--always-on-roundtrip` and the `graphify --help`/`install`
smoke all pass.

## Files changed

| File | Change |
|------|--------|
| `graphify/report.py` | add `_portable_root_label()`; use it in the header |
| `tests/test_report.py` | RED→GREEN tests for the header + helper |
| `CHANGELOG.md` | entry under 0.9.41 keyed to #2628 |
