### PR TITLE
test(install): stop three Windows failures that assume the POSIX layout

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -259,7 +259,7 @@ def test_codex_skill_contains_spawn_agent():
     """Codex skill file must reference spawn_agent."""
     import graphify
 
-    skill = (Path(graphify.__file__).parent / "skill-codex.md").read_text()
+    skill = (Path(graphify.__file__).parent / "skill-codex.md").read_text(encoding="utf-8")
     assert "spawn_agent" in skill
 
 
@@ -271,7 +271,10 @@ def test_codex_skill_uses_graphify_with_existing_graph():
     fast-path block, which jumps straight to the query flow when a graph exists.
     """
     import graphify
-    skill = (Path(graphify.__file__).parent / "skill-codex.md").read_text()
+    # encoding= matters: the skill is UTF-8 and the assertions below carry an em
+    # dash and an en dash. Without it Windows decodes through the locale codepage
+    # and the match fails on a file that is perfectly fine.
+    skill = (Path(graphify.__file__).parent / "skill-codex.md").read_text(encoding="utf-8")
     assert "Fast path — existing graph" in skill
     assert "skip Steps 1–5 entirely and jump straight to `## For /graphify query`" in skill
     assert "graphify query" in skill
@@ -1161,7 +1164,10 @@ def test_hermes_skill_destination_posix_uses_home():
     from graphify.__main__ import _platform_skill_destination
     with patch("graphify.__main__.platform.system", return_value="Linux"):
         dst = _platform_skill_destination("hermes", project=False)
-    assert str(dst).endswith(".hermes/skills/graphify/SKILL.md"), dst
+    # Compare the path, not the host's separator: patching platform.system() does
+    # not change pathlib's flavour, so on Windows dst is still a WindowsPath and
+    # str() renders backslashes. The POSIX branch IS being exercised here.
+    assert dst.as_posix().endswith(".hermes/skills/graphify/SKILL.md"), dst
 
 
 def _cli_dispatched_commands() -> set[str]:

--- a/tests/test_install_roundtrip.py
+++ b/tests/test_install_roundtrip.py
@@ -57,6 +57,11 @@ def test_skill_roundtrip_at_real_destination(platform, project, tmp_path, monkey
     home.mkdir()
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
+    # hermes resolves its Windows destination through %LOCALAPPDATA%, not ~ (#1403),
+    # so patching Path.home alone leaves it pointing at conftest._sandbox_home and
+    # the startswith(home) check below compares against the wrong tree. Redirect it
+    # to this test's home, mirroring what conftest does session-wide.
+    monkeypatch.setenv("LOCALAPPDATA", str(home / "AppData" / "Local"))
 
     with patch("graphify.__main__.Path.home", return_value=home):
         dst = mainmod._platform_skill_destination(


### PR DESCRIPTION
Three install tests fail on Windows for reasons that have nothing to do with what they are testing. Same class as #2647 and #2651: the assertion, not the product, is what assumes POSIX.

No product code changes.

## 1. `test_codex_skill_uses_graphify_with_existing_graph`

```python
skill = (Path(graphify.__file__).parent / "skill-codex.md").read_text()
assert "Fast path — existing graph" in skill
```

`read_text()` with no `encoding=` uses the locale codepage, so on Windows the skill's UTF-8 em dash is decoded as cp1252 and `Fast path — existing graph` never matches. The file is fine; the read is not.

Note this is the same defect #2209 fixes in `test_merge_chunks_validation.py` and `test_pipeline.py`. That PR does not touch `test_install.py`, so there is no overlap, but it is the same fix and worth landing together.

## 2. `test_hermes_skill_destination_posix_uses_home`

```python
assert str(dst).endswith(".hermes/skills/graphify/SKILL.md"), dst
```

The test patches `platform.system()` to `"Linux"` to exercise the non-Windows branch, but patching that does not change `pathlib`'s flavour — `Path` on Windows is still `WindowsPath`, so `str(dst)` comes back with backslashes and the forward-slash suffix never matches. The branch under test *is* being reached; only the comparison is wrong. `as_posix()` compares the path rather than the host's separator.

## 3. `test_skill_roundtrip_at_real_destination[user-hermes]`

The test patches `Path.home` to its own `home` and then asserts the destination lands under it. Hermes on Windows deliberately resolves through `%LOCALAPPDATA%` instead of `~` (#1403), and `LOCALAPPDATA` still points at the session-wide sandbox home from `conftest._sandbox_home`, so the destination lands under *that* home and the assertion fails:

```
'...\sandbox-home2166\AppData\Local\hermes\skills\graphify\SKILL.md'
  .startswith('...\test_skill_roundtrip_at_real_d12\home')  ->  False
```

Redirecting `LOCALAPPDATA` alongside the `Path.home` patch is what the test already means by "home" — it mirrors exactly what `conftest` does, just scoped to this test's directory. The assertion then checks the real thing again instead of passing by accident on POSIX.

## Deliberately not included

The three `gemini` failures in `test_uninstall_scope.py` and `test_install_references.py` look like the same class but are not: they hardcode `~/.gemini/skills/graphify` while the install lands in `~/.agents/skills/graphify` on Windows, which is a shared destination with the `agents` platform. Whether the test or the product is wrong depends on a call I cannot make from outside — I opened #2800 with both options rather than guess, because the two answers require opposite edits to these same tests. Happy to follow up once it is decided.

## Validation

Windows 11, Python 3.12, branched off `4fca621` (0.9.44).

Full suite: `20 failed, 4469 passed` -> `17 failed, 4472 passed`. Exactly the three above move from fail to pass, and nothing else changes state:

```
FIXED:
  tests/test_install.py::test_codex_skill_uses_graphify_with_existing_graph
  tests/test_install.py::test_hermes_skill_destination_posix_uses_home
  tests/test_install_roundtrip.py::test_skill_roundtrip_at_real_destination[user-hermes]
NEW:
  (none)
```

The remaining 17 are pre-existing Windows failures — symlink privileges, FIFO/socket fixtures, the three gemini ones above, and similar — untouched by this.

On Linux all three passed before and still pass: these assertions were true there by accident of platform, so this is a no-op on your CI. The point is only that the Windows run stops lying about them.
