### PR TITLE
fix(build): normalize legacy numeric edge confidences to INFERRED on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 ## 0.9.46 (unreleased)
 
+- Fix: a `graph.json` written by a pre-enum graphify version, whose edges carry a numeric `confidence` (1.0/0.95/0.9/0.85) instead of `EXTRACTED`/`INFERRED`/`AMBIGUOUS`, now loads silently instead of warning once per legacy edge on every load (a June-2026 graph produced 73 warnings per load). The number normalizes to `INFERRED` — numeric confidences only ever came from the LLM semantic pass, and LLM-derived edges are INFERRED by definition — and the original float is preserved in the `confidence_score` companion field (an explicit `confidence_score` already on the edge wins).
+
 - Fix: node-id normalization is now caseless-stable for combining-mark sequences — `casefold` and NFKC don't commute, so a single pass left `normalize_id(s) != normalize_id(s.casefold())` for inputs like Greek ypogegrammeni followed by a combining accent; normalization now iterates casefold+NFKC to a fixpoint. Letter/digit-bearing ids are unchanged, so existing graphs are not re-keyed.
 
 - Fix: Java annotations now emit `references` edges to their type — including class-literal arguments (`@Repeatable(Foo.class)`, `@Uses({A.class, B.class})`) and annotation-member return types — so a container annotation is no longer a disconnected island; string/enum arguments are not mistaken for type references (#2426, thanks @oleksii-tumanov).

--- a/graphify/build.py
+++ b/graphify/build.py
@@ -210,9 +210,23 @@ def _fold_edge_aliases(edge: dict) -> None:
     is not provenance) and never a threshold mapping of the float. The
     ``confidence_score`` key itself is NOT popped: it is a legitimate companion
     field that the edge loop sanitizes and to_json round-trips.
+
+    A NUMERIC ``confidence`` (pre-enum graphs stored the LLM pass's float —
+    1.0/0.95/0.9/0.85 — directly in the field) normalizes to ``INFERRED``:
+    numeric confidences only ever came from the LLM semantic pass, and
+    LLM-derived edges are INFERRED by definition. The original float moves to
+    ``confidence_score`` unless an explicit one is already present (the
+    companion field is the authority). Without this fold, every reload of a
+    pre-enum graph re-warns once per legacy edge, forever. ``bool`` is
+    excluded despite subclassing ``int``: ``True`` is not a score.
     """
     if not edge.get("relation") and isinstance(edge.get("type"), str) and edge["type"]:
         edge["relation"] = edge.pop("type")
+    _conf = edge.get("confidence")
+    if isinstance(_conf, (int, float)) and not isinstance(_conf, bool):
+        if edge.get("confidence_score") is None:
+            edge["confidence_score"] = float(_conf)
+        edge["confidence"] = "INFERRED"
     if not edge.get("confidence") and edge.get("confidence_score") is not None:
         edge["confidence"] = "INFERRED"
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -172,6 +172,62 @@ def test_legacy_edge_type_confidence_score_aliases_folded():
     assert "type" not in data
 
 
+def test_legacy_numeric_confidence_normalized_to_inferred(capsys):
+    """Pre-enum graphs stored the LLM pass's float directly in `confidence`
+    (1.0/0.95/0.9/0.85). Reloading such a graph must not warn once per edge on
+    every load — the number normalizes to INFERRED (numeric confidences only
+    ever came from the LLM semantic pass, and LLM-derived edges are INFERRED
+    by definition) with the original float preserved in confidence_score."""
+    ext = {"nodes": [{"id": "n1", "label": "A", "file_type": "code", "source_file": "a.py"},
+                     {"id": "n2", "label": "B", "file_type": "code", "source_file": "b.py"},
+                     {"id": "n3", "label": "C", "file_type": "code", "source_file": "c.py"}],
+           "edges": [{"source": "n1", "target": "n2", "relation": "calls",
+                      "confidence": 0.95, "source_file": "a.py"},
+                     {"source": "n2", "target": "n3", "relation": "references",
+                      "confidence": 1.0, "source_file": "b.py"}],
+           "input_tokens": 0, "output_tokens": 0}
+    G = build_from_json(ext)
+    err = capsys.readouterr().err
+    assert "invalid confidence" not in err
+    assert "Extraction warning" not in err
+    d12 = edge_data(G, "n1", "n2")
+    assert d12["confidence"] == "INFERRED"
+    assert d12["confidence_score"] == 0.95
+    d23 = edge_data(G, "n2", "n3")
+    assert d23["confidence"] == "INFERRED"
+    assert d23["confidence_score"] == 1.0
+
+
+def test_legacy_numeric_confidence_existing_score_wins():
+    """A numeric `confidence` next to an explicit `confidence_score` must not
+    overwrite the explicit score — the companion field is the authority."""
+    ext = {"nodes": [{"id": "n1", "label": "A", "file_type": "code", "source_file": "a.py"},
+                     {"id": "n2", "label": "B", "file_type": "code", "source_file": "b.py"}],
+           "edges": [{"source": "n1", "target": "n2", "relation": "calls",
+                      "confidence": 0.9, "confidence_score": 0.4, "source_file": "a.py"}],
+           "input_tokens": 0, "output_tokens": 0}
+    G = build_from_json(ext)
+    data = edge_data(G, "n1", "n2")
+    assert data["confidence"] == "INFERRED"
+    assert data["confidence_score"] == 0.4
+
+
+def test_legacy_numeric_confidence_links_spelling_reload(capsys):
+    """The on-disk shape of the defect: a NetworkX-serialized graph.json
+    (`links` spelling) from a pre-enum version reloads without a validator
+    warning per edge and its edges land INFERRED."""
+    raw = {"nodes": [{"id": "n1", "label": "A", "file_type": "code", "source_file": "a.py"},
+                     {"id": "n2", "label": "B", "file_type": "code", "source_file": "b.py"}],
+           "links": [{"source": "n1", "target": "n2", "relation": "calls",
+                      "confidence": 0.85, "source_file": "a.py"}]}
+    G = build_from_json(raw)
+    err = capsys.readouterr().err
+    assert "invalid confidence" not in err
+    data = edge_data(G, "n1", "n2")
+    assert data["confidence"] == "INFERRED"
+    assert data["confidence_score"] == 0.85
+
+
 def test_node_alias_canonical_field_wins():
     """#2194: when both the canonical field and its alias are present, the
     canonical value wins and the alias key is left untouched."""


### PR DESCRIPTION
## The defect

Graphs written by graphify versions before the confidence enum contract (`EXTRACTED` / `INFERRED` / `AMBIGUOUS`) carry **numeric** edge confidences — `1.0`, `0.95`, `0.9`, `0.85` — from the era when the LLM semantic pass wrote its float directly into `confidence`. The current validator rejects those values, so every load of a pre-enum graph re-warns once per legacy edge, forever. Real-world case: a June-2026 graph produced **73 warnings on every load**.

## The fix

Extend `_fold_edge_aliases` in `graphify/build.py` — the existing #2194 pre-validation canonicalization point — so a numeric `confidence`:

- normalizes to **`INFERRED`**, and
- moves its original float into the **`confidence_score`** companion field (an explicit `confidence_score` already on the edge wins; `bool` is excluded since `True` is not a score).

Because every validating load path (extract, `update`/`build_merge`, cluster-only reload, label, diagnostics) funnels through `build_from_json`, which remaps `links`→`edges` and folds aliases before `validate_extraction`, one shim heals them all — and the next write persists the normalized enum, so read-only surfaces (`serve`/query) see clean values from then on.

## Mapping rationale

Any numeric value maps to `INFERRED`: numeric confidences only ever came from the LLM semantic pass, and LLM-derived edges are `INFERRED` by definition. This mirrors the existing `confidence_score`-alias backfill's own rule ("never EXTRACTED — alias recovery is not provenance", never a threshold mapping of the float).

## Tests (Red→Green)

Three new tests in `tests/test_build.py` next to the #2194 alias-fold family:

- `test_legacy_numeric_confidence_normalized_to_inferred` — numeric-confidence extraction loads with **no** `invalid confidence` warning; edges land `INFERRED` with the float preserved in `confidence_score` (failed before the fix with the exact reported warning, passes after)
- `test_legacy_numeric_confidence_existing_score_wins` — an explicit `confidence_score` is not overwritten
- `test_legacy_numeric_confidence_links_spelling_reload` — the on-disk shape of the defect: a NetworkX-serialized `links`-keyed graph.json reloads silently

Full suite: 4606 passed, 48 skipped; the only 5 failures (`test_ollama_retry_cap.py` ×4, one ordering-dependent `test_labeling` case) fail identically on a clean `origin/v8` checkout on this host — pre-existing, unrelated. `ruff check` clean. CHANGELOG entry added under 0.9.46 (unreleased).

Note: opened from a fork — the authenticated account has read-only access to this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)