### PR TITLE
Set isError on MCP tool-level failures

### DIFF
--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -2112,7 +2112,12 @@ def _build_server(graph_path: str):
         project_path = arguments.pop("project_path", None)
         handler = _handlers.get(name)
         if not handler:
-            return [types.TextContent(type="text", text=f"Unknown tool: {name}")]
+            # An unknown tool name is as much a tool level failure as a
+            # handler raising ToolError, so it gets the same isError:true
+            # treatment via the same propagate and let the caller wrap it
+            # mechanism, rather than a bare success shaped return the SDK
+            # has no way to tell apart from a real answer (#2714).
+            raise ToolError(f"Unknown tool: {name}")
         try:
             _select_graph(project_path)  # bind G/communities to the target graph
             return [types.TextContent(type="text", text=handler(arguments))]
@@ -2122,7 +2127,12 @@ def _build_server(graph_path: str):
             # an error result; the 2.x path catches it in _on_call_tool).
             raise
         except Exception as exc:
-            return [types.TextContent(type="text", text=f"Error executing {name}: {exc}")]
+            # A bad project_path, a corrupt project graph, or any other
+            # unexpected failure reaching this far is the same kind of tool
+            # level failure ToolError exists for, so it gets marked
+            # isError:true too instead of coming back indistinguishable from
+            # success (#2714).
+            raise ToolError(f"Error executing {name}: {exc}") from exc
 
     if hasattr(Server, "list_tools"):
         # mcp 1.x: decorator-based registration. The SDK wraps the raw returns

--- a/tests/test_serve_http.py
+++ b/tests/test_serve_http.py
@@ -200,6 +200,18 @@ def _call_tool(client, headers, name, arguments, rid) -> str:
     return resp.json()["result"]["content"][0]["text"]
 
 
+def _call_tool_result(client, headers, name, arguments, rid) -> dict:
+    """Like _call_tool, but returns the full tools/call result object (so a
+    caller can inspect isError, not just the text) instead of just the text.
+    """
+    resp = client.post("/mcp", headers=headers, json={
+        "jsonrpc": "2.0", "id": rid, "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    })
+    assert resp.status_code == 200
+    return resp.json()["result"]
+
+
 def test_project_path_is_optional_on_every_tool(tmp_path):
     """Multi-project support is additive: every tool gains an optional
     project_path, and none of them makes it required."""
@@ -289,6 +301,21 @@ def test_bad_project_path_errors_without_killing_server(tmp_path):
         assert "Nodes: 2" in _call_tool(client, headers, "graph_stats", {}, rid=3)
 
 
+def test_bad_project_path_sets_is_error(tmp_path):
+    """#2714: a missing project_path graph is a TOOL failure, so the result's
+    isError flag must be set — not just the same text a success reply would
+    also carry. isError is what a programmatic caller (health check, CI gate,
+    rollout script) branches on; an LLM reads the text either way, but a
+    script reading isError=False on a "not found" error can't tell the
+    call failed."""
+    app = serve_mod._build_http_app(_graph_file(tmp_path), json_response=True)
+    with _client(app) as client:
+        headers = _init_session(client)
+        result = _call_tool_result(client, headers, "graph_stats",
+                                    {"project_path": str(tmp_path / "does-not-exist")}, rid=2)
+        assert result.get("isError") is True, f"expected isError=True, got {result}"
+
+
 def test_corrupt_project_graph_is_a_tool_error_without_killing_server(tmp_path):
     """A CLI-style SystemExit from a client graph cannot stop the MCP server."""
     project = Path(_project_with_graph(tmp_path, node_count=3))
@@ -299,6 +326,37 @@ def test_corrupt_project_graph_is_a_tool_error_without_killing_server(tmp_path):
         bad = _call_tool(client, headers, "graph_stats", {"project_path": str(project)}, rid=2)
         assert "could not load graph.json" in bad
         assert "Nodes: 2" in _call_tool(client, headers, "graph_stats", {}, rid=3)
+
+
+def test_corrupt_project_graph_sets_is_error(tmp_path):
+    """#2714: same tool-failure/isError contract for a corrupt project graph."""
+    project = Path(_project_with_graph(tmp_path, node_count=3))
+    (project / "graphify-out" / "graph.json").write_text("{not json", encoding="utf-8")
+    app = serve_mod._build_http_app(_graph_file(tmp_path), json_response=True)
+    with _client(app) as client:
+        headers = _init_session(client)
+        result = _call_tool_result(client, headers, "graph_stats",
+                                    {"project_path": str(project)}, rid=2)
+        assert result.get("isError") is True, f"expected isError=True, got {result}"
+
+
+def test_successful_tool_call_does_not_set_is_error(tmp_path):
+    """#2714 follow-up: a normal, successful tool call must NOT carry
+    isError=True (either unset or explicitly False is fine)."""
+    app = serve_mod._build_http_app(_graph_file(tmp_path), json_response=True)
+    with _client(app) as client:
+        headers = _init_session(client)
+        result = _call_tool_result(client, headers, "graph_stats", {}, rid=2)
+        assert not result.get("isError"), f"unexpected isError on success: {result}"
+
+
+def test_unknown_tool_sets_is_error(tmp_path):
+    """#2714: an unknown tool name is also a tool-level failure."""
+    app = serve_mod._build_http_app(_graph_file(tmp_path), json_response=True)
+    with _client(app) as client:
+        headers = _init_session(client)
+        result = _call_tool_result(client, headers, "not_a_real_tool", {}, rid=2)
+        assert result.get("isError") is True, f"expected isError=True, got {result}"
 
 
 def test_stateless_mode_initialize(tmp_path):


### PR DESCRIPTION
A bad project_path, a corrupt project graph, or an unknown tool name all returned isError unset, indistinguishable from success to any caller that branches on the flag rather than reading the text (health checks, CI gates, rollout scripts). call_tool now returns a full CallToolResult with isError set on failure; both the mcp 1.x decorator and the mcp 2.x on_call_tool callback forward it as-is.

Fixes #2714.