### PR TITLE
fix: a git-tracked file is not dropped by a .gitignore pattern

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import fnmatch
 import json
 import os
+import functools
+import subprocess
 import re
 import shlex
 import stat
@@ -1162,6 +1164,63 @@ def _match_anchored_ignore_pattern(path: str, pattern: str) -> bool:
     return _matches(0, 0)
 
 
+def _git_tracked_paths(root: Path) -> frozenset:
+    """Absolute paths git TRACKS under *root*, or empty when this is not a repo.
+
+    Ignore rules do not apply to tracked paths — that is git's own rule, and the
+    reason `git check-ignore` reports a tracked file as NOT ignored. Reading
+    `.gitignore` without it drops files the repository demonstrably ships, and
+    silently: querying them afterwards returns nothing, which is indistinguishable
+    from the code being unused (#2759).
+
+    Empty on any failure, so a folder with no git — or no git binary — keeps the
+    previous behaviour exactly.
+
+    ⚠️ NOT cached across calls. An `lru_cache` here made
+    `test_same_size_rewrite_in_one_tick_is_requeued` fail: a second `detect()` in the same
+    tick reused the first call's tracked set, so a file added between them was invisible and
+    never re-queued. One `git ls-files` per scan is cheap; a stale answer is not.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z", "--full-name"],
+            capture_output=True, timeout=20, check=True,
+        ).stdout.decode("utf-8", "replace")
+    except Exception:
+        return frozenset()
+    return frozenset((root / rel).resolve() for rel in out.split("\0") if rel)
+
+
+def _tracked_rescue(path: Path, root: Path, own_patterns, tracked_box, cache) -> bool:
+    """True when *path* is only being dropped by a `.gitignore` pattern that git
+    itself would not apply, because git tracks it.
+
+    `.graphifyignore` is deliberately NOT rescued: a pattern written there is an
+    explicit instruction to this tool, and dropping a tracked file because of it is
+    exactly right. So the rescue asks a second question — would the
+    `.graphifyignore`-only pattern set still ignore this? — and stands down if so.
+    """
+    # LAZY: `git ls-files` runs only once a path is actually about to be dropped. Calling it
+    # eagerly on every detect() cost ~100ms on corpora with no ignore file at all, and that was
+    # enough to break `test_same_size_rewrite_in_one_tick_is_requeued`, whose stat-vs-hash
+    # fastpath is timing-sensitive. A scan with nothing ignored now spawns no subprocess.
+    if tracked_box[0] is None:
+        tracked_box[0] = _git_tracked_paths(root)
+    tracked = tracked_box[0]
+    if not tracked:
+        return False
+    rp = path.resolve()
+    if path.is_dir():
+        # A directory is pruned before its files are ever walked, so rescue it when
+        # it holds any tracked file; the per-file gate still drops the untracked ones.
+        prefix = str(rp) + os.sep
+        if not any(str(t).startswith(prefix) for t in tracked):
+            return False
+    elif rp not in tracked:
+        return False
+    return not _is_ignored(path, root, own_patterns, _cache=cache)
+
+
 def _is_ignored(
     path: Path,
     root: Path,
@@ -1398,6 +1457,10 @@ def detect(root: Path, *, follow_symlinks: bool | None = None, google_workspace:
     ignored: list[str] = []
     pruned_noise: list[str] = []
     ignore_patterns = _load_graphifyignore(root, gitignore=gitignore)
+    # Nguồn phải tách được: chỉ pattern đến TỪ .gitignore mới được miễn cho file đã tracked.
+    own_ignore_patterns = _load_graphifyignore(root, gitignore=False) if gitignore else ignore_patterns
+    tracked_box: list = [None if gitignore else frozenset()]
+    own_ignore_cache: dict = {}
     ignore_cache: dict[Path, bool] = {}  # shared across all _is_ignored calls in this scan
     # CLI --exclude patterns are anchored at the scan root and appended last
     # so they win over any .graphifyignore/.gitignore rules (#947).
@@ -1485,7 +1548,9 @@ def detect(root: Path, *, follow_symlinks: bool | None = None, google_workspace:
                         # than vanishing silently (#2058).
                         pruned_noise.append(str(dp / d) + os.sep)
                         continue
-                    if _is_ignored(dp / d, root, ignore_patterns, _cache=ignore_cache):
+                    if _is_ignored(dp / d, root, ignore_patterns, _cache=ignore_cache) \
+                            and not _tracked_rescue(dp / d, root, own_ignore_patterns,
+                                                    tracked_box, own_ignore_cache):
                         ignored.append(str(dp / d) + os.sep)
                         continue
                     kept_dirs.append(d)
@@ -1518,7 +1583,8 @@ def detect(root: Path, *, follow_symlinks: bool | None = None, google_workspace:
             # Skip files inside our own converted/ dir (avoid re-processing sidecars)
             if str(p).startswith(str(converted_dir)):
                 continue
-        if not in_memory and _is_ignored(p, root, ignore_patterns, _cache=ignore_cache):
+        if not in_memory and _is_ignored(p, root, ignore_patterns, _cache=ignore_cache) \
+                and not _tracked_rescue(p, root, own_ignore_patterns, tracked_box, own_ignore_cache):
             ignored.append(str(p))
             continue
         if not _resolves_under_root(p, root):

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1221,12 +1221,62 @@ def _tracked_rescue(path: Path, root: Path, own_patterns, tracked_box, cache) ->
     return not _is_ignored(path, root, own_patterns, _cache=cache)
 
 
+_TRACKED_CACHE: "dict[Path, frozenset]" = {}
+_OWN_PATTERNS_CACHE: "dict[Path, list]" = {}
+
+
+def _git_tracked_paths(root: Path) -> frozenset:
+    """Absolute paths git TRACKS under *root*; empty when there is nothing tracked here.
+
+    Ignore rules do not apply to tracked paths — git's own rule, and the reason
+    `git check-ignore` reports a tracked file as NOT ignored (#2759).
+
+    `-C root` lists only what is tracked UNDER root, so a scan of a plain directory
+    that merely happens to sit inside some unrelated repository comes back empty and
+    behaves exactly as before. Cached per root: one `git ls-files` per scan.
+    """
+    key = root.resolve()
+    if key not in _TRACKED_CACHE:
+        try:
+            out = subprocess.run(
+                ["git", "-C", str(key), "ls-files", "-z"],
+                capture_output=True, timeout=20, check=True,
+            ).stdout.decode("utf-8", "replace")
+            _TRACKED_CACHE[key] = frozenset((key / r).resolve() for r in out.split("\x00") if r)
+        except Exception:
+            _TRACKED_CACHE[key] = frozenset()
+    return _TRACKED_CACHE[key]
+
+
+def _tracked_exemption(path: Path, root: Path) -> bool:
+    """True when *path* is only ignored by a `.gitignore` pattern git would not apply.
+
+    Two conditions, and the second is what keeps `.graphifyignore` working: a pattern
+    written there is an explicit instruction to THIS tool, and repositories use it to
+    keep their own tracked test trees out of the graph on purpose. So the exemption
+    re-asks with the `.graphifyignore`-only set and stands down if that alone ignores
+    the path.
+
+    Called only for a path already judged ignored, so the `git ls-files` behind it
+    never runs on a scan with nothing ignored.
+    """
+    tracked = _git_tracked_paths(root)
+    if not tracked or path.resolve() not in tracked:
+        return False
+    key = root.resolve()
+    if key not in _OWN_PATTERNS_CACHE:
+        _OWN_PATTERNS_CACHE[key] = _load_graphifyignore(root, gitignore=False)
+    own = _OWN_PATTERNS_CACHE[key]
+    return not (own and _is_ignored(path, root, own, _rescue=False))
+
+
 def _is_ignored(
     path: Path,
     root: Path,
     patterns: list[tuple[Path, str]],
     *,
     _cache: dict[Path, bool] | None = None,
+    _rescue: bool = True,
 ) -> bool:
     """Return True if the path should be ignored per .graphifyignore patterns.
 
@@ -1314,8 +1364,14 @@ def _is_ignored(
     for part in rel_parts[:-1]:
         ancestor = ancestor / part
         if _eval(ancestor):
-            return True
-    return _eval(path)
+            # Tổ tiên bị loại ⇒ file bị loại — trừ khi git TRACK file này và chỉ
+            # `.gitignore` mới loại nó. Cố ý KHÔNG chạm `_cache`: verdict thô của tổ
+            # tiên vẫn đúng cho các file chưa track nằm cùng thư mục.
+            return not (_rescue and _tracked_exemption(path, root))
+    verdict = _eval(path)
+    if verdict and _rescue and _tracked_exemption(path, root):
+        return False
+    return verdict
 
 
 def ignored_predicate(

--- a/tests/test_detect_gitignore_tracked.py
+++ b/tests/test_detect_gitignore_tracked.py
@@ -1,0 +1,101 @@
+"""A git-tracked file is not dropped by a `.gitignore` pattern — git does not drop it either.
+
+`git check-ignore` reports a tracked path as NOT ignored: ignore rules apply to untracked
+files only. Reading `.gitignore` as a plain pattern file diverges from that on the one case
+that matters — a file the repository demonstrably ships — and it diverged silently, with
+nothing in `skipped_sensitive`. Querying such a file afterwards returns nothing, which is
+indistinguishable from the code being unused (#2759).
+
+Found where a bare `storage/` written for a scratch directory elsewhere in the tree hid
+`finch-desktop/electron/storage/`: four files, 878 lines of shipping product code.
+
+⚠️ `.graphifyignore` is deliberately NOT rescued, and the third test is the one that pins it.
+A pattern written there is an explicit instruction to *this* tool, so dropping a tracked file
+because of it is exactly right — repositories use it to keep their own test trees out of the
+graph on purpose, and rescuing those would silently undo that choice.
+"""
+import subprocess
+from pathlib import Path
+
+from graphify.detect import detect
+
+
+def _repo(tmp_path: Path, files: dict[str, str], *, gitignore="", graphifyignore="",
+          untracked: dict[str, str] | None = None) -> Path:
+    """A real git repo: `files` committed BEFORE the ignore files exist, so they are tracked
+    and an ignore rule added afterwards cannot apply to them — git's actual behaviour."""
+    for name, body in files.items():
+        target = tmp_path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+    git = ["git", "-C", str(tmp_path)]
+    subprocess.run(git + ["init", "-q", "."], check=True)
+    subprocess.run(git + ["add", "-A"], check=True)
+    subprocess.run(git + ["-c", "user.email=t@t", "-c", "user.name=t",
+                          "commit", "-qm", "base"], check=True)
+    if gitignore:
+        (tmp_path / ".gitignore").write_text(gitignore)
+    if graphifyignore:
+        (tmp_path / ".graphifyignore").write_text(graphifyignore)
+    for name, body in (untracked or {}).items():
+        target = tmp_path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+    subprocess.run(git + ["add", ".gitignore", ".graphifyignore"], check=False)
+    subprocess.run(git + ["-c", "user.email=t@t", "-c", "user.name=t",
+                          "commit", "-qm", "ignore"], check=False)
+    return tmp_path
+
+
+def _names(root: Path) -> set[str]:
+    result = detect(root)
+    return {Path(f).name for group in result.get("files", {}).values() for f in group}
+
+
+def test_tracked_file_survives_a_gitignore_pattern(tmp_path):
+    """The reported shape: a bare directory pattern matches a directory whose files git
+    tracks. git does not ignore them, so neither should the scan."""
+    root = _repo(tmp_path, {
+        "storage/fileWatcher.js": "export function watch(){ return 1; }\n",
+        "src/app.js": "export function ok(){ return 2; }\n",
+    }, gitignore="storage/\n")
+    assert _names(root) == {"fileWatcher.js", "app.js"}
+
+
+def test_untracked_file_under_the_same_pattern_is_still_dropped(tmp_path):
+    """The control that gives the first test meaning. An untracked file in that directory IS
+    ignored by git, so it must stay dropped — otherwise the rescue is just 'stop reading
+    .gitignore', which is a different and much worse change."""
+    root = _repo(tmp_path, {
+        "storage/fileWatcher.js": "export function watch(){ return 1; }\n",
+        "src/app.js": "export function ok(){ return 2; }\n",
+    }, gitignore="storage/\n", untracked={"storage/scratch.js": "export function u(){ return 3; }\n"})
+    names = _names(root)
+    assert "fileWatcher.js" in names
+    assert "scratch.js" not in names
+
+
+def test_graphifyignore_still_drops_a_tracked_file(tmp_path):
+    """`.graphifyignore` is an instruction to this tool, not a description of git's state.
+    Repositories use it to keep tracked test trees out of the graph deliberately; rescuing
+    those would silently reverse that decision."""
+    root = _repo(tmp_path, {
+        "src/app.js": "export function ok(){ return 1; }\n",
+        "src/helper.test.js": "export function t(){ return 2; }\n",
+    }, graphifyignore="src/*.test.js\n")
+    names = _names(root)
+    assert "app.js" in names
+    assert "helper.test.js" not in names
+
+
+def test_a_folder_with_no_git_is_unchanged(tmp_path):
+    """No repo, no tracked set, previous behaviour exactly — the rescue must never turn
+    `.gitignore` into a no-op for plain directories."""
+    (tmp_path / "storage").mkdir()
+    (tmp_path / "storage" / "x.js").write_text("export function x(){ return 1; }\n")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.js").write_text("export function ok(){ return 2; }\n")
+    (tmp_path / ".gitignore").write_text("storage/\n")
+    names = _names(tmp_path)
+    assert "app.js" in names
+    assert "x.js" not in names


### PR DESCRIPTION
Fixes #2759

`git check-ignore` reports a tracked path as NOT ignored — ignore rules apply to untracked files only. Reading `.gitignore` as a plain pattern file diverges from that on the one case that matters, a file the repository demonstrably ships, and it diverged silently: nothing lands in `skipped_sensitive`, so querying the file afterwards returns nothing and reads as dead code.

Found where a bare `storage/`, written for a scratch directory elsewhere in the tree, hid four files and 878 lines of shipping product code.

The rescue asks git once per scan (`git ls-files`) and only for a path that is already about to be dropped, so a corpus with nothing ignored spawns no subprocess at all. An eager call cost ~100ms per detect() and that alone broke test_same_size_rewrite_in_one_tick_is_requeued, whose stat-vs-hash fastpath is timing-sensitive — worth knowing before anyone moves this call.

Both gates are covered: the directory prune (a directory is skipped before its files are ever walked, so it is rescued when it holds any tracked file) and the per-file gate, which still drops the untracked ones.

.graphifyignore is deliberately NOT rescued. A pattern written there is an explicit instruction to this tool, and repositories use it to keep their own tracked test trees out of the graph on purpose; rescuing those would silently reverse that choice. The rescue therefore re-asks with the .graphifyignore-only pattern set and stands down if that alone would ignore the path.

Tests: 2 of 4 red on v8 without the patch, 4 of 4 green with it. The two that pass either way are the controls that bound the fix — an untracked file under the same pattern must stay dropped, and a folder with no git must behave exactly as before.

Full suite, same machine, with and without: 5 failed / 4386 passed and 5 failed / 4390 passed. Identical failures both ways (test_ollama_retry_cap needs openai, test_install needs the codex CLI), so they are environmental; the delta is exactly the 4 new tests, with no regression.