### PR TITLE
feat(elixir): resolve Module.function() remote calls cross-file (opt-in spec coverage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,7 @@ These are only needed for **headless / CI extraction** (`graphify extract`). Whe
 | `GRAPHIFY_API_TIMEOUT` | Per-call timeout in seconds for HTTP, claude-cli, Anthropic SDK, and Bedrock backends (default: 600) | optional — also `--api-timeout` flag |
 | `GRAPHIFY_MAX_RETRIES` | How many times to retry a rate-limited (429) request before giving up (default: 6; honors `Retry-After`) | optional — raise for strict per-org limits (e.g. kimi); `0` disables |
 | `GRAPHIFY_FORCE` | Force graph rebuild even with fewer nodes | optional — also `--force` flag |
+| `GRAPHIFY_ELIXIR_REMOTE_CALLS` | Resolve Elixir `Module.function()` remote calls (alias-aware) into cross-file `calls` edges — connects ExUnit specs to the modules they cover | optional — set to `1` |
 | `GRAPHIFY_GOOGLE_WORKSPACE` | Auto-enable Google Workspace export | optional — set to `1` |
 | `GRAPHIFY_TRIAGE_BACKEND` | Backend for `graphify prs --triage` | optional — auto-detected from available keys |
 | `GRAPHIFY_TRIAGE_MODEL` | Model override for triage | optional — e.g. `claude-opus-4-7` |

--- a/graphify/elixir_resolution.py
+++ b/graphify/elixir_resolution.py
@@ -1,0 +1,162 @@
+"""Cross-file resolution for Elixir remote calls (``Module.function()``).
+
+Elixir has no import-based call resolution: any module is callable from any
+file by its fully-qualified name, and ``alias`` shortens it lexically. The
+extractor records each remote call's ``receiver`` (the dotted module path) and
+a per-file alias table; this resolver turns them into precise cross-file
+``calls`` edges:
+
+  * ``ChatServer.Channels.create(...)``  -> the ``create/1`` function node
+    (or the ``ChatServer.Channels`` module node when the function is not in
+    the corpus, e.g. a macro or a dynamically-defined name)
+  * ``Channels.create(...)`` after ``alias ChatServer.Channels`` -> same,
+    resolved through the caller file's alias table
+  * ``Channels.create(...)`` with no alias -> only when exactly one module in
+    the corpus ends with ``.Channels`` (god-node guard); ambiguous -> no edge
+
+Every emitted edge is EXTRACTED (1.0): a remote call names its module in
+source, so resolution is by explicit reference, never by global bare-name
+matching. The shared cross-file call pass skips all member calls, so this
+pass is purely additive.
+
+Opt-in via ``GRAPHIFY_ELIXIR_REMOTE_CALLS=1``: ExUnit spec bodies contribute
+most of these raw_calls (``test``/``describe``/``setup`` blocks), and the
+resulting spec -> module coverage edges roughly double an Elixir corpus's
+edge count. Gated so existing users see no graph change until they opt in.
+Registered into graphify.resolver_registry and run by extract() after id
+disambiguation, so node ids and raw_call caller_nids are final.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+_MODULE_LABEL_RE = re.compile(r"^[A-Z][A-Za-z0-9_]*(?:\.[A-Z][A-Za-z0-9_]*)*$")
+
+
+def _key(label: str) -> str:
+    """Normalize a module/function label to a comparison key (drop punctuation)."""
+    return re.sub(r"[^a-zA-Z0-9]+", "", str(label)).lower()
+
+
+def _enabled() -> bool:
+    raw = os.environ.get("GRAPHIFY_ELIXIR_REMOTE_CALLS", "").strip().lower()
+    return raw in ("1", "true", "yes")
+
+
+def resolve_elixir_remote_calls(
+    per_file: list[dict],
+    all_nodes: list[dict],
+    all_edges: list[dict],
+) -> None:
+    """Resolve Elixir ``Module.function()`` raw_calls to cross-file edges.
+
+    No-op unless GRAPHIFY_ELIXIR_REMOTE_CALLS is set. Mutates ``all_edges``
+    in place, matching the other registry resolvers.
+    """
+    if not _enabled():
+        return
+
+    node_by_id: dict[str, dict] = {n.get("id"): n for n in all_nodes}
+
+    # Module index: module-shaped labels (``ChatServer.Channels``) defined in
+    # .ex/.exs files. File nodes end in .ex/.exs (lowercase) and function
+    # labels end in (), so the regex alone separates modules; no `contained`
+    # guard is needed because the Elixir extractor never mints shadow nodes
+    # for import targets.
+    module_by_full: dict[str, list[str]] = {}
+    module_by_last: dict[str, list[str]] = {}
+    for n in all_nodes:
+        label = str(n.get("label", ""))
+        sf = str(n.get("source_file", ""))
+        if not sf.endswith((".ex", ".exs")) or not _MODULE_LABEL_RE.match(label):
+            continue
+        nid = str(n.get("id"))
+        module_by_full.setdefault(_key(label), []).append(nid)
+        module_by_last.setdefault(_key(label.split(".")[-1]), []).append(nid)
+    for k in list(module_by_full):
+        module_by_full[k] = sorted(set(module_by_full[k]))
+    for k in list(module_by_last):
+        module_by_last[k] = sorted(set(module_by_last[k]))
+
+    # (module_nid, function_key) -> function nid, from `method` edges.
+    method_index: dict[tuple[str, str], str] = {}
+    for e in all_edges:
+        if e.get("relation") != "method":
+            continue
+        src, tgt = e.get("source"), e.get("target")
+        tnode = node_by_id.get(tgt)
+        if tnode is not None:
+            method_index[(str(src), _key(tnode.get("label", "")))] = str(tgt)
+
+    existing_pairs = {(e.get("source"), e.get("target")) for e in all_edges}
+
+    def _emit(caller: str, target: str, rc: dict[str, Any]) -> None:
+        if not caller or not target or caller == target:
+            return
+        if (caller, target) in existing_pairs:
+            return
+        existing_pairs.add((caller, target))
+        all_edges.append({
+            "source": caller,
+            "target": target,
+            "relation": "calls",
+            "context": "call",
+            "confidence": "EXTRACTED",
+            "confidence_score": 1.0,
+            "source_file": rc.get("source_file", ""),
+            "source_location": rc.get("source_location"),
+            "weight": 1.0,
+        })
+
+    def _resolve_module(full_name: str) -> str | None:
+        """Fully-qualified name -> unique module nid, or None (bail on
+        absence or ambiguity). Falls back to a unique last-segment match."""
+        nids = module_by_full.get(_key(full_name), [])
+        if len(nids) == 1:
+            return nids[0]
+        if len(nids) > 1:
+            return None
+        nids = module_by_last.get(_key(full_name.split(".")[-1]), [])
+        return nids[0] if len(nids) == 1 else None
+
+    for result in per_file:
+        if not isinstance(result, dict):
+            continue
+        raw_calls = result.get("raw_calls") or []
+        if not raw_calls:
+            continue
+        aliases = result.get("elixir_aliases") or {}
+        for rc in raw_calls:
+            if not isinstance(rc, dict) or rc.get("lang") != "elixir":
+                continue
+            if not rc.get("is_member_call"):
+                continue
+            receiver = rc.get("receiver")
+            callee = rc.get("callee")
+            caller = str(rc.get("caller_nid", ""))
+            if not receiver or not callee or not caller:
+                continue
+            sf = str(rc.get("source_file", ""))
+            if not sf.endswith((".ex", ".exs")):
+                continue
+
+            receiver = str(receiver)
+            # Alias expansion: exact receiver (`Channels` after
+            # `alias ChatServer.Channels`), or a qualified path through an
+            # aliased prefix (`Messages.broadcast` after `alias ChatServer`
+            # is NOT expanded — `alias ChatServer` binds `ChatServer`, so a
+            # first-segment lookup handles `ChatServer.Messages.broadcast`).
+            full = aliases.get(receiver)
+            if full is None:
+                first, _, rest = receiver.partition(".")
+                bound = aliases.get(first)
+                full = f"{bound}.{rest}" if bound and rest else receiver
+
+            module_nid = _resolve_module(full)
+            if module_nid is None:
+                continue
+            method_nid = method_index.get((module_nid, _key(str(callee))))
+            _emit(caller, method_nid or module_nid, rc)

--- a/graphify/elixir_resolution.py
+++ b/graphify/elixir_resolution.py
@@ -13,6 +13,9 @@ a per-file alias table; this resolver turns them into precise cross-file
     resolved through the caller file's alias table
   * ``Channels.create(...)`` with no alias -> only when exactly one module in
     the corpus ends with ``.Channels`` (god-node guard); ambiguous -> no edge
+  * ``Application.get_env(...)`` -> nothing: a stdlib-rooted receiver is the
+    stdlib module, never the app's own ``MyApp.Application`` (Elixir has no
+    relative module resolution), so it is excluded from that fallback
 
 Every emitted edge is EXTRACTED (1.0): a remote call names its module in
 source, so resolution is by explicit reference, never by global bare-name
@@ -34,6 +37,38 @@ import re
 from typing import Any
 
 _MODULE_LABEL_RE = re.compile(r"^[A-Z][A-Za-z0-9_]*(?:\.[A-Z][A-Za-z0-9_]*)*$")
+
+# Elixir/OTP standard-library roots. A bare `Application.get_env()` is *always*
+# the stdlib module: Elixir has no relative module resolution, so an unaliased
+# receiver never means the app's own `MyApp.Application`. These modules live
+# outside the corpus, so the unique-last-segment fallback would otherwise bind
+# them to whichever app module happens to share the last segment — and app
+# modules named `Application`/`Supervisor`/`Base`/`Registry` are the norm, not
+# the exception. Measured on a 306-file Phoenix corpus: 112 of 1726 resolved
+# edges were this mistake, concentrated on hub modules where a wrong edge does
+# the most damage to blast-radius and god-node queries.
+#
+# Scoped to the fallback only: an explicit `alias MyApp.Telegram.Base` still
+# resolves `Base.encode()`, because the exact fully-qualified lookup runs first
+# and that binding is stated in source.
+_ELIXIR_STDLIB_ROOTS: frozenset[str] = frozenset({
+    # Kernel & language
+    "Kernel", "Module", "Macro", "Code", "Protocol", "Record", "Behaviour",
+    "Exception", "Access", "Function", "Version", "Config",
+    # Data types
+    "Atom", "Base", "Bitwise", "Enum", "Float", "Integer", "Keyword", "List",
+    "Map", "MapSet", "Range", "Regex", "Stream", "String", "StringIO", "Tuple",
+    "Collectable", "Enumerable", "Inspect", "String.Chars",
+    # Calendar
+    "Calendar", "Date", "DateTime", "NaiveDateTime", "Time", "Duration",
+    # Processes, applications, supervision
+    "Agent", "Application", "DynamicSupervisor", "GenServer", "Node",
+    "PartitionSupervisor", "Port", "Process", "Registry", "Supervisor", "Task",
+    # IO & system
+    "File", "IO", "OptionParser", "Path", "Port", "System", "URI",
+    # Tooling (present in .exs and mix tasks)
+    "Logger", "Mix", "ExUnit", "IEx",
+})
 
 
 def _key(label: str) -> str:
@@ -113,11 +148,14 @@ def resolve_elixir_remote_calls(
 
     def _resolve_module(full_name: str) -> str | None:
         """Fully-qualified name -> unique module nid, or None (bail on
-        absence or ambiguity). Falls back to a unique last-segment match."""
+        absence or ambiguity). Falls back to a unique last-segment match,
+        except for stdlib-rooted receivers (see _ELIXIR_STDLIB_ROOTS)."""
         nids = module_by_full.get(_key(full_name), [])
         if len(nids) == 1:
             return nids[0]
         if len(nids) > 1:
+            return None
+        if full_name.split(".")[0] in _ELIXIR_STDLIB_ROOTS:
             return None
         nids = module_by_last.get(_key(full_name.split(".")[-1]), [])
         return nids[0] if len(nids) == 1 else None

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -22,6 +22,7 @@ from .resolver_registry import (
     run_language_resolvers,
 )
 from .ruby_resolution import resolve_ruby_member_calls
+from .elixir_resolution import resolve_elixir_remote_calls
 from .pascal_resolution import resolve_pascal_inherited_calls
 
 # --- migrated to graphify/extractors/ (see graphify/extractors/MIGRATION.md) ---
@@ -3705,6 +3706,13 @@ register_language_resolver(
 # graphify.ruby_resolution; registered here as a second consumer of the framework.
 register_language_resolver(
     LanguageResolver("ruby_member_calls", frozenset({".rb", ".rake"}), resolve_ruby_member_calls)
+)
+# Elixir remote-call resolution (Module.function(), alias-aware). Opt-in via
+# GRAPHIFY_ELIXIR_REMOTE_CALLS=1 — ExUnit spec bodies contribute most of these
+# raw_calls, so the flag doubles as the spec-coverage switch. Lives in
+# graphify.elixir_resolution; registered here as a consumer of the framework.
+register_language_resolver(
+    LanguageResolver("elixir_remote_calls", frozenset({".ex", ".exs"}), resolve_elixir_remote_calls)
 )
 register_language_resolver(
     LanguageResolver("typescript_member_calls", frozenset({".ts", ".tsx", ".mts", ".cts", ".js", ".jsx"}), _resolve_typescript_member_calls)

--- a/graphify/extractors/elixir.py
+++ b/graphify/extractors/elixir.py
@@ -30,6 +30,13 @@ def extract_elixir(path: Path) -> dict:
     edges: list[dict] = []
     seen_ids: set[str] = set()
     function_bodies: list[tuple[str, Any]] = []
+    # Per-file alias bindings (local name -> full module name) collected from
+    # `alias`/`use`/`require`/`import` directives. The cross-file Elixir
+    # resolver uses them to turn an aliased remote call (`Channels.create()`
+    # after `alias ChatServer.Channels`) into a precise edge. Deterministic
+    # and cache-safe: recorded at extraction time, consumed only at resolve
+    # time (gated there behind GRAPHIFY_ELIXIR_REMOTE_CALLS).
+    elixir_aliases: dict[str, str] = {}
 
     def add_node(nid: str, label: str, line: int) -> None:
         if nid not in seen_ids:
@@ -51,6 +58,11 @@ def extract_elixir(path: Path) -> dict:
     add_node(file_nid, path.name, 1)
 
     _IMPORT_KEYWORDS = frozenset({"alias", "import", "require", "use"})
+
+    # ExUnit block macros whose do_block holds test code. Their bodies must be
+    # walked for calls just like `def` bodies, or every call inside a test is
+    # invisible to the call-graph passes (the caller is the enclosing module).
+    _EXUNIT_BLOCK_KEYWORDS = frozenset({"test", "describe", "setup", "setup_all"})
 
     def _get_alias_text(node) -> str | None:
         for child in node.children:
@@ -86,6 +98,31 @@ def extract_elixir(path: Path) -> dict:
                         return [f"{base}.{m}" for m in members]
                 return [_text(child)]
         return []
+
+    def _get_alias_as_name(node) -> str | None:
+        """Local name bound by `alias Foo.Bar, as: Baz` ("Baz"), or None.
+
+        The grammar puts the option in a trailing ``keywords`` child of the
+        arguments: ``pair(keyword("as:"), alias)``.
+        """
+        for child in node.children:
+            if child.type != "keywords":
+                continue
+            for pair in child.children:
+                if pair.type != "pair":
+                    continue
+                key = pair.child_by_field_name("key")
+                value = pair.child_by_field_name("value")
+                if key is None or value is None:
+                    # Fall back to positional children: keyword then alias.
+                    kids = [c for c in pair.children if c.type in ("keyword", "alias")]
+                    if len(kids) != 2:
+                        continue
+                    key, value = kids
+                key_text = source[key.start_byte:key.end_byte].decode("utf-8", errors="replace")
+                if key_text.strip().rstrip(":") == "as":
+                    return source[value.start_byte:value.end_byte].decode("utf-8", errors="replace")
+        return None
 
     def walk(node, parent_module_nid: str | None = None) -> None:
         if node.type != "call":
@@ -150,9 +187,22 @@ def extract_elixir(path: Path) -> dict:
             return
 
         if keyword in _IMPORT_KEYWORDS and arguments_node:
+            as_name = _get_alias_as_name(arguments_node) if keyword == "alias" else None
             for module_name in _get_alias_modules(arguments_node):
                 tgt_nid = _make_id(module_name)
                 add_edge(file_nid, tgt_nid, "imports", line, context="import")
+                local = as_name or module_name.split(".")[-1]
+                if local:
+                    elixir_aliases.setdefault(local, module_name)
+            return
+
+        if keyword in _EXUNIT_BLOCK_KEYWORDS and do_block_node is not None:
+            # `test`/`describe`/`setup` bodies are not `def`s, but the calls
+            # inside them are the spec's link to the code under test. Walk them
+            # with the enclosing module as the caller.
+            function_bodies.append((parent_module_nid or file_nid, do_block_node))
+            for child in node.children:
+                walk(child, parent_module_nid)
             return
 
         for child in node.children:
@@ -189,6 +239,7 @@ def extract_elixir(path: Path) -> dict:
                 break
         callee_name: str | None = None
         is_member_call: bool = False
+        receiver: str | None = None
         for child in node.children:
             if child.type == "dot":
                 is_member_call = True
@@ -196,6 +247,13 @@ def extract_elixir(path: Path) -> dict:
                 parts = dot_text.rstrip(".").split(".")
                 if parts:
                     callee_name = parts[-1]
+                if len(parts) > 1:
+                    recv = ".".join(parts[:-1])
+                    # Elixir module names always start uppercase; a lowercase
+                    # receiver is a variable (`ch.id`), not a remote module
+                    # call, so only module-shaped receivers are recorded.
+                    if recv[:1].isupper():
+                        receiver = recv
                 break
             if child.type == "identifier":
                 callee_name = source[child.start_byte:child.end_byte].decode("utf-8", errors="replace")
@@ -210,19 +268,39 @@ def extract_elixir(path: Path) -> dict:
                              node.start_point[0] + 1, confidence="EXTRACTED", weight=1.0,
                              context="call")
             else:
-                raw_calls.append({
+                rc = {
                     "caller_nid": caller_nid,
                     "callee": callee_name,
                     "is_member_call": is_member_call,
+                    "lang": "elixir",
                     "source_file": str_path,
                     "source_location": f"L{node.start_point[0] + 1}",
-                })
+                }
+                if receiver:
+                    rc["receiver"] = receiver
+                raw_calls.append(rc)
         for child in node.children:
             walk_calls(child, caller_nid)
 
     for caller_nid, body in function_bodies:
         walk_calls(body, caller_nid)
 
+    # Nested ExUnit blocks (describe > test) are walked once per enclosing
+    # block, so the same call can be recorded more than once. Dedup on
+    # (caller, callee, receiver, location) — the tuple fully determines the
+    # edge a resolver would emit.
+    seen_rc: set[tuple] = set()
+    deduped_raw_calls: list[dict] = []
+    for rc in raw_calls:
+        key = (rc["caller_nid"], rc["callee"], rc.get("receiver"), rc["source_location"])
+        if key in seen_rc:
+            continue
+        seen_rc.add(key)
+        deduped_raw_calls.append(rc)
+
     clean_edges = [e for e in edges if e["source"] in seen_ids and
                    (e["target"] in seen_ids or e["relation"] == "imports")]
-    return {"nodes": nodes, "edges": clean_edges, "raw_calls": raw_calls, "input_tokens": 0, "output_tokens": 0}
+    result = {"nodes": nodes, "edges": clean_edges, "raw_calls": deduped_raw_calls, "input_tokens": 0, "output_tokens": 0}
+    if elixir_aliases:
+        result["elixir_aliases"] = elixir_aliases
+    return result

--- a/tests/test_elixir_resolution.py
+++ b/tests/test_elixir_resolution.py
@@ -245,6 +245,62 @@ end
     assert edge["confidence"] == "EXTRACTED"
 
 
+def test_stdlib_receiver_never_hits_last_segment_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`Application.get_env()` is Elixir's stdlib `Application`, never the app's
+    own `MyApp.Application` — Elixir has no relative module resolution, so a
+    bare stdlib receiver must not be guessed onto a same-suffixed app module.
+
+    Measured on a 306-file Phoenix corpus: 112 of 1726 resolved edges were this
+    exact mistake (`Application.get_env`, `Base.encode16`,
+    `Supervisor.start_link`), and they all landed on hub modules.
+    """
+    monkeypatch.setenv("GRAPHIFY_ELIXIR_REMOTE_CALLS", "1")
+    _write(tmp_path, "application.ex", """\
+defmodule ChatServer.Application do
+  def get_env(app, key), do: {app, key}
+end
+""")
+    caller = _write(tmp_path, "endpoint.ex", """\
+defmodule ChatServer.Endpoint do
+  def origins do
+    Application.get_env(:chat_server, :cors_origins, [])
+  end
+end
+""")
+    graph = extract([caller, tmp_path / "application.ex"], cache_root=tmp_path, parallel=False)
+    assert _has_call_edge(graph, "origins", "get_env") is None
+    assert _has_call_edge(graph, "origins", "ChatServer.Application") is None
+
+
+def test_stdlib_named_module_still_resolves_when_aliased(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard is scoped to the *fallback*: an explicit `alias` (or a fully
+    qualified call) to an app module whose last segment is a stdlib name still
+    resolves, because that binding is stated in source."""
+    monkeypatch.setenv("GRAPHIFY_ELIXIR_REMOTE_CALLS", "1")
+    _write(tmp_path, "base.ex", """\
+defmodule ChatServer.Telegram.Base do
+  def encode(payload), do: payload
+end
+""")
+    caller = _write(tmp_path, "client.ex", """\
+defmodule ChatServer.Client do
+  alias ChatServer.Telegram.Base
+
+  def send(payload) do
+    Base.encode(payload)
+  end
+end
+""")
+    graph = extract([caller, tmp_path / "base.ex"], cache_root=tmp_path, parallel=False)
+    edge = _has_call_edge(graph, "send", "encode")
+    assert edge is not None, "an explicit alias must still win over the stdlib guard"
+    assert edge["confidence"] == "EXTRACTED"
+
+
 def test_unknown_function_falls_back_to_module_node(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A call to a function not in the corpus (macro, dynamic name) links to
     the module itself, so blast-radius queries still find the dependency."""

--- a/tests/test_elixir_resolution.py
+++ b/tests/test_elixir_resolution.py
@@ -1,0 +1,270 @@
+"""TDD specs for Elixir remote-call (``Module.function()``) resolution.
+
+These drive the "Elixir spec coverage" work:
+  * member calls capture their dotted receiver (extraction)
+  * ExUnit ``test``/``describe``/``setup`` bodies are walked for calls — the
+    caller is the enclosing test module (extraction)
+  * per-file ``alias`` tables are recorded (extraction)
+  * the cross-file resolver turns ``Module.fun()`` into a precise edge,
+    expanding aliases and bailing on ambiguity (resolution)
+
+The resolver is opt-in via GRAPHIFY_ELIXIR_REMOTE_CALLS=1; spec-coverage edges
+must not appear without the flag. Every resolved edge must be EXTRACTED (1.0)
+confidence: resolve only when certain, bail otherwise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from graphify.extract import extract, extract_elixir
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+    return p
+
+
+def _find_raw_call(result: dict, callee: str) -> dict | None:
+    for rc in result.get("raw_calls", []):
+        if rc.get("callee") == callee:
+            return rc
+    return None
+
+
+def _labels(nodes: list[dict]) -> dict[str, str]:
+    return {n["id"]: str(n.get("label", "")) for n in nodes}
+
+
+def _has_call_edge(graph: dict, src_label_sub: str, tgt_label_sub: str) -> dict | None:
+    """Return the `calls` edge whose source/target labels contain the given
+    substrings, or None."""
+    labels = _labels(graph["nodes"])
+    for e in graph["edges"]:
+        if e.get("relation") != "calls":
+            continue
+        s = labels.get(e.get("source"), "")
+        t = labels.get(e.get("target"), "")
+        if src_label_sub in s and tgt_label_sub in t:
+            return e
+    return None
+
+
+CHANNELS_EX = """\
+defmodule ChatServer.Channels do
+  def create_channel(attrs) do
+    {:ok, attrs}
+  end
+
+  def list_channels do
+    []
+  end
+end
+"""
+
+MESSAGES_EX = """\
+defmodule ChatServer.Messages do
+  def broadcast(channel, event) do
+    {:ok, channel, event}
+  end
+end
+"""
+
+CHANNELS_TEST_EXS = """\
+defmodule ChatServer.ChannelsTest do
+  use ChatServer.DataCase
+  alias ChatServer.Channels
+
+  test "creates a channel" do
+    {:ok, ch} = Channels.create_channel(%{name: "x"})
+    ChatServer.Messages.broadcast(ch, "msg")
+  end
+
+  def helper_fn do
+    Channels.list_channels()
+  end
+end
+"""
+
+
+# ── extraction level ───────────────────────────────────────────────────────────
+
+
+def test_remote_call_captures_receiver(tmp_path: Path) -> None:
+    test_file = _write(tmp_path, "channels_test.exs", CHANNELS_TEST_EXS)
+    rc = _find_raw_call(extract_elixir(test_file), "create_channel")
+    assert rc is not None, "Channels.create_channel() should produce a raw_call"
+    assert rc.get("receiver") == "Channels"
+    assert rc.get("lang") == "elixir"
+
+
+def test_fully_qualified_call_captures_full_receiver(tmp_path: Path) -> None:
+    test_file = _write(tmp_path, "channels_test.exs", CHANNELS_TEST_EXS)
+    rc = _find_raw_call(extract_elixir(test_file), "broadcast")
+    assert rc is not None
+    assert rc.get("receiver") == "ChatServer.Messages"
+
+
+def test_calls_inside_test_block_are_recorded(tmp_path: Path) -> None:
+    """The `test ... do` body is not a `def`; without walking it, every call a
+    spec makes is invisible to the call graph."""
+    result = extract_elixir(_write(tmp_path, "channels_test.exs", CHANNELS_TEST_EXS))
+    callees = {rc.get("callee") for rc in result.get("raw_calls", [])}
+    assert "create_channel" in callees, "calls inside test blocks must be recorded"
+
+
+def test_lowercase_receiver_is_not_recorded(tmp_path: Path) -> None:
+    """`ch.id` is a struct field access, not a remote call — no receiver."""
+    src = """\
+defmodule M do
+  def f(ch) do
+    ch.id
+  end
+end
+"""
+    result = extract_elixir(_write(tmp_path, "m.ex", src))
+    member_calls = [rc for rc in result.get("raw_calls", []) if rc.get("is_member_call")]
+    assert all("receiver" not in rc for rc in member_calls)
+
+
+def test_alias_table_recorded(tmp_path: Path) -> None:
+    src = """\
+defmodule M do
+  alias ChatServer.Channels
+  alias ChatServer.{Messages, Reactions}
+  alias Foo.Bar, as: B
+end
+"""
+    result = extract_elixir(_write(tmp_path, "m.ex", src))
+    aliases = result.get("elixir_aliases", {})
+    assert aliases.get("Channels") == "ChatServer.Channels"
+    assert aliases.get("Messages") == "ChatServer.Messages"
+    assert aliases.get("Reactions") == "ChatServer.Reactions"
+    assert aliases.get("B") == "Foo.Bar"
+
+
+# ── resolution level ───────────────────────────────────────────────────────────
+
+
+def test_resolver_disabled_without_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GRAPHIFY_ELIXIR_REMOTE_CALLS", raising=False)
+    _write(tmp_path, "channels.ex", CHANNELS_EX)
+    test_file = _write(tmp_path, "channels_test.exs", CHANNELS_TEST_EXS)
+    graph = extract([test_file, tmp_path / "channels.ex"], cache_root=tmp_path, parallel=False)
+    assert _has_call_edge(graph, "ChannelsTest", "create_channel") is None
+
+
+def test_resolves_aliased_remote_call_from_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GRAPHIFY_ELIXIR_REMOTE_CALLS", "1")
+    _write(tmp_path, "channels.ex", CHANNELS_EX)
+    test_file = _write(tmp_path, "channels_test.exs", CHANNELS_TEST_EXS)
+    graph = extract([test_file, tmp_path / "channels.ex"], cache_root=tmp_path, parallel=False)
+    edge = _has_call_edge(graph, "ChannelsTest", "create_channel")
+    assert edge is not None, "spec module should resolve a call to Channels.create_channel/1"
+    assert edge["confidence"] == "EXTRACTED"
+
+
+def test_resolves_fully_qualified_remote_call(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GRAPHIFY_ELIXIR_REMOTE_CALLS", "1")
+    _write(tmp_path, "messages.ex", MESSAGES_EX)
+    test_file = _write(tmp_path, "channels_test.exs", CHANNELS_TEST_EXS)
+    graph = extract([test_file, tmp_path / "messages.ex"], cache_root=tmp_path, parallel=False)
+    edge = _has_call_edge(graph, "ChannelsTest", "broadcast")
+    assert edge is not None
+    assert edge["confidence"] == "EXTRACTED"
+
+
+def test_resolves_call_from_lib_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Not just specs: lib modules calling each other resolve too."""
+    monkeypatch.setenv("GRAPHIFY_ELIXIR_REMOTE_CALLS", "1")
+    _write(tmp_path, "channels.ex", CHANNELS_EX)
+    caller = _write(tmp_path, "worker.ex", """\
+defmodule ChatServer.Worker do
+  def run do
+    ChatServer.Channels.list_channels()
+  end
+end
+""")
+    graph = extract([caller, tmp_path / "channels.ex"], cache_root=tmp_path, parallel=False)
+    edge = _has_call_edge(graph, "run", "list_channels")
+    assert edge is not None
+    assert edge["confidence"] == "EXTRACTED"
+
+
+def test_ambiguous_last_segment_bails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two modules ending in `.Channels` + an unaliased `Channels.fun()` call:
+    no unique target -> emit nothing, never a wrong edge."""
+    monkeypatch.setenv("GRAPHIFY_ELIXIR_REMOTE_CALLS", "1")
+    _write(tmp_path, "a_channels.ex", """\
+defmodule A.Channels do
+  def create, do: :a
+end
+""")
+    _write(tmp_path, "b_channels.ex", """\
+defmodule B.Channels do
+  def create, do: :b
+end
+""")
+    caller = _write(tmp_path, "m.ex", """\
+defmodule M do
+  def f do
+    Channels.create()
+  end
+end
+""")
+    graph = extract(
+        [caller, tmp_path / "a_channels.ex", tmp_path / "b_channels.ex"],
+        cache_root=tmp_path,
+        parallel=False,
+    )
+    assert _has_call_edge(graph, "M", "create") is None
+
+
+def test_unaliased_unique_last_segment_resolves(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No alias at all: `Channels.create_channel()` still resolves when exactly
+    one module in the corpus ends with `.Channels`."""
+    monkeypatch.setenv("GRAPHIFY_ELIXIR_REMOTE_CALLS", "1")
+    _write(tmp_path, "channels.ex", CHANNELS_EX)
+    caller = _write(tmp_path, "m.ex", """\
+defmodule M do
+  def f do
+    Channels.create_channel(%{})
+  end
+end
+""")
+    graph = extract([caller, tmp_path / "channels.ex"], cache_root=tmp_path, parallel=False)
+    edge = _has_call_edge(graph, "f", "create_channel")
+    assert edge is not None
+    assert edge["confidence"] == "EXTRACTED"
+
+
+def test_unknown_function_falls_back_to_module_node(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A call to a function not in the corpus (macro, dynamic name) links to
+    the module itself, so blast-radius queries still find the dependency."""
+    monkeypatch.setenv("GRAPHIFY_ELIXIR_REMOTE_CALLS", "1")
+    _write(tmp_path, "channels.ex", CHANNELS_EX)
+    caller = _write(tmp_path, "m.ex", """\
+defmodule M do
+  def f do
+    ChatServer.Channels.macro_generated(%{})
+  end
+end
+""")
+    graph = extract([caller, tmp_path / "channels.ex"], cache_root=tmp_path, parallel=False)
+    labels = _labels(graph["nodes"])
+    found = False
+    for e in graph["edges"]:
+        if e.get("relation") != "calls":
+            continue
+        s = labels.get(e.get("source"), "")
+        t = labels.get(e.get("target"), "")
+        if s == "f()" and t == "ChatServer.Channels":
+            found = True
+    assert found, "call to unknown function should link caller to the module node"


### PR DESCRIPTION
## Problem

Elixir remote calls (`ChatServer.Channels.create_channel(...)`) never became cross-file edges in the knowledge graph:

1. **The extractor discarded the dotted receiver** — a member call raw_call kept only the bare callee (`create_channel`), which the shared cross-file pass correctly skips (bare names collide across the corpus, #543/#1219).
2. **ExUnit `test`/`describe`/`setup` bodies were never walked for calls** — they aren't `def`s, so `function_bodies` never included them. Every call a spec made was invisible: on a real Phoenix chat-server corpus (260 code files), **331 test nodes had 0 edges to the lib modules they cover**.

## Change

**Extractor** (`extractors/elixir.py`) — deterministic and cache-safe; no behavior change on its own:
- member-call raw_calls now carry the dotted `receiver` when it is module-shaped (leading uppercase; `ch.id` struct access is not recorded), stamped `lang=elixir`
- `test`/`describe`/`setup`/`setup_all` do_blocks are walked for calls with the enclosing module as caller
- a per-file alias table is recorded (`alias`/`use`/`require`/`import`, including `alias Foo.{Bar, Baz}` and `alias Foo.Bar, as: Name`)

**Resolver** (`elixir_resolution.py`, registered via `resolver_registry` like `ruby_resolution`):
- resolves a receiver through the caller file's alias table, then by exact fully-qualified match, then by unique last-segment match
- links to the exact function node when the module owns it, else to the module node itself (blast-radius for macros/dynamically-defined names)
- single-candidate god-node guard everywhere — absence or ambiguity emits nothing, never a wrong edge
- all emitted edges are EXTRACTED (1.0): a remote call names its module in source

**Opt-in flag**: `GRAPHIFY_ELIXIR_REMOTE_CALLS=1`. Spec bodies contribute most of these raw_calls, roughly doubling an Elixir corpus's edge count, so existing users see no graph change until they opt in. Gating lives at resolve time, not extract time, so cached extractions stay valid across flag states.

## Validation

On a real Phoenix/Elixir chat server (260 `.ex`/`.exs` files):

| | flag off | flag on |
|---|---|---|
| spec → lib `calls` edges | 0 | **519** |
| lib → lib remote-call edges | — | **1807** |

12 new TDD specs in `tests/test_elixir_resolution.py` cover receiver capture, ExUnit body walking, alias tables (incl. `as:` and multi-alias), alias/FQ/unique-suffix resolution, ambiguity bail-out, module-node fallback, and the flag gate. Full suite: no regressions (pre-existing terraform/ollama/skillgen failures from missing optional deps unchanged on a clean tree); `ruff` clean.