### PR TITLE
fix(extract): make the partial-parse warning actionable, and stop citing closed #2551 (#2788)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -5621,19 +5621,36 @@ def extract(
         # results, so those fall back to the file-node-only arm.
         if len(_res.get("nodes", [])) <= 1 or _pe.get("multiline_error"):
             _rel = os.path.relpath(str(_p), str(root)).replace("\\", "/")
-            _syntax_error_files.append((_rel, _pe.get("first_error_line")))
+            # Symbols recovered from the file, excluding its own file node. This
+            # is what separates the two cases the warning otherwise blurs: a file
+            # that contributed nothing but its file node is a total loss, while
+            # one that yielded most of its symbols and lost an ERROR region is
+            # partial. "May be partially extracted" rendered both identically.
+            _kept = max(len(_res.get("nodes", [])) - 1, 0)
+            _syntax_error_files.append((_rel, _pe.get("first_error_line"), _kept))
     if _syntax_error_files:
+        def _describe_syntax_error(rel: str, line: "int | None", kept: int) -> str:
+            _where = f"first error at line {line}" if line else "syntax error"
+            _got = "no symbols extracted" if kept == 0 else f"{kept} symbol(s) extracted"
+            return f"{rel} ({_where}, {_got})"
+
         _shown = ", ".join(
-            f"{x} (first error at line {ln})" if ln else x
-            for x, ln in _syntax_error_files[:5]
+            _describe_syntax_error(*f) for f in _syntax_error_files[:5]
         )
         _more = (
             f" (+{len(_syntax_error_files) - 5} more)"
             if len(_syntax_error_files) > 5 else ""
         )
+        # No issue reference here. This message used to end in "(#2551)" for
+        # EVERY language, and #2551 is closed and Kotlin-specific ("bundled
+        # grammar rejects one-line type bodies"). It was the only lead the
+        # message offered, so a reader following it landed on a resolved problem
+        # in another language and concluded their own was already tracked
+        # (#2788). The file, the line and the symbol count are the actionable
+        # part; a single hardcoded number cannot be right for every grammar.
         print(
             f"  warning: {len(_syntax_error_files)} file(s) had syntax errors and "
-            f"may be partially extracted: {_shown}{_more} (#2551)",
+            f"may be partially extracted: {_shown}{_more}",
             file=sys.stderr, flush=True,
         )
 

--- a/tests/test_partial_extraction_warning.py
+++ b/tests/test_partial_extraction_warning.py
@@ -1,0 +1,82 @@
+"""The partial-extraction warning must be actionable and must not misdirect.
+
+It used to end in a hardcoded `(#2551)` for EVERY language. #2551 is closed and
+Kotlin-specific ("bundled grammar rejects one-line type bodies"), so a reader
+following the only lead the message offered landed on a resolved problem in a
+different language — and at least one did, recording an Astro failure as
+"already tracked upstream" on the strength of that number (#2788).
+
+The message also could not distinguish a file that contributed nothing but its
+own file node from one that yielded most of its symbols and lost an ERROR
+region. Both rendered as "may be partially extracted".
+
+Part 1 of #2788 — the Astro frontmatter parse itself — is NOT addressed here;
+that belongs to the .svelte/.astro AST work in #2731.
+"""
+import re
+
+import pytest
+
+from graphify.extract import extract
+
+# Any hardcoded issue citation, not just 2551 — re-introducing a different
+# number for a message that covers every grammar is the same mistake.
+_ISSUE_CITATION = re.compile(r"\(#\d+\)")
+
+
+def _partial_parse_fixture(tmp_path):
+    """A file the parser ACCEPTS only through ERROR recovery — an unclosed table
+    constructor swallowing the function that follows it.
+
+    Deliberately not the Kotlin one-line body from #2551: whether that shape
+    trips the gate depends on the bundled grammar build, and these tests are
+    about the MESSAGE, which must read the same whichever grammar produced it.
+    """
+    f = tmp_path / "broken.lua"
+    f.write_text("local t = {\nfunction f() end\n", encoding="utf-8")
+    return f
+
+
+def _run(tmp_path, files, capsys):
+    extract([*files], root=tmp_path)
+    return capsys.readouterr().err
+
+
+def test_warning_carries_no_hardcoded_issue_number(tmp_path, capsys):
+    err = _run(tmp_path, [_partial_parse_fixture(tmp_path)], capsys)
+    assert "partially extracted" in err, f"fixture no longer trips the gate: {err!r}"
+    assert not _ISSUE_CITATION.search(err), (
+        f"the warning still cites a single issue for every language: {err!r}")
+    assert "#2551" not in err
+
+
+def test_warning_names_the_file_and_how_much_survived(tmp_path, capsys):
+    err = _run(tmp_path, [_partial_parse_fixture(tmp_path)], capsys)
+    assert "partially extracted" in err, err
+    assert "broken.lua" in err
+    assert ("no symbols extracted" in err
+            or re.search(r"\d+ symbol\(s\) extracted", err)), (
+        f"the warning does not say how much survived: {err!r}")
+
+
+def test_warning_still_reports_the_first_error_line(tmp_path, capsys):
+    """The line number was the one actionable thing the old message had; it must
+    survive the rewrite."""
+    err = _run(tmp_path, [_partial_parse_fixture(tmp_path)], capsys)
+    assert re.search(r"first error at line \d+", err), err
+
+
+def test_a_clean_file_is_silent(tmp_path, capsys):
+    f = tmp_path / "fine.py"
+    f.write_text("def ok():\n    return 1\n", encoding="utf-8")
+    err = _run(tmp_path, [f], capsys)
+    assert "partially extracted" not in err
+    assert "syntax errors" not in err
+
+
+def test_the_citation_is_gone_from_the_source_not_just_one_path():
+    import graphify.extract as ex
+    text = open(ex.__file__, encoding="utf-8").read()
+    assert "may be partially extracted: {_shown}{_more} (#2551)" not in text
+    assert "no symbols extracted" in text
+    assert "symbol(s) extracted" in text


### PR DESCRIPTION
Addresses the second half of #2788.

**Scope, up front:** this fixes the *warning*, not the Astro parse. #2788 reports two things, and part 1 — the Astro extractor failing at line 1 on an ordinary `---` frontmatter fence — looks like it belongs to @RepairYourTech's open #2731, which gives `.svelte`/`.astro` a real AST pass via script masking. I have deliberately not touched that. Leaving the issue open for part 1.

## The bug

`extract.py` emits the partial-parse warning with a hardcoded issue reference, for every language:

```python
f"may be partially extracted: {_shown}{_more} (#2551)",
```

#2551 is **closed** (`state=CLOSED reason=COMPLETED`) and Kotlin-specific: *"Kotlin: bundled grammar rejects one-line type bodies"*. The surrounding comments already know this — one calls it "the genuine #2551 Kotlin one-line-body" case — but the citation is still attached to all of them, including the `.luau` case that has its own open issue (#2520) and the Astro case that had none.

The cost is not theoretical. From the report:

> We initially recorded this astro failure as "already tracked upstream" on the strength of that number, and only found otherwise by opening it.

The citation is the only lead the message offers, and it points at a resolved problem in a different language.

## The change

Drop the reference, and replace it with something the reader can act on. The issue asks for this directly:

> A count of what was dropped, even approximate, would make it actionable.

We cannot know what was *dropped*, but we know exactly what was *kept*, and that separates the two cases the warning currently blurs together:

```
before:
  warning: 1 file(s) had syntax errors and may be partially extracted:
    website/src/pages/index.astro (first error at line 1) (#2551)

after:
  warning: 1 file(s) had syntax errors and may be partially extracted:
    website/src/pages/index.astro (first error at line 1, no symbols extracted)
```

`no symbols extracted` means the file contributed nothing but its own file node — total loss for that file. `12 symbols extracted` means the parser recovered and an ERROR region dissolved some lines — partial, and probably lower priority. Those are very different situations and the old message rendered them identically.

The count is `len(nodes) - 1`, excluding the file's own node, which is the number a reader would reconstruct by hand anyway.

## What is unchanged

The gate is untouched: the same files warn as before, still governed by the `#2610`/`#2599` condition (`len(nodes) <= 1 or multiline_error`) that keeps fully-recovered TS/TSX noise silent. This only changes the wording of a warning that already fired.

`tests/test_ts_parse_warning.py` asserts the *absence* of `"syntax errors"` and `"partially extracted"` for valid files — both phrases are kept verbatim, so that guard still means what it meant.

## Tests

`tests/test_partial_extraction_warning.py`: the warning names the file and its first error line, reports `no symbols extracted` when only the file node survived and `N symbol(s) extracted` when more did, carries no `#2551`, and stays silent for a file that parses cleanly. The no-citation assertion is written against any `(#NNNN)` shape rather than the literal `2551`, so re-introducing a different hardcoded issue number fails too.

## Validation

Windows 11, Python 3.12, branched off `4fca621` (0.9.44).

- Full suite: `20 failed, 4469 passed` -> `20 failed, 4474 passed`. **Identical failure set** — no regressions; the +5 are the new tests.
