### PR TITLE
fix(js): shadow for...of / for...in loop bindings in indirect_call resolution (#2606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: a PHP `use` import written with a leading-backslash / fully-qualified prefix now resolves to its target definition instead of being dropped (#2661, thanks @ousamabenyounes).
 - Fix: an unresolved local JS/TS import (to a file absent from the scan) now emits a stable, portable `ref` target id instead of leaking a per-checkout absolute-path slug (#2457, thanks @rohit-jsfreaky).
 - Fix: `graphify benchmark` no longer crashes on a node whose label is `None` (#2674, thanks @Arthuro0103).
+- Fix: a JS/TS `for...of` / `for...in` loop binding (`for (const entry of xs)`) used as a value — e.g. in an object-shorthand argument `push({ entry })` — no longer fabricates an `indirect_call` edge to an unrelated same-named module callable (#2606, thanks @ousamabenyounes); the loop binding is now shadowed like parameters and `const`/`let` declarators, completing the arrow-parameter and catch-binding shadow fixes.
 
 ## 0.9.40 (2026-08-11)
 

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -1246,6 +1246,16 @@ def _js_local_bound_names(func_node, source: bytes) -> set[str]:
                 name = c.child_by_field_name("name")
                 if name is not None:
                     _js_collect_pattern_idents(name, source, bound)
+            elif c.type == "for_in_statement":
+                # `for (const entry of xs)` / `for (const {k} of xs)`: the loop
+                # binding is the `left` pattern, NOT wrapped in a
+                # variable_declarator, so the branch above misses it and `entry`
+                # read as a by-name reference to any same-named module callable
+                # (#2606). C-style `for (let i = 0; ...)` uses a lexical_declaration
+                # with real declarators, already covered by the recursion below.
+                left = c.child_by_field_name("left")
+                if left is not None:
+                    _js_collect_pattern_idents(left, source, bound)
             walk(c)
 
     body = func_node.child_by_field_name("body")

--- a/tests/test_indirect_call_for_of_binding_shadow.py
+++ b/tests/test_indirect_call_for_of_binding_shadow.py
@@ -1,0 +1,97 @@
+"""A `for...of` / `for...in` loop binding must shadow indirect_call references.
+
+`_js_local_bound_names` collected parameters and `variable_declarator` targets,
+but the loop variable of `for (const entry of xs)` is the statement's `left`
+pattern, NOT wrapped in a `variable_declarator`. So `entry` contributed nothing
+to the shadow set: used in an object-shorthand argument (`push({ entry })`) it
+read as an unresolved by-name reference, resolved against the corpus-wide label
+index, and fabricated an INFERRED `indirect_call` edge to an unrelated same-named
+module callable (#2606). A generic fixture/helper name then became a false
+high-betweenness hub, distorting god-node and community analysis.
+
+C-style `for (let i = 0; ...)` uses a `lexical_declaration` with real
+declarators, which was always handled — the same declared/undeclared trap as the
+single-arrow-parameter and catch-binding cases.
+"""
+import os
+from pathlib import Path
+
+from graphify.extract import extract
+
+
+def _extract_js_dir(tmp_path, files: dict[str, str]):
+    base = tmp_path / "src"
+    base.mkdir()
+    for name, body in files.items():
+        (base / name).write_text(body)
+    old = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        r = extract(
+            [Path("src") / name for name in files],
+            cache_root=Path(".cache"), parallel=False,
+        )
+    finally:
+        os.chdir(old)
+    nid = {n["label"].rstrip("()"): n["id"] for n in r["nodes"]}
+    return r, nid
+
+
+def _indirect(r):
+    return {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "indirect_call"}
+
+
+def test_for_of_binding_does_not_fabricate_indirect_call(tmp_path):
+    """The reported shape: a `for...of` binding `entry` used in an
+    object-shorthand argument must not resolve to an unrelated `entry()`."""
+    r, nid = _extract_js_dir(tmp_path, {
+        "declaration.mjs": (
+            "export function entry(signature) {\n"
+            "  return { signature };\n"
+            "}\n"
+            "export const fixture = entry(\"public.entry()\");\n"
+        ),
+        "consumer.mjs": (
+            "export function findNamed(entries, lookup) {\n"
+            "  const resolved = [];\n"
+            "  for (const entry of entries) {\n"
+            "    if (lookup(entry.name)) resolved.push({ entry });\n"
+            "  }\n"
+            "  return resolved;\n"
+            "}\n"
+        ),
+    })
+    assert (nid["findNamed"], nid["entry"]) not in _indirect(r)
+
+
+def test_for_of_destructuring_binding_shadows(tmp_path):
+    """A destructured loop binding (`for (const { entry } of xs)`) must shadow
+    the same way — `_js_collect_pattern_idents` walks the pattern."""
+    r, nid = _extract_js_dir(tmp_path, {
+        "declaration.mjs": "export function entry(x) { return x; }\n",
+        "consumer.mjs": (
+            "export function findNamed(rows) {\n"
+            "  const out = [];\n"
+            "  for (const { entry } of rows) {\n"
+            "    out.push({ entry });\n"
+            "  }\n"
+            "  return out;\n"
+            "}\n"
+        ),
+    })
+    assert (nid["findNamed"], nid["entry"]) not in _indirect(r)
+
+
+def test_genuine_reference_outside_the_loop_still_emits(tmp_path):
+    """Widening the shadow set must not blanket-suppress: a same-named callable
+    referenced from a function that does NOT bind it in a loop still resolves."""
+    r, nid = _extract_js_dir(tmp_path, {"a.js": (
+        "function entry(x){ return x; }\n"
+        "export function findNamed(rows) {\n"
+        "  const out = [];\n"
+        "  for (const entry of rows) { out.push({ entry }); }\n"
+        "  return out;\n"
+        "}\n"
+        "export function elsewhere(pool) { pool.submit(entry); }\n"
+    )})
+    assert (nid["elsewhere"], nid["entry"]) in _indirect(r)


### PR DESCRIPTION
## Summary

Fix #2606

A JS/TS `for...of` / `for...in` loop binding used as a *value* fabricates a phantom `indirect_call` edge to an unrelated same-named module function.

`_js_local_bound_names` collected parameters and `variable_declarator` targets, but the loop variable of `for (const entry of xs)` is the statement's `left` pattern — **not** wrapped in a `variable_declarator` — so `entry` contributed nothing to the per-function shadow set. Referenced as a value (object-shorthand `push({ entry })`), it read as an unresolved by-name reference, resolved against the corpus-wide label index, and minted an INFERRED `indirect_call` edge (0.8) to an unrelated top-level `entry()` in another file. A generic fixture/helper name then becomes a false high-betweenness hub, distorting god-node and community analysis.

This is the same declared/undeclared trap already fixed for single-arrow parameters (#2568-era) and catch bindings — the loop binding is now collected alongside parameters and `const`/`let`/`var` declarators. Both bare (`for (const entry of xs)`) and destructured (`for (const { entry } of xs)`) forms are handled; C-style `for (let i = 0; ...)` uses a `lexical_declaration` with real declarators and was always covered.

## Reproduces with

`declaration.mjs` defines `entry()`, `consumer.mjs` loops `for (const entry of entries)` and does `resolved.push({ entry })`. On `v8` before the fix:

```
indirect_call consumer_findnamed -> declaration_entry   (source consumer.mjs:4)
```

Expected: no edge — the `entry` is a `for...of` binding, not the imported/module function.

## Test verification (RED → GREEN)

New `tests/test_indirect_call_for_of_binding_shadow.py`.

RED (prod fix reverted, tests intact):
```
FAILED test_for_of_binding_does_not_fabricate_indirect_call
FAILED test_for_of_destructuring_binding_shadows
2 failed, 1 passed
```
The passing one is the positive control (`test_genuine_reference_outside_the_loop_still_emits`) — a same-named callable referenced outside the loop still resolves, so the shadow-set widening does not blanket-suppress real edges.

GREEN (with fix):
```
3 passed
```

## Full suite

`uv run --frozen pytest tests/ -q` → `4331 passed, 3 skipped`. The only failures are 3 pre-existing `tests/test_ollama.py` backend-detection tests that fail identically on the unmodified `v8` base (a local Ollama is reachable on the test host); they are unrelated to this change.

## Files changed

| File | Change |
|------|--------|
| `graphify/extractors/engine.py` | collect `for_in_statement.left` binding in `_js_local_bound_names` |
| `tests/test_indirect_call_for_of_binding_shadow.py` | new regression tests + positive control |
| `CHANGELOG.md` | entry under 0.9.41 |
