### PR TITLE
fix(js): shadow untracked function-expression bindings from indirect_call args

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -786,7 +786,14 @@ _JS_CONFIG = LanguageConfig(
     call_accessor_node_types=frozenset({"member_expression"}),
     call_accessor_field="property",
     call_accessor_object_field="object",
-    function_boundary_types=frozenset({"function_declaration", "generator_function_declaration", "arrow_function", "method_definition"}),
+    # `function_expression` belongs here so UNTRACKED inline/nested expressions
+    # reach walk_calls' existing closure handler, which already names the type
+    # (`_JS_CLOSURE_TYPES`). Without it the gate never opens, so such an
+    # expression's parameters and locals never fold into extra_locals for its
+    # subtree and read as by-name references (#2241 family). A top-level
+    # `const f = function (…) {}` is tracked via its declarator and was already
+    # fine; the inline/nested forms are what this covers.
+    function_boundary_types=frozenset({"function_declaration", "generator_function_declaration", "arrow_function", "method_definition", "function_expression"}),
     import_handler=_import_js,
 )
 
@@ -807,7 +814,8 @@ _TS_CONFIG = LanguageConfig(
     call_accessor_node_types=frozenset({"member_expression"}),
     call_accessor_field="property",
     call_accessor_object_field="object",
-    function_boundary_types=frozenset({"function_declaration", "generator_function_declaration", "arrow_function", "method_definition"}),
+    # `function_expression`: see the note on the JS config above.
+    function_boundary_types=frozenset({"function_declaration", "generator_function_declaration", "arrow_function", "method_definition", "function_expression"}),
     import_handler=_import_js,
 )
 

--- a/tests/test_indirect_call_function_expression_shadow.py
+++ b/tests/test_indirect_call_function_expression_shadow.py
@@ -1,0 +1,191 @@
+"""An untracked `function (…) {…}` expression's bindings must shadow indirect_call args.
+
+`walk_calls` gates its untracked-closure handling on
+`config.function_boundary_types`, and that handler already names the type it
+should receive:
+
+    _JS_CLOSURE_TYPES = ("arrow_function", "function_expression")
+
+But `function_expression` was absent from the JS and TS `function_boundary_types`
+sets, so the gate never opened for one. An INLINE or NESTED expression's body was
+walked with the ENCLOSING function's `extra_locals`, and its own parameters and
+locals folded into nothing: a bare reference to one of them, passed on as a call
+argument, read as an unresolved by-name reference and fabricated an
+`indirect_call` edge (INFERRED, 0.8) to an unrelated same-named callable
+elsewhere in the corpus.
+
+Scope: a top-level `const f = function (…) {}` is tracked through its declarator
+and already had its own shadow-set entry, so it was never affected — see
+`test_top_level_const_function_expression_was_already_tracked`. The gap is the
+untracked inline/nested forms.
+
+That made the two callback forms disagree, which is what hid it:
+
+    xs.some(k => sink(k))                  # arrow — shadowed, correct
+    xs.some(function (k) { return sink(k) })  # function expression — fabricated
+
+Minified bundles name nearly every private function with a single letter, and
+`function (err, res) {…}` callbacks are pervasive in older JS, so the two collide
+constantly. Same family as `catch_clause.parameter` and the single unparenthesised
+arrow parameter: a binding form that never reached the shadow set.
+"""
+import os
+from pathlib import Path
+
+from graphify.extract import extract
+
+VENDOR = "var Lib=function(){function k(a){return a}return{k:k}}();\n"
+
+
+def _extract_js_dir(tmp_path, files: dict[str, str]):
+    base = tmp_path / "src"
+    base.mkdir()
+    for name, body in files.items():
+        (base / name).write_text(body)
+    old = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        r = extract(
+            [Path("src") / name for name in files],
+            cache_root=Path(".cache"), parallel=False,
+        )
+    finally:
+        os.chdir(old)
+    nid = {n["label"].rstrip("()"): n["id"] for n in r["nodes"]}
+    return r, nid
+
+
+def _indirect(r):
+    return {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "indirect_call"}
+
+
+def test_inline_function_expression_param_emits_no_indirect_call(tmp_path):
+    """The reported shape: a minified bundle's private `k` must not become a
+    fabricated target because an inline callback names its parameter `k`."""
+    r, nid = _extract_js_dir(tmp_path, {
+        "vendor.min.js": VENDOR,
+        "a.js": "export function run(xs, m){ return xs.some(function (k) { return m.indexOf(k); }); }\n",
+    })
+    assert all(t != nid["k"] for _s, t in _indirect(r))
+
+
+def test_named_function_expression_param_shadows(tmp_path):
+    """A named function expression is the same node type and must behave alike."""
+    r, nid = _extract_js_dir(tmp_path, {
+        "vendor.min.js": VENDOR,
+        "a.js": "export function run(xs, m){ return xs.some(function nm(k) { return m.indexOf(k); }); }\n",
+    })
+    assert all(t != nid["k"] for _s, t in _indirect(r))
+
+
+def test_nested_const_function_expression_shadows(tmp_path):
+    """Not only the inline-argument position: a `const` inside a function body
+    binds no tracked symbol, so the expression stays untracked."""
+    r, nid = _extract_js_dir(tmp_path, {
+        "vendor.min.js": VENDOR,
+        "a.js": "export function run(m){ const f = function (k) { return m.indexOf(k); }; return f(1); }\n",
+    })
+    assert all(t != nid["k"] for _s, t in _indirect(r))
+
+
+def test_top_level_const_function_expression_was_already_tracked(tmp_path):
+    """Boundary control: a MODULE-level `const f = function (…) {}` gets its own
+    node and shadow-set entry through the declarator, so it never went through
+    this gate and passes with and without the fix. Documents what is NOT the
+    bug, so the scope of the change stays legible."""
+    r, nid = _extract_js_dir(tmp_path, {
+        "vendor.min.js": VENDOR,
+        "a.js": "export const f = function (k) { return [].indexOf(k); };\n",
+    })
+    assert "f" in nid
+    assert all(t != nid["k"] for _s, t in _indirect(r))
+
+
+def test_function_expression_local_shadows(tmp_path):
+    """Locals, not just parameters, are scoped to the expression's body."""
+    r, nid = _extract_js_dir(tmp_path, {
+        "vendor.min.js": VENDOR,
+        "a.js": "export function run(m){ return [].map(function () { const k = 1; return m.get(k); }); }\n",
+    })
+    assert all(t != nid["k"] for _s, t in _indirect(r))
+
+
+def test_arrow_callback_still_shadows(tmp_path):
+    """Control: the arrow path was already correct and must stay correct."""
+    r, nid = _extract_js_dir(tmp_path, {
+        "vendor.min.js": VENDOR,
+        "a.js": "export function run(xs, m){ return xs.some(k => m.indexOf(k)); }\n",
+    })
+    assert all(t != nid["k"] for _s, t in _indirect(r))
+
+
+def test_same_named_reference_after_the_expression_still_resolves(tmp_path):
+    """The bindings are scoped to the expression: a same-named module callable
+    referenced AFTER it, in the enclosing function, must still resolve."""
+    r, nid = _extract_js_dir(tmp_path, {"a.js": (
+        "function k(x){ return x; }\n"
+        "export function run(m){ [].map(function (z) { return z; }); return m.get(k); }\n"
+    )})
+    assert (nid["run"], nid["k"]) in _indirect(r)
+
+
+def test_sibling_function_expression_param_does_not_leak(tmp_path):
+    """Two function expressions in one initializer are SEPARATE scopes: the
+    first one's parameter must not shadow the second one's body. This is the
+    #2568 shape — several closures registered under one id — reached through
+    the function-expression form rather than the arrow form."""
+    r, nid = _extract_js_dir(tmp_path, {"a.js": (
+        "function k(x){ return x; }\n"
+        "function wrap(a, b){ return a || b; }\n"
+        "export const handler = wrap(\n"
+        "  function (k) { return k; },\n"
+        "  function (pool) { return pool.submit(k); }\n"
+        ");\n"
+    )})
+    assert (nid["handler"], nid["k"]) in _indirect(r)
+
+
+def test_genuine_reference_inside_the_function_expression_still_emits(tmp_path):
+    """Widening the shadow set must not blanket-suppress inside the body: an
+    unshadowed callable referenced there still emits."""
+    r, nid = _extract_js_dir(tmp_path, {"a.js": (
+        "function handler(x){ return x; }\n"
+        "export function run(xs){ return xs.map(function (pool) { return pool.submit(handler); }); }\n"
+    )})
+    assert (nid["run"], nid["handler"]) in _indirect(r)
+
+
+def test_call_attribution_inside_the_expression_is_unchanged(tmp_path):
+    """Adding a type to `function_boundary_types` must not change WHERE calls are
+    attributed. Before, a function expression was not a boundary at all, so
+    walk_calls recursed in normally; now it takes the boundary branch, which
+    descends explicitly with the enclosing `caller_nid` (#1630/#1740). Both
+    routes must land the call on the enclosing function, not drop it or
+    re-parent it."""
+    r, nid = _extract_js_dir(tmp_path, {"a.js": (
+        "function helper(x){ return x; }\n"
+        "export function run(xs){ return xs.map(function (row) { return helper(row); }); }\n"
+    )})
+    calls = {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "calls"}
+    assert (nid["run"], nid["helper"]) in calls
+
+
+def test_typescript_function_expression_shadows(tmp_path):
+    """The TS config carries its own copy of the set; both were missing the type."""
+    base = tmp_path / "src"
+    base.mkdir()
+    (base / "vendor.min.ts").write_text(VENDOR)
+    (base / "a.ts").write_text(
+        "export function run(xs: number[], m: number[]): boolean {\n"
+        "  return xs.some(function (k: number) { return m.indexOf(k) >= 0; });\n"
+        "}\n"
+    )
+    old = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        r = extract([Path("src") / "vendor.min.ts", Path("src") / "a.ts"],
+                    cache_root=Path(".cache"), parallel=False)
+    finally:
+        os.chdir(old)
+    nid = {n["label"].rstrip("()"): n["id"] for n in r["nodes"]}
+    assert all(t != nid["k"] for _s, t in _indirect(r))


### PR DESCRIPTION
## Summary

`function_expression` is missing from the JS and TS `function_boundary_types` sets, so an
**untracked** (inline or nested) `function (…) {…}` expression's own parameters and locals never
enter its subtree shadow set. A bare reference to one of them, passed on as a call argument,
reads as an unresolved by-name reference and fabricates an `indirect_call` edge (INFERRED, 0.8)
to an unrelated same-named callable elsewhere in the corpus.

The two callback forms disagree, which is what hides it:

```js
xs.some(k => sink(k))                     // arrow — shadowed, correct
xs.some(function (k) { return sink(k) })  // function expression — fabricated edge
```

Same family as `catch_clause.parameter` and the single unparenthesised arrow parameter: a
binding form that never reached the shadow set.

Reproduced against `v8 @ 7281f27` (v0.9.43).

## Reproduction

```js
// src/vendor.min.js
var Lib=function(){function k(a){return a}return{k:k}}();

// src/a.js
export function run(xs, m){ return xs.some(function (k) { return m.indexOf(k); }); }
```

```python
from graphify.extract import extract
from pathlib import Path
r = extract([Path('src/vendor.min.js'), Path('src/a.js')], cache_root=Path('.c'), parallel=False)
print([e for e in r['edges'] if e['relation'] == 'indirect_call'])
```

Emits `run() --indirect_call [INFERRED]--> k()`, where `k` is the minified bundle's private
function. `k` in `a.js` is the callback's own parameter. Rewriting the callback as
`xs.some(k => m.indexOf(k))` emits nothing — same binding, opposite result.

## Cause

`walk_calls` gates its untracked-closure handling on `config.function_boundary_types`:

```python
if node.type in config.function_boundary_types:
    ...
    if (config.ts_module in ("tree_sitter_javascript", "tree_sitter_typescript")
            and node.type in _JS_DESCEND_TYPES):
        ...
        closure_locals = extra_locals | _js_local_bound_names(node, source)
```

and that handler already names the type it should receive:

```python
_JS_CLOSURE_TYPES = ("arrow_function", "function_expression")
_JS_DESCEND_TYPES = _JS_CLOSURE_TYPES + ("function_declaration", "generator_function_declaration")
```

But `graphify/extract.py` has, in the JS config and again in the TS config:

```python
function_boundary_types=frozenset({"function_declaration", "generator_function_declaration",
                                   "arrow_function", "method_definition"}),
```

`function_expression` is absent, so the outer gate never opens for one and the fold below is
unreachable. The body is instead walked with the *enclosing* function's `extra_locals`.

### Scope

A top-level `const f = function (…) {}` is tracked through its declarator, gets its own node,
and already had its own shadow-set entry — it never went through this gate and was unaffected.
Measured on unmodified `7281f27`:

```
TOP-LEVEL  const f = function (k)  -> fabricated edge: no
NESTED     const f = function (k)  -> fabricated edge: yes
```

The gap is the untracked inline/nested forms. A boundary control test pins this so the scope
stays legible.

### Why it survived

| | |
|---|---|
| `4744dfe` (#1630) | introduced the descent pair `("arrow_function", "function_expression")` — the type has been named as a closure since then |
| #1740 | anonymous arrow callbacks dropped their calls, because `arrow_function` **is** in the boundary set; fixed by descending instead of stopping |
| `51b7b9f` (#2241) | added the shadow-set fold *inside* that descent — its repro and all six of its tests are arrow-based |
| `09aeb97` | last touched the JS `function_boundary_types` line (generators); `function_expression` was never added |

The fold from `51b7b9f` inherited a gate that admits arrows but not function expressions, and
everything that exercised it used arrows. This PR completes that change.

Conversely, `function_expression` never had #1740's call-dropping problem precisely *because*
it was absent from the set — `walk_calls` recursed into it normally. Adding the type routes it
through the boundary branch instead, which descends explicitly with the same `caller_nid`, so
call attribution is unchanged. That is asserted directly by
`test_call_attribution_inside_the_expression_is_unchanged`, and verified against the baseline:
`run --calls--> helper` is emitted identically before and after.

## Fix

The same one-token addition in the JS and TS configs — two lines in `graphify/extract.py`.
No handler code changes; this only lets the existing path receive the type it already names.
TSX inherits the set from the TS config.

## Tests

`tests/test_indirect_call_function_expression_shadow.py`, following the shape of
`test_indirect_call_arrow_single_param_shadow.py` and
`test_indirect_call_catch_binding_shadow.py`.

Six of the eleven are controls that must pass with **and** without the fix — they exist to catch
over-suppression, per the standard applied on #2517.

| test | before | after |
|---|---|---|
| inline anon `function (k)` callback param | FAIL | pass |
| named `function nm(k)` callback param | FAIL | pass |
| nested `const f = function (k) {…}` | FAIL | pass |
| `function () { const k = 1; … }` local | FAIL | pass |
| TypeScript `function (k: number)` | FAIL | pass |
| *control:* arrow callback still shadows | pass | pass |
| *control:* same-named reference after the expression still resolves | pass | pass |
| *control:* sibling function expression's param does not leak (#2568 shape) | pass | pass |
| *control:* unshadowed callable inside the body still emits | pass | pass |
| *control:* top-level `const f = function (…) {}` was already tracked | pass | pass |
| *control:* call attribution inside the expression is unchanged | pass | pass |

```
without the fix: 5 failed, 6 passed
with the fix:    11 passed
```

The sibling control uses two closures in one initializer, which is the #2568 shape reached
through the function-expression form rather than the arrow form:

```js
export const handler = wrap(
  function (k) { return k; },
  function (pool) { return pool.submit(k); }
);
```

Full suite on this branch: **4177 passed, 183 skipped, 13 failed** — the same 13 fail on
unmodified `7281f27` in this environment, with the failing sets identical in both directions.
They are `test_terraform` ×7 (`tree_sitter_hcl not installed`), `test_ollama_retry_cap` ×4,
`test_install_references::test_built_wheel_ships_the_full_skill_payload`, and
`test_labeling::test_label_communities_batches_when_over_batch_size` (flaky independent of this
change — 3 passes / 2 failures in 5 consecutive runs on the same tree).

## Measured effect

Extracted with and without the fix over the same corpora, diffing the `indirect_call` edge sets.
Minified bundles are excluded: whether `j() -> b()` inside a one-line bundle is real is not a
judgment worth making, and every reference in such a file reports the same line.

| corpus | files | edges before | after | removed | added |
|---|---|---|---|---|---|
| mongoose | 294 | 53 | 47 | 6 | 0 |
| handlebars | 106 | 70 | 56 | 14 | 0 |
| eslint | 414 | 361 | 358 | 3 | 0 |
| happy-dom | 1800 | 4 | 4 | 0 | 0 |
| puppeteer-extra-plugin-stealth | 54 | 7 | 7 | 0 | 0 |
| application corpus | 51 | 31 | 31 | 0 | 0 |
| **total** | **2719** | | | **23** | **0** |

**23 fabricated edges removed, 0 introduced.**

Spot-checking the largest group, handlebars `template() -> blockParams()` (×5): suppressed
because `program: function (i, data, declaredBlockParams, blockParams, depths)` binds
`blockParams` as a parameter. Correct.

Including minified files the raw counts are 43 removed / 3 added; all 3 "added" are in
`handlebars.amd.min.js`, where the same references move from L27 to L28 — a re-attribution
artifact of single-line files, not new edges.

## Interaction with existing behaviour

Re-verified on this branch, all still correct:

- single unparenthesised arrow parameter — shadows, and does not shadow outside the arrow
- `catch (e)` binding — shadows; `catch {}` and post-clause references unaffected
- the `for...of` / `for...in` loop-binding behaviour from `a995921` — unchanged
- the #2568 sibling-closure case, including that issue's own positive control — unchanged
