### PR TITLE
fix(query): name the graph the answer came from (#2789)

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -1047,6 +1047,7 @@ def dispatch_command(cmd: str) -> None:
             depth=2,
             token_budget=budget,
             context_filters=context_filters,
+            graph_path=str(gp),
         )
         querylog.log_query(
             kind="query",

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -1135,6 +1135,27 @@ def _cut_lines_to_budget(lines: list[str], token_budget: int, narrow_hint: str) 
     )
 
 
+def _display_graph_path(graph_path: str) -> str:
+    """Render a graph path for the query header.
+
+    Relative to the CWD when it sits underneath it — `graphify-out/graph.json`,
+    which is the ordinary case and stays short. Absolute otherwise, because a
+    graph outside the directory you are standing in is precisely the situation
+    the header exists to make visible (#2789). Always POSIX separators so the
+    line reads the same on either platform. Falls back to the path as given if
+    it cannot be resolved; this is a display helper and must never be the reason
+    a query fails.
+    """
+    try:
+        p = Path(graph_path).resolve()
+        try:
+            return p.relative_to(Path.cwd().resolve()).as_posix()
+        except ValueError:
+            return p.as_posix()
+    except (OSError, RuntimeError, ValueError):
+        return str(graph_path)
+
+
 def _query_graph_text(
     G: nx.Graph,
     question: str,
@@ -1143,6 +1164,7 @@ def _query_graph_text(
     depth: int = 3,
     token_budget: int = 2000,
     context_filters: list[str] | None = None,
+    graph_path: str | None = None,
 ) -> str:
     terms = _query_terms(question)
     # One graph scoring pass produces both the combined ranking (used to drive
@@ -1175,6 +1197,17 @@ def _query_graph_text(
         f"Traversal: {mode.upper()} depth={depth}",
         f"Start: {[G.nodes[n].get('label', n) for n in start_nodes]}",
     ]
+    # Name the graph this answer came from. `graphify-out/` resolves against the
+    # CWD, so running a query from a parent project while thinking about a
+    # vendored subproject silently answers from the wrong corpus — the output is
+    # well-formed and confidently wrong, and nothing in it said which graph was
+    # opened (#2789). Shown relative when the graph is under the CWD (the normal
+    # case, and short), absolute when it is not — which is exactly the case worth
+    # noticing. The node count travels with it because "355 nodes" vs "3178
+    # nodes" is often the first thing that looks wrong.
+    if graph_path:
+        header_parts.insert(0, f"Graph: {_display_graph_path(graph_path)} "
+                               f"({G.number_of_nodes()} nodes)")
     if resolved_filters:
         header_parts.append(f"Context: {', '.join(resolved_filters)} ({filter_source})")
     header_parts.append(f"{len(nodes)} nodes found")
@@ -1682,6 +1715,7 @@ def _build_server(graph_path: str):
             depth=depth,
             token_budget=budget,
             context_filters=context_filter,
+            graph_path=str(active_graph_path),
         )
         querylog.log_query(
             kind="mcp_query",

--- a/tests/test_query_names_its_graph.py
+++ b/tests/test_query_names_its_graph.py
@@ -1,0 +1,134 @@
+"""A query answer must say which graph it came from.
+
+`graphify-out/` resolves against the CWD. Running `graphify query` from a parent
+project while thinking about a vendored subproject answers from the parent's
+graph — and the answer is well-formed, confident, and wrong. Nothing in the
+output named the graph file, the scan root, or the node count, so the only way to
+notice was recognising community labels you had not assigned (#2789).
+
+The header now leads with the graph. It is shown relative to the CWD when it
+sits underneath it (the ordinary case, and short) and absolute when it does not,
+which is exactly the case worth noticing. The node count travels with it because
+"355 nodes" against "3178 nodes" is often the first thing that looks wrong.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from graphify.build import build_from_json
+from graphify.serve import _display_graph_path, _query_graph_text
+
+
+def _graph(n=2):
+    nodes = [{"id": f"n{i}", "label": f"Symbol{i}", "file_type": "code",
+              "source_file": f"src/m{i}.py"} for i in range(n)]
+    edges = [{"source": f"n{i}", "target": f"n{i+1}", "relation": "calls",
+              "confidence": "EXTRACTED", "source_file": f"src/m{i}.py"}
+             for i in range(n - 1)]
+    return build_from_json({"nodes": nodes, "edges": edges, "hyperedges": []})
+
+
+def _header(G, **kw):
+    return _query_graph_text(G, "Symbol0", **kw).splitlines()[0]
+
+
+# ---------------------------------------------------------------------------
+# The header
+# ---------------------------------------------------------------------------
+
+def test_header_names_the_graph_and_its_size(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    gp = tmp_path / "graphify-out" / "graph.json"
+    gp.parent.mkdir(parents=True)
+    gp.write_text("{}", encoding="utf-8")
+    header = _header(_graph(4), graph_path=str(gp))
+    assert header.startswith("Graph: graphify-out/graph.json (4 nodes) | ")
+    assert "Traversal:" in header
+
+
+def test_a_graph_outside_the_cwd_is_shown_in_full(tmp_path, monkeypatch):
+    """The case the issue is about: the answer came from somewhere else."""
+    here = tmp_path / "parent"
+    other = tmp_path / "elsewhere" / "graphify-out"
+    here.mkdir()
+    other.mkdir(parents=True)
+    gp = other / "graph.json"
+    gp.write_text("{}", encoding="utf-8")
+    monkeypatch.chdir(here)
+    header = _header(_graph(), graph_path=str(gp))
+    assert "elsewhere" in header, header
+    assert Path(header.split("Graph: ")[1].split(" (")[0]).is_absolute()
+
+
+def test_header_is_unchanged_when_no_path_is_supplied():
+    """Callers that do not know their graph path keep the old header exactly."""
+    header = _header(_graph())
+    assert header.startswith("Traversal:")
+    assert "Graph:" not in header
+
+
+def test_the_node_count_is_the_graphs_not_the_traversals():
+    """`N nodes found` at the end is the traversal result; the count next to the
+    graph is the whole corpus. Conflating them would hide the mismatch this is
+    meant to surface."""
+    G = _graph(6)
+    header = _header(G, graph_path="graphify-out/graph.json")
+    assert "(6 nodes)" in header
+    assert G.number_of_nodes() == 6
+
+
+# ---------------------------------------------------------------------------
+# _display_graph_path
+# ---------------------------------------------------------------------------
+
+def test_display_is_relative_under_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    p = tmp_path / "graphify-out" / "graph.json"
+    p.parent.mkdir(parents=True)
+    p.write_text("{}", encoding="utf-8")
+    assert _display_graph_path(str(p)) == "graphify-out/graph.json"
+
+
+def test_display_uses_posix_separators(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    p = tmp_path / "a" / "b" / "graph.json"
+    p.parent.mkdir(parents=True)
+    p.write_text("{}", encoding="utf-8")
+    shown = _display_graph_path(str(p))
+    assert "\\" not in shown, shown
+    assert shown == "a/b/graph.json"
+
+
+def test_display_is_absolute_outside_cwd(tmp_path, monkeypatch):
+    here = tmp_path / "here"
+    there = tmp_path / "there"
+    here.mkdir()
+    there.mkdir()
+    monkeypatch.chdir(here)
+    shown = _display_graph_path(str(there / "graph.json"))
+    assert Path(shown).is_absolute()
+    assert "there" in shown
+
+
+def test_display_never_raises_on_a_hostile_path():
+    """A display helper must not be the reason a query fails."""
+    for bad in ["", "\x00bad", "?" * 300, "://not/a/path"]:
+        assert isinstance(_display_graph_path(bad), str)
+
+
+def test_two_projects_produce_distinguishable_headers(tmp_path, monkeypatch):
+    """The end-to-end point: the parent and the subproject must not look alike."""
+    parent = tmp_path / "Proj"
+    sub = parent / "Sub"
+    (parent / "graphify-out").mkdir(parents=True)
+    (sub / "graphify-out").mkdir(parents=True)
+    for d in (parent, sub):
+        (d / "graphify-out" / "graph.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.chdir(parent)
+    h_parent = _header(_graph(9), graph_path=str(parent / "graphify-out" / "graph.json"))
+    h_sub = _header(_graph(3), graph_path=str(sub / "graphify-out" / "graph.json"))
+    assert h_parent != h_sub
+    assert "(9 nodes)" in h_parent and "(3 nodes)" in h_sub
+    assert "Sub/graphify-out/graph.json" in h_sub


### PR DESCRIPTION
Fixes #2789.

Thanks @cdtatarevich — "confident, well-formed answer from the wrong corpus" is the right framing, and it is what made this worth fixing rather than documenting.

## The change

The query header now leads with the graph it opened, and its size:

```
Graph: graphify-out/graph.json (355 nodes) | Traversal: BFS depth=2 | Start: [...] | 33 nodes found
```

Relative to the CWD when the graph sits underneath it — the ordinary case, and short enough not to be noise. Absolute when it does not, which is exactly the case worth noticing:

```
Graph: C:/other/proj/graphify-out/graph.json (3178 nodes) | Traversal: BFS depth=2 | ...
```

Two details that are deliberate rather than incidental:

**The count is the corpus, not the traversal.** The line already ends with `N nodes found`, which is the traversal result. The number next to the path is the whole graph, because your report's tell was a 355-node subproject answering as a 3178-node parent. Reusing the traversal count would have hidden precisely that.

**Absolute is the loud form.** Elsewhere in the codebase absolute host paths are something to avoid (#2598, #2628) because they get *written into artifacts* and travel between machines. This is terminal output for the operator standing in a directory, so the reasoning inverts: a path outside the CWD should look different from one inside it.

## Scope

`graph_path` is optional and the header is byte-identical when it is not passed, so no existing caller changes behaviour. The two call sites that do know their path — the CLI `query` command and the MCP `query` tool — now pass it, and both already had the resolved path in hand for `querylog.log_query(corpus=...)`, so nothing new is computed.

I did **not** add a `--graph`-mismatch warning or make `query` search upward for a nearer `graphify-out/`. Both were tempting, but changing *which* graph is opened is a behavioural decision with its own failure modes, and the issue's actual complaint is that the choice was invisible. Making it visible is the smaller, complete fix; happy to follow up on resolution if you want it.

`_display_graph_path` swallows resolution failures and falls back to the string it was handed — a display helper must never be the reason a query fails, and there is a test feeding it null bytes and 300-character garbage.

## Tests

`tests/test_query_names_its_graph.py` (9 tests): the relative and absolute forms, POSIX separators on both platforms, the unchanged header when no path is supplied, the corpus-vs-traversal count distinction, hostile input, and an end-to-end check that a parent project and a vendored subproject produce headers you can tell apart — the exact scenario from the report.

## Validation

Windows 11, Python 3.12, branched off `4fca621` (0.9.44).

- Full suite: `20 failed, 4469 passed` -> `20 failed, 4478 passed`. **Identical failure set** — no regressions; the +9 are the new tests.
