### PR TITLE
fix(python): resolve relative subpackage import to package __init__ (#2455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: `query` no longer prints the truncation banner when no nodes were actually cut (only trailing edges overflowed the budget) (#2601, thanks @ousamabenyounes); a genuine node truncation still warns.
 - Fix: a PHP `use` import written with a leading-backslash / fully-qualified prefix now resolves to its target definition instead of being dropped (#2661, thanks @ousamabenyounes).
 - Fix: an unresolved local JS/TS import (to a file absent from the scan) now emits a stable, portable `ref` target id instead of leaking a per-checkout absolute-path slug (#2457, thanks @rohit-jsfreaky).
+- Fix: a Python relative import of a sibling subpackage (`from ...graphs import x`, where `graphs/` is a package) now resolves its `imports_from` edge to the package's `__init__.py` file node, matching the companion `imports` edge, instead of leaking a per-checkout absolute-path slug for a nonexistent `graphs.py` (#2455, thanks @vanjos).
 - Fix: `graphify benchmark` no longer crashes on a node whose label is `None` (#2674, thanks @Arthuro0103).
 
 ## 0.9.40 (2026-08-11)

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -124,6 +124,7 @@ from graphify.extractors.resolution import (  # noqa: E402,F401
     _resolve_js_import_target,
     _resolve_js_module_path,
     _resolve_lua_import_target,
+    _probe_python_module_candidate,
     _resolve_python_module_path,
     _resolve_tsconfig_alias,
     _resolve_workspace_import,
@@ -350,8 +351,20 @@ def _import_python(node, source: bytes, file_nid: str, stem: str, edges: list, s
                 base = Path(str_path).parent
                 for _ in range(dots - 1):
                     base = base.parent
-                rel = (module_name.replace(".", "/") + ".py") if module_name else "__init__.py"
-                target_path = base / rel
+                # A relative import can name a subpackage (a directory with an
+                # __init__.py), not a module file. Probing the candidate on disk
+                # (mirroring the companion `imports` edge's
+                # _resolve_python_module_path) resolves `graphs` -> graphs/__init__.py
+                # instead of a nonexistent graphs.py: without it the target keeps an
+                # absolute-path-derived slug that the target_file stamp below can't
+                # heal, so it dangles per-checkout (#2455).
+                candidate = base / module_name.replace(".", "/") if module_name else base
+                resolved = _probe_python_module_candidate(candidate)
+                if resolved is not None:
+                    target_path = resolved
+                else:
+                    rel = (module_name.replace(".", "/") + ".py") if module_name else "__init__.py"
+                    target_path = base / rel
                 tgt_nid = _make_id(str(target_path))
             else:
                 tgt_nid = _make_id(raw)

--- a/tests/test_python_import_resolution.py
+++ b/tests/test_python_import_resolution.py
@@ -60,6 +60,42 @@ def test_ordinary_relative_import_still_resolves(tmp_path: Path):
     assert _has_edge(result, source_file, target_symbol, "imports")
 
 
+def test_relative_subpackage_import_from_targets_package_init(tmp_path: Path):
+    # `from ...graphs import build_graph` where `graphs/` is a package (a dir
+    # with __init__.py, not a graphs.py module). The imports_from edge must
+    # target the package's __init__.py file node, matching the companion
+    # `imports` edge — not an absolute-scan-path slug for a nonexistent
+    # graphs.py that dangles per-checkout (#2455).
+    init = _write(tmp_path / "src/mypkg/__init__.py", "")
+    api_init = _write(tmp_path / "src/mypkg/api/__init__.py", "")
+    routes_init = _write(tmp_path / "src/mypkg/api/routes/__init__.py", "")
+    graphs_init = _write(
+        tmp_path / "src/mypkg/graphs/__init__.py",
+        "def build_graph():\n    return {}\n",
+    )
+    health = _write(
+        tmp_path / "src/mypkg/api/routes/health.py",
+        "from ...graphs import build_graph\n",
+    )
+
+    result = extract(
+        [init, api_init, routes_init, graphs_init, health], cache_root=tmp_path
+    )
+
+    health_file = _node_id(result, "health.py", "src/mypkg/api/routes/health.py")
+    graphs_pkg = _node_id(result, "__init__.py", "src/mypkg/graphs/__init__.py")
+
+    assert _has_edge(result, health_file, graphs_pkg, "imports_from")
+    # No imports_from edge out of health may carry an unresolved absolute-path
+    # slug (the pre-fix `<scan>_src_mypkg_graphs_py` target).
+    health_targets = [
+        e["target"]
+        for e in result["edges"]
+        if e["source"] == health_file and e["relation"] == "imports_from"
+    ]
+    assert all(t.endswith("graphs_init") for t in health_targets), health_targets
+
+
 def test_python_package_reexport_resolves_import_and_call_to_origin_symbol(tmp_path: Path):
     origin = _write(tmp_path / "pkg/foo.py", "def Foo():\n    return 1\n")
     barrel = _write(tmp_path / "pkg/__init__.py", "from .foo import Foo as PublicFoo\n")


### PR DESCRIPTION
## Summary

Fix #2455

A Python relative import of a sibling **subpackage** (`from ...graphs import build_graph`, where `graphs/` is a package — a directory with `__init__.py`, not a `graphs.py` module) emitted an `imports_from` edge whose target was an absolute-scan-path-derived slug for a nonexistent `graphs.py`, instead of resolving to the package's `__init__.py` file node.

Root cause: `_import_python` built the relative target as `base/<module>.py` unconditionally. For a subpackage that file does not exist, so the existence-gated `target_file` stamp never fired, and the `#2169` remap had nothing to canonicalize — the edge kept a per-checkout absolute-path slug (`<scan>_src_mypkg_graphs_py`) that matches no node and dangles. This is the same reproducibility class as #2262/#2273/#2457.

Fix: probe the candidate on disk with `_probe_python_module_candidate` — the exact resolver the companion `imports` edge already uses via `_resolve_python_module_path` — so `graphs` resolves to `graphs/__init__.py`. The `target_file` stamp then fires and the edge canonicalizes to the real package file node. A genuinely nonexistent module still falls back to the prior dangling behaviour, unchanged.

## Reproduces with

```
src/mypkg/__init__.py
src/mypkg/api/__init__.py
src/mypkg/api/routes/__init__.py
src/mypkg/graphs/__init__.py            -> def build_graph(): return {}
src/mypkg/api/routes/health.py          -> from ...graphs import build_graph
```

Before (on `v8`):
```
src_mypkg_api_routes_health --imports_from--> <scan>_src_mypkg_graphs_py   # BUG: graphs.py does not exist
src_mypkg_api_routes_health --imports-->      src_mypkg_graphs_init_build_graph
```
After:
```
src_mypkg_api_routes_health --imports_from--> src_mypkg_graphs_init
src_mypkg_api_routes_health --imports-->      src_mypkg_graphs_init_build_graph
```

## Test verification (RED → GREEN)

New test `test_relative_subpackage_import_from_targets_package_init` in `tests/test_python_import_resolution.py`.

RED — unmodified `v8` base, new test applied, no prod fix:
```
F
E   AssertionError: assert False
     +  where False = _has_edge(..., 'src_mypkg_api_routes_health', 'src_mypkg_graphs_init', 'imports_from')
tests/test_python_import_resolution.py: AssertionError
1 failed
```

GREEN — with the fix:
```
tests/test_python_import_resolution.py::test_relative_subpackage_import_from_targets_package_init
1 passed
```

## Full local suite

`uv run --frozen pytest tests/ -q` → `4328 passed, 3 skipped` (+1 new). The 4 failing tests (`test_ollama.py::*`, one `test_labeling` ordering artifact) are pre-existing and reproduce identically on the unmodified `v8` base — they are backend-detection env leakage (`GEMINI_API_KEY`), unrelated to this change (which touches only `_import_python`). skillgen validators (`--check`, `--monolith-roundtrip`, `--always-on-roundtrip`) and `graphify --help` smoke all green.

## Files changed

| File | Change |
|------|--------|
| `graphify/extract.py` | `_import_python`: probe the relative-import candidate on disk so a subpackage resolves to its `__init__.py` |
| `tests/test_python_import_resolution.py` | regression test for subpackage `imports_from` resolution |
| `CHANGELOG.md` | entry under 0.9.41 |
