### PR TITLE
perf(detect): index ignore patterns by anchor; lru_cache fix

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1336,28 +1336,61 @@ class _AnchorIndex:
 
     ``detect()`` extends the list as its walk finds nested ignore files, so
     ``_refresh`` indexes only the new tail.
+
+    Contract: the source list is append-only for as long as an index is live.
+    Every producer here obeys it — ``detect()`` and ``_is_scan_ignored`` only
+    ``append``/``extend``. ``_refresh`` still catches a shrink and a rewritten
+    tail (a same-length ``pop`` + ``append`` included) and rebuilds; an
+    *interior* rewrite is undetectable in O(1) and is what the contract buys.
+    Because reads go through ``entries``, even that degrades to a stale answer
+    rather than a wrong one.
     """
 
-    __slots__ = ("_patterns", "_by_anchor", "_indexed")
+    __slots__ = ("_patterns", "_entries", "_by_anchor")
 
     def __init__(self, patterns: list[tuple[Path, str]]) -> None:
         self._patterns = patterns
+        self._entries: list[tuple[Path, str]] = []
         self._by_anchor: dict[Path, list[int]] = {}
-        self._indexed = 0
         self._refresh()
 
+    @property
+    def entries(self) -> list[tuple[Path, str]]:
+        """The entries the buckets index, snapshotted as they were indexed.
+
+        Callers must read patterns from here, not from the source list: an
+        index is only ever consistent with what it indexed, and ``_is_ignored``
+        slices ``target.parts`` by ``len(anchor.parts)`` on the promise that the
+        bucket's anchor is an ancestor. Reading a source entry that has since
+        been swapped would break that promise and build a nonsense relative
+        path, so the snapshot keeps a stale index merely stale.
+        """
+        return self._entries
+
     def _refresh(self) -> None:
-        n = len(self._patterns)
-        if n == self._indexed:
+        patterns = self._patterns
+        n = len(patterns)
+        indexed = len(self._entries)
+        if n == indexed and (not indexed or patterns[-1] is self._entries[-1]):
             return
-        if n < self._indexed:
-            # Shrunk: the list was truncated or reused for a different scan.
+        # Anything but a pure append invalidates the buckets: indices shift, and
+        # a replaced entry can move to another anchor. Length alone cannot see a
+        # same-length edit, so the last indexed entry doubles as a sentinel —
+        # it catches truncate-then-append and any tail rewrite. An interior
+        # rewrite is out of contract (see the class docstring); the snapshot
+        # bounds its blast radius to staleness.
+        if n < indexed or (indexed and patterns[indexed - 1] is not self._entries[-1]):
+            # Cleared in place, not rebound: callers hold ``entries`` across a
+            # ``candidates()`` call, which refreshes.
+            self._entries.clear()
             self._by_anchor.clear()
-            self._indexed = 0
+            indexed = 0
+        entries = self._entries
         by_anchor = self._by_anchor
-        for i in range(self._indexed, n):
-            by_anchor.setdefault(self._patterns[i][0], []).append(i)
-        self._indexed = n
+        for i in range(indexed, n):
+            entry = patterns[i]
+            entries.append(entry)
+            by_anchor.setdefault(entry[0], []).append(i)
 
     def candidates(self, target: Path) -> list[int]:
         """Indices of the patterns that can match *target*, in original order.
@@ -1460,7 +1493,9 @@ def _is_ignored(
         # rediscovered the same fact one raised ValueError at a time.
         target_parts = target.parts
         n_target = len(target_parts)
-        for anchor, pattern in (patterns[i] for i in index.candidates(target)):
+        candidates = index.candidates(target)  # refreshes the index first
+        entries = index.entries
+        for anchor, pattern in (entries[i] for i in candidates):
             negated = pattern.startswith("!")
             raw = pattern[1:] if negated else pattern
             directory_only = raw.endswith("/")

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -11,7 +11,6 @@ import time
 import unicodedata
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from functools import lru_cache
 from pathlib import Path
 from typing import Callable
 
@@ -1249,32 +1248,165 @@ def _load_graphifyignore(root: Path, *, gitignore: bool = True) -> list[tuple[Pa
     return patterns
 
 
+def _match_globstar_parts(
+    path_parts: tuple[str, ...],
+    pattern_parts: tuple[str, ...],
+    path_idx: int,
+    pattern_idx: int,
+    memo: dict[tuple[int, int], bool],
+) -> bool:
+    """Component-wise match where ``**`` spans zero or more path components.
+
+    Module-level with a passed-in memo, not a nested ``lru_cache``: a recursive
+    closure wrapped in its own cache references itself through that cache, so
+    every call leaked a reference cycle for the GC to reclaim — and the cache
+    died before it could serve a second call. This memo dies by refcount.
+
+    A trailing ``**`` still requires at least one remaining path component.
+    """
+    key = (path_idx, pattern_idx)
+    hit = memo.get(key)
+    if hit is not None:
+        return hit
+
+    n_path = len(path_parts)
+    n_pattern = len(pattern_parts)
+    if pattern_idx == n_pattern:
+        result = path_idx == n_path
+    else:
+        part = pattern_parts[pattern_idx]
+        if part == "**":
+            if pattern_idx == n_pattern - 1:
+                result = path_idx < n_path
+            else:
+                result = _match_globstar_parts(
+                    path_parts, pattern_parts, path_idx, pattern_idx + 1, memo
+                ) or (
+                    path_idx < n_path
+                    and _match_globstar_parts(
+                        path_parts, pattern_parts, path_idx + 1, pattern_idx, memo
+                    )
+                )
+        else:
+            result = (
+                path_idx < n_path
+                and fnmatch.fnmatchcase(path_parts[path_idx], part)
+                and _match_globstar_parts(
+                    path_parts, pattern_parts, path_idx + 1, pattern_idx + 1, memo
+                )
+            )
+
+    memo[key] = result
+    return result
+
+
 def _match_anchored_ignore_pattern(path: str, pattern: str) -> bool:
     """Match an anchored gitignore pattern without letting ``*`` cross ``/``."""
     path_parts = tuple(path.split("/"))
     pattern_parts = tuple(pattern.split("/"))
 
-    @lru_cache(maxsize=None)
-    def _matches(path_idx: int, pattern_idx: int) -> bool:
-        if pattern_idx == len(pattern_parts):
-            return path_idx == len(path_parts)
-
-        part = pattern_parts[pattern_idx]
-        if part == "**":
-            if pattern_idx == len(pattern_parts) - 1:
-                return path_idx < len(path_parts)
-            return _matches(path_idx, pattern_idx + 1) or (
-                path_idx < len(path_parts)
-                and _matches(path_idx + 1, pattern_idx)
-            )
-
-        return (
-            path_idx < len(path_parts)
-            and fnmatch.fnmatchcase(path_parts[path_idx], part)
-            and _matches(path_idx + 1, pattern_idx + 1)
+    if "**" not in pattern_parts:
+        # Without ``**`` each pattern component eats exactly one path component,
+        # so this is a straight zip and the recursion below would never reuse a
+        # memo entry. Also the common shape: 54 of 57,283 patterns in a large
+        # monorepo contain ``**``.
+        if len(path_parts) != len(pattern_parts):
+            return False
+        return all(
+            fnmatch.fnmatchcase(part, pat)
+            for part, pat in zip(path_parts, pattern_parts)
         )
 
-    return _matches(0, 0)
+    return _match_globstar_parts(path_parts, pattern_parts, 0, 0, {})
+
+
+class _AnchorIndex:
+    """Anchor-bucketed view over a flat ``[(anchor_dir, pattern), ...]`` list.
+
+    ``_is_ignored`` only needs patterns whose anchor is an ancestor of (or equal
+    to) the target; the rest are inert, per the invariant ``ignored_predicate``
+    documents. Bucketing by anchor turns the per-path cost from O(all patterns)
+    into O(path depth) dict lookups.
+
+    The flat scan it replaces tested each anchor with
+    ``target.relative_to(anchor)``, which on CPython 3.12+ scans
+    ``target.parents`` linearly, minting a ``Path`` per element, then raises
+    ``ValueError`` for the ~97% of anchors that are not ancestors. On a monorepo
+    with 1,697 ``.gitignore`` files (57k patterns) that was 813ms per path.
+
+    ``detect()`` extends the list as its walk finds nested ignore files, so
+    ``_refresh`` indexes only the new tail.
+    """
+
+    __slots__ = ("_patterns", "_by_anchor", "_indexed")
+
+    def __init__(self, patterns: list[tuple[Path, str]]) -> None:
+        self._patterns = patterns
+        self._by_anchor: dict[Path, list[int]] = {}
+        self._indexed = 0
+        self._refresh()
+
+    def _refresh(self) -> None:
+        n = len(self._patterns)
+        if n == self._indexed:
+            return
+        if n < self._indexed:
+            # Shrunk: the list was truncated or reused for a different scan.
+            self._by_anchor.clear()
+            self._indexed = 0
+        by_anchor = self._by_anchor
+        for i in range(self._indexed, n):
+            by_anchor.setdefault(self._patterns[i][0], []).append(i)
+        self._indexed = n
+
+    def candidates(self, target: Path) -> list[int]:
+        """Indices of the patterns that can match *target*, in original order.
+
+        Order matters: ``_eval`` is last-match-wins, so a later ``!`` negation
+        (or a CLI ``--exclude``) must still override an earlier rule. The
+        candidate set is exactly ``{target} | set(target.parents)`` — the anchors
+        ``relative_to`` accepted — so this matches the scan it replaces.
+        """
+        self._refresh()
+        by_anchor = self._by_anchor
+        if not by_anchor:
+            return []
+        buckets: list[list[int]] = []
+        anchor = target
+        while True:
+            bucket = by_anchor.get(anchor)
+            if bucket is not None:
+                buckets.append(bucket)
+            parent = anchor.parent
+            if parent == anchor:  # reached the filesystem/drive root
+                break
+            anchor = parent
+        if not buckets:
+            return []
+        if len(buckets) == 1:
+            return buckets[0]  # already ascending
+        return sorted(i for bucket in buckets for i in bucket)
+
+
+# Identity-keyed memo so every _is_ignored caller gets the index without a
+# signature change. The entry holds the list, so its id() cannot be recycled
+# while live. Cap covers the lists one path can interleave: _is_scan_ignored
+# alternates two per scan, and a `watch` rebuild has its own plus two
+# predicates' pairs — evicting below that rebuilds per call, not per scan.
+_ANCHOR_INDEX_MEMO_MAX = 8
+_ANCHOR_INDEX_MEMO: dict[int, tuple[list[tuple[Path, str]], _AnchorIndex]] = {}
+
+
+def _anchor_index(patterns: list[tuple[Path, str]]) -> _AnchorIndex:
+    key = id(patterns)
+    hit = _ANCHOR_INDEX_MEMO.get(key)
+    if hit is not None and hit[0] is patterns:
+        return hit[1]
+    if len(_ANCHOR_INDEX_MEMO) >= _ANCHOR_INDEX_MEMO_MAX:
+        _ANCHOR_INDEX_MEMO.clear()
+    index = _AnchorIndex(patterns)
+    _ANCHOR_INDEX_MEMO[key] = (patterns, index)
+    return index
 
 
 def _is_ignored(
@@ -1300,6 +1432,8 @@ def _is_ignored(
     if not patterns:
         return False
 
+    index = _anchor_index(patterns)
+
     def _eval(target: Path) -> bool:
         """Apply last-match-wins to a single target path."""
         if _cache is not None and target in _cache:
@@ -1320,7 +1454,13 @@ def _is_ignored(
             return False
 
         result = False
-        for anchor, pattern in patterns:
+        # gitignore semantics: patterns from A/.gitignore apply ONLY to paths
+        # under A, so only anchors on the target's ancestor chain can match. The
+        # index yields those in list order, replacing a full-list scan that
+        # rediscovered the same fact one raised ValueError at a time.
+        target_parts = target.parts
+        n_target = len(target_parts)
+        for anchor, pattern in (patterns[i] for i in index.candidates(target)):
             negated = pattern.startswith("!")
             raw = pattern[1:] if negated else pattern
             directory_only = raw.endswith("/")
@@ -1329,17 +1469,16 @@ def _is_ignored(
             if not p:
                 continue
 
-            # gitignore semantics: patterns from A/.gitignore apply ONLY to paths
-            # under A. Matching non-anchored patterns against root-relative paths
-            # let e.g. .hypothesis/.gitignore's bare "*" ignore the ENTIRE repo
-            # (detect() returned 0 files). The anchor dir itself is exempt — an
-            # ignore file governs its directory's contents, not the directory.
+            # Matching non-anchored patterns against root-relative paths let e.g.
+            # .hypothesis/.gitignore's bare "*" ignore the ENTIRE repo (detect()
+            # returned 0 files). The anchor dir itself is exempt — an ignore file
+            # governs its contents, not itself. anchor is a known ancestor here,
+            # so the relative path is a part-slice and equal depth means
+            # anchor == target, i.e. the old relative_to's ".".
             matched = False
-            try:
-                rel_anchor = _nfc(str(target.relative_to(anchor)).replace(os.sep, "/"))
-            except ValueError:
-                continue  # target outside this pattern's anchor: cannot match
-            if rel_anchor != ".":
+            n_anchor = len(anchor.parts)
+            if n_anchor < n_target:
+                rel_anchor = _nfc("/".join(target_parts[n_anchor:]))
                 rel = rel_anchor
                 if not path_relative:
                     try:

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -7,6 +7,7 @@ import re
 import shlex
 import stat
 import subprocess
+import threading
 import time
 import unicodedata
 from concurrent.futures import ThreadPoolExecutor
@@ -1337,6 +1338,13 @@ class _AnchorIndex:
     ``detect()`` extends the list as its walk finds nested ignore files, so
     ``_refresh`` indexes only the new tail.
 
+    ``watch`` drives this from two threads — the watchdog observer thread calls
+    ``_is_ignored`` per filesystem event while the main thread rebuilds — so
+    ``lookup`` serialises refreshes under ``_lock`` and hands back the candidate
+    indices together with the snapshot they index. Invalidation rebinds
+    ``_entries`` rather than clearing it, so a snapshot a reader already holds
+    stays internally consistent even as the index rebuilds underneath it.
+
     Contract: the source list is append-only for as long as an index is live.
     Every producer here obeys it — ``detect()`` and ``_is_scan_ignored`` only
     ``append``/``extend``. ``_refresh`` still catches a shrink and a rewritten
@@ -1346,13 +1354,14 @@ class _AnchorIndex:
     rather than a wrong one.
     """
 
-    __slots__ = ("_patterns", "_entries", "_by_anchor")
+    __slots__ = ("_patterns", "_entries", "_by_anchor", "_lock")
 
     def __init__(self, patterns: list[tuple[Path, str]]) -> None:
         self._patterns = patterns
         self._entries: list[tuple[Path, str]] = []
         self._by_anchor: dict[Path, list[int]] = {}
-        self._refresh()
+        self._lock = threading.Lock()
+        self._refresh()  # not yet shared; _lock guards every later refresh
 
     @property
     def entries(self) -> list[tuple[Path, str]]:
@@ -1364,10 +1373,15 @@ class _AnchorIndex:
         bucket's anchor is an ancestor. Reading a source entry that has since
         been swapped would break that promise and build a nonsense relative
         path, so the snapshot keeps a stale index merely stale.
+
+        Prefer ``lookup``: indices and snapshot must be captured together, or a
+        concurrent rebuild between the two reads pairs indices with the wrong
+        list. This accessor exists for tests and for that paired capture.
         """
         return self._entries
 
     def _refresh(self) -> None:
+        """Index the new tail. Callers must hold ``_lock``."""
         patterns = self._patterns
         n = len(patterns)
         indexed = len(self._entries)
@@ -1380,10 +1394,11 @@ class _AnchorIndex:
         # rewrite is out of contract (see the class docstring); the snapshot
         # bounds its blast radius to staleness.
         if n < indexed or (indexed and patterns[indexed - 1] is not self._entries[-1]):
-            # Cleared in place, not rebound: callers hold ``entries`` across a
-            # ``candidates()`` call, which refreshes.
-            self._entries.clear()
-            self._by_anchor.clear()
+            # Rebound, not cleared in place: a reader that captured the old
+            # snapshot from ``lookup`` keeps a list that only ever grew, so its
+            # indices stay aligned instead of running off a truncated list.
+            self._entries = []
+            self._by_anchor = {}
             indexed = 0
         entries = self._entries
         by_anchor = self._by_anchor
@@ -1392,15 +1407,28 @@ class _AnchorIndex:
             entries.append(entry)
             by_anchor.setdefault(entry[0], []).append(i)
 
+    def lookup(self, target: Path) -> tuple[list[int], list[tuple[Path, str]]]:
+        """Candidate indices and the snapshot they index, captured together.
+
+        One critical section for both: taken separately, a rebuild landing
+        between the two reads pairs indices with a list they do not belong to.
+        """
+        with self._lock:
+            self._refresh()
+            return self._candidates(target), self._entries
+
     def candidates(self, target: Path) -> list[int]:
-        """Indices of the patterns that can match *target*, in original order.
+        """Indices of the patterns that can match *target*, in original order."""
+        return self.lookup(target)[0]
+
+    def _candidates(self, target: Path) -> list[int]:
+        """Callers must hold ``_lock``.
 
         Order matters: ``_eval`` is last-match-wins, so a later ``!`` negation
         (or a CLI ``--exclude``) must still override an earlier rule. The
         candidate set is exactly ``{target} | set(target.parents)`` — the anchors
         ``relative_to`` accepted — so this matches the scan it replaces.
         """
-        self._refresh()
         by_anchor = self._by_anchor
         if not by_anchor:
             return []
@@ -1430,16 +1458,23 @@ _ANCHOR_INDEX_MEMO_MAX = 8
 _ANCHOR_INDEX_MEMO: dict[int, tuple[list[tuple[Path, str]], _AnchorIndex]] = {}
 
 
+_ANCHOR_INDEX_LOCK = threading.Lock()
+
+
 def _anchor_index(patterns: list[tuple[Path, str]]) -> _AnchorIndex:
-    key = id(patterns)
-    hit = _ANCHOR_INDEX_MEMO.get(key)
-    if hit is not None and hit[0] is patterns:
-        return hit[1]
-    if len(_ANCHOR_INDEX_MEMO) >= _ANCHOR_INDEX_MEMO_MAX:
-        _ANCHOR_INDEX_MEMO.clear()
-    index = _AnchorIndex(patterns)
-    _ANCHOR_INDEX_MEMO[key] = (patterns, index)
-    return index
+    # Locked because `watch` reaches this from the observer thread and the main
+    # thread at once: without it two threads can each build an index for the
+    # same list and one silently loses its memo entry, rebuilding per event.
+    with _ANCHOR_INDEX_LOCK:
+        key = id(patterns)
+        hit = _ANCHOR_INDEX_MEMO.get(key)
+        if hit is not None and hit[0] is patterns:
+            return hit[1]
+        if len(_ANCHOR_INDEX_MEMO) >= _ANCHOR_INDEX_MEMO_MAX:
+            _ANCHOR_INDEX_MEMO.clear()
+        index = _AnchorIndex(patterns)
+        _ANCHOR_INDEX_MEMO[key] = (patterns, index)
+        return index
 
 
 def _is_ignored(
@@ -1493,8 +1528,9 @@ def _is_ignored(
         # rediscovered the same fact one raised ValueError at a time.
         target_parts = target.parts
         n_target = len(target_parts)
-        candidates = index.candidates(target)  # refreshes the index first
-        entries = index.entries
+        # Paired capture: indices and the snapshot they index must come from
+        # one critical section, or a concurrent rebuild misaligns them.
+        candidates, entries = index.lookup(target)
         for anchor, pattern in (entries[i] for i in candidates):
             negated = pattern.startswith("!")
             raw = pattern[1:] if negated else pattern

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -3159,6 +3159,64 @@ def test_anchor_index_memo_survives_a_reused_list_identity(tmp_path):
     assert _anchor_index(other) is not first
 
 
+def test_anchor_index_rebuilds_when_a_same_length_edit_rewrites_the_tail(tmp_path):
+    """Length alone cannot see pop+append, so the tail entry is the sentinel."""
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    target = sub / "x.py"
+    target.write_text("x")
+    patterns = [(tmp_path, "*.log"), (sub, "*.py")]
+    index = _anchor_index(patterns)
+    assert index.candidates(target) == [0, 1]
+    assert _is_ignored(target, tmp_path, patterns) is True
+
+    # Same length, different content: slot 1 moves from an ancestor anchor to a
+    # sibling one. A stale bucket would still offer it, and _eval would slice
+    # target.parts by the sibling's depth and match the leftover "x.py".
+    patterns.pop()
+    patterns.append((tmp_path / "elsewhere", "*.py"))
+    assert index.candidates(target) == [0]
+    assert _is_ignored(target, tmp_path, patterns) is False
+
+
+def test_anchor_index_rebuilds_on_in_place_tail_replacement(tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    target = sub / "x.py"
+    target.write_text("x")
+    patterns = [(tmp_path, "*.log"), (sub, "*.py")]
+    index = _AnchorIndex(patterns)
+    assert index.candidates(target) == [0, 1]
+    patterns[-1] = (tmp_path / "elsewhere", "*.py")
+    assert index.candidates(target) == [0]
+
+
+def test_anchor_index_reads_its_own_snapshot_not_the_live_list(tmp_path):
+    """An interior rewrite is out of contract and undetectable in O(1). Reads
+    go through the snapshot so it degrades to stale, never to applying a
+    sibling subtree's rule: _eval slices target.parts by len(anchor.parts) on
+    the promise the bucketed anchor is an ancestor, and a swapped-in
+    non-ancestor of equal depth would slice to a bogus relative path."""
+    sub = tmp_path / "sub"
+    other = tmp_path / "other"
+    sub.mkdir()
+    other.mkdir()
+    target = sub / "x.py"
+    target.write_text("x")
+    # A trailing entry the rewrite leaves alone, so the tail sentinel stays
+    # quiet and the interior edit really does go undetected.
+    patterns = [(sub, "nothing.txt"), (tmp_path, "*.zzz")]
+    assert _is_ignored(target, tmp_path, patterns) is False
+
+    # Interior rewrite: the sub bucket still points at slot 0, but slot 0 in
+    # the live list now belongs to a sibling anchor that is no ancestor.
+    patterns[0] = (other, "x.py")
+    index = _anchor_index(patterns)
+    assert index.candidates(target) == [0, 1]
+    assert index.entries[0] == (sub, "nothing.txt")   # snapshot, not the list
+    assert _is_ignored(target, tmp_path, patterns) is False  # stale, not wrong
+
+
 @pytest.mark.parametrize("path,pattern,expected", [
     ("a/b/c.py", "a/b/c.py", True),
     ("a/b/c.py", "a/*/c.py", True),

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -3217,6 +3217,60 @@ def test_anchor_index_reads_its_own_snapshot_not_the_live_list(tmp_path):
     assert _is_ignored(target, tmp_path, patterns) is False  # stale, not wrong
 
 
+def test_anchor_index_refresh_is_atomic_across_threads(tmp_path):
+    """`watch` calls _is_ignored from the observer thread on every filesystem
+    event while the main thread rebuilds, so a refresh must not tear: the
+    entries snapshot is a list parallel to the bucket indices, and two threads
+    indexing the same tail would append it twice and leave `entries[i]`
+    pointing at some other anchor's rule."""
+    import sys
+    import threading
+
+    root = tmp_path
+    target = root / "d5" / "f.py"
+    ancestors = frozenset(target.parents)
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)  # maximise interleaving under the GIL
+    try:
+        violations = []
+        for _ in range(10):
+            patterns = [(root, "*.a")]
+            index = _AnchorIndex(patterns)
+            done = threading.Event()
+
+            def grow():
+                try:
+                    for i in range(300):
+                        patterns.append((root / f"d{i}", f"*.g{i}"))
+                finally:
+                    done.set()
+
+            def look():
+                while not done.is_set():
+                    candidates, entries = index.lookup(target)
+                    for i in candidates:
+                        if i >= len(entries):
+                            violations.append(("index past snapshot", i))
+                            return
+                        anchor_dir = entries[i][0]
+                        # candidates() promises every anchor it yields is an
+                        # ancestor of the target; _eval slices target.parts by
+                        # that anchor's depth and would build nonsense otherwise.
+                        if anchor_dir != target and anchor_dir not in ancestors:
+                            violations.append(("misaligned", i, str(anchor_dir)))
+                            return
+
+            threads = [threading.Thread(target=grow)]
+            threads += [threading.Thread(target=look) for _ in range(3)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+            assert not violations, violations[:3]
+    finally:
+        sys.setswitchinterval(old_interval)
+
+
 @pytest.mark.parametrize("path,pattern,expected", [
     ("a/b/c.py", "a/b/c.py", True),
     ("a/b/c.py", "a/*/c.py", True),

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -3066,3 +3066,151 @@ def test_sensitive_env_template_inside_secrets_dir_still_dropped(path):
     """Stage 1 dir guard runs before the Stage 2 template exemption: anything
     under a secrets/credentials dir stays excluded, template suffix or not."""
     assert _is_sensitive(Path(path)), f"{path} is under a secrets dir, must stay excluded (#2184)"
+
+
+# --- #1958: ignore-matcher cost (anchor index + memo-free globstar matcher) ---
+
+from graphify.detect import (
+    _AnchorIndex,
+    _anchor_index,
+    _match_anchored_ignore_pattern,
+    _ANCHOR_INDEX_MEMO,
+)
+
+
+def _flat_candidates(patterns, target):
+    """What the pre-#1958 flat scan kept: the anchors relative_to() accepted."""
+    out = []
+    for i, (anchor, _pattern) in enumerate(patterns):
+        try:
+            target.relative_to(anchor)
+        except ValueError:
+            continue
+        out.append(i)
+    return out
+
+
+def test_anchor_index_selects_exactly_the_relative_to_survivors(tmp_path):
+    """The index must select the same set the relative_to() scan did."""
+    a = tmp_path / "a" / "b"
+    sibling = tmp_path / "other"
+    a.mkdir(parents=True)
+    sibling.mkdir()
+    patterns = [
+        (tmp_path, "*.log"),
+        (sibling, "*.py"),      # sibling subtree: inert for targets under a/b
+        (tmp_path / "a", "gen/"),
+        (a, "*.tmp"),
+    ]
+    target = a / "x.py"
+    index = _anchor_index(patterns)
+    assert index.candidates(target) == _flat_candidates(patterns, target)
+
+
+def test_anchor_index_preserves_original_order_for_last_match_wins(tmp_path):
+    """_eval is last-match-wins, so a later ! must still override an earlier
+    rule even when the two live in different anchor buckets."""
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    patterns = [
+        (sub, "keep.py"),      # nested rule ...
+        (tmp_path, "!keep.py"),  # ... overridden by a later root-anchored one
+    ]
+    target = sub / "keep.py"
+    assert _anchor_index(patterns).candidates(target) == [0, 1]
+    assert _is_ignored(target, tmp_path, patterns) is False
+
+    patterns.reverse()  # flip the order: the nested rule now wins
+    _ANCHOR_INDEX_MEMO.clear()
+    assert _is_ignored(target, tmp_path, patterns) is True
+
+
+def test_anchor_index_indexes_appended_patterns(tmp_path):
+    """detect() extends the list mid-walk; the index must see the new tail."""
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    target = sub / "x.py"
+    target.write_text("x")
+    patterns = [(tmp_path, "*.log")]
+    assert _is_ignored(target, tmp_path, patterns) is False
+    patterns.append((sub, "*.py"))  # a nested .gitignore discovered mid-walk
+    assert _is_ignored(target, tmp_path, patterns) is True
+
+
+def test_anchor_index_rebuilds_when_the_pattern_list_shrinks(tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    target = sub / "x.py"
+    target.write_text("x")
+    patterns = [(tmp_path, "*.log"), (sub, "*.py")]
+    index = _AnchorIndex(patterns)
+    assert index.candidates(target) == [0, 1]
+    del patterns[1]
+    assert index.candidates(target) == [0]
+
+
+def test_anchor_index_memo_survives_a_reused_list_identity(tmp_path):
+    """The memo is id()-keyed, so it must hold the list: a freed one's address
+    could be recycled and hand a later scan somebody else's index."""
+    patterns = [(tmp_path, "*.py")]
+    first = _anchor_index(patterns)
+    assert _anchor_index(patterns) is first
+    other = [(tmp_path, "*.log")]
+    assert _anchor_index(other) is not first
+
+
+@pytest.mark.parametrize("path,pattern,expected", [
+    ("a/b/c.py", "a/b/c.py", True),
+    ("a/b/c.py", "a/*/c.py", True),
+    ("a/b/c.py", "a/*.py", False),       # * must not cross a /
+    ("a/b/c.py", "a/**/c.py", True),
+    ("a/b/c/d.py", "a/**/d.py", True),
+    ("a/c.py", "a/**/c.py", True),       # ** spans zero components
+    ("a/b/c.py", "a/b", False),          # pattern shorter than the path
+    ("a", "a/**", False),                # trailing ** needs a component to eat
+    ("a/b", "a/**", True),
+    ("a/b/c/d/e.py", "**/c/**/*.py", True),
+    ("a/b/x.txt", "**/*.py", False),
+])
+def test_match_anchored_ignore_pattern_semantics(path, pattern, expected):
+    """Semantics must survive the move off the nested lru_cache."""
+    assert _match_anchored_ignore_pattern(path, pattern) is expected
+
+
+def test_globstar_match_leaves_no_cyclic_garbage():
+    """The old nested lru_cache closure referenced itself through its own
+    cache, leaking a cycle per call for the GC to reclaim."""
+    import gc
+
+    gc.collect()
+    gc.set_debug(gc.DEBUG_SAVEALL)
+    try:
+        before = len(gc.garbage)
+        for _ in range(500):
+            _match_anchored_ignore_pattern("a/b/c/d/e.py", "**/c/**/*.py")
+        gc.collect()
+        created = len(gc.garbage) - before
+    finally:
+        gc.set_debug(0)
+        del gc.garbage[:]
+        gc.collect()
+    assert created == 0, f"{created} cyclic objects from 500 globstar matches"
+
+
+def test_sibling_anchored_patterns_do_not_cost_per_path_work(tmp_path):
+    """Sibling-anchored patterns are inert, so a path's candidate set stays
+    O(its own depth), not O(all patterns)."""
+    target_dir = tmp_path / "pkg0" / "src"
+    target_dir.mkdir(parents=True)
+    target = target_dir / "main.py"
+    target.write_text("x")
+    patterns = [(tmp_path, "*.log")]
+    for i in range(1, 200):
+        sibling = tmp_path / f"pkg{i}"
+        patterns.extend((sibling, f"*.gen{j}") for j in range(10))
+    patterns.append((target_dir, "*.tmp"))
+
+    candidates = _anchor_index(patterns).candidates(target)
+    assert candidates == _flat_candidates(patterns, target)
+    assert len(candidates) == 2  # only the root and the file's own dir
+    assert _is_ignored(target, tmp_path, patterns) is False


### PR DESCRIPTION
Fixes #1958 and #2834

detect() accumulates ignore patterns into one flat [(anchor_dir, pattern)] list and _is_ignored() rescanned all of it per path. Two costs fell out of that on a 356k-file corpus with 1,697 .gitignore files (57,286 patterns):

Anchor selection. The scan tested every anchor with target.relative_to(anchor). On CPython 3.12+ that scans target.parents linearly (_PathParents is a Sequence with no __contains__ override), minting a Path per element whose __eq__ raises and catches an AttributeError off an unset __slots__ member, then throws ValueError away for the ~97% of anchors that are not ancestors. Measured 813ms per path. _AnchorIndex buckets the list by anchor so a lookup walks the target's own ancestor chain instead — the same candidate set relative_to accepted, in list order so last-match-wins and ! negations are unaffected. The list is append-only during a walk, so the index refreshes over the new tail only.

Cyclic garbage. _match_anchored_ignore_pattern wrapped a recursive closure in its own @lru_cache, so every call built a reference cycle only the GC could reclaim (14 cyclic objects per call), and the cache was discarded before it could serve a second call. It is now a module-level function taking an explicit dict memo, with patterns lacking ** skipping the recursion entirely (54 of 57,283 patterns contain **).

Behavior is unchanged: differentially fuzzed against the previous implementations — 200k random plus exhaustive small-space pattern/path pairs for the matcher, and 3,000 random pattern sets x 40 files for _is_ignored, covering sibling anchors, negations and directory-only rules — 0 mismatches. On a synthetic 1,500-anchor / 30k-pattern corpus, 807ms -> 0.089ms per path, and 500 globstar matches now leave 0 cyclic objects.

Tests: 18 new in test_detect.py. Suite: 4,621 passed, 48 skipped, no regressions (test_labeling.py::test_label_communities_batches_when_over_batch_size and the four in test_ollama_retry_cap.py fail identically before this change).