### PR TITLE
fix(llm): hoist the covered-files set out of the uncovered-files loop

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -2511,9 +2511,18 @@ def extract_corpus_parallel(
         if sf:
             p = Path(sf)
             covered.add(p if p.is_absolute() else (root / p))
+    # Resolve `covered` once (local patch): the set comprehension used to be
+    # rebuilt from scratch inside the generator below, once per `dispatched`
+    # item -- O(len(dispatched) * len(covered)) resolve() syscalls instead of
+    # O(len(dispatched) + len(covered)). On a real corpus (~23k dispatched
+    # semantic files) that's on the order of hundreds of millions of realpath
+    # calls, observed taking multiple hours with no end in sight (py-spy
+    # showed the same call site continuously for over an hour, CPU still
+    # climbing) before this was caught and fixed.
+    _covered_resolved = {c.resolve() for c in covered}
     uncovered = sorted(
         p for p in dispatched
-        if p.resolve() not in {c.resolve() for c in covered}
+        if p.resolve() not in _covered_resolved
     )
     merged["uncovered_files"] = [str(p) for p in uncovered]
     if uncovered:


### PR DESCRIPTION
## Summary

`extract_corpus_parallel`'s uncovered-files reconciliation (`graphify/llm.py`, ~line 2508-2517) rebuilds
`{c.resolve() for c in covered}` from scratch **inside** the generator passed to `sorted()`, once per item in
`dispatched`:

```python
uncovered = sorted(
    p for p in dispatched
    if p.resolve() not in {c.resolve() for c in covered}   # rebuilt every iteration
)
```

That's **O(len(dispatched) × len(covered))** `Path.resolve()` calls (each a real `realpath` syscall) instead
of the obviously-intended O(len(dispatched) + len(covered)). This PR hoists the set comprehension out of the
loop so it's computed once.

## Impact

Found on a real ~23,000-file semantic-extraction run: this single reconciliation step sat in this exact call
chain continuously for **over an hour** (confirmed live via `py-spy dump` sampling — same stack frame,
climbing CPU time, no progress), before the run was interrupted rather than left to finish. The interrupt
traceback pointed at this exact line, independently confirming the `py-spy` diagnosis.

## Measured

```
N=1000 (dispatched=covered=1000, scaled down from the real ~23,000 for a fast comparison):
  old (rebuild per item):  76.85s
  new (precomputed once):   0.25s   (~312x)
```

Quadratic growth means the real corpus size (~23x larger) projects to roughly `23² ≈ 529x` worse than the
N=1000 old-code number — on the order of **11+ hours** for this one step alone before this fix.

## Fix

```python
covered_resolved = {c.resolve() for c in covered}
uncovered = sorted(
    p for p in dispatched
    if p.resolve() not in covered_resolved
)
```

Pure hoist of a loop-invariant computation — verified the result set is identical to the old code via an
`assert` in the reproduction script (see commit message). No behavior change, no API change.

## Testing

- Existing `tests/test_chunking.py` coverage for this exact code path (checkpoint scoping, out-of-scope node
  dropping, `uncovered_files` detection/warning) passes unchanged.
- Full existing test suite passes with no new failures.