### PR TITLE
fix(js): retain lazy CommonJS require dependencies

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -1786,7 +1786,7 @@ def _find_require_call(value_node):
         return _find_require_call(obj)
     return None
 
-def _require_imports_js(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str) -> bool:
+def _require_imports_js(node, source: bytes, importer_nid: str, stem: str, edges: list, str_path: str) -> bool:
     """Detect CommonJS require imports inside lexical_declaration / variable_declaration.
 
     Handles three patterns:
@@ -1825,7 +1825,7 @@ def _require_imports_js(node, source: bytes, file_nid: str, stem: str, edges: li
         tgt_nid, resolved_path = resolved
         line = node.start_point[0] + 1
         edge = {
-            "source": file_nid,
+            "source": importer_nid,
             "target": tgt_nid,
             "relation": "imports_from",
             "context": "import",
@@ -1862,7 +1862,7 @@ def _require_imports_js(node, source: bytes, file_nid: str, stem: str, edges: li
         if target_stem is not None:
             for sym in sym_names:
                 edges.append({
-                    "source": file_nid,
+                    "source": importer_nid,
                     "target": _make_id(target_stem, sym),
                     "relation": "imports",
                     "context": "import",
@@ -4657,6 +4657,14 @@ def _extract_generic(
                     for child in node.children:
                         walk_calls(child, caller_nid, receiver_types, closure_locals)
             return
+
+        # CommonJS imports are valid at any lexical depth.  The module-level
+        # pass records top-level require() declarations; this pass owns function
+        # bodies, so detect lazy/cycle-breaking requires here and attribute the
+        # dependency to the enclosing callable rather than silently dropping it.
+        if (config.ts_module in ("tree_sitter_javascript", "tree_sitter_typescript")
+                and node.type in ("lexical_declaration", "variable_declaration")):
+            _require_imports_js(node, source, caller_nid, stem, edges, str_path)
 
         if node.type in config.call_types:
             # JS/TS dynamic imports: await import('./foo.js')

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -776,6 +776,31 @@ def test_extract_js_member_require_emits_property_symbol():
     assert _make_id(helpers_stem, "helperFn") in sym_targets
 
 
+def test_extract_js_function_scoped_require_emits_import_edge(tmp_path):
+    """Lazy CommonJS requires belong to their enclosing function, not nowhere."""
+    target = tmp_path / "target.js"
+    target.write_text("exports.helper = () => 42;\n", encoding="utf-8")
+    caller = tmp_path / "lazy.js"
+    caller.write_text(
+        "function useItLazily() {\n"
+        "  const { helper } = require('./target');\n"
+        "  return helper();\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    result = extract([caller, target], cache_root=tmp_path, root=tmp_path, parallel=False)
+    labels = {node["id"]: node["label"] for node in result["nodes"]}
+    lazy_edges = [
+        edge for edge in result["edges"]
+        if edge["relation"] == "imports_from" and "target" in edge["target"]
+    ]
+
+    assert len(lazy_edges) == 1
+    assert labels[lazy_edges[0]["source"]] == "useItLazily()"
+    assert lazy_edges[0]["confidence"] == "EXTRACTED"
+
+
 def test_extract_js_arrow_function_still_extracted():
     """Regression: arrow functions in lexical_declaration must still produce nodes."""
     from graphify.extract import extract_js


### PR DESCRIPTION
## Summary
- detect CommonJS \equire()\ declarations while traversing JavaScript and TypeScript function bodies
- emit the resolved \imports_from\ and symbol import edges from the enclosing callable
- preserve existing file-level edges for module-scope requires

Fixes #2700.

## Validation
- uv run pytest tests/test_extract.py -q
- uv run pytest tests/test_extract.py::test_extract_js_function_scoped_require_emits_import_edge tests/test_extract.py::test_extract_js_destructured_require_imports_from tests/test_extract.py::test_extract_js_destructured_require_named_symbols tests/test_languages.py -q
- uv run ruff check graphify/extractors/engine.py tests/test_extract.py
- uv run graphify update .