### PR TITLE
fix(clone): accept multiple GitHub URLs and reject unknown flags (#2703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: a PHP `use` import written with a leading-backslash / fully-qualified prefix now resolves to its target definition instead of being dropped (#2661, thanks @ousamabenyounes).
 - Fix: an unresolved local JS/TS import (to a file absent from the scan) now emits a stable, portable `ref` target id instead of leaking a per-checkout absolute-path slug (#2457, thanks @rohit-jsfreaky).
 - Fix: `graphify benchmark` no longer crashes on a node whose label is `None` (#2674, thanks @Arthuro0103).
+- Fix: `graphify clone` now accepts multiple GitHub URLs and clones each one instead of silently dropping every URL past the first, matching the multi-repo workflow (#2703); unknown flags are rejected with a usage message, and `--out` is refused with multiple URLs to keep destinations unambiguous.
 
 ## 0.9.40 (2026-08-11)
 

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -2407,28 +2407,46 @@ def dispatch_command(cmd: str) -> None:
         print(f"Written to: {out_path}")
 
     elif cmd == "clone":
+        _CLONE_USAGE = (
+            "Usage: graphify clone <github-url> [<github-url> ...] "
+            "[--branch <branch>] [--out <dir>]"
+        )
         if len(sys.argv) < 3:
+            print(_CLONE_USAGE, file=sys.stderr)
+            sys.exit(1)
+        urls: list[str] = []
+        branch: str | None = None
+        out_dir: Path | None = None
+        args = sys.argv[2:]
+        i = 0
+        while i < len(args):
+            a = args[i]
+            if a == "--branch" and i + 1 < len(args):
+                branch = args[i + 1]
+                i += 2
+            elif a == "--out" and i + 1 < len(args):
+                out_dir = Path(args[i + 1])
+                i += 2
+            elif a.startswith("-"):
+                print(f"error: unknown option: {a}", file=sys.stderr)
+                print(_CLONE_USAGE, file=sys.stderr)
+                sys.exit(1)
+            else:
+                urls.append(a)
+                i += 1
+        if not urls:
+            print(_CLONE_USAGE, file=sys.stderr)
+            sys.exit(1)
+        if out_dir is not None and len(urls) > 1:
             print(
-                "Usage: graphify clone <github-url> [--branch <branch>] [--out <dir>]",
+                "error: --out is only valid with a single URL; drop --out to clone "
+                "multiple repos into ~/.graphify/repos/<owner>/<repo>",
                 file=sys.stderr,
             )
             sys.exit(1)
-        url = sys.argv[2]
-        branch: str | None = None
-        out_dir: Path | None = None
-        args = sys.argv[3:]
-        i = 0
-        while i < len(args):
-            if args[i] == "--branch" and i + 1 < len(args):
-                branch = args[i + 1]
-                i += 2
-            elif args[i] == "--out" and i + 1 < len(args):
-                out_dir = Path(args[i + 1])
-                i += 2
-            else:
-                i += 1
-        local_path = _clone_repo(url, branch=branch, out_dir=out_dir)
-        print(local_path)
+        for url in urls:
+            local_path = _clone_repo(url, branch=branch, out_dir=out_dir)
+            print(local_path)
 
     elif cmd == "export":
         subcmd = sys.argv[2] if len(sys.argv) > 2 else ""

--- a/graphify/skills/agents/references/github-and-merge.md
+++ b/graphify/skills/agents/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/amp/references/github-and-merge.md
+++ b/graphify/skills/amp/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/claude/references/github-and-merge.md
+++ b/graphify/skills/claude/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/claw/references/github-and-merge.md
+++ b/graphify/skills/claw/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/codex/references/github-and-merge.md
+++ b/graphify/skills/codex/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/copilot/references/github-and-merge.md
+++ b/graphify/skills/copilot/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/droid/references/github-and-merge.md
+++ b/graphify/skills/droid/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/kilo/references/github-and-merge.md
+++ b/graphify/skills/kilo/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/kiro/references/github-and-merge.md
+++ b/graphify/skills/kiro/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/opencode/references/github-and-merge.md
+++ b/graphify/skills/opencode/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/pi/references/github-and-merge.md
+++ b/graphify/skills/pi/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/trae/references/github-and-merge.md
+++ b/graphify/skills/trae/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/vscode/references/github-and-merge.md
+++ b/graphify/skills/vscode/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/graphify/skills/windows/references/github-and-merge.md
+++ b/graphify/skills/windows/references/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tests/test_clone_cli.py
+++ b/tests/test_clone_cli.py
@@ -1,0 +1,110 @@
+"""`graphify clone` multi-URL support (#2703).
+
+The clone command used to silently swallow every URL after the first: a user
+who typed `graphify clone url1 url2` got only url1 cloned and no indication
+that url2 was dropped. Multi-repo analysis is the exact workflow issue #2703
+asks about, so extra URLs are now cloned in turn and each destination path is
+printed on its own line. Unknown flags are rejected instead of skipped.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from graphify import cli
+
+
+def _stub_clone(monkeypatch):
+    calls: list[tuple[str, str | None, Path | None]] = []
+
+    def fake(url, branch=None, out_dir=None):
+        calls.append((url, branch, out_dir))
+        return Path(f"/tmp/fake/{url.rsplit('/', 1)[-1]}")
+
+    monkeypatch.setattr(cli, "_clone_repo", fake)
+    return calls
+
+
+def test_clone_multiple_urls_are_all_cloned(monkeypatch, capsys):
+    calls = _stub_clone(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "graphify",
+            "clone",
+            "https://github.com/foo/bar",
+            "https://github.com/baz/qux",
+        ],
+    )
+    cli.dispatch_command("clone")
+    assert [c[0] for c in calls] == [
+        "https://github.com/foo/bar",
+        "https://github.com/baz/qux",
+    ]
+    out = capsys.readouterr().out.splitlines()
+    assert "/tmp/fake/bar" in out
+    assert "/tmp/fake/qux" in out
+
+
+def test_clone_single_url_still_works(monkeypatch, capsys):
+    calls = _stub_clone(monkeypatch)
+    monkeypatch.setattr(
+        sys, "argv", ["graphify", "clone", "https://github.com/foo/bar"]
+    )
+    cli.dispatch_command("clone")
+    assert calls == [("https://github.com/foo/bar", None, None)]
+    assert "/tmp/fake/bar" in capsys.readouterr().out
+
+
+def test_clone_branch_flag_applies_to_all(monkeypatch):
+    calls = _stub_clone(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "graphify",
+            "clone",
+            "https://github.com/foo/bar",
+            "https://github.com/baz/qux",
+            "--branch",
+            "dev",
+        ],
+    )
+    cli.dispatch_command("clone")
+    assert [c[1] for c in calls] == ["dev", "dev"]
+
+
+def test_clone_rejects_out_with_multiple_urls(monkeypatch, capsys):
+    _stub_clone(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "graphify",
+            "clone",
+            "https://github.com/foo/bar",
+            "https://github.com/baz/qux",
+            "--out",
+            "/tmp/dest",
+        ],
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli.dispatch_command("clone")
+    assert exc.value.code == 1
+    assert "--out" in capsys.readouterr().err
+
+
+def test_clone_rejects_unknown_flag(monkeypatch, capsys):
+    _stub_clone(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["graphify", "clone", "https://github.com/foo/bar", "--nope"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli.dispatch_command("clone")
+    assert exc.value.code == 1
+    assert "--nope" in capsys.readouterr().err

--- a/tools/skillgen/expected/graphify__skills__agents__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__agents__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__amp__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__amp__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__claude__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__claude__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__claw__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__claw__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__codex__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__codex__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__copilot__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__copilot__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__droid__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__droid__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__kilo__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__kilo__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__kiro__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__kiro__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__opencode__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__opencode__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__pi__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__pi__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__trae__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__trae__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__vscode__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__vscode__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/expected/graphify__skills__windows__references__github-and-merge.md
+++ b/tools/skillgen/expected/graphify__skills__windows__references__github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \

--- a/tools/skillgen/fragments/references/shared/github-and-merge.md
+++ b/tools/skillgen/fragments/references/shared/github-and-merge.md
@@ -12,9 +12,8 @@ LOCAL_PATH=$(graphify clone <github-url> [--branch <branch>])
 
 **Multiple repos (cross-repo graph):**
 ```bash
-# Clone each repo, run the full pipeline on each, then merge
-graphify clone <url1>   # → ~/.graphify/repos/<owner1>/<repo1>
-graphify clone <url2>   # → ~/.graphify/repos/<owner2>/<repo2>
+# Clone each repo (one call or many — both work), run the full pipeline on each, then merge
+graphify clone <url1> <url2>   # → ~/.graphify/repos/<owner1>/<repo1> and .../<owner2>/<repo2>
 # Run /graphify on each local path to produce their graph.json files
 # Then merge:
 graphify merge-graphs \


### PR DESCRIPTION
`graphify clone` used to silently drop every URL past the first, which is the exact multi-repo workflow issue #2703 asks about. It now clones each URL in turn and prints each destination path; unknown flags are rejected with a usage message, and `--out` is refused with multiple URLs to keep destinations unambiguous.

## Test verification (RED → GREEN)

With the fix reverted, the new test fails (RED):

```
            ],
        )
>       with pytest.raises(SystemExit) as exc:
             ^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE <class 'SystemExit'>

tests/test_clone_cli.py:94: Failed
----------------------------- Captured stdout call -----------------------------
/tmp/fake/bar
_______________________ test_clone_rejects_unknown_flag ________________________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x78e8b1661480>
capsys = <_pytest.capture.CaptureFixture object at 0x78e8b1763360>

    def test_clone_rejects_unknown_flag(monkeypatch, capsys):
        _stub_clone(monkeypatch)
        monkeypatch.setattr(
            sys,
            "argv",
            ["graphify", "clone", "https://github.com/foo/bar", "--nope"],
        )
>       with pytest.raises(SystemExit) as exc:
             ^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE <class 'SystemExit'>

tests/test_clone_cli.py:107: Failed
----------------------------- Captured stdout call -----------------------------
/tmp/fake/bar
=============================== warnings summary ===============================
.venv/lib/python3.13/site-packages/_hypothesis_pytestplugin.py:481
  /home/ousama/www/public/ousamabenyounes/graphify/.venv/lib/python3.13/site-packages/_hypothesis_pytestplugin.py:481: UserWarning: Skipping collection of '.hypothesis' directory - this usually means you've explicitly set the `norecursedirs` pytest config option, replacing rather than extending the default ignores.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_clone_cli.py::test_clone_multiple_urls_are_all_cloned - Ass...
FAILED tests/test_clone_cli.py::test_clone_branch_flag_applies_to_all - Asser...
FAILED tests/test_clone_cli.py::test_clone_rejects_out_with_multiple_urls - F...
FAILED tests/test_clone_cli.py::test_clone_rejects_unknown_flag - Failed: DID...
==================== 4 failed, 1 passed, 1 warning in 0.32s ====================
```

With the fix applied, the test passes (GREEN):

```
Uninstalled 1 package in 1ms
Installed 1 package in 3ms
============================= test session starts ==============================
platform linux -- Python 3.13.12, pytest-9.0.3, pluggy-1.6.0 -- /home/ousama/www/public/ousamabenyounes/graphify/.venv/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /home/ousama/www/public/ousamabenyounes/graphify
configfile: pyproject.toml
plugins: cov-7.1.0, hypothesis-6.153.0, anyio-4.13.0
collecting ... collected 5 items

tests/test_clone_cli.py::test_clone_multiple_urls_are_all_cloned PASSED  [ 20%]
tests/test_clone_cli.py::test_clone_single_url_still_works PASSED        [ 40%]
tests/test_clone_cli.py::test_clone_branch_flag_applies_to_all PASSED    [ 60%]
tests/test_clone_cli.py::test_clone_rejects_out_with_multiple_urls PASSED [ 80%]
tests/test_clone_cli.py::test_clone_rejects_unknown_flag PASSED          [100%]

=============================== warnings summary ===============================
.venv/lib/python3.13/site-packages/_hypothesis_pytestplugin.py:481
  /home/ousama/www/public/ousamabenyounes/graphify/.venv/lib/python3.13/site-packages/_hypothesis_pytestplugin.py:481: UserWarning: Skipping collection of '.hypothesis' directory - this usually means you've explicitly set the `norecursedirs` pytest config option, replacing rather than extending the default ignores.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================= 5 passed, 1 warning in 0.25s =========================
```

## Full local suite

Command: `env -u GEMINI_API_KEY -u GOOGLE_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u KIMI_API_KEY -u DEEPSEEK_API_KEY -u OLLAMA_HOST uv run --frozen pytest tests/ -q --tb=short && uv run --frozen python -m tools.skillgen --check && uv run --frozen python -m tools.skillgen --audit-coverage && uv run --frozen python -m tools.skillgen --schema-singleton && uv run --frozen python -m tools.skillgen --monolith-roundtrip && uv run --frozen python -m tools.skillgen --always-on-roundtrip`

```
........................................................................ [ 87%]
........................................................................ [ 89%]
........................................................................ [ 91%]
........................................................................ [ 92%]
........................................................................ [ 94%]
........................................................................ [ 96%]
........................................................................ [ 97%]
........................................................................ [ 99%]
...................                                                      [100%]
=============================== warnings summary ===============================
.venv/lib/python3.13/site-packages/_hypothesis_pytestplugin.py:481
  /home/ousama/www/public/ousamabenyounes/graphify/.venv/lib/python3.13/site-packages/_hypothesis_pytestplugin.py:481: UserWarning: Skipping collection of '.hypothesis' directory - this usually means you've explicitly set the `norecursedirs` pytest config option, replacing rather than extending the default ignores.
    warnings.warn(

tests/test_serve_http.py:17
  /home/ousama/www/public/ousamabenyounes/graphify/tests/test_serve_http.py:17: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
    from starlette.testclient import TestClient  # noqa: E402

tests/test_chunking.py::test_checkpoint_scopes_cache_writes_to_chunk_files
tests/test_chunking.py::test_out_of_scope_nodes_are_dropped_from_merged_result
  /home/ousama/www/public/ousamabenyounes/graphify/graphify/llm.py:2354: RuntimeWarning: semantic cache skipped out-of-scope source_file 'B.py'; the file was not dispatched for extraction
    _scs(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
4336 passed, 3 skipped, 4 warnings in 124.85s (0:02:04)
Uninstalled 1 package in 0.70ms
Installed 1 package in 5ms
check OK: 134 artifact(s) match committed output and expected/.
Uninstalled 1 package in 0.99ms
Installed 1 package in 4ms
audit-coverage OK: every per-host v8 heading single-homes in that host's render.
Uninstalled 1 package in 1ms
Installed 1 package in 4ms
schema-singleton OK: the file_type enum is the six-value superset everywhere.
Uninstalled 1 package in 1ms
Installed 1 package in 6ms
monolith-roundtrip OK: each monolith matches v8 modulo the enum unification.
Uninstalled 1 package in 1ms
Installed 1 package in 5ms
always-on-roundtrip OK: each always_on/*.md reproduces its former constant byte for byte.
```

Fix #2703
