### PR TITLE
fix(install): honor CLAUDE_CONFIG_DIR in always-on CLAUDE.md registration (#2694)

### DIFF
--- a/graphify/install.py
+++ b/graphify/install.py
@@ -633,9 +633,21 @@ def install(platform: str = "claude", *, project: bool = False, project_dir: Pat
         print(f"  command installed ->  {command_dst}")
 
     if cfg["claude_md"]:
-        # Register in the matching Claude Code scope.
-        claude_md = (project_dir / ".claude" / "CLAUDE.md") if project else Path.home() / ".claude" / "CLAUDE.md"
-        registration = _skill_registration(".claude/skills/graphify/SKILL.md" if project else "~/.claude/skills/graphify/SKILL.md")
+        # Register in the matching Claude Code scope. Honor CLAUDE_CONFIG_DIR
+        # for the global (non-project) case, same as _platform_skill_destination
+        # does for the skill copy path (#527) -- this always-on registration
+        # path was missed by that fix (#2694).
+        if project:
+            claude_md = project_dir / ".claude" / "CLAUDE.md"
+            skill_ref = ".claude/skills/graphify/SKILL.md"
+        elif os.environ.get("CLAUDE_CONFIG_DIR"):
+            config_dir = Path(os.environ["CLAUDE_CONFIG_DIR"])
+            claude_md = config_dir / "CLAUDE.md"
+            skill_ref = str(config_dir / "skills" / "graphify" / "SKILL.md")
+        else:
+            claude_md = Path.home() / ".claude" / "CLAUDE.md"
+            skill_ref = "~/.claude/skills/graphify/SKILL.md"
+        registration = _skill_registration(skill_ref)
         if claude_md.exists():
             content = claude_md.read_text(encoding="utf-8")
             if "graphify" in content:


### PR DESCRIPTION
Fixes #2694

The always-on CLAUDE.md registration path resolved `Path.home()` unconditionally,
ignoring CLAUDE_CONFIG_DIR — the same issue #527 fixed for the skill-copy path,
but that fix didn't cover this always-on registration path (as noted by @yotamleo
in the issue).

This mirrors the existing CLAUDE_CONFIG_DIR check from
`_platform_skill_destination` into the CLAUDE.md registration block.

Tested locally on all three scopes:
- `--project` → writes to project-local `.claude/CLAUDE.md`, ignores CLAUDE_CONFIG_DIR (unchanged)
- global + `CLAUDE_CONFIG_DIR` set → now correctly writes to `$CLAUDE_CONFIG_DIR/CLAUDE.md`
- global, no env var → unchanged fallback to `~/.claude/CLAUDE.md`

Full test suite: 289 passed, 1 unrelated pre-existing failure (missing `build`
dev dependency in local env, unrelated to this change).