### PR TITLE
Fix #2738: Prevent all-punctuation identifiers from collapsing in make_id

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -949,7 +949,19 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
                 continue
             if "source_file" in node:
                 node["source_file"] = _norm_source_file(node["source_file"], _root)
-        G.add_node(node["id"], **{k: v for k, v in node.items() if k != "id"})
+        
+        node_id = node["id"]
+        attrs = {k: v for k, v in node.items() if k != "id"}
+        if node_id in G:
+            existing_label = G.nodes[node_id].get("label")
+            new_label = attrs.get("label")
+            if existing_label and new_label and existing_label != new_label:
+                source_file = G.nodes[node_id].get("source_file") or attrs.get("source_file")
+                if source_file:
+                    if _is_file_node_label(existing_label, source_file) and not _is_file_node_label(new_label, source_file):
+                        del attrs["label"]
+        
+        G.add_node(node_id, **attrs)
     node_set = set(G.nodes())
 
     # #1145 (extended): merge LLM ghost-duplicate nodes into AST canonical nodes.

--- a/graphify/ids.py
+++ b/graphify/ids.py
@@ -65,4 +65,12 @@ def make_id(*parts: str) -> str:
     part) and then run through :func:`normalize_id`, so the result is identical to
     what the builder produces from the joined string.
     """
-    return normalize_id("_".join(p.strip("_.") for p in parts if p))
+    normalized_parts = []
+    for p in parts:
+        if not p:
+            continue
+        norm_p = normalize_id(p)
+        if not norm_p:
+            norm_p = "underscore"
+        normalized_parts.append(norm_p)
+    return normalize_id("_".join(normalized_parts))


### PR DESCRIPTION
Fixes #2738

## Summary

This PR addresses the issue where private, all-punctuation identifiers (like Dart's `const Foo._()`) collapse during ID normalization and overwrite their parent file node's label, which subsequently breaks `_is_file_node()` detection and causes file nodes to be incorrectly classified as god nodes.

## Changes
1. **Primary Fix**: Updated `make_id()` in `graphify/ids.py`. When an entity is given but normalizes to an empty string (i.e. it only contains punctuation like `_`), `make_id()` now explicitly falls back to emitting `"underscore"` instead of silently collapsing. This prevents the symbol's ID from colliding with the file's ID.
2. **Secondary Fix**: Updated node merging logic in `build_from_json()` inside `graphify/build.py`. When `G.add_node()` merges attributes for an existing node, it now preferentially keeps the label that matches the source filename instead of allowing arbitrary overlapping symbols to overwrite it.