### PR TITLE
Add native /graphify slash command for OpenCode

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -114,7 +114,7 @@ from graphify.install import (  # noqa: E402,F401
     _KILO_CONFIG_JSONC_PATH,
     _OPENCODE_PLUGIN_JS,
     _OPENCODE_PLUGIN_PATH,
-    _OPENCODE_CONFIG_PATH,
+    _OPENCODE_COMMAND_PATH,
     _PLATFORM_CONFIG,
 )
 from graphify.cli import (  # noqa: E402,F401

--- a/graphify/command-opencode.md
+++ b/graphify/command-opencode.md
@@ -1,0 +1,14 @@
+---
+description: Build or query a graphify knowledge graph
+---
+
+Invoke the `graphify` skill immediately with these arguments: $ARGUMENTS
+
+If no arguments were supplied, treat the target path as `.`.
+
+Examples:
+- `/graphify`
+- `/graphify src --update`
+- `/graphify query "what connects auth to billing?"`
+
+Do not answer from raw files before handing off to the `graphify` skill.

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -704,6 +704,7 @@ def install(platform: str = "claude", *, project: bool = False, project_dir: Pat
 
     if platform == "opencode":
         _install_opencode_plugin(project_dir if project else Path("."))
+        _install_opencode_command(project_dir if project else Path("."))
 
     if project:
         _print_project_git_add_hint([_project_scope_root(skill_dst, project_dir)])
@@ -1391,53 +1392,57 @@ export const GraphifyPlugin = async ({ directory }) => {
 };
 """
 _OPENCODE_PLUGIN_PATH = Path(".opencode") / "plugins" / "graphify.js"
-_OPENCODE_CONFIG_PATH = Path(".opencode") / "opencode.json"
 def _install_opencode_plugin(project_dir: Path) -> None:
-    """Write graphify.js plugin and register it in opencode.json."""
+    """Write graphify.js plugin to the auto-loaded .opencode/plugins/ directory.
+
+    OpenCode auto-loads every plugin file under .opencode/plugins/ (project) or
+    ~/.config/opencode/plugins/ (global) at startup — no config.json entry
+    needed. A prior version also registered the plugin's path in the "plugin"
+    array of .opencode/opencode.json, which was both redundant (the file was
+    already auto-loaded) and broken for a global install (the entry was a
+    project-relative path written into a project-relative opencode.json, never
+    the global ~/.config/opencode/opencode.json), leaving a dead config entry
+    behind (#2709).
+    """
     plugin_file = project_dir / _OPENCODE_PLUGIN_PATH
     plugin_file.parent.mkdir(parents=True, exist_ok=True)
     plugin_file.write_text(_OPENCODE_PLUGIN_JS, encoding="utf-8")
     print(f"  {_OPENCODE_PLUGIN_PATH}  ->  tool.execute.before hook written")
-
-    config_file = project_dir / _OPENCODE_CONFIG_PATH
-    if config_file.exists():
-        try:
-            config = json.loads(config_file.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            config = {}
-    else:
-        config = {}
-
-    plugins = config.setdefault("plugin", [])
-    entry = _OPENCODE_PLUGIN_PATH.as_posix()
-    if entry not in plugins:
-        plugins.append(entry)
-        config_file.write_text(json.dumps(config, indent=2), encoding="utf-8")
-        print(f"  {_OPENCODE_CONFIG_PATH}  ->  plugin registered")
-    else:
-        print(f"  {_OPENCODE_CONFIG_PATH}  ->  plugin already registered (no change)")
 def _uninstall_opencode_plugin(project_dir: Path) -> None:
-    """Remove graphify.js plugin and deregister from opencode.json."""
+    """Remove graphify.js plugin from .opencode/plugins/."""
     plugin_file = project_dir / _OPENCODE_PLUGIN_PATH
     if plugin_file.exists():
         plugin_file.unlink()
         print(f"  {_OPENCODE_PLUGIN_PATH}  ->  removed")
+_OPENCODE_COMMAND_PATH = Path(".opencode") / "commands" / "graphify.md"
+def _install_opencode_command(project_dir: Path) -> None:
+    """Write the native OpenCode /graphify slash command.
 
-    config_file = project_dir / _OPENCODE_CONFIG_PATH
-    if not config_file.exists():
-        return
-    try:
-        config = json.loads(config_file.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return
-    plugins = config.get("plugin", [])
-    entry = _OPENCODE_PLUGIN_PATH.as_posix()
-    if entry in plugins:
-        plugins.remove(entry)
-        if not plugins:
-            config.pop("plugin")
-        config_file.write_text(json.dumps(config, indent=2), encoding="utf-8")
-        print(f"  {_OPENCODE_CONFIG_PATH}  ->  plugin deregistered")
+    OpenCode skills are NOT slash commands — they're loaded on-demand by the
+    agent via the skill tool based on description matching. Only a markdown
+    file under .opencode/commands/ (or ~/.config/opencode/commands/ globally)
+    becomes a `/`-menu entry. Installing only the skill and the reminder
+    plugin (as before) left /graphify absent from the TUI's command menu even
+    though the skill loaded correctly and the docs told users to type it
+    (#2709).
+    """
+    command_src = Path(__file__).parent / "command-opencode.md"
+    if not command_src.exists():
+        print(
+            "error: command-opencode.md not found in package - reinstall graphify",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    command_dst = project_dir / _OPENCODE_COMMAND_PATH
+    command_dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(command_src, command_dst)
+    print(f"  {_OPENCODE_COMMAND_PATH}  ->  /graphify command installed")
+def _uninstall_opencode_command(project_dir: Path) -> None:
+    """Remove the native OpenCode /graphify slash command."""
+    command_file = project_dir / _OPENCODE_COMMAND_PATH
+    if command_file.exists():
+        command_file.unlink()
+        print(f"  {_OPENCODE_COMMAND_PATH}  ->  removed")
 def _resolve_graphify_exe(project: bool = False) -> str:
     """Return the absolute path to the graphify executable, with forward slashes.
 
@@ -1549,6 +1554,7 @@ def _agents_install(project_dir: Path, platform: str, project: bool = False) -> 
         _install_codex_hook(project_dir or Path("."), project=project)
     elif platform == "opencode":
         _install_opencode_plugin(project_dir or Path("."))
+        _install_opencode_command(project_dir or Path("."))
     elif platform == "kilo":
         _install_kilo_plugin(project_dir or Path("."))
 
@@ -1700,6 +1706,7 @@ def _agents_uninstall(project_dir: Path, platform: str = "") -> None:
         print("No AGENTS.md found in current directory - nothing to do")
         if platform == "opencode":
             _uninstall_opencode_plugin(project_dir or Path("."))
+            _uninstall_opencode_command(project_dir or Path("."))
         elif platform == "kilo":
             _uninstall_kilo_plugin(project_dir or Path("."))
         return
@@ -1710,6 +1717,7 @@ def _agents_uninstall(project_dir: Path, platform: str = "") -> None:
         print("graphify section not found in AGENTS.md - nothing to do")
         if platform == "opencode":
             _uninstall_opencode_plugin(project_dir or Path("."))
+            _uninstall_opencode_command(project_dir or Path("."))
         elif platform == "kilo":
             _uninstall_kilo_plugin(project_dir or Path("."))
         return
@@ -1723,6 +1731,7 @@ def _agents_uninstall(project_dir: Path, platform: str = "") -> None:
 
     if platform == "opencode":
         _uninstall_opencode_plugin(project_dir or Path("."))
+        _uninstall_opencode_command(project_dir or Path("."))
     elif platform == "kilo":
         _uninstall_kilo_plugin(project_dir or Path("."))
 def _kilo_uninstall_global() -> list[str]:
@@ -1863,6 +1872,7 @@ def uninstall_all(project_dir: Path | None = None, purge: bool = False) -> None:
     # which neither the AGENTS.md cleanup nor amp's removal reaches.
     _remove_skill_file("agents")
     _uninstall_opencode_plugin(pd)
+    _uninstall_opencode_command(pd)
     _uninstall_codex_hook(pd)
 
     # Git hook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ include-package-data = false
 # under graphify/skills/<host>/references/, and the always-on injection blocks
 # under graphify/always_on/. There is no graphify/skills/<host>/SKILL.md in the
 # repo, so no SKILL.md glob is needed here.
-graphify = ["skill.md", "skill-codex.md", "skill-opencode.md", "skill-kilo.md", "command-kilo.md", "skill-aider.md", "skill-amp.md", "skill-agents.md", "skill-copilot.md", "skill-claw.md", "skill-windows.md", "skill-droid.md", "skill-trae.md", "skill-kiro.md", "skill-vscode.md", "skill-pi.md", "skill-devin.md", "skills/*/references/*.md", "always_on/*.md"]
+graphify = ["skill.md", "skill-codex.md", "skill-opencode.md", "skill-kilo.md", "command-kilo.md", "command-opencode.md", "skill-aider.md", "skill-amp.md", "skill-agents.md", "skill-copilot.md", "skill-claw.md", "skill-windows.md", "skill-droid.md", "skill-trae.md", "skill-kiro.md", "skill-vscode.md", "skill-pi.md", "skill-devin.md", "skills/*/references/*.md", "always_on/*.md"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -773,42 +773,72 @@ def test_opencode_plugin_uses_semicolon_not_ampersand(tmp_path):
     assert '" && \' +' not in body, "'&&' breaks PowerShell 5.1 (#1646)"
 
 
-def test_opencode_agents_install_registers_plugin_in_config(tmp_path):
-    """opencode install registers the plugin in .opencode/opencode.json."""
+def test_opencode_agents_install_does_not_register_plugin_in_config(tmp_path):
+    """#2709: OpenCode auto-loads every plugin file under .opencode/plugins/ at
+    startup, so registering it in opencode.json's "plugin" array is redundant
+    — and for a global install the entry was a project-relative path written
+    into a project-relative opencode.json, never the global one, leaving a
+    dead config entry. Install must not create/touch opencode.json at all."""
     _agents_install(tmp_path, "opencode")
     config_file = tmp_path / ".opencode" / "opencode.json"
-    assert config_file.exists()
-    import json as _json
-
-    config = _json.loads(config_file.read_text())
-    assert any("graphify.js" in p for p in config.get("plugin", []))
+    assert not config_file.exists()
 
 
-def test_opencode_agents_install_merges_existing_config(tmp_path):
-    """opencode install preserves existing .opencode/opencode.json keys."""
+def test_opencode_agents_install_does_not_touch_existing_config(tmp_path):
+    """#2709: an existing .opencode/opencode.json (and its own "plugin" array)
+    must be left byte-for-byte untouched — the plugin file's presence under
+    .opencode/plugins/ is what OpenCode actually auto-loads from."""
     import json as _json
 
     config_file = tmp_path / ".opencode" / "opencode.json"
     config_file.parent.mkdir(parents=True, exist_ok=True)
-    config_file.write_text(_json.dumps({"model": "claude-opus-4-5", "plugin": []}))
+    original = _json.dumps({"model": "claude-opus-4-5", "plugin": ["some-other-plugin"]})
+    config_file.write_text(original)
     _agents_install(tmp_path, "opencode")
-    config = _json.loads(config_file.read_text())
-    assert config["model"] == "claude-opus-4-5"
-    assert any("graphify.js" in p for p in config["plugin"])
+    assert config_file.read_text() == original
 
 
 def test_opencode_agents_uninstall_removes_plugin(tmp_path):
-    """opencode uninstall removes the plugin file and deregisters from opencode.json."""
+    """opencode uninstall removes the plugin file. It must not touch
+    opencode.json — install no longer writes to it either (#2709)."""
     import json as _json
+
+    config_file = tmp_path / ".opencode" / "opencode.json"
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    original = _json.dumps({"plugin": ["some-other-plugin"]})
+    config_file.write_text(original)
 
     _agents_install(tmp_path, "opencode")
     _agents_uninstall(tmp_path, platform="opencode")
     plugin = tmp_path / ".opencode" / "plugins" / "graphify.js"
     assert not plugin.exists()
-    config_file = tmp_path / ".opencode" / "opencode.json"
-    if config_file.exists():
-        config = _json.loads(config_file.read_text())
-        assert not any("graphify.js" in p for p in config.get("plugin", []))
+    assert config_file.read_text() == original
+
+
+def test_opencode_install_writes_native_slash_command(tmp_path):
+    """#2709: OpenCode skills are not slash commands — only a markdown file
+    under .opencode/commands/ (or ~/.config/opencode/commands/ globally)
+    becomes a `/`-menu entry. Installing only the skill + reminder plugin (as
+    before) left /graphify absent from the TUI command menu."""
+    _agents_install(tmp_path, "opencode")
+    command_file = tmp_path / ".opencode" / "commands" / "graphify.md"
+    assert command_file.exists()
+    body = command_file.read_text()
+    assert "$ARGUMENTS" in body
+
+
+def test_opencode_uninstall_removes_native_slash_command(tmp_path):
+    _agents_install(tmp_path, "opencode")
+    _agents_uninstall(tmp_path, platform="opencode")
+    command_file = tmp_path / ".opencode" / "commands" / "graphify.md"
+    assert not command_file.exists()
+
+
+def test_opencode_command_file_exists_in_package():
+    import graphify
+
+    pkg = Path(graphify.__file__).parent
+    assert (pkg / "command-opencode.md").exists()
 
 
 def test_kilo_agents_install_writes_agents_md(tmp_path):


### PR DESCRIPTION
OpenCode skills are loaded on-demand by the agent via description matching; they are not slash commands. Only a markdown file under .opencode/commands/ becomes a /-menu entry, so installing just the skill and reminder plugin left /graphify absent from the TUI command menu even though the skill loaded correctly and the docs told users to type it.

Ship a command-opencode.md template (mirroring the existing Kilo command file) that loads the skill and forwards $ARGUMENTS, and wire it into opencode install/uninstall alongside the existing plugin.

Also drops the .opencode/opencode.json "plugin" array registration: OpenCode already auto-loads every file under .opencode/plugins/, so the registration was redundant, and for a global install it wrote a project-relative path into a project-relative config file that a global setup never reads, leaving a dead entry behind.

Fixes #2709.