### PR TITLE
fix(cli): preserve graph artifacts when community labeling fails

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -1974,11 +1974,18 @@ def dispatch_command(cmd: str) -> None:
                     for cid, members in communities.items()
                     if cid not in existing_labels or existing_labels.get(cid) == f"Community {cid}"
                 }
-            generated_labels, _ = generate_community_labels(
+            generated_labels, label_source = generate_community_labels(
                 G, label_communities_input, backend=label_backend, model=label_model, gods=gods,
                 max_concurrency=label_max_concurrency, batch_size=label_batch_size,
                 usage_out=label_token_usage,
             )
+            if label_source == "failed":
+                print(
+                    "[graphify label] community labeling failed for every requested batch; "
+                    "no graph artifacts were changed. Check the backend and retry.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
             # Only let the LLM OVERRIDE where it produced a real name — its no-backend
             # fallback returns "Community {cid}" placeholders, which must not clobber
             # the deterministic hub labels. Also reject a model echoing the prompt

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -3046,9 +3046,8 @@ def label_communities(
     for any community the backend did not name. Per-batch failures are logged
     to stderr and skipped — the surviving batches still contribute labels.
 
-    Raises on the first batch's backend/parse failure if it leaves *no* labels
-    written. Callers that want graceful degradation should use
-    :func:`generate_community_labels`.
+    Raises if no batch produces a label. Callers that want graceful degradation
+    should use :func:`generate_community_labels`.
     """
     labels = _placeholder_community_labels(communities)
     cap = len(communities) if max_communities is None else max_communities
@@ -3120,10 +3119,12 @@ def label_communities(
             for future in as_completed(futures):
                 _merge(*future.result())
 
-    if written == 0 and errors:
-        # Every batch failed; propagate the lowest-index error so the message is
-        # deterministic and generate_community_labels degrades cleanly.
-        raise errors[min(errors)]
+    if written == 0:
+        if errors:
+            # Every batch failed; propagate the lowest-index error so the message
+            # is deterministic and generate_community_labels can report failure.
+            raise errors[min(errors)]
+        raise ValueError("labeling produced no community labels")
     return labels
 
 
@@ -3139,10 +3140,12 @@ def generate_community_labels(
     batch_size: int = _LABEL_BATCH_SIZE,
     usage_out: dict | None = None,
 ) -> tuple[dict[int, str], str]:
-    """CLI entry point: resolve a backend, name communities, and degrade to
-    ``Community N`` placeholders on any failure (no backend, API error, malformed
-    reply). Returns ``(labels, source)`` where source is ``"llm"`` or
-    ``"placeholder"``. Never raises."""
+    """CLI entry point: resolve a backend and name communities.
+
+    Returns ``(labels, source)`` where ``source`` is ``"llm"`` when at least one
+    requested batch succeeds, ``"placeholder"`` when no backend is configured,
+    or ``"failed"`` when every requested batch fails. Never raises.
+    """
     if backend is None:
         try:
             backend = detect_backend()
@@ -3167,7 +3170,7 @@ def generate_community_labels(
         if not quiet:
             print(
                 f"[graphify label] warning: community labeling failed ({exc}); "
-                "using Community N placeholders.",
+                "no labels were generated.",
                 file=sys.stderr,
             )
-        return _placeholder_community_labels(communities), "placeholder"
+        return _placeholder_community_labels(communities), "failed"

--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -163,6 +163,53 @@ def test_label_cli_missing_only_preserves_existing_labels(tmp_path, monkeypatch)
     assert labels == {"0": "Order Management", "1": "Payment Flow"}
 
 
+def test_label_cli_all_failed_preserves_existing_artifacts(tmp_path, monkeypatch, capsys):
+    """An all-failed requested labeling run must not rewrite graph artifacts."""
+    import graphify.__main__ as cli
+
+    out = tmp_path / "graphify-out"
+    out.mkdir()
+    _two_community_graph(out)
+    (out / "GRAPH_REPORT.md").write_text("PREVIOUS REPORT\n", encoding="utf-8")
+    (out / ".graphify_analysis.json").write_text('{"previous": true}\n', encoding="utf-8")
+    (out / ".graphify_labels.json").write_text(
+        '{"0": "Curated Orders", "1": "Curated Payments"}\n', encoding="utf-8"
+    )
+    (out / ".graphify_labels.json.sig").write_text('{"0": "sig-0", "1": "sig-1"}\n', encoding="utf-8")
+    (out / "graph.html").write_text("<html>previous</html>\n", encoding="utf-8")
+    backup = out / "existing-backup"
+    backup.mkdir()
+    (backup / "sentinel").write_text("leave me alone\n", encoding="utf-8")
+
+    def always_fail(prompt, *, backend, max_tokens=200):
+        raise RuntimeError("backend down")
+
+    monkeypatch.setattr("graphify.llm._call_llm", always_fail)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["graphify", "label", str(tmp_path), "--backend", "gemini", "--no-viz"],
+    )
+
+    before = {
+        path.relative_to(out).as_posix(): (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in out.rglob("*")
+        if path.is_file()
+    }
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 1
+    assert "no graph artifacts were changed" in capsys.readouterr().err
+    after = {
+        path.relative_to(out).as_posix(): (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in out.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+
+
 def test_label_communities_partial_reply_fills_placeholder(monkeypatch):
     G, communities = _graph()
     monkeypatch.setattr("graphify.llm._call_llm",
@@ -195,7 +242,18 @@ def test_generate_community_labels_degrades_on_error(monkeypatch):
     monkeypatch.setattr("graphify.llm._call_llm",
                         lambda p, *, backend, max_tokens=200: "not json")
     labels, source = generate_community_labels(G, communities, backend="gemini", quiet=True)
-    assert source == "placeholder"
+    assert source == "failed"
+    assert labels == {0: "Community 0", 1: "Community 1"}
+
+
+def test_generate_community_labels_fails_when_backend_names_nothing(monkeypatch):
+    G, communities = _graph()
+    monkeypatch.setattr(
+        "graphify.llm._call_llm",
+        lambda p, *, backend, max_tokens=200: "{}",
+    )
+    labels, source = generate_community_labels(G, communities, backend="gemini", quiet=True)
+    assert source == "failed"
     assert labels == {0: "Community 0", 1: "Community 1"}
 
 
@@ -444,8 +502,8 @@ def test_label_communities_accumulates_token_usage(monkeypatch):
             usage_out["input"] = usage_out.get("input", 0) + 100
             usage_out["output"] = usage_out.get("output", 0) + 10
         # one name per community id present in this batch
-        cids = [int(line.split()[1].rstrip(":")) for line in prompt.splitlines()
-                if line.startswith("Community ")]
+        cids = [int(line.split(":", 1)[0]) for line in prompt.splitlines()
+                if re.match(r"^\d+: ", line)]
         return json.dumps({str(c): f"Name {c}" for c in cids})
 
     monkeypatch.setattr("graphify.llm._call_llm", fake_call)


### PR DESCRIPTION
## Summary

An explicit community-labeling run could fail every LLM batch, fall back to deterministic placeholder labels, and still rewrite graph artifacts while returning exit code 0. This change makes that path fail closed before any backup or artifact write.

## Changes

- Distinguish the no-backend placeholder fallback from an all-batches-failed result.
- Exit nonzero with an actionable message when every requested labeling batch fails.
- Preserve the existing graph, report, analysis, label sidecar/signature, HTML, and backup state on that failure path.
- Keep no-backend fallback, --no-label, and partial-success behavior unchanged.
- Add regression coverage for artifact preservation and empty successful responses.

Related to #2573.

## Validation

- uv run --frozen pytest tests/test_labeling.py tests/test_cli_export.py -q — 74 passed.
- uv run --frozen ruff check graphify/llm.py graphify/cli.py tests/test_labeling.py — passed.
- python -m py_compile graphify/llm.py graphify/cli.py tests/test_labeling.py — passed.
- git diff --check — passed.
- uv run --frozen graphify update . — completed successfully.
- Skillgen check, coverage audit, schema singleton, and both round-trip checks — passed.