### PR TITLE
fix(export): stabilize graph.json field order across a read-rebuild round-trip

### DIFF
--- a/graphify/export.py
+++ b/graphify/export.py
@@ -325,6 +325,22 @@ def to_json(G: nx.Graph, communities: dict[int, list[str]], output_path: str, *,
         if true_src is not None and true_tgt is not None:
             link["source"] = true_src
             link["target"] = true_tgt
+    # Canonicalize the key order WITHIN each node/link dict. node_link_data always
+    # appends the node key (`id`) at the end, so a node whose `id` was an inline
+    # attribute on a cold build (position varies) lands last after a read-rebuild
+    # (build_from_json consumes `id` as the pure node key). The values are
+    # identical either way, but the field order churns, so a byte-diff of two
+    # equivalent graph.json files is noisy and any position-sensitive consumer
+    # sees a spurious change on every round-trip. Emit a stable order — the
+    # identity keys first, then the remaining keys sorted — so the serialized
+    # form is invariant regardless of how the attribute was stored in memory.
+    def _canonical(item: dict, lead: tuple[str, ...]) -> dict:
+        leading = [k for k in lead if k in item]
+        rest = sorted(k for k in item if k not in leading)
+        return {k: item[k] for k in (*leading, *rest)}
+
+    data["nodes"] = [_canonical(n, ("id", "label")) for n in data["nodes"]]
+    data["links"] = [_canonical(link, ("source", "target", "relation")) for link in data["links"]]
     data["nodes"].sort(key=_json_sort_key)
     data["links"].sort(key=_json_sort_key)
     if "hyperedges" not in getattr(G, "graph", {}):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -73,6 +73,55 @@ def test_to_json_sorts_graph_collections_across_insertion_order(tmp_path):
     assert outputs[0].read_bytes() == outputs[1].read_bytes()
 
 
+def test_to_json_field_order_stable_across_read_rebuild(tmp_path):
+    """graph.json survives a build -> write -> read-back -> write round-trip
+    byte-for-byte. node_link_data always appends the node key (`id`) last, so a
+    node whose `id` was an inline attribute on a cold build lands mid-dict, while
+    the same node after build_from_json consumes `id` as the pure node key lands
+    last — identical values, churned field order. Emitting a canonical key order
+    keeps the two serializations identical. Regression guard: the earlier
+    determinism test only varied insertion order within one build and missed
+    this."""
+    extraction = {
+        "nodes": [
+            {"id": "a_foo", "label": "foo", "file_type": "code", "source_file": "a.py"},
+            {"id": "b_bar", "label": "bar", "file_type": "code", "source_file": "b.py"},
+            {"id": "c_baz", "label": "baz", "file_type": "code", "source_file": "c.py"},
+        ],
+        "edges": [
+            {"source": "a_foo", "target": "b_bar", "relation": "calls",
+             "confidence": "EXTRACTED", "confidence_score": 1.0, "source_file": "a.py"},
+            {"source": "b_bar", "target": "c_baz", "relation": "references",
+             "confidence": "EXTRACTED", "confidence_score": 1.0, "source_file": "b.py"},
+        ],
+        "hyperedges": [],
+    }
+    communities = {0: ["a_foo", "b_bar", "c_baz"]}
+
+    first = tmp_path / "first.json"
+    to_json(build_from_json(extraction), communities, str(first),
+            built_at_commit="fixed", force=True)
+    reread = json.loads(first.read_text())
+
+    second = tmp_path / "second.json"
+    to_json(build_from_json(reread), communities, str(second),
+            built_at_commit="fixed", force=True)
+
+    # Byte-identity is the strongest statement of "no cosmetic churn".
+    assert first.read_bytes() == second.read_bytes()
+
+    data = json.loads(first.read_text())
+    # `id` leads every node; source/target lead every link — the identity-first
+    # order node_link_data does not guarantee on its own.
+    for node in data["nodes"]:
+        assert list(node.keys())[0] == "id"
+    for link in data["links"]:
+        assert list(link.keys())[:2] == ["source", "target"]
+    # Endpoints are never swapped by the reordering.
+    endpoints = sorted((e["source"], e["target"]) for e in data["links"])
+    assert endpoints == [("a_foo", "b_bar"), ("b_bar", "c_baz")]
+
+
 def test_to_json_commit_fallback_uses_output_repo_not_cwd(tmp_path, monkeypatch):
     # Without an explicit built_at_commit, provenance must come from the repo
     # the graph is written into, not from whatever repo the shell happens to


### PR DESCRIPTION
Completes #2582.

#2582 made `graph.json` **collection order** byte-stable — the order of nodes, links, and hyperedges across each array — but its scope note deliberately stopped there: *"intentionally limited to collection ordering; mapping-key ordering is unchanged."* This PR closes that gap.

`networkx.node_link_data()` always appends the node key (`id`) at the **end** of each node dict. On a cold build `id` is still an inline attribute and lands mid-dict; after `build_from_json` consumes `id` as the pure node key, a re-serialize appends it last. The values are identical, but the field order churns — so a `graph.json` that is written, reloaded (e.g. by `update`/`cluster-only`), and re-written is **not** byte-stable, defeating #2582's guarantee on the mapping-key axis:

- Cold build: `["label", "file_type", "source_file", "id", "community", "norm_label"]`
- After read → rebuild → write: `["label", "file_type", "source_file", "community", "norm_label", "id"]`

The fix emits a canonical key order in `to_json`, just before the existing record sort: nodes lead with `id`, links with `source`/`target`/`relation`, then remaining keys sorted. The serialized form is now invariant regardless of how the attribute was stored in memory, so `build → write → read → write` is byte-identical. Endpoints are untouched — the `_src`/`_tgt` direction restore (#563/#1061) already guards `source`/`target`, and this change only reorders keys, never values.

## Reproduction (deterministic, no API key needed)

```python
import json, tempfile, os
from pathlib import Path
from graphify.export import to_json
from graphify.build import build_from_json

extraction = {
  "nodes": [
    {"id":"a_foo","label":"foo","file_type":"code","source_file":"a.py"},
    {"id":"b_bar","label":"bar","file_type":"code","source_file":"b.py"},
  ],
  "edges": [
    {"source":"a_foo","target":"b_bar","relation":"calls",
     "confidence":"EXTRACTED","confidence_score":1.0,"source_file":"a.py"},
  ],
  "hyperedges": [],
}
d = tempfile.mkdtemp()
p1 = os.path.join(d,"g1.json")
to_json(build_from_json(extraction), {0:["a_foo","b_bar"]}, p1, built_at_commit="x", force=True)
raw1 = json.loads(Path(p1).read_text())
p2 = os.path.join(d,"g2.json")
to_json(build_from_json(raw1), {0:["a_foo","b_bar"]}, p2, built_at_commit="x", force=True)
print("byte-identical:", Path(p1).read_bytes() == Path(p2).read_bytes())  # False before, True after
```

## Test

`tests/test_export.py::test_to_json_field_order_stable_across_read_rebuild` — builds a graph, writes it, reads it back with `build_from_json`, writes again, and asserts the two files are byte-identical with `id` leading every node and `source`/`target` leading every link. Fails before the patch (the round-trip churns `id`'s position), passes after. The existing `test_to_json_sorts_graph_collections_across_insertion_order` missed this because it only varied insertion order within a single build and never exercised a read-rebuild.

`uv run pytest tests/ -q`: 4335 passed, 45 skipped. The 5 failures (`test_ollama_retry_cap.py` ×4, `test_labeling.py::test_label_communities_batches_when_over_batch_size`) are pre-existing on the untouched `v8` tip and unrelated — verified by reverting `export.py`/`test_export.py` to pristine `origin/v8`, where they still fail. They touch the Ollama retry cap and community-label batching, not export/serialization.
