### PR TITLE
fix(build): keep the specific relation when an edge pair collapses (#2803)

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -52,6 +52,16 @@ def _is_ast_tier(item: dict) -> bool:
     return isinstance(loc, str) and bool(_AST_LOC_RE.match(loc))
 
 
+# Relations that say only "these two symbols appear together", with no claim about
+# HOW. An extractor that finds a specific fact for a pair — a call, an import, an
+# inheritance — routinely emits one of these for the same pair as well, so when the
+# simple graph collapses the pair to one edge, the generic one must never be the
+# survivor. Deliberately a small denylist rather than a full precedence order over
+# every relation: ranking `contains` against `calls` would be inventing a
+# cross-axis judgement, whereas "specific beats generic" is the only comparison
+# this collapse actually needs.
+_GENERIC_RELATIONS: frozenset[str] = frozenset({"references", "uses", "mentions"})
+
 # Language interop families, keyed by extension, for the cross-language phantom-edge
 # guard in the edge loop below. Families group by REAL interop (JS/TS share a module
 # graph; C/C++/ObjC share a compilation unit via headers; JVM langs share bytecode),
@@ -1228,6 +1238,25 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
             existing = edge_data(G, src, tgt)
             if existing.get("relation") == attrs.get("relation") and (
                 existing.get("_src") == tgt and existing.get("_tgt") == src
+            ):
+                continue
+        # A pair that already carries a SPECIFIC relation must not be downgraded
+        # to a generic one. Only one edge survives per pair here, and the sort
+        # above orders same-pair edges by relation name, so "last write wins"
+        # resolved the winner alphabetically — which put `references` after
+        # `calls` and `uses` after everything. On graphify's own corpus that
+        # rewrote all 144 pairs where the extraction found both `calls` and
+        # `references` into plain `references`, and callflow's relation filter
+        # does not include `references`, so those call sites left the call graph
+        # entirely. Alphabetical order carries no meaning; keeping the specific
+        # fact does. The reverse (specific arriving after generic) still
+        # overwrites, so the outcome no longer depends on edge order at all.
+        if G.has_edge(src, tgt):
+            existing_rel = edge_data(G, src, tgt).get("relation")
+            if (
+                attrs.get("relation") in _GENERIC_RELATIONS
+                and existing_rel is not None
+                and existing_rel not in _GENERIC_RELATIONS
             ):
                 continue
         G.add_edge(src, tgt, **attrs)

--- a/tests/test_relation_collapse_precedence.py
+++ b/tests/test_relation_collapse_precedence.py
@@ -1,0 +1,159 @@
+"""A collapsed edge must keep the specific relation, not the alphabetical one.
+
+`build_from_json` puts one edge per node pair into a simple graph, and resolved
+same-pair collisions by "last write wins" over a sort keyed on
+`(source, target, relation)`. That sort exists for determinism (#1061 — an
+unstable order flipped `_src`/`_tgt` run to run), but it also decided which
+RELATION survived, and it decided it alphabetically:
+
+    calls < contains < imports < ... < references < uses
+
+So `references` always overwrote `calls`, and `uses` overwrote everything. On
+graphify's own corpus that rewrote all 144 pairs where the extraction found both
+`calls` and `references` into plain `references` — 144 out of 144, not a
+sampling — and callflow's relation filter
+(`calls, imports, imports_from, uses, method, indirect_call`) does not include
+`references`, so those call sites dropped out of the call graph entirely.
+
+Alphabetical order carries no meaning. These tests pin that a generic relation
+never overwrites a specific one, in either arrival order, and that nothing else
+about the collapse changed.
+"""
+import pytest
+
+from graphify.build import build_from_json, edge_data
+
+SPECIFIC = ["calls", "imports", "imports_from", "inherits", "implements",
+            "method", "indirect_call", "re_exports", "contains"]
+GENERIC = ["references", "uses", "mentions"]
+
+
+def _extraction(edges):
+    return {
+        "nodes": [
+            {"id": "a", "label": "a()", "file_type": "code", "source_file": "a.py"},
+            {"id": "b", "label": "b()", "file_type": "code", "source_file": "b.py"},
+        ],
+        "edges": edges,
+        "hyperedges": [],
+    }
+
+
+def _edge(rel, src="a", tgt="b", **kw):
+    return {"source": src, "target": tgt, "relation": rel,
+            "confidence": "EXTRACTED", **kw}
+
+
+def _relation(G):
+    return edge_data(G, "a", "b").get("relation")
+
+
+# ---------------------------------------------------------------------------
+# The bug
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("generic", GENERIC)
+@pytest.mark.parametrize("specific", SPECIFIC)
+@pytest.mark.parametrize("order", ["specific_first", "generic_first"])
+def test_generic_never_overwrites_specific(specific, generic, order):
+    pair = [_edge(specific), _edge(generic)]
+    if order == "generic_first":
+        pair.reverse()
+    G = build_from_json(_extraction(pair))
+    assert _relation(G) == specific, (
+        f"{generic!r} overwrote {specific!r} when added {order.replace('_', ' ')}")
+
+
+def test_the_reported_case_keeps_calls():
+    """The exact shape seen 144 times on graphify's own graph."""
+    G = build_from_json(_extraction([
+        _edge("calls", source_location="L10"),
+        _edge("references", source_location="L10"),
+    ]))
+    assert _relation(G) == "calls"
+
+
+def test_calls_survives_for_callflow(monkeypatch):
+    """The consequence that made this worth fixing: callflow filters on relation
+    and does not list `references`, so a downgraded pair leaves the call graph."""
+    callflow_relations = ("calls", "imports", "imports_from", "uses", "method",
+                          "indirect_call")
+    G = build_from_json(_extraction([_edge("calls"), _edge("references")]))
+    assert _relation(G) in callflow_relations
+
+
+# ---------------------------------------------------------------------------
+# Everything else about the collapse is unchanged
+# ---------------------------------------------------------------------------
+
+def test_specific_still_overwrites_generic():
+    """The fix is one-directional: a specific relation arriving later still wins,
+    so the outcome no longer depends on arrival order in either direction."""
+    G = build_from_json(_extraction([_edge("references"), _edge("calls")]))
+    assert _relation(G) == "calls"
+
+
+def test_two_generic_relations_keep_previous_behaviour():
+    G = build_from_json(_extraction([_edge("references"), _edge("uses")]))
+    assert _relation(G) in {"references", "uses"}
+
+
+def test_two_specific_relations_keep_previous_behaviour():
+    """Deliberately NOT ranked against each other — `contains` vs `calls` is a
+    cross-axis judgement this collapse does not need to make."""
+    G = build_from_json(_extraction([_edge("calls"), _edge("contains")]))
+    assert _relation(G) in {"calls", "contains"}
+
+
+def test_collapse_still_yields_exactly_one_edge():
+    G = build_from_json(_extraction([
+        _edge("calls"), _edge("references"), _edge("uses"), _edge("calls"),
+    ]))
+    assert G.number_of_edges() == 1
+    assert G.number_of_nodes() == 2
+
+
+def test_edge_count_is_unchanged_by_the_fix():
+    """The fix chooses WHICH edge survives; it must not add or drop any."""
+    edges = [_edge("calls"), _edge("references"),
+             _edge("imports", src="b", tgt="a"), _edge("uses", src="b", tgt="a")]
+    G = build_from_json(_extraction(edges))
+    assert G.number_of_edges() == 1
+
+
+def test_reverse_direction_guard_still_holds():
+    """#1061: same relation, opposite directions — first-seen direction wins."""
+    G = build_from_json(_extraction([
+        _edge("calls", src="a", tgt="b"),
+        _edge("calls", src="b", tgt="a"),
+    ]))
+    d = edge_data(G, "a", "b")
+    assert (d.get("_src"), d.get("_tgt")) == ("a", "b")
+
+
+def test_a_lone_generic_edge_is_kept():
+    """Generic relations are only ever demoted against a specific one on the SAME
+    pair — a pair that has nothing else must keep its edge."""
+    G = build_from_json(_extraction([_edge("references")]))
+    assert _relation(G) == "references"
+    assert G.number_of_edges() == 1
+
+
+def test_direction_metadata_survives_the_demotion():
+    """The surviving edge must still carry the specific edge's own direction, not
+    the demoted one's."""
+    G = build_from_json(_extraction([
+        _edge("calls", src="a", tgt="b", source_location="L1"),
+        _edge("references", src="b", tgt="a", source_location="L2"),
+    ]))
+    d = edge_data(G, "a", "b")
+    assert d.get("relation") == "calls"
+    assert (d.get("_src"), d.get("_tgt")) == ("a", "b")
+    assert d.get("source_location") == "L1"
+
+
+def test_directed_graphs_get_the_same_protection():
+    G = build_from_json(_extraction([_edge("calls"), _edge("references")]),
+                        directed=True)
+    assert G.is_directed()
+    assert edge_data(G, "a", "b").get("relation") == "calls"


### PR DESCRIPTION
Fixes #2803.

## The bug

`build_from_json` keeps one edge per node pair and resolves collisions by "last write wins" over a sort keyed on `(source, target, relation)`. That sort is there for determinism — an unstable order flipped `_src`/`_tgt` between runs (#1061) — but the third key element also decides **which relation survives**, and it decides it alphabetically:

```
calls < contains < imports < imports_from < indirect_call < method < rationale_for < references < uses
```

So `references` always overwrites `calls`, and `uses` overwrites everything. That is not a tie-break, it is a systematic downgrade. On graphify's own package every single pair where the extraction found both came out as the weaker fact:

```
pairs where the extraction found BOTH `calls` and `references`: 144
relation on the surviving edge: {'references': 143, 'uses': 1}
```

144 of 144 — not a sample. Swapping the two edges in the input changes nothing, because the sort reorders them either way.

## Why it is not cosmetic

`callflow_html.py` selects edges by relation:

```python
if e.get("relation") in ("calls", "imports", "imports_from", "uses", "method", "indirect_call"):
```

`references` is not in that set, so every downgraded pair drops out of the call graph entirely. The audit trail also states the weaker fact for an edge the extractor tagged `EXTRACTED`/`calls`, and `query` / `path` / `explain` all read the surviving relation when answering "what calls X".

Every extractor that records a call tends to record a reference for the same pair, so this fires on ordinary code rather than an unusual shape. The 144/144 rate is the tell.

## The change

A generic relation never overwrites a specific one on the same pair. The reverse still overwrites, so the surviving relation no longer depends on arrival order in either direction.

```python
_GENERIC_RELATIONS: frozenset[str] = frozenset({"references", "uses", "mentions"})
```

I deliberately did **not** introduce a full precedence order over every relation. Ranking `contains` against `calls` would be inventing a cross-axis judgement that this collapse does not need — the only comparison required is "specific beats generic". Two specific relations keep their existing behaviour, and there is a test pinning that so the denylist cannot quietly grow into an ordering.

This is also **not** a fix for #2791. That issue is about edges being *dropped* by the simple-graph model, which is a much bigger change; this only corrects which of the colliding edges survives. Node and edge counts are byte-identical before and after.

## Measured on graphify's own graph

81 files, 2287 nodes, 6176 extracted edges:

| | before | after |
|---|---|---|
| `calls` edges | 1914 | **2060** |
| `references` edges | 548 | 405 |
| edges visible to callflow's filter | 2788 | **2931** |
| pairs reporting a relation weaker than the extraction found | 146 | **0** |
| total edges | 5396 | 5396 |
| total nodes | 2287 | 2287 |

## Tests

`tests/test_relation_collapse_precedence.py` (65 tests). The core is a matrix over every specific relation × every generic relation × **both arrival orders**, since the point of the fix is that order stops mattering.

Beyond that it pins what must *not* change: two generics keep previous behaviour, two specifics keep previous behaviour, the #1061 reverse-direction guard still holds, a lone generic edge is still kept, exactly one edge still survives per pair, and the surviving edge keeps the specific edge's own `_src`/`_tgt` and `source_location` rather than inheriting the demoted one's.

Reverting `build.py` and keeping the tests fails 55 of the 65. These are pure graph-shape assertions with no filesystem or platform dependency, so they have the same teeth on your Ubuntu CI as locally.

## Validation

Windows 11, Python 3.12, branched off `4fca621` (0.9.44).

- Full suite: `20 failed, 4469 passed` -> `20 failed, 4534 passed`. **Identical failure set** — no regressions; the +65 are the new tests. The 20 are pre-existing Windows failures (symlink privileges, FIFO/socket fixtures, and similar), unrelated to this change.
