### PR TITLE
Add GRAPHIFY_CLAUDE_CLI_BARE opt-in for claude -p spawns

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -404,8 +404,8 @@ def _no_window_kwargs() -> dict:
     return {}
 
 
-def _claude_cli_bare_args() -> list[str]:
-    """``--bare`` for `claude -p`, opt-in via GRAPHIFY_CLAUDE_CLI_BARE=1.
+def _claude_cli_minimal_args() -> list[str]:
+    """``--safe-mode`` for `claude -p`, opt-in via GRAPHIFY_CLAUDE_CLI_MINIMAL=1.
 
     Each `claude -p` spawn (one per extraction chunk, plus one per community
     label) boots a full Claude Code session with the user's global config,
@@ -413,15 +413,24 @@ def _claude_cli_bare_args() -> list[str]:
     extraction pipeline this is pure overhead, and worse: a failing or
     cancelled SessionEnd hook can flip the process exit code to nonzero, so a
     chunk whose extraction actually succeeded gets recorded as a hook
-    failure instead (#2693). `--bare` skips auto-discovery of hooks, skills,
-    plugins, MCP servers, auto memory, and CLAUDE.md for that one spawn — it
-    does not touch the user's global config, and does not affect the
-    subscription/OAuth auth graphify's claude-cli backend relies on.
+    failure instead (#2693). `--safe-mode` disables CLAUDE.md, plugins,
+    skills, hooks, and MCP servers for that one spawn — it does not touch
+    the user's global config.
+
+    Deliberately NOT `--bare`: that flag also skips keychain reads and
+    forces API-key-only auth (`ANTHROPIC_API_KEY` or `apiKeyHelper`), which
+    breaks the claude-cli backend for exactly the population it exists for
+    (Pro/Max subscribers routing through subscription auth instead of
+    provisioning a pay-as-you-go key — see _call_claude_cli's docstring).
+    `--safe-mode` disables the same customizations without touching
+    auth/model selection/permissions (confirmed against a real CLI: with
+    ANTHROPIC_API_KEY unset, `--bare` returns "Not logged in", `--safe-mode`
+    replies normally — thanks @yotamleo for catching this in review).
 
     Opt-in and off by default: existing users may rely on their hooks firing
     for every session, including these ones.
     """
-    return ["--bare"] if os.environ.get("GRAPHIFY_CLAUDE_CLI_BARE", "").strip() == "1" else []
+    return ["--safe-mode"] if os.environ.get("GRAPHIFY_CLAUDE_CLI_MINIMAL", "").strip() == "1" else []
 
 
 def _resolve_api_timeout(default: float = 600.0) -> float:
@@ -1771,7 +1780,7 @@ def _call_claude_cli(user_message: str, max_tokens: int = 8192, *, deep_mode: bo
         claude_cmd, "-p",
         "--output-format", "json",
         "--no-session-persistence",
-        *_claude_cli_bare_args(),
+        *_claude_cli_minimal_args(),
         *add_dir_args,
     ]
     # claude-cli defaults to Opus, which is overkill for the structured-JSON
@@ -2963,7 +2972,7 @@ def _call_llm(
             raise RuntimeError("Claude Code CLI not found on $PATH")
         cli_args = [
             claude_cmd, "-p", "--output-format", "json", "--no-session-persistence",
-            *_claude_cli_bare_args(),
+            *_claude_cli_minimal_args(),
         ]
         if model is not None:
             cli_args.extend(["--model", mdl])

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -404,6 +404,26 @@ def _no_window_kwargs() -> dict:
     return {}
 
 
+def _claude_cli_bare_args() -> list[str]:
+    """``--bare`` for `claude -p`, opt-in via GRAPHIFY_CLAUDE_CLI_BARE=1.
+
+    Each `claude -p` spawn (one per extraction chunk, plus one per community
+    label) boots a full Claude Code session with the user's global config,
+    including SessionStart/SessionEnd hooks and plugins. For an unattended
+    extraction pipeline this is pure overhead, and worse: a failing or
+    cancelled SessionEnd hook can flip the process exit code to nonzero, so a
+    chunk whose extraction actually succeeded gets recorded as a hook
+    failure instead (#2693). `--bare` skips auto-discovery of hooks, skills,
+    plugins, MCP servers, auto memory, and CLAUDE.md for that one spawn — it
+    does not touch the user's global config, and does not affect the
+    subscription/OAuth auth graphify's claude-cli backend relies on.
+
+    Opt-in and off by default: existing users may rely on their hooks firing
+    for every session, including these ones.
+    """
+    return ["--bare"] if os.environ.get("GRAPHIFY_CLAUDE_CLI_BARE", "").strip() == "1" else []
+
+
 def _resolve_api_timeout(default: float = 600.0) -> float:
     """Honour GRAPHIFY_API_TIMEOUT env var override, else use default (seconds)."""
     raw = os.environ.get("GRAPHIFY_API_TIMEOUT", "").strip()
@@ -1751,6 +1771,7 @@ def _call_claude_cli(user_message: str, max_tokens: int = 8192, *, deep_mode: bo
         claude_cmd, "-p",
         "--output-format", "json",
         "--no-session-persistence",
+        *_claude_cli_bare_args(),
         *add_dir_args,
     ]
     # claude-cli defaults to Opus, which is overkill for the structured-JSON
@@ -2940,7 +2961,10 @@ def _call_llm(
                 raise RuntimeError("Claude Code CLI not found on $PATH")
         elif shutil.which("claude") is None:
             raise RuntimeError("Claude Code CLI not found on $PATH")
-        cli_args = [claude_cmd, "-p", "--output-format", "json", "--no-session-persistence"]
+        cli_args = [
+            claude_cmd, "-p", "--output-format", "json", "--no-session-persistence",
+            *_claude_cli_bare_args(),
+        ]
         if model is not None:
             cli_args.extend(["--model", mdl])
         proc = subprocess.run(

--- a/tests/test_claude_cli_backend.py
+++ b/tests/test_claude_cli_backend.py
@@ -209,29 +209,29 @@ def test_envelope_survives_preamble_around_array_shaped_stream():
     assert [n["label"] for n in result["nodes"]] == ["Foo", "greet"]
 
 
-def test_call_llm_bare_flag_opt_in(monkeypatch):
+def test_call_llm_minimal_flag_opt_in(monkeypatch):
     """#2693: the labeling-call spawn (_call_llm's own claude-cli branch, used
-    for community labels) honours GRAPHIFY_CLAUDE_CLI_BARE the same as the
+    for community labels) honours GRAPHIFY_CLAUDE_CLI_MINIMAL the same as the
     extraction spawn (_call_claude_cli)."""
     envelope = dict(_ENVELOPE, result="a fine label")
     completed = MagicMock(returncode=0, stdout=json.dumps(envelope), stderr="")
-    monkeypatch.setenv("GRAPHIFY_CLAUDE_CLI_BARE", "1")
+    monkeypatch.setenv("GRAPHIFY_CLAUDE_CLI_MINIMAL", "1")
     with patch("shutil.which", return_value="/fake/bin/claude"), \
          patch("subprocess.run", return_value=completed) as run:
         llm._call_llm("dummy", backend="claude-cli")
     argv = run.call_args.args[0]
-    assert "--bare" in argv
+    assert "--safe-mode" in argv
 
 
-def test_call_llm_bare_flag_absent_by_default(monkeypatch):
+def test_call_llm_minimal_flag_absent_by_default(monkeypatch):
     envelope = dict(_ENVELOPE, result="a fine label")
     completed = MagicMock(returncode=0, stdout=json.dumps(envelope), stderr="")
-    monkeypatch.delenv("GRAPHIFY_CLAUDE_CLI_BARE", raising=False)
+    monkeypatch.delenv("GRAPHIFY_CLAUDE_CLI_MINIMAL", raising=False)
     with patch("shutil.which", return_value="/fake/bin/claude"), \
          patch("subprocess.run", return_value=completed) as run:
         llm._call_llm("dummy", backend="claude-cli")
     argv = run.call_args.args[0]
-    assert "--bare" not in argv
+    assert "--safe-mode" not in argv
 
 
 def test_raises_on_garbage_envelope():
@@ -264,47 +264,62 @@ def test_no_session_persistence_flag_in_subprocess(fake_claude):
     assert "--no-session-persistence" in call_args
 
 
-# ---------- GRAPHIFY_CLAUDE_CLI_BARE opt-in (#2693) ----------
+# ---------- GRAPHIFY_CLAUDE_CLI_MINIMAL opt-in (#2693) ----------
 # Each `claude -p` spawn boots a full Claude Code session with the user's
 # global config, including SessionStart/SessionEnd hooks. A failing/cancelled
 # hook can flip the exit code to nonzero for a chunk whose extraction actually
-# succeeded. --bare skips hook/skill/plugin/MCP/CLAUDE.md auto-discovery for
-# that one spawn; it must stay off by default so existing hook setups keep
-# firing.
+# succeeded. --safe-mode skips hook/skill/plugin/MCP/CLAUDE.md auto-discovery
+# for that one spawn without touching auth (unlike --bare, which forces
+# API-key-only auth and breaks the subscription-auth population this backend
+# exists for — see _claude_cli_minimal_args' docstring); it must stay off by
+# default so existing hook setups keep firing.
 
 
-def test_bare_flag_absent_by_default(fake_claude, monkeypatch):
-    monkeypatch.delenv("GRAPHIFY_CLAUDE_CLI_BARE", raising=False)
+def test_minimal_flag_absent_by_default(fake_claude, monkeypatch):
+    monkeypatch.delenv("GRAPHIFY_CLAUDE_CLI_MINIMAL", raising=False)
     llm._call_claude_cli("dummy", max_tokens=8192)
     argv = fake_claude.call_args.args[0]
-    assert "--bare" not in argv
+    assert "--safe-mode" not in argv
 
 
-def test_bare_flag_present_when_opted_in(fake_claude, monkeypatch):
-    monkeypatch.setenv("GRAPHIFY_CLAUDE_CLI_BARE", "1")
+def test_minimal_flag_present_when_opted_in(fake_claude, monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_CLAUDE_CLI_MINIMAL", "1")
     llm._call_claude_cli("dummy", max_tokens=8192)
     argv = fake_claude.call_args.args[0]
-    assert "--bare" in argv
+    assert "--safe-mode" in argv
 
 
-def test_bare_flag_absent_for_any_non_one_value(fake_claude, monkeypatch):
+def test_minimal_flag_absent_for_any_non_one_value(fake_claude, monkeypatch):
     """Only the exact value "1" opts in — matches GRAPHIFY_CLAUDE_CLI_PARALLEL's
     convention elsewhere in this module."""
-    monkeypatch.setenv("GRAPHIFY_CLAUDE_CLI_BARE", "true")
+    monkeypatch.setenv("GRAPHIFY_CLAUDE_CLI_MINIMAL", "true")
     llm._call_claude_cli("dummy", max_tokens=8192)
     argv = fake_claude.call_args.args[0]
-    assert "--bare" not in argv
+    assert "--safe-mode" not in argv
 
 
-def test_bare_args_helper():
+def test_minimal_flag_never_emits_bare():
+    """#2693 regression: --bare must never be used here — it forces
+    API-key-only auth (ANTHROPIC_API_KEY / apiKeyHelper) and drops OAuth/
+    keychain reads, which fails outright for the subscription-auth users the
+    claude-cli backend exists for."""
     import os as _os
-    _os.environ.pop("GRAPHIFY_CLAUDE_CLI_BARE", None)
-    assert llm._claude_cli_bare_args() == []
-    _os.environ["GRAPHIFY_CLAUDE_CLI_BARE"] = "1"
+    _os.environ["GRAPHIFY_CLAUDE_CLI_MINIMAL"] = "1"
     try:
-        assert llm._claude_cli_bare_args() == ["--bare"]
+        assert "--bare" not in llm._claude_cli_minimal_args()
     finally:
-        _os.environ.pop("GRAPHIFY_CLAUDE_CLI_BARE", None)
+        _os.environ.pop("GRAPHIFY_CLAUDE_CLI_MINIMAL", None)
+
+
+def test_minimal_args_helper():
+    import os as _os
+    _os.environ.pop("GRAPHIFY_CLAUDE_CLI_MINIMAL", None)
+    assert llm._claude_cli_minimal_args() == []
+    _os.environ["GRAPHIFY_CLAUDE_CLI_MINIMAL"] = "1"
+    try:
+        assert llm._claude_cli_minimal_args() == ["--safe-mode"]
+    finally:
+        _os.environ.pop("GRAPHIFY_CLAUDE_CLI_MINIMAL", None)
 
 
 # ---------- extraction instructions delivered in the user turn ----------

--- a/tests/test_claude_cli_backend.py
+++ b/tests/test_claude_cli_backend.py
@@ -209,6 +209,31 @@ def test_envelope_survives_preamble_around_array_shaped_stream():
     assert [n["label"] for n in result["nodes"]] == ["Foo", "greet"]
 
 
+def test_call_llm_bare_flag_opt_in(monkeypatch):
+    """#2693: the labeling-call spawn (_call_llm's own claude-cli branch, used
+    for community labels) honours GRAPHIFY_CLAUDE_CLI_BARE the same as the
+    extraction spawn (_call_claude_cli)."""
+    envelope = dict(_ENVELOPE, result="a fine label")
+    completed = MagicMock(returncode=0, stdout=json.dumps(envelope), stderr="")
+    monkeypatch.setenv("GRAPHIFY_CLAUDE_CLI_BARE", "1")
+    with patch("shutil.which", return_value="/fake/bin/claude"), \
+         patch("subprocess.run", return_value=completed) as run:
+        llm._call_llm("dummy", backend="claude-cli")
+    argv = run.call_args.args[0]
+    assert "--bare" in argv
+
+
+def test_call_llm_bare_flag_absent_by_default(monkeypatch):
+    envelope = dict(_ENVELOPE, result="a fine label")
+    completed = MagicMock(returncode=0, stdout=json.dumps(envelope), stderr="")
+    monkeypatch.delenv("GRAPHIFY_CLAUDE_CLI_BARE", raising=False)
+    with patch("shutil.which", return_value="/fake/bin/claude"), \
+         patch("subprocess.run", return_value=completed) as run:
+        llm._call_llm("dummy", backend="claude-cli")
+    argv = run.call_args.args[0]
+    assert "--bare" not in argv
+
+
 def test_raises_on_garbage_envelope():
     completed = MagicMock(returncode=0, stdout="not json", stderr="")
     with patch("shutil.which", return_value="/fake/bin/claude"), \
@@ -237,6 +262,49 @@ def test_no_session_persistence_flag_in_subprocess(fake_claude):
     llm._call_claude_cli("dummy", max_tokens=8192)
     call_args = fake_claude.call_args[0][0]
     assert "--no-session-persistence" in call_args
+
+
+# ---------- GRAPHIFY_CLAUDE_CLI_BARE opt-in (#2693) ----------
+# Each `claude -p` spawn boots a full Claude Code session with the user's
+# global config, including SessionStart/SessionEnd hooks. A failing/cancelled
+# hook can flip the exit code to nonzero for a chunk whose extraction actually
+# succeeded. --bare skips hook/skill/plugin/MCP/CLAUDE.md auto-discovery for
+# that one spawn; it must stay off by default so existing hook setups keep
+# firing.
+
+
+def test_bare_flag_absent_by_default(fake_claude, monkeypatch):
+    monkeypatch.delenv("GRAPHIFY_CLAUDE_CLI_BARE", raising=False)
+    llm._call_claude_cli("dummy", max_tokens=8192)
+    argv = fake_claude.call_args.args[0]
+    assert "--bare" not in argv
+
+
+def test_bare_flag_present_when_opted_in(fake_claude, monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_CLAUDE_CLI_BARE", "1")
+    llm._call_claude_cli("dummy", max_tokens=8192)
+    argv = fake_claude.call_args.args[0]
+    assert "--bare" in argv
+
+
+def test_bare_flag_absent_for_any_non_one_value(fake_claude, monkeypatch):
+    """Only the exact value "1" opts in — matches GRAPHIFY_CLAUDE_CLI_PARALLEL's
+    convention elsewhere in this module."""
+    monkeypatch.setenv("GRAPHIFY_CLAUDE_CLI_BARE", "true")
+    llm._call_claude_cli("dummy", max_tokens=8192)
+    argv = fake_claude.call_args.args[0]
+    assert "--bare" not in argv
+
+
+def test_bare_args_helper():
+    import os as _os
+    _os.environ.pop("GRAPHIFY_CLAUDE_CLI_BARE", None)
+    assert llm._claude_cli_bare_args() == []
+    _os.environ["GRAPHIFY_CLAUDE_CLI_BARE"] = "1"
+    try:
+        assert llm._claude_cli_bare_args() == ["--bare"]
+    finally:
+        _os.environ.pop("GRAPHIFY_CLAUDE_CLI_BARE", None)
 
 
 # ---------- extraction instructions delivered in the user turn ----------


### PR DESCRIPTION
Each claude -p spawn (one per extraction chunk, plus one per
community label) boots a full Claude Code session with the user's
global config, including SessionStart/SessionEnd hooks and plugins.
For an unattended extraction pipeline this is pure overhead, and
worse: a failing or cancelled SessionEnd hook can flip the process
exit code to nonzero, so a chunk whose extraction actually succeeded
gets recorded as a hook failure instead.

GRAPHIFY_CLAUDE_CLI_MINIMAL=1 passes --safe-mode to both claude-cli
spawn sites (_call_claude_cli's extraction path, and _call_llm's
labeling path). --safe-mode disables CLAUDE.md, plugins, skills,
hooks, and MCP servers for that one spawn, without touching auth,
model selection, or permissions. Opt-in and off by default, matching
the existing GRAPHIFY_CLAUDE_CLI_MODEL / GRAPHIFY_CLAUDE_CLI_PARALLEL
convention already in this module -- existing users who rely on their
hooks firing are unaffected.

**Edit:** the first version of this PR used --bare instead of
--safe-mode. @yotamleo caught in review that --bare forces
API-key-only auth (ANTHROPIC_API_KEY / apiKeyHelper) and never reads
OAuth/keychain credentials -- verified against a real CLI (2.1.257):
with ANTHROPIC_API_KEY unset, `claude -p --bare` returns "Not logged
in" while a plain `claude -p` succeeds. That would have broken the
claude-cli backend for exactly the population it exists for (Pro/Max
subscribers on subscription auth). Switched to --safe-mode, which
covers the same ask (hooks/plugins/MCP/CLAUDE.md disabled) without
touching auth, and renamed the env var from
GRAPHIFY_CLAUDE_CLI_BARE to GRAPHIFY_CLAUDE_CLI_MINIMAL since it no
longer maps to a specific CLI flag name.

Verification:
- 8 tests covering both spawn sites: flag absent by default, flag
  present when GRAPHIFY_CLAUDE_CLI_MINIMAL=1, flag absent for any other
  value (only the exact string "1" opts in), a direct regression test
  that --bare is never emitted, and a direct test of the extracted
  helper.
- Full suite: 4368 passed, 0 failed.
- ruff and skillgen --check clean.

Fixes #2693.