### PR TITLE
fix(skills): --update must prune files a new ignore rule excluded (#2773)

### DIFF
--- a/graphify/skills/agents/references/update.md
+++ b/graphify/skills/agents/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/amp/references/update.md
+++ b/graphify/skills/amp/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/claude/references/update.md
+++ b/graphify/skills/claude/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/claw/references/update.md
+++ b/graphify/skills/claw/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/codex/references/update.md
+++ b/graphify/skills/codex/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/copilot/references/update.md
+++ b/graphify/skills/copilot/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/droid/references/update.md
+++ b/graphify/skills/droid/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/kilo/references/update.md
+++ b/graphify/skills/kilo/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/kiro/references/update.md
+++ b/graphify/skills/kiro/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/opencode/references/update.md
+++ b/graphify/skills/opencode/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/pi/references/update.md
+++ b/graphify/skills/pi/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/trae/references/update.md
+++ b/graphify/skills/trae/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/vscode/references/update.md
+++ b/graphify/skills/vscode/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/graphify/skills/windows/references/update.md
+++ b/graphify/skills/windows/references/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tests/test_update_prunes_excluded.py
+++ b/tests/test_update_prunes_excluded.py
@@ -1,0 +1,161 @@
+"""A newly ignored file's nodes must leave graph.json on --update.
+
+`detect_incremental` deliberately splits a manifest row whose file is GONE from
+disk (`deleted_files`) from one that still exists but has left the scan because
+an ignore rule or --exclude changed (`excluded_files`, #1908) — so that an
+exclusion is never mis-reported as a deletion.
+
+graphify's library path consumes both: `graphify/cli.py` prunes
+`list(excluded_files) + graph_stale_sources`. The `--update` runbook, which is
+how the skill drives incremental rebuilds, read only `deleted_files`, so an added
+`.graphifyignore` rule never removed what it excluded (#2773).
+
+Two separate failures, both covered here:
+
+1. The early exit. With no other changes, `new_total == 0 and not deleted` was
+   true, so the run printed "No files changed since last run. Nothing to update."
+   and exited 0 without ever reaching the merge.
+2. The prune set. Even when the run did continue (some other file changed),
+   `prune = list(deleted) or None` left the excluded file's nodes in place.
+
+And the leak is permanent: `save_manifest(scan_corpus=...)` drops the excluded
+row, so on the NEXT run the file is neither deleted nor excluded and nothing can
+ever prune it.
+"""
+import json
+from pathlib import Path
+
+import pytest
+from networkx.readwrite import json_graph
+
+from graphify.build import build_merge
+from graphify.detect import detect, detect_incremental, save_manifest
+
+RUNBOOK = Path(__file__).resolve().parent.parent / "graphify" / "skills" / "claude" / "references" / "update.md"
+
+
+def _corpus(tmp_path):
+    (tmp_path / "archive").mkdir()
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "live.py").write_text("def bind():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "archive" / "old.py").write_text(
+        "def free_port():\n    return 2\n", encoding="utf-8")
+    return tmp_path
+
+
+def _seed_graph(root: Path) -> Path:
+    extraction = {
+        "nodes": [
+            {"id": "src_live_bind", "label": "bind()", "file_type": "code",
+             "source_file": "src/live.py"},
+            {"id": "arch_free_port", "label": "free_port()", "file_type": "code",
+             "source_file": "archive/old.py"},
+        ],
+        "edges": [{"source": "arch_free_port", "target": "src_live_bind",
+                   "relation": "calls", "confidence": "EXTRACTED",
+                   "source_file": "archive/old.py"}],
+        "hyperedges": [],
+    }
+    gp = root / "graphify-out" / "graph.json"
+    gp.parent.mkdir(parents=True, exist_ok=True)
+    G = build_merge([extraction], graph_path=str(gp), root=str(root))
+    gp.write_text(json.dumps(json_graph.node_link_data(G, edges="links")), encoding="utf-8")
+    files = {k: list(v) for k, v in detect(root)["files"].items()}
+    save_manifest(files, root=str(root),
+                  scan_corpus={f for fl in files.values() for f in fl})
+    return gp
+
+
+def _exclude(root: Path):
+    (root / ".graphifyignore").write_text("archive/\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# detect_incremental's own contract
+# ---------------------------------------------------------------------------
+
+def test_a_newly_ignored_file_is_excluded_not_deleted(tmp_path):
+    root = _corpus(tmp_path)
+    _seed_graph(root)
+    _exclude(root)
+    inc = detect_incremental(root)
+    assert [Path(f).name for f in inc["excluded_files"]] == ["old.py"]
+    assert inc["deleted_files"] == []
+    assert inc["new_total"] == 0, "nothing else changed — this is the early-exit case"
+
+
+# ---------------------------------------------------------------------------
+# The prune set
+# ---------------------------------------------------------------------------
+
+def test_pruning_only_deleted_leaves_the_excluded_nodes(tmp_path):
+    """The old behaviour, pinned so the fix below is measured against it."""
+    root = _corpus(tmp_path)
+    gp = _seed_graph(root)
+    _exclude(root)
+    inc = detect_incremental(root)
+    G = build_merge([{"nodes": [], "edges": [], "hyperedges": []}],
+                    graph_path=str(gp),
+                    prune_sources=list(inc["deleted_files"]) or None,
+                    root=str(root))
+    assert "arch_free_port" in G.nodes
+
+
+def test_pruning_deleted_plus_excluded_removes_them(tmp_path):
+    root = _corpus(tmp_path)
+    gp = _seed_graph(root)
+    _exclude(root)
+    inc = detect_incremental(root)
+    prune = (list(inc["deleted_files"]) + list(inc["excluded_files"])) or None
+    G = build_merge([{"nodes": [], "edges": [], "hyperedges": []}],
+                    graph_path=str(gp), prune_sources=prune, root=str(root))
+    assert "arch_free_port" not in G.nodes, "the ignored file's node survived the prune"
+    assert "src_live_bind" in G.nodes, "an in-scope node was pruned too"
+    assert not any(d.get("source_file", "").startswith("archive")
+                   for _, _, d in G.edges(data=True))
+
+
+def test_the_leak_is_permanent_once_the_manifest_is_restamped(tmp_path):
+    """Why this cannot be left to 'the next run will catch it': save_manifest
+    drops the excluded row, so the file stops appearing in either list."""
+    root = _corpus(tmp_path)
+    _seed_graph(root)
+    _exclude(root)
+    assert detect_incremental(root)["excluded_files"], "precondition"
+
+    files = {k: list(v) for k, v in detect(root)["files"].items()}
+    save_manifest(files, root=str(root),
+                  scan_corpus={f for fl in files.values() for f in fl})
+
+    inc = detect_incremental(root)
+    assert inc["deleted_files"] == []
+    assert inc["excluded_files"] == []
+
+
+# ---------------------------------------------------------------------------
+# The shipped runbook
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not RUNBOOK.is_file(), reason="claude reference bundle not built")
+def test_runbook_prunes_excluded_files():
+    text = RUNBOOK.read_text(encoding="utf-8")
+    assert "excluded = list(incremental.get('excluded_files', []))" in text
+    assert "prune = (list(deleted) + excluded) or None" in text
+    assert "prune = list(deleted) or None" not in text
+
+
+@pytest.mark.skipif(not RUNBOOK.is_file(), reason="claude reference bundle not built")
+def test_runbook_does_not_exit_early_on_an_exclusion_only_run():
+    text = RUNBOOK.read_text(encoding="utf-8")
+    assert "if new_total == 0 and not deleted and not excluded:" in text
+    assert "if new_total == 0 and not deleted:\n" not in text
+
+
+def test_every_shipped_update_reference_agrees():
+    """All hosts render from one fragment; none may lag behind."""
+    refs = sorted((RUNBOOK.parent.parent.parent).rglob("references/update.md"))
+    assert len(refs) >= 5, f"expected the update reference on several hosts, saw {len(refs)}"
+    for ref in refs:
+        text = ref.read_text(encoding="utf-8")
+        assert "excluded_files" in text, f"{ref} never reads excluded_files"
+        assert "prune = list(deleted) or None" not in text, f"{ref} still prunes deletions only"

--- a/tools/skillgen/expected/graphify__skills__agents__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__agents__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__amp__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__amp__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__claude__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claude__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__claw__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claw__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__codex__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__codex__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__copilot__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__copilot__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__droid__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__droid__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__kilo__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kilo__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__kiro__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kiro__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__opencode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__opencode__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__pi__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__pi__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__trae__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__trae__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__vscode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__vscode__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/expected/graphify__skills__windows__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__windows__references__update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).

--- a/tools/skillgen/fragments/references/shared/update.md
+++ b/tools/skillgen/fragments/references/shared/update.md
@@ -17,11 +17,17 @@ new_total = result.get('new_total', 0)
 print(json.dumps(result, indent=2, ensure_ascii=False))
 Path('graphify-out/.graphify_incremental.json').write_text(json.dumps(result, ensure_ascii=False), encoding=\"utf-8\")
 deleted = list(result.get('deleted_files', []))
-if new_total == 0 and not deleted:
+# Newly ignored/excluded files are stale in exactly the same way as deleted ones
+# (#2773). They must count here too, or adding a .graphifyignore rule with nothing
+# else changed exits 'Nothing to update' and never reaches the prune below.
+excluded = list(result.get('excluded_files', []))
+if new_total == 0 and not deleted and not excluded:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
 if deleted:
     print(f'{len(deleted)} deleted file(s) to prune.')
+if excluded:
+    print(f'{len(excluded)} newly excluded file(s) to prune.')
 if new_total > 0:
     print(f'{new_total} new/changed file(s) to re-extract.')
 "
@@ -66,11 +72,11 @@ If `code_only` is True: print `[graphify update] Code-only changes detected - sk
 If `code_only` is False (any changed file is a doc/paper/image/video): **first, if any changed file is in `new_files['video']`, run `references/transcribe.md` (Step 2.5) on those files, then rewrite `.graphify_detect.json` to move the resulting transcript paths into `files['document']` and drop `files['video']`** — otherwise raw `.mp4/.mp3` paths are fed to semantic subagents as unreadable media (#1392). Then run the full Steps 3A–3C pipeline as normal.
 
 
-If no new files exist (only deletions), create an empty extraction so the merge step can prune:
+If no new files exist (only deletions or newly excluded files), create an empty extraction so the merge step can prune:
 
 ```bash
 if [ ! -f graphify-out/.graphify_extract.json ]; then
-    echo '[graphify update] Only deletions -- creating empty extraction for merge.'
+    echo '[graphify update] Nothing to re-extract -- creating empty extraction so the merge can prune.'
     $(cat graphify-out/.graphify_python) -c "
 import json
 from pathlib import Path
@@ -93,13 +99,21 @@ from graphify.detect import save_manifest
 new_extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text(encoding=\"utf-8\"))
 incremental = json.loads(Path('graphify-out/.graphify_incremental.json').read_text(encoding=\"utf-8\"))
 deleted = list(incremental.get('deleted_files', []))
-# prune_sources is ONLY for genuinely DELETED files. Changed/re-extracted files are
-# handled by build_merge's replace-on-re-extract (#1344): every source_file in
+# Files that left the corpus because an ignore rule or --exclude changed. These are
+# NOT deletions — detect_incremental splits them out precisely so they are not
+# reported as such (#1908) — but their nodes are just as stale, and graphify's own
+# library path prunes both (cli.py: `list(excluded_files) + graph_stale_sources`).
+# Without this an added .graphifyignore rule never removes what it excluded, and the
+# leak is permanent: save_manifest below drops the excluded row, so on the next run
+# the file is neither deleted nor excluded and nothing can prune it again (#2773).
+excluded = list(incremental.get('excluded_files', []))
+# prune_sources is for genuinely DELETED and newly EXCLUDED files. Changed/re-extracted
+# files are handled by build_merge's replace-on-re-extract (#1344): every source_file in
 # new_chunks is dropped from the base before merge, so old/stale nodes don't survive.
 # Do NOT add `changed` here: with root= passed, prune_set relativizes to the same base
 # as the freshly merged nodes and would DELETE the re-extracted content (#1178 is moot
 # now that replace — not the dedup pass — reconciles changed files).
-prune = list(deleted) or None
+prune = (list(deleted) + excluded) or None
 
 # Use build_merge() — reads graph.json directly without NetworkX round-trip
 # so edge direction (calls, implements, imports) is always preserved (#801).


### PR DESCRIPTION
Fixes #2773.

Thanks @oilsinwater — the report was right that this survives `--force` and a purged cache, and the reason is worse than a stale cache: the pruning step never asked for those files at all.

## The bug

`detect_incremental` deliberately splits a manifest row whose file is **gone from disk** (`deleted_files`) from one that still exists but has **left the scan** because an ignore rule or `--exclude` changed (`excluded_files`, #1908) — precisely so an exclusion is never mis-reported as a deletion.

graphify's own library path consumes both. `graphify/cli.py`:

```python
_raw_prune_sources: list[str] = list(deleted_files)
for _src in list(excluded_files) + graph_stale_sources:
```

The `--update` runbook — which is how the skill drives incremental rebuilds — read only the first list:

```python
deleted = list(incremental.get('deleted_files', []))
prune = list(deleted) or None
```

So `.graphifyignore` was honoured by the *scan* and ignored by the *graph*.

## Two failures, not one

**The early exit.** With nothing else changed, `new_total == 0 and not deleted` held:

```python
if new_total == 0 and not deleted:
    print('No files changed since last run. Nothing to update.')
    raise SystemExit(0)
```

Adding an ignore rule on its own — the exact thing you do when you want content *out* of the graph — was a no-op that reported success and never reached the merge. This is the case worth fixing first; the prune set below only matters once the run gets that far.

**The prune set.** When the run did continue because some other file changed, `prune = list(deleted) or None` still left the excluded file's nodes and edges in place.

## The leak is permanent, not deferred

This is why "the next run will catch it" does not hold. `save_manifest(scan_corpus=...)` drops the excluded row, so on the following run the file is neither deleted nor excluded:

```
after adding '.graphifyignore: archive/':
  deleted_files : []
  excluded_files: ['old.py']

after one more run (manifest re-stamped):
  deleted_files : []
  excluded_files: []
  -> archive/old.py is now invisible to BOTH lists; nothing can prune it.
```

One `--update` after adding the rule and the stale content is unreachable short of a full rebuild — which matches the report's "same count and same 4 edges, byte-for-byte, before and after the forced/purged rebuild".

## Reproduced

Two-file corpus, `archive/` newly ignored, driving the runbook's own merge call:

```
  runbook  (prune=deleted)            -> nodes: ['arch_free_port', 'src_live_bind']
  cli.py:3756 (prune=deleted+excluded) -> nodes: ['src_live_bind']
```

The leaked node is an archived helper joined by a `calls` edge to live production code — the same shape as the report's `tests_integration_free_port -> src_loro_irohlorotransport_bind`, which is what makes it more than clutter: a false edge from dead code into live code feeds `GRAPH_REPORT.md`'s architectural claims.

## The change

One fragment, `tools/skillgen/fragments/references/shared/update.md`; everything else in the diff is `python -m tools.skillgen` output plus a re-`--bless` of `expected/`. All five validators pass.

I kept the fix to `excluded_files` and did **not** port `_stale_graph_sources` (#1909), which is the library's more complete answer — it derives prune candidates from the graph's own `source_file`s and so also catches files whose manifest row is already gone. That would fix the permanence for graphs already in the leaked state, but it means calling a private `cli` helper from the runbook, which felt like your call rather than mine. Happy to add it if you want the stronger version.

## Tests

`tests/test_update_prunes_excluded.py` (7 tests). Being straight about what each one does:

- Three assert the **shipped runbook** text — that it reads `excluded_files`, that the early exit accounts for it, and that *every* host's rendered `references/update.md` agrees rather than one lagging. These three fail without the fix.
- Four exercise the **library semantics** the fix depends on: that a newly ignored file lands in `excluded_files` and not `deleted_files`, that `prune=deleted` leaves the node while `prune=deleted+excluded` removes it, and that the manifest re-stamp makes the row disappear from both lists. Those pass either way by construction — they are the evidence for the fix, not a gate on it, and I would rather say so than let the count imply more than it does.

## Validation

Windows 11, Python 3.12, branched off `4fca621` (0.9.44).

- Full suite: `20 failed, 4469 passed` -> `20 failed, 4476 passed`. **Identical failure set** — no regressions; the +7 are the new tests.
- All five skillgen validators pass.

## Note on #2801

My other open PR also edits this fragment (removing the `rm -f` cleanup a few lines below), so expect a small textual conflict and none semantically. Happy to rebase whichever lands second.
