### PR TITLE
fix(dart): emit intra-file calls so .dart files are not stars

### DIFF
--- a/graphify/extractors/dart.py
+++ b/graphify/extractors/dart.py
@@ -525,4 +525,108 @@ def extract_dart(path: Path) -> dict:
             add_node(target_nid, clean_name, source_file=None)
             add_edge(file_nid, target_nid, "references", context="type_lookup")
 
+    # 8. Intra-file call graph (invocations and widget composition)
+    # Sections 1-7 only ever link members back to the file node, so a .dart file
+    # collapses into a star: N members, N-1 `defines` edges, nothing between them.
+    # Resolve call sites inside function bodies against declarations in this same
+    # file. Names that resolve to nothing (imported symbols, receiver-qualified
+    # calls into other libraries) are dropped rather than guessed.
+    call_keywords = {
+        "if", "for", "while", "switch", "catch", "return", "assert", "await",
+        "super", "this", "new", "case", "do", "else", "in", "is", "as", "rethrow",
+        "yield", "throw", "print", "setState",
+    }
+
+    # Class bodies, so a method's calls are attributed to its enclosing class.
+    # Member functions collapse to one node per name per file (`build` is defined
+    # by every widget here), which would make method-level callers meaningless.
+    class_spans: list[tuple[int, int, str]] = []
+    for m in re.finditer(class_pattern, src_clean, re.MULTILINE):
+        body_start = src_clean.find("{", m.end())
+        if body_start == -1:
+            continue
+        # `class A = B with C;` has no body - its brace belongs to the next class
+        semi = src_clean.find(";", m.end())
+        if semi != -1 and semi < body_start:
+            continue
+        class_spans.append((m.start(), _find_matching_brace(src_clean, m.end()),
+                            _make_id(stem, m.group(1))))
+    declared_classes = {m.group(1): _make_id(stem, m.group(1))
+                        for m in re.finditer(class_pattern, src_clean, re.MULTILINE)}
+
+    # Function bodies, re-derived with the same filters section 5 applies
+    declared_funcs: dict[str, str] = {}
+    func_bodies: list[tuple[int, int, str]] = []
+    for m in re.finditer(method_pattern, src_clean, re.MULTILINE):
+        name = m.group(1).split(".")[-1]
+        if name in {"if", "for", "while", "switch", "catch", "return", "void",
+                    "dynamic", "final", "const", "get", "set"}:
+            continue
+        if re.match(r"^[A-Z]", name):
+            continue
+        nid = _make_id(stem, name)
+        declared_funcs[name] = nid
+
+        start_idx = m.start()
+        brace_pos = src_clean.find("{", start_idx)
+        semi_pos = src_clean.find(";", start_idx)
+        arrow_pos = src_clean.find("=>", start_idx)
+        if brace_pos == -1:
+            continue
+        if semi_pos != -1 and semi_pos < brace_pos:
+            continue
+        if arrow_pos != -1 and arrow_pos < brace_pos:
+            continue
+        func_bodies.append((brace_pos, _find_matching_brace(src_clean, start_idx), nid))
+
+    def _enclosing_class(pos: int) -> str | None:
+        """Innermost class whose body contains pos, or None for top-level code."""
+        owner = None
+        owner_start = -1
+        for c_start, c_end, c_nid in class_spans:
+            if c_start <= pos < c_end and c_start > owner_start:
+                owner, owner_start = c_nid, c_start
+        return owner
+
+    # A receiver makes the call belong to another object: `_controller.dispose()`
+    # is not this widget's `dispose`, and `super.initState()` is a framework
+    # upcall, not a local one. Only unqualified calls and `this.`/`widget.` are
+    # resolvable against this file without real type inference.
+    call_site_pattern = re.compile(r"(?:(\w+)\s*\.\s*)?\b([A-Za-z_]\w*)\s*\(")
+    self_receivers = {"this", "widget"}
+
+    call_counts: dict[tuple[str, str], list] = {}
+    for body_start, body_end, func_nid in func_bodies:
+        caller = _enclosing_class(body_start) or func_nid
+        body = src_clean[body_start:body_end]
+        for cm in call_site_pattern.finditer(body):
+            receiver, callee = cm.group(1), cm.group(2)
+            if receiver is not None and receiver not in self_receivers:
+                continue
+            if receiver is None and cm.start() > 0 and body[cm.start() - 1] == ".":
+                continue  # cascade (`..dispose()`) - target is some other object
+            if callee in call_keywords:
+                continue
+            if callee in declared_classes:
+                # Constructor invocation - in Flutter this is how a widget tree
+                # is assembled, and it is the only edge that links siblings.
+                # Checked before declared_funcs: a constructor declaration
+                # (`const _ScoreHeader({super.key})`) also matches method_pattern,
+                # so the two maps collide on every widget name.
+                target, context = declared_classes[callee], "widget_composition"
+            elif callee in declared_funcs:
+                target, context = declared_funcs[callee], "call"
+            else:
+                continue
+            if target == caller:
+                continue
+            entry = call_counts.get((caller, target))
+            if entry is None:
+                call_counts[(caller, target)] = [1, context]
+            else:
+                entry[0] += 1
+
+    for (caller, target), (count, context) in call_counts.items():
+        add_edge(caller, target, "calls", weight=float(count), context=context)
+
     return {"nodes": nodes, "edges": edges}

--- a/tests/test_dart.py
+++ b/tests/test_dart.py
@@ -636,5 +636,177 @@ class TestDart(unittest.TestCase):
         self.assertEqual(nav_edge["target"], "route_home_id_123_type_auth")
 
 
+    def test_intra_file_calls_and_widget_composition(self):
+        """Calls inside function bodies resolve against declarations in the same file.
+
+        Without this every .dart file is a star: members only ever link back to
+        the file node, never to each other.
+        """
+        code_content = textwrap.dedent("""
+        import 'package:flutter/material.dart';
+
+        class ProductScreen extends StatefulWidget {
+          const ProductScreen({super.key});
+          @override
+          State<ProductScreen> createState() => _ProductScreenState();
+        }
+
+        class _ProductScreenState extends State<ProductScreen> {
+          Product? _product;
+          Timer? _timer;
+
+          @override
+          void initState() {
+            super.initState();
+            _load();
+          }
+
+          @override
+          void dispose() {
+            _timer.cancel();
+            _controller.dispose();
+            super.dispose();
+          }
+
+          Future<void> _load() async {
+            final p = await api.fetchProduct(widget.barcode);
+            _remember(p);
+          }
+
+          void _remember(Product p) {
+            history.add(p);
+          }
+
+          @override
+          Widget build(BuildContext context) {
+            return _ProductView(product: _product);
+          }
+        }
+
+        class _ProductView extends StatelessWidget {
+          const _ProductView({this.product});
+          @override
+          Widget build(BuildContext context) {
+            return Column(children: [
+              _ScoreHeader(),
+              _BreakdownCard(),
+            ]);
+          }
+        }
+
+        class _ScoreHeader extends StatelessWidget {
+          const _ScoreHeader();
+          @override
+          Widget build(BuildContext context) => const Text('score');
+        }
+
+        class _BreakdownCard extends StatelessWidget {
+          const _BreakdownCard();
+          @override
+          Widget build(BuildContext context) {
+            return Column(children: [_row('a'), _row('b')]);
+          }
+
+          Widget _row(String label) => Text(label);
+        }
+        """)
+
+        file_path = self.temp_path / "product_screen.dart"
+        file_path.write_text(code_content, encoding="utf-8")
+
+        result = extract_dart(file_path)
+        edges = result["edges"]
+        stem = _file_stem(file_path)
+
+        def call_edge(source_label, target_label):
+            return next(
+                (
+                    e
+                    for e in edges
+                    if e["relation"] == "calls"
+                    and e["source"] == _make_id(stem, source_label)
+                    and e["target"] == _make_id(stem, target_label)
+                ),
+                None,
+            )
+
+        # A. Widget composition: a constructor invocation is what links siblings.
+        # This is the only edge that gives a Flutter file any internal structure.
+        compose = call_edge("_ProductScreenState", "_ProductView")
+        self.assertIsNotNone(compose)
+        self.assertEqual(compose["context"], "widget_composition")
+        self.assertEqual(compose["confidence"], "EXTRACTED")
+
+        self.assertIsNotNone(call_edge("_ProductView", "_ScoreHeader"))
+        self.assertIsNotNone(call_edge("_ProductView", "_BreakdownCard"))
+
+        # B. Plain helper calls, attributed to the enclosing class rather than to
+        # the method: member ids are (stem, name), so every widget's `build`
+        # collapses onto one node and a method-level caller would be meaningless.
+        load = call_edge("_ProductScreenState", "_load")
+        self.assertIsNotNone(load)
+        self.assertEqual(load["context"], "call")
+        self.assertIsNotNone(call_edge("_ProductScreenState", "_remember"))
+
+        # C. Repeated call sites are counted in the weight, not duplicated.
+        row = call_edge("_BreakdownCard", "_row")
+        self.assertIsNotNone(row)
+        self.assertEqual(row["weight"], 2.0)
+
+        # D. No self-loops when a class calls its own members.
+        self.assertEqual([e for e in edges if e["source"] == e["target"]], [])
+
+    def test_intra_file_calls_ignore_foreign_receivers(self):
+        """Only unqualified calls and this./widget. resolve locally.
+
+        `_controller.dispose()` is not this widget's `dispose`, and
+        `super.initState()` is a framework upcall - matching either against local
+        declarations invents edges that do not exist.
+        """
+        code_content = textwrap.dedent("""
+        class Screen extends StatefulWidget {
+          const Screen();
+        }
+
+        class _ScreenState extends State<Screen> {
+          @override
+          void initState() {
+            super.initState();
+            this.refresh();
+          }
+
+          @override
+          void dispose() {
+            _controller.dispose();
+            _sub..cancel()..close();
+            super.dispose();
+          }
+
+          void refresh() {
+            widget.rebuild();
+          }
+
+          void rebuild() {}
+        }
+        """)
+
+        file_path = self.temp_path / "screen.dart"
+        file_path.write_text(code_content, encoding="utf-8")
+
+        result = extract_dart(file_path)
+        stem = _file_stem(file_path)
+        calls = [e for e in result["edges"] if e["relation"] == "calls"]
+        targets = {e["target"] for e in calls}
+
+        # this./widget. are the widget itself, so these resolve
+        self.assertIn(_make_id(stem, "refresh"), targets)
+        self.assertIn(_make_id(stem, "rebuild"), targets)
+
+        # super.initState()/super.dispose() are framework upcalls, and
+        # _controller.dispose()/_sub..cancel() belong to other objects
+        self.assertNotIn(_make_id(stem, "initState"), targets)
+        self.assertNotIn(_make_id(stem, "dispose"), targets)
+        self.assertNotIn(_make_id(stem, "cancel"), targets)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## The problem

`extract_dart` links every member back to the file node and never to another member, so a `.dart` file comes out as a star: N members, N−1 `defines` edges, nothing in between. Section 7 does find invocations, but attributes them to the **file** node as `references`, so no call structure survives.

On a Flutter + TypeScript app in one repo:

| | edges |
|---|---|
| `.dart` | defines 567, imports 171, references 125, inherits 56, **calls 0** |
| `.ts` | contains 285, imports 203, **calls 167** |

The consequence is not just missing edges. A star's cohesion is `2(n−1)/n(n−1)` — the mathematical floor — so `GRAPH_REPORT.md` flags every Flutter community as weakly interconnected and suggests splitting it. On the app above, the 74-node community around a product screen scored 0.027 and was reported as the loosest thing in the project; it was simply the biggest file. Clustering also had no signal left except inheritance from framework base classes, so Louvain grouped "all StatefulWidgets in the project" and "all StatelessWidgets in the project" rather than anything about the product.

## The change

A self-contained section 8 in `graphify/extractors/dart.py` that resolves call sites inside function bodies against declarations in the same file.

- **Calls are attributed to the enclosing class, not the method.** Member ids are `(stem, name)`, so all 17 `build` methods in one file collapse onto a single node — a method-level caller would carry no information. Top-level functions still resolve to themselves.
- **Constructor invocation of a locally declared class becomes `calls` with `context="widget_composition"`.** In Flutter this is the only edge that assembles sibling widgets into a tree, and it is what turns a flat file into a readable structure.
- **Only unqualified calls plus `this.`/`widget.` resolve.** `_controller.dispose()` is not this widget's `dispose`, `super.initState()` is a framework upcall, and `..cancel()` is a cascade onto some other object. Without type inference, matching those against local declarations invents edges. An earlier iteration did exactly that and produced `_LoadingViewState → dispose` from `_controller.dispose()`.
- **Unresolved names are dropped, not guessed** — imported symbols and calls into other libraries add nothing, so the pass introduces no cross-file speculation.
- Repeated call sites raise `weight` instead of duplicating the edge; self-loops are skipped.

`calls` is already in `SEMANTIC_RELATIONS`, so no vocabulary change is needed.

## Result

Same app, after the change:

| | before | after |
|---|---|---|
| `calls` from `.dart` | 0 | 112 |
| graph edges | 2321 | 2458 |
| Flutter communities in the top 12 with internal structure (not a star) | 0 of 5 | 3 of 6 |

The 1691-line product screen now splits by feature instead of by Flutter class kind:

- alternatives subtree — `_AlternativesSection(+State)`, `_AlternativeTile`, `_AlternativesEmpty`, `_AlternativesSkeleton`
- score breakdown and additives — `_BreakdownCard`, `_AdditivesCardState`, `_row`, `_factRow`, `_riskExplanation`
- actions and error handling — `_snack`, `_addPhoto`, `_shareSheet`, `_favoriteButtons`, `_describeError`

What stays a star is the residue of plain fields and locals, which genuinely have no edges other than `defines`.

## Tests

Two cases added to `tests/test_dart.py`:

- `test_intra_file_calls_and_widget_composition` — composition edges, plain helper calls, enclosing-class attribution, weight counting, no self-loops
- `test_intra_file_calls_ignore_foreign_receivers` — `this.`/`widget.` resolve; `super.`, receiver-qualified calls and cascades do not

`tests/test_dart.py` passes 7/7. Full suite: 90 failures before and after (pre-existing, in `test_skillgen` / `test_terraform` / `test_tree_html`, unrelated to this change), passing count 4118 → 4120 — exactly the two new tests. TypeScript extraction is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)