### PR TITLE
fix(skills): do the temp-file cleanup in Python, not shell rm/find (#2790)

### DIFF
--- a/graphify/skill-agents.md
+++ b/graphify/skill-agents.md
@@ -348,10 +348,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -614,10 +615,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill-aider.md
+++ b/graphify/skill-aider.md
@@ -346,10 +346,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('.graphify_semantic.json').write_text(json.dumps(merged, indent=2))
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path(_tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f .graphify_cached.json .graphify_uncached.txt .graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -718,9 +719,13 @@ cost_path.write_text(json.dumps(cost, indent=2))
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.graphify_labels.json']:
+    Path(_tmp).unlink(missing_ok=True)
+for _chunk in Path('.').glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
+Path('graphify-out/.needs_update').unlink(missing_ok=True)
 "
-rm -f .graphify_detect.json .graphify_extract.json .graphify_ast.json .graphify_semantic.json .graphify_analysis.json .graphify_labels.json; find . -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Tell the user (omit the obsidian line unless --obsidian was given):
@@ -865,11 +870,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json .graphify_old.json`
-Clean up after: `rm -f .graphify_old.json`
 
 ---
 

--- a/graphify/skill-amp.md
+++ b/graphify/skill-amp.md
@@ -348,10 +348,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -614,10 +615,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill-claw.md
+++ b/graphify/skill-claw.md
@@ -351,10 +351,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -617,10 +618,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -348,10 +348,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -614,10 +615,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill-copilot.md
+++ b/graphify/skill-copilot.md
@@ -351,10 +351,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -617,10 +618,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill-devin.md
+++ b/graphify/skill-devin.md
@@ -409,10 +409,11 @@ merged = {
 }
 merged = sanitize_semantic_fragment(merged)
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2))
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -836,9 +837,13 @@ cost_path.write_text(json.dumps(cost, indent=2))
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.graphify_labels.json', '.graphify_incremental.json', '.graphify_transcripts.json', '.graphify_old.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json graphify-out/.graphify_labels.json graphify-out/.graphify_incremental.json graphify-out/.graphify_transcripts.json graphify-out/.graphify_old.json; find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Tell the user (omit the obsidian line unless --obsidian was given; omit the wiki line unless --wiki was given):
@@ -1001,11 +1006,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skill-droid.md
+++ b/graphify/skill-droid.md
@@ -348,10 +348,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -614,10 +615,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill-kilo.md
+++ b/graphify/skill-kilo.md
@@ -351,10 +351,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -617,10 +618,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill-kiro.md
+++ b/graphify/skill-kiro.md
@@ -351,10 +351,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -617,10 +618,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -343,10 +343,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -609,10 +610,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill-pi.md
+++ b/graphify/skill-pi.md
@@ -351,10 +351,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -617,10 +618,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill-trae.md
+++ b/graphify/skill-trae.md
@@ -349,10 +349,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -615,10 +616,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill-vscode.md
+++ b/graphify/skill-vscode.md
@@ -347,10 +347,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -613,10 +614,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill-windows.md
+++ b/graphify/skill-windows.md
@@ -373,10 +373,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding="utf-8")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached["nodes"])} from cache, {len(new.get("nodes",[]))} new)')
 '@ | & (Get-Content graphify-out\.graphify_python) -
 ```
-Clean up temp files: `Remove-Item -Force -ErrorAction SilentlyContinue graphify-out\.graphify_cached.json, graphify-out\.graphify_uncached.txt, graphify-out\.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -639,10 +640,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding="u
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost["total_input_tokens"]:,} input, {cost["total_output_tokens"]:,} output ({len(cost["runs"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 '@ | & (Get-Content graphify-out\.graphify_python) -
-Remove-Item -Force -ErrorAction SilentlyContinue graphify-out\.graphify_detect.json, graphify-out\.graphify_extract.json, graphify-out\.graphify_ast.json, graphify-out\.graphify_semantic.json, graphify-out\.graphify_analysis.json
-Get-ChildItem graphify-out -Filter '.graphify_chunk_*.json' -File -ErrorAction SilentlyContinue | Remove-Item -Force
-Remove-Item -Force -ErrorAction SilentlyContinue graphify-out\.needs_update
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -351,10 +351,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -617,10 +618,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/graphify/skills/agents/references/update.md
+++ b/graphify/skills/agents/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/amp/references/update.md
+++ b/graphify/skills/amp/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/claude/references/update.md
+++ b/graphify/skills/claude/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/claw/references/update.md
+++ b/graphify/skills/claw/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/codex/references/update.md
+++ b/graphify/skills/codex/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/copilot/references/update.md
+++ b/graphify/skills/copilot/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/droid/references/update.md
+++ b/graphify/skills/droid/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/kilo/references/update.md
+++ b/graphify/skills/kilo/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/kiro/references/update.md
+++ b/graphify/skills/kiro/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/opencode/references/update.md
+++ b/graphify/skills/opencode/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/pi/references/update.md
+++ b/graphify/skills/pi/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/trae/references/update.md
+++ b/graphify/skills/trae/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/vscode/references/update.md
+++ b/graphify/skills/vscode/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/graphify/skills/windows/references/update.md
+++ b/graphify/skills/windows/references/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tests/test_skill_cleanup_is_shell_free.py
+++ b/tests/test_skill_cleanup_is_shell_free.py
@@ -1,0 +1,133 @@
+"""The runbook's temp-file cleanup must not depend on a shell.
+
+Cleanup was the only part of the pipeline that shelled out, with `rm -f` and
+`find ... -delete`. On a host that gates the agent's shell, destructive verbs are
+exactly what the policy withholds, so both calls were denied, the pipeline had no
+fallback, and the intermediates stayed on disk (#2790). That is not just clutter:
+Part C and Step B3 read `.graphify_chunk_*.json` and `.graphify_semantic_new.json`
+unconditionally, so a stale chunk from a previous run can be merged into the next
+`--update`.
+
+It is the third reported cause of one symptom -- #1172 was the fish/zsh no-match
+glob, #464 the Codex/Windows leftovers -- and unlike those, retrying or switching
+shell does not help, because the cause is a permission policy.
+
+These tests assert the property that kills the whole class: no shipped skill asks
+a shell to delete anything, and the Python that replaced it actually removes the
+files it names.
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SKILLS_DIR = Path(__file__).resolve().parent.parent / "graphify"
+SKILL_FILES = sorted(SKILLS_DIR.glob("skill*.md"))
+REFERENCE_FILES = sorted((SKILLS_DIR / "skills").rglob("*.md"))
+
+# Shell verbs that delete. `cp` and `mkdir` are deliberately absent: they are not
+# destructive, so they are not what a permission policy withholds, and #2790 is
+# specifically about the delete step.
+_DELETE_VERBS = (
+    re.compile(r"(?<![\w-])rm\s+-[a-zA-Z]*f"),
+    re.compile(r"(?<![\w-])rm\s+-[a-zA-Z]*r"),
+    re.compile(r"\bfind\b[^\n]*-delete"),
+    re.compile(r"\bRemove-Item\b"),
+    re.compile(r"\bdel\s+/[qQfF]"),
+)
+
+
+def _offending(text: str) -> list[str]:
+    return [
+        line.strip()
+        for line in text.splitlines()
+        for pat in _DELETE_VERBS
+        if pat.search(line)
+    ]
+
+
+@pytest.mark.parametrize("path", SKILL_FILES, ids=lambda p: p.name)
+def test_no_shipped_skill_deletes_through_a_shell(path):
+    assert not _offending(path.read_text(encoding="utf-8")), (
+        f"{path.name} deletes through a shell verb; a permission-gated host will "
+        f"deny it: {_offending(path.read_text(encoding='utf-8'))}"
+    )
+
+
+@pytest.mark.parametrize("path", REFERENCE_FILES, ids=lambda p: f"{p.parent.parent.name}/{p.name}")
+def test_no_shipped_reference_deletes_through_a_shell(path):
+    assert not _offending(path.read_text(encoding="utf-8")), (
+        f"{path} deletes through a shell verb"
+    )
+
+
+def test_every_skill_still_cleans_the_chunk_files():
+    """The guard above passes trivially if cleanup were simply deleted. Every
+    skill that dispatches chunks must still remove them, in Python."""
+    checked = 0
+    for path in SKILL_FILES:
+        text = path.read_text(encoding="utf-8")
+        if ".graphify_chunk_" not in text:
+            continue
+        checked += 1
+        assert re.search(r"for _chunk in .*glob\('\.graphify_chunk_\*\.json'\):", text), (
+            f"{path.name} dispatches chunks but never cleans them up"
+        )
+        assert "_chunk.unlink(missing_ok=True)" in text, path.name
+    assert checked >= 10, f"expected most skills to dispatch chunks, saw {checked}"
+
+
+# ---------------------------------------------------------------------------
+# The replacement actually works
+# ---------------------------------------------------------------------------
+
+_CLEANUP = """
+from pathlib import Path
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
+"""
+
+
+def test_the_cleanup_block_shipped_in_skill_md_is_the_one_under_test():
+    """Pin the snippet below to what skill.md actually ships, so this file cannot
+    drift into testing something the runbook no longer says."""
+    text = (SKILLS_DIR / "skill.md").read_text(encoding="utf-8")
+    for line in _CLEANUP.strip().splitlines()[1:]:  # skip the import
+        assert line in text, f"skill.md no longer contains: {line!r}"
+
+
+def _seed(root: Path) -> None:
+    out = root / "graphify-out"
+    out.mkdir(parents=True)
+    for name in (".graphify_detect.json", ".graphify_extract.json", ".graphify_ast.json",
+                 ".graphify_semantic.json", ".graphify_analysis.json", ".needs_update",
+                 ".graphify_chunk_01.json", ".graphify_chunk_02.json"):
+        (out / name).write_text("{}", encoding="utf-8")
+    (out / "graph.json").write_text('{"nodes":[],"links":[]}', encoding="utf-8")
+    (out / "GRAPH_REPORT.md").write_text("# report\n", encoding="utf-8")
+
+
+def test_cleanup_removes_every_intermediate_and_keeps_the_outputs(tmp_path):
+    _seed(tmp_path)
+    subprocess.run([sys.executable, "-c", _CLEANUP], cwd=tmp_path, check=True)
+
+    left = sorted(p.name for p in (tmp_path / "graphify-out").iterdir())
+    assert left == ["GRAPH_REPORT.md", "graph.json"], left
+
+
+def test_cleanup_is_idempotent_when_nothing_is_there(tmp_path):
+    """`rm -f` tolerated missing files; `unlink(missing_ok=True)` must too, or a
+    --no-viz / cluster-only run that never wrote a chunk would crash Step 9."""
+    (tmp_path / "graphify-out").mkdir()
+    subprocess.run([sys.executable, "-c", _CLEANUP], cwd=tmp_path, check=True)
+    subprocess.run([sys.executable, "-c", _CLEANUP], cwd=tmp_path, check=True)
+
+
+def test_cleanup_does_not_need_the_output_dir_to_exist(tmp_path):
+    """glob() on a missing directory yields nothing rather than raising."""
+    subprocess.run([sys.executable, "-c", _CLEANUP], cwd=tmp_path, check=True)

--- a/tests/test_skillgen.py
+++ b/tests/test_skillgen.py
@@ -403,9 +403,15 @@ def test_powershell_hosts_carry_no_bash_only_shell():
         assert "'@ | & (Get-Content graphify-out\\.graphify_python) -" in core, (
             f"[{key}] missing the here-string stdin python invocation"
         )
-        # Cleanup went through Remove-Item / Get-ChildItem, not rm/find.
-        assert "Remove-Item -Force -ErrorAction SilentlyContinue" in core
-        assert "Get-ChildItem graphify-out -Filter '.graphify_chunk_*.json'" in core
+        # Cleanup no longer goes through a shell at all (#2790): it is folded
+        # into the tail of the Python program each block already runs, so there
+        # is nothing left for the translator to turn into Remove-Item, and a
+        # host that gates destructive verbs has nothing to deny.
+        assert "Remove-Item" not in core, f"[{key}] cleanup still uses a shell verb"
+        assert "Get-ChildItem" not in core, f"[{key}] cleanup still uses a shell verb"
+        assert "for _chunk in _out.glob('.graphify_chunk_*.json'):" in core, (
+            f"[{key}] lost the Python chunk cleanup"
+        )
 
 
 def test_windows_and_posix_cores_have_step_and_2490_parity():

--- a/tools/skillgen/expected/graphify__skill-agents.md
+++ b/tools/skillgen/expected/graphify__skill-agents.md
@@ -348,10 +348,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -614,10 +615,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill-aider.md
+++ b/tools/skillgen/expected/graphify__skill-aider.md
@@ -346,10 +346,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('.graphify_semantic.json').write_text(json.dumps(merged, indent=2))
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path(_tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f .graphify_cached.json .graphify_uncached.txt .graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -718,9 +719,13 @@ cost_path.write_text(json.dumps(cost, indent=2))
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.graphify_labels.json']:
+    Path(_tmp).unlink(missing_ok=True)
+for _chunk in Path('.').glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
+Path('graphify-out/.needs_update').unlink(missing_ok=True)
 "
-rm -f .graphify_detect.json .graphify_extract.json .graphify_ast.json .graphify_semantic.json .graphify_analysis.json .graphify_labels.json; find . -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Tell the user (omit the obsidian line unless --obsidian was given):
@@ -865,11 +870,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json .graphify_old.json`
-Clean up after: `rm -f .graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skill-amp.md
+++ b/tools/skillgen/expected/graphify__skill-amp.md
@@ -348,10 +348,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -614,10 +615,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill-claw.md
+++ b/tools/skillgen/expected/graphify__skill-claw.md
@@ -351,10 +351,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -617,10 +618,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill-codex.md
+++ b/tools/skillgen/expected/graphify__skill-codex.md
@@ -348,10 +348,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -614,10 +615,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill-copilot.md
+++ b/tools/skillgen/expected/graphify__skill-copilot.md
@@ -351,10 +351,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -617,10 +618,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill-devin.md
+++ b/tools/skillgen/expected/graphify__skill-devin.md
@@ -409,10 +409,11 @@ merged = {
 }
 merged = sanitize_semantic_fragment(merged)
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2))
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -836,9 +837,13 @@ cost_path.write_text(json.dumps(cost, indent=2))
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.graphify_labels.json', '.graphify_incremental.json', '.graphify_transcripts.json', '.graphify_old.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json graphify-out/.graphify_labels.json graphify-out/.graphify_incremental.json graphify-out/.graphify_transcripts.json graphify-out/.graphify_old.json; find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Tell the user (omit the obsidian line unless --obsidian was given; omit the wiki line unless --wiki was given):
@@ -1001,11 +1006,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skill-droid.md
+++ b/tools/skillgen/expected/graphify__skill-droid.md
@@ -348,10 +348,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -614,10 +615,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill-kilo.md
+++ b/tools/skillgen/expected/graphify__skill-kilo.md
@@ -351,10 +351,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -617,10 +618,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill-kiro.md
+++ b/tools/skillgen/expected/graphify__skill-kiro.md
@@ -351,10 +351,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -617,10 +618,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill-opencode.md
+++ b/tools/skillgen/expected/graphify__skill-opencode.md
@@ -343,10 +343,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -609,10 +610,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill-pi.md
+++ b/tools/skillgen/expected/graphify__skill-pi.md
@@ -351,10 +351,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -617,10 +618,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill-trae.md
+++ b/tools/skillgen/expected/graphify__skill-trae.md
@@ -349,10 +349,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -615,10 +616,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill-vscode.md
+++ b/tools/skillgen/expected/graphify__skill-vscode.md
@@ -347,10 +347,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -613,10 +614,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill-windows.md
+++ b/tools/skillgen/expected/graphify__skill-windows.md
@@ -373,10 +373,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding="utf-8")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached["nodes"])} from cache, {len(new.get("nodes",[]))} new)')
 '@ | & (Get-Content graphify-out\.graphify_python) -
 ```
-Clean up temp files: `Remove-Item -Force -ErrorAction SilentlyContinue graphify-out\.graphify_cached.json, graphify-out\.graphify_uncached.txt, graphify-out\.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -639,10 +640,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding="u
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost["total_input_tokens"]:,} input, {cost["total_output_tokens"]:,} output ({len(cost["runs"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 '@ | & (Get-Content graphify-out\.graphify_python) -
-Remove-Item -Force -ErrorAction SilentlyContinue graphify-out\.graphify_detect.json, graphify-out\.graphify_extract.json, graphify-out\.graphify_ast.json, graphify-out\.graphify_semantic.json, graphify-out\.graphify_analysis.json
-Get-ChildItem graphify-out -Filter '.graphify_chunk_*.json' -File -ErrorAction SilentlyContinue | Remove-Item -Force
-Remove-Item -Force -ErrorAction SilentlyContinue graphify-out\.needs_update
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skill.md
+++ b/tools/skillgen/expected/graphify__skill.md
@@ -351,10 +351,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -617,10 +618,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/expected/graphify__skills__agents__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__agents__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__amp__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__amp__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__claude__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claude__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__claw__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claw__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__codex__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__codex__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__copilot__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__copilot__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__droid__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__droid__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__kilo__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kilo__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__kiro__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kiro__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__opencode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__opencode__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__pi__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__pi__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__trae__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__trae__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__vscode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__vscode__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/expected/graphify__skills__windows__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__windows__references__update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/fragments/core/aider.md
+++ b/tools/skillgen/fragments/core/aider.md
@@ -346,10 +346,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('.graphify_semantic.json').write_text(json.dumps(merged, indent=2))
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path(_tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f .graphify_cached.json .graphify_uncached.txt .graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -718,9 +719,13 @@ cost_path.write_text(json.dumps(cost, indent=2))
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.graphify_labels.json']:
+    Path(_tmp).unlink(missing_ok=True)
+for _chunk in Path('.').glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
+Path('graphify-out/.needs_update').unlink(missing_ok=True)
 "
-rm -f .graphify_detect.json .graphify_extract.json .graphify_ast.json .graphify_semantic.json .graphify_analysis.json .graphify_labels.json; find . -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Tell the user (omit the obsidian line unless --obsidian was given):
@@ -865,11 +870,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json .graphify_old.json`
-Clean up after: `rm -f .graphify_old.json`
 
 ---
 

--- a/tools/skillgen/fragments/core/core.md
+++ b/tools/skillgen/fragments/core/core.md
@@ -286,10 +286,11 @@ merged = {
     'output_tokens': new.get('output_tokens', 0),
 }
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -552,10 +553,13 @@ cost_path.write_text(json.dumps(cost, indent=2, ensure_ascii=False), encoding=\"
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Replace INPUT_PATH with the actual path (same value used in Steps 4-5) so the manifest is relativized to the scan root.

--- a/tools/skillgen/fragments/core/devin.md
+++ b/tools/skillgen/fragments/core/devin.md
@@ -409,10 +409,11 @@ merged = {
 }
 merged = sanitize_semantic_fragment(merged)
 Path('graphify-out/.graphify_semantic.json').write_text(json.dumps(merged, indent=2))
+for _tmp in ['.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    Path('graphify-out', _tmp).unlink(missing_ok=True)
 print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len(cached[\"nodes\"])} from cache, {len(new.get(\"nodes\",[]))} new)')
 "
 ```
-Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
 #### Part C - Merge AST + semantic into final extraction
 
@@ -836,9 +837,13 @@ cost_path.write_text(json.dumps(cost, indent=2))
 
 print(f'This run: {input_tok:,} input tokens, {output_tok:,} output tokens')
 print(f'All time: {cost[\"total_input_tokens\"]:,} input, {cost[\"total_output_tokens\"]:,} output ({len(cost[\"runs\"])} runs)')
+
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', '.graphify_ast.json', '.graphify_semantic.json', '.graphify_analysis.json', '.graphify_labels.json', '.graphify_incremental.json', '.graphify_transcripts.json', '.graphify_old.json', '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
 "
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json graphify-out/.graphify_ast.json graphify-out/.graphify_semantic.json graphify-out/.graphify_analysis.json graphify-out/.graphify_labels.json graphify-out/.graphify_incremental.json graphify-out/.graphify_transcripts.json graphify-out/.graphify_old.json; find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
 ```
 
 Tell the user (omit the obsidian line unless --obsidian was given; omit the wiki line unless --wiki was given):
@@ -1001,11 +1006,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/fragments/references/shared/update.md
+++ b/tools/skillgen/fragments/references/shared/update.md
@@ -191,11 +191,11 @@ if old_data:
         print('New nodes:', ', '.join(n['label'] for n in diff['new_nodes'][:5]))
     if diff['new_edges']:
         print('New edges:', len(diff['new_edges']))
+Path('graphify-out/.graphify_old.json').unlink(missing_ok=True)
 "
 ```
 
 Before the merge step, save the old graph: `cp graphify-out/graph.json graphify-out/.graphify_old.json`
-Clean up after: `rm -f graphify-out/.graphify_old.json`
 
 ---
 

--- a/tools/skillgen/gen.py
+++ b/tools/skillgen/gen.py
@@ -919,6 +919,42 @@ def _is_chunk_cleanup_line(line: str) -> bool:
     return ".graphify_chunk_*.json" in line or ("find " in line and "-name '.graphify_chunk_" in line)
 
 
+def _is_shell_free_cleanup_line(line: str) -> bool:
+    """Whether a line belongs to the shell-free rewrite of the temp-file cleanup.
+
+    The cleanup steps were the only part of the runbook that shelled out, using
+    ``rm -f`` and ``find ... -delete``. Hosts that gate the agent's shell deny
+    destructive verbs as a matter of policy, so the cleanup silently did nothing
+    and a stale ``.graphify_chunk_*.json`` survived into the next ``--update``,
+    where Part C reads it unconditionally (graphify #2790). That is the third
+    reported cause of the same symptom, after the fish/zsh glob (#1172, see
+    :func:`_is_chunk_cleanup_line`) and the Codex/Windows leftovers (#464).
+
+    The fix folds the cleanup into the tail of the Python program each block
+    already runs, so no shell verb is involved on any host and nothing new is
+    spawned. That deliberately adds no fence, no ``$(cat ...) -c`` invocation and
+    no import — only statements that name graphify's own intermediates — which is
+    what keeps this predicate narrow enough to be worth having.
+
+    Both sides are matched so the multiset diff classifies the change: the removed
+    ``rm -f`` (bare command or inside a prose code span) and the added Python.
+    """
+    s = line.strip()
+    if "rm -f " in s and (".graphify_" in s or ".needs_update" in s):
+        return True
+    if s == "_out = Path('graphify-out')" or s == "_chunk.unlink(missing_ok=True)":
+        return True
+    if s.startswith("for _tmp in [") and s.endswith("]:"):
+        return True
+    if s.startswith("for _chunk in ") and s.endswith("glob('.graphify_chunk_*.json'):"):
+        return True
+    if s.endswith(".unlink(missing_ok=True)") and (
+        "_tmp" in s or ".graphify_" in s or ".needs_update" in s
+    ):
+        return True
+    return False
+
+
 def _is_trigger_line(line: str) -> bool:
     """Whether a line is the non-spec ``trigger:`` frontmatter field (#1180).
 
@@ -1150,6 +1186,7 @@ _SANCTIONED_MONOLITH_DIFFS = (
     _is_enum_line,
     _is_frontmatter_description_line,
     _is_chunk_cleanup_line,
+    _is_shell_free_cleanup_line,
     _is_directed_fix_line,
     _is_content_scope_fix_line,
     _is_cache_unlink_fix_line,


### PR DESCRIPTION
Fixes #2790.

Thanks @cdtatarevich — the diagnosis was already right, including which files a later `--update` would read back.

## First: #2797 covers the same issue

@hudsonwa opened #2797 on this about a minute before I pushed, so please read these as alternatives and take whichever you prefer — I am not attached to mine landing.

The approaches differ, and the difference is mostly about surface area rather than taste:

- **#2797** adds a `graphify clean <dir>` subcommand and switches `graphify/skill.md` to call it. One command, no inline Python, and a reusable entry point.
- **This PR** folds the cleanup into the Python each block already runs, and goes through `tools/skillgen/fragments/` so every host is regenerated.

Two things I would check on #2797 before choosing it, offered as review rather than argument:

1. It edits `graphify/skill.md` directly without the matching `tools/skillgen/fragments/core/core.md` change. The generated artifacts cannot be edited in place, and its CI reflects that — `skillgen-check: FAILURE`, alongside `test (3.10): FAILURE`. Fixable by moving the edit into the fragment and regenerating.
2. It fixes `skill.md` only. The other 20 skills and every `references/update.md` still carry `rm -f` / `find -delete` / `Remove-Item`, so the denial reproduces unchanged on codex, windows, droid and the rest.

Neither is a reason to prefer this PR over the idea in #2797 — a `graphify clean` subcommand is a cleaner call site than an inline loop, and it matches how the runbook already invokes `graphify export obsidian` and `graphify query`. If you want that shape, the right end state is probably #2797's subcommand called from the **fragments**, regenerated across all hosts. I am happy to close this and send exactly that, or to rebase this onto #2797 once it lands — the fragment and regeneration plumbing here is needed either way.

## The change

Cleanup was the only part of the runbook that shelled out. It now runs in Python, so no host is asked to `rm` anything:

```diff
-rm -f graphify-out/.graphify_detect.json graphify-out/.graphify_extract.json ...
-find graphify-out -maxdepth 1 -name '.graphify_chunk_*.json' -delete 2>/dev/null
-rm -f graphify-out/.needs_update 2>/dev/null || true
+_out = Path('graphify-out')
+for _tmp in ['.graphify_detect.json', '.graphify_extract.json', ..., '.needs_update']:
+    (_out / _tmp).unlink(missing_ok=True)
+for _chunk in _out.glob('.graphify_chunk_*.json'):
+    _chunk.unlink(missing_ok=True)
```

The one design choice worth calling out: the cleanup is **folded into the tail of the Python program each block already runs**, rather than added as its own `$(cat ...) -c` step.

I tried the separate-step version first and backed it out. It works, but it adds a fence, an invocation line, a bare `"`, and a `from pathlib import Path` to every site — and `--monolith-roundtrip` then needs those generic lines added to the sanctioned-diff allowlist, which would blunt a guard whose whole job is catching drift in the hand-maintained monoliths. Folding adds only statements that name graphify's own intermediates, so the new predicate stays narrow.

I went through every site rather than just Step 9, since the same denial hits each one: Part B's temp files, Step 9, and the `--update` old-graph cleanup in `references/shared/update.md`. After this there is no `rm`/`find -delete`/`Remove-Item` left in any shipped skill or reference.

`cp` and `mkdir -p` are deliberately untouched. They are not destructive, so they are not what these policies withhold, and #2790 is about the delete step.

## Two consequences I want to flag rather than bury

**The PowerShell render no longer contains `Remove-Item` or `Get-ChildItem`.** There is nothing left for the POSIX→PowerShell translator to rewrite, so `test_powershell_hosts_carry_no_bash_only_shell` — which asserted those cmdlets were *present* — now asserts they are absent. Changing an existing assertion deserves a second look, so: that test was pinning the #2528 translation of a line this PR removes, and the surviving assertions (no bash-only tokens, here-string invocation, chunk cleanup still happens) are unchanged.

**Cleanup now runs only if the step's own program succeeds**, where the shell form ran unconditionally (`|| true`). I think this is the better behaviour — a failed Step 9 keeps its intermediates for debugging, and the next run overwrites them anyway — but it is a real behavioural change and not strictly required by the issue, so say the word if you would rather it stayed unconditional.

## Generated artifacts

Edited `tools/skillgen/fragments/{core/core.md,core/devin.md,core/aider.md,references/shared/update.md}` and regenerated; the other 60-odd changed files are `python -m tools.skillgen` output plus a re-`--bless` of `expected/`. All five validators pass:

```
check OK: 134 artifact(s) match committed output and expected/.
audit-coverage OK: every per-host v8 heading single-homes in that host's render.
schema-singleton OK: the file_type enum is the six-value superset everywhere.
monolith-roundtrip OK: each monolith matches v8 modulo the enum unification.
always-on-roundtrip OK: each always_on/*.md reproduces its former constant byte for byte.
```

`_is_shell_free_cleanup_line` is the new sanctioned change-class for `--monolith-roundtrip`, sitting next to `_is_chunk_cleanup_line`, which sanctioned the #1172 rewrite of these same lines.

## Tests

`tests/test_skill_cleanup_is_shell_free.py` (133 tests — mostly the per-file parametrization across every shipped skill and reference) asserts the property that closes the class rather than the specific strings:

- no shipped skill or reference deletes through a shell verb (`rm -rf`/`rm -f`, `find -delete`, `Remove-Item`, `del /q`), parametrized per file so a regression names the file;
- every skill that dispatches chunks still cleans them up — otherwise the guard above would pass trivially by deleting cleanup altogether;
- the snippet under test is pinned to what `skill.md` actually ships, so this file cannot drift into testing something the runbook no longer says;
- the replacement is executed in a temp tree and must remove every intermediate while leaving `graph.json` and `GRAPH_REPORT.md`, be idempotent, and tolerate a missing `graphify-out/` (a `--no-viz` or cluster-only run that never wrote a chunk must not crash Step 9 — `rm -f` tolerated that and `unlink(missing_ok=True)` has to as well).

Reverting the fragments and keeping the tests fails 32 of them, on any platform — these are file-content assertions, so they have teeth on your Ubuntu CI, not just locally.

## Validation

Windows 11, Python 3.12, branched off `4fca621` (0.9.44).

- Full suite: `20 failed, 4469 passed` -> `21 failed, 4601 passed`. The +132 are the new tests.
- All five skillgen validators pass (output above).
- The one extra failure is `test_incremental_mtime_collision.py::test_same_size_rewrite_in_one_tick_is_requeued`, which I do **not** believe this PR causes: it passes 4/4 in isolation and 4/4 running its whole file, and it also surfaced once in a full-suite run on an unrelated branch of mine (a `cli.py` hook change) before passing in isolation there too. It depends on two writes landing in the same filesystem timestamp tick, so it looks load-sensitive under a full run. Nothing here touches detect, cache or manifest. Flagging it rather than quietly reporting 20.

## Note on #2782

That PR edits the same three core fragments and touches the `.needs_update` line in the same Step 9 block, so expect a textual conflict here and a large one in the regenerated artifacts. No semantic overlap — it is fixing the dot/no-dot flag name, this is removing the shell verbs around it. Happy to rebase on top of it if it lands first; no preference on ordering.
