### PR TITLE
Fix SSRF guard rejecting private proxies

### DIFF
--- a/graphify/security.py
+++ b/graphify/security.py
@@ -192,6 +192,19 @@ class _SSRFGuardedHTTPConnection(http.client.HTTPConnection):
             self._tunnel()
 
 
+class _ProxyAwareHTTPConnection(_SSRFGuardedHTTPConnection):
+    """HTTPConnection that skips SSRF IP validation for the proxy hop."""
+
+    def connect(self) -> None:
+        self.sock = socket.create_connection(
+            (self.host, self.port),
+            self.timeout,
+            self.source_address,
+        )
+        if self._tunnel_host:
+            self._tunnel()
+
+
 class _SSRFGuardedHTTPSConnection(http.client.HTTPSConnection):
     """HTTPSConnection variant of _SSRFGuardedHTTPConnection.
 
@@ -214,10 +227,28 @@ class _SSRFGuardedHTTPSConnection(http.client.HTTPSConnection):
         self.sock = self._context.wrap_socket(sock, server_hostname=self.host)
 
 
+class _ProxyAwareHTTPSConnection(_SSRFGuardedHTTPSConnection):
+    """HTTPSConnection that skips SSRF IP validation for the proxy hop."""
+
+    def connect(self) -> None:
+        sock = socket.create_connection(
+            (self.host, self.port),
+            self.timeout,
+            self.source_address,
+        )
+        if self._tunnel_host:
+            self.sock = sock
+            self._tunnel()
+            sock = self.sock
+        self.sock = self._context.wrap_socket(sock, server_hostname=self.host)
+
+
 class _SSRFGuardedHTTPHandler(urllib.request.HTTPHandler):
     """urllib handler that routes http:// through _SSRFGuardedHTTPConnection."""
 
     def http_open(self, req):
+        if req.has_proxy():
+            return self.do_open(_ProxyAwareHTTPConnection, req)
         return self.do_open(_SSRFGuardedHTTPConnection, req)
 
 
@@ -225,6 +256,8 @@ class _SSRFGuardedHTTPSHandler(urllib.request.HTTPSHandler):
     """urllib handler that routes https:// through _SSRFGuardedHTTPSConnection."""
 
     def https_open(self, req):
+        if getattr(req, "_tunnel_host", None) or req.has_proxy():
+            return self.do_open(_ProxyAwareHTTPSConnection, req)
         return self.do_open(_SSRFGuardedHTTPSConnection, req)
 
 


### PR DESCRIPTION
Fixes #2761

This PR modifies the SSRF guard connection classes (`_SSRFGuardedHTTPConnection` and `_SSRFGuardedHTTPSConnection`) to be proxy-aware. When a request is explicitly configured to use a proxy, the private IP address check is bypassed for the proxy endpoint itself, while `validate_url` independently preserves SSRF protections for the final destination URL.

Changes:
- Added `_ProxyAwareHTTPConnection` and `_ProxyAwareHTTPSConnection` subclasses to safely connect to proxies without applying IP blocking on the proxy's resolved address.
- Updated `_SSRFGuardedHTTPHandler` and `_SSRFGuardedHTTPSHandler` to detect if the request is using a proxy (`req.has_proxy()` or `req._tunnel_host`) and dispatch to the correct connection type.
