### PR TITLE
Add personal idea graph workflow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,6 +26,7 @@ Signatures below are the real ones - `tests/test_architecture_doc.py` imports ev
 | `wiki.py` | `to_wiki(G, communities, output_dir, ...)` | graph → one markdown article per community + `index.md` |
 | `callflow_html.py` | `write_callflow_html(...)` | graphify-out files → Mermaid architecture/call-flow HTML |
 | `ingest.py` | `ingest(url, target_dir, ...)` | URL → file saved to corpus dir |
+| `idea.py` | `request_infranodus`, `cytoscape_elements`, `create_idea_graph` | idea text → InfraNodus graph → Obsidian note + clickable Cytoscape HTML |
 | `cache.py` | `check_semantic_cache(files, root)`, `save_semantic_cache(nodes, edges, ...)` | files → cached nodes / edges / hyperedges + the list of files still needing extraction |
 | `security.py` | `validate_url`, `safe_fetch`, `validate_graph_path`, `sanitize_label` | URL / path / label → validated value, or raises |
 | `validate.py` | `validate_extraction(data)`, `assert_valid(data)` | extraction dict → **list of schema error strings** (`validate_extraction` returns them; `assert_valid` raises) |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,7 +28,7 @@ Signatures below are the real ones - `tests/test_architecture_doc.py` imports ev
 | `ingest.py` | `ingest(url, target_dir, ...)` | URL → file saved to corpus dir |
 | `idea.py` | `request_infranodus`, `cytoscape_elements`, `create_idea_graph` | idea text → InfraNodus graph → Obsidian note + clickable Cytoscape HTML |
 | `cache.py` | `check_semantic_cache(files, root)`, `save_semantic_cache(nodes, edges, ...)` | files → cached nodes / edges / hyperedges + the list of files still needing extraction |
-| `security.py` | `validate_url`, `safe_fetch`, `validate_graph_path`, `sanitize_label` | URL / path / label → validated value, or raises |
+| `security.py` | `validate_url`, `build_safe_opener`, `safe_fetch`, `validate_graph_path`, `sanitize_label` | URL / path / label → validated value, SSRF-safe opener, or raises |
 | `validate.py` | `validate_extraction(data)`, `assert_valid(data)` | extraction dict → **list of schema error strings** (`validate_extraction` returns them; `assert_valid` raises) |
 | `serve.py` | `serve(graph_path)`, `serve_http(graph_path, *, host, port, ...)` | graph file path → MCP stdio server / HTTP server |
 | `watch.py` | `watch(watch_path, debounce=3.0)`, `check_update(watch_path)` | directory → rebuild on change; `check_update` reports whether a re-extraction is pending |

--- a/README.md
+++ b/README.md
@@ -663,6 +663,13 @@ graphify extract ./raw --code-only # index code only — local AST, no API key (
 /graphify add <video-url>
 /graphify add https://... --author "Name" --contributor "Name"
 
+# Capture a personal idea in Obsidian and analyze it as a clickable Cytoscape graph.
+# InfraNodus requests default to doNotSave=true; the API token stays in Python.
+INFRANODUS_API_KEY=... graphify idea "A neighborhood tool library with skill sharing" \
+  --title "Neighborhood tool library" --vault ~/Notes
+# Rebuild from a previously saved InfraNodus response without a network request:
+graphify idea --file idea.md --vault ~/Notes --response infranodus-response.json
+
 /graphify query "what connects attention to the optimizer?"
 /graphify query "..." --dfs --budget 1500
 /graphify path "DigestAuth" "Response"

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -533,6 +533,11 @@ def _run_cli() -> None:
         print("    --author \"Name\"         tag the author of the content")
         print("    --contributor \"Name\"    tag who added it to the corpus")
         print("    --dir <path>            target directory (default: ./raw)")
+        print("  idea \"<text>\"            turn an idea into an Obsidian note + clickable Cytoscape graph")
+        print("    --vault PATH            Obsidian vault (or set GRAPHIFY_OBSIDIAN_VAULT)")
+        print("    --title TITLE           note and graph title")
+        print("    --response JSON         use a saved InfraNodus response instead of the API")
+        print("                            API token env: INFRANODUS_API_KEY")
         print("  watch <path>            watch a folder and rebuild the graph on code changes")
         print("  update <path>           re-extract code files and update the graph (no LLM needed)")
         print("    --force                 overwrite graph.json even if the rebuild has fewer nodes")
@@ -701,7 +706,9 @@ def _run_cli() -> None:
     # (e.g. "cursor install --help" was silently installing into Cursor, #821).
     # Exempt: free-text commands (user string may contain these tokens), and
     # "install"/"uninstall" which have their own per-subcommand help handlers.
-    _FREE_TEXT_CMDS = {"query", "explain", "path", "save-result", "install", "uninstall"}
+    _FREE_TEXT_CMDS = {
+        "query", "explain", "path", "save-result", "idea", "install", "uninstall"
+    }
     if cmd not in _FREE_TEXT_CMDS and any(a in {"-h", "--help", "-?"} for a in sys.argv[2:]):
         print(f"Run 'graphify --help' for full usage.")
         return

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -803,7 +803,11 @@ def _reenter_main() -> None:
 
 
 def dispatch_command(cmd: str) -> None:
-    if cmd == "provider":
+    if cmd == "idea":
+        from graphify.idea import main as _idea_main
+        _idea_main(sys.argv[2:])
+
+    elif cmd == "provider":
         from graphify.llm import _custom_providers_path, BACKENDS
         import json as _json
         subcmd = sys.argv[2] if len(sys.argv) > 2 else ""

--- a/graphify/idea.py
+++ b/graphify/idea.py
@@ -6,6 +6,7 @@ import html
 import json
 import os
 import re
+import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -14,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from graphify.exporters.base import COMMUNITY_COLORS
-from graphify.security import _build_opener
+from graphify.security import build_safe_opener
 
 
 INFRANODUS_ENDPOINT = "https://infranodus.com/api/v1/graphAndStatements"
@@ -24,7 +25,7 @@ _MAX_RESPONSE_BYTES = 20 * 1024 * 1024
 def _safe_stem(value: str) -> str:
     stem = re.sub(r'[\\/:*?"<>|#^[\]]', "", value).strip().strip(".")
     stem = re.sub(r"\s+", " ", stem)
-    if not stem:
+    if not any(character.isalnum() for character in stem):
         raise ValueError("Idea title must contain at least one letter or number.")
     encoded = stem.encode("utf-8")
     if len(encoded) > 180:
@@ -83,7 +84,7 @@ def request_infranodus(
         method="POST",
     )
     try:
-        with _build_opener().open(request, timeout=timeout) as response:
+        with build_safe_opener().open(request, timeout=timeout) as response:
             raw = response.read(_MAX_RESPONSE_BYTES + 1)
     except urllib.error.HTTPError as exc:
         raise RuntimeError(f"InfraNodus request failed with HTTP {exc.code}.") from exc
@@ -158,6 +159,11 @@ def cytoscape_elements(
     note_uri: str,
 ) -> list[dict[str, Any]]:
     """Convert an InfraNodus Graphology graph to Cytoscape elements."""
+    if (
+        urllib.parse.urlparse(note_uri).scheme.lower() != "obsidian"
+        or not note_uri.lower().startswith("obsidian://")
+    ):
+        raise ValueError("Node note URI must use the obsidian:// scheme.")
     graph = _graphology_graph(response)
     graph_url, _summary = _response_metadata(response)
     elements: list[dict[str, Any]] = [
@@ -191,7 +197,10 @@ def cytoscape_elements(
             community = int(attrs.get("community", 0))
         except (TypeError, ValueError):
             community = 0
-        degree = attrs.get("weighedDegree", attrs.get("degree", 0))
+        degree = attrs.get(
+            "weighedDegree",
+            attrs.get("weightedDegree", attrs.get("degree", 0)),
+        )
         try:
             rank = float(degree)
         except (TypeError, ValueError):
@@ -304,7 +313,8 @@ def render_note(
 
 def render_cytoscape_html(title: str, elements: list[dict[str, Any]]) -> str:
     safe_title = html.escape(title)
-    elements_json = json.dumps(elements, ensure_ascii=False).replace("</", "<\\/")
+    # ASCII escaping also protects JS line parsing from literal U+2028/U+2029.
+    elements_json = json.dumps(elements).replace("</", "<\\/")
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -383,13 +393,42 @@ cy.on('tap', 'node', event => {{
 """
 
 
-def _write_new(path: Path, content: str, *, force: bool) -> None:
-    if path.exists() and not force:
-        raise FileExistsError(f"Refusing to overwrite existing file: {path}")
+def _write_new(path: Path, content: str, *, force: bool) -> tuple[int, int]:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.tmp")
-    temporary.write_text(content, encoding="utf-8")
-    temporary.replace(path)
+    fd, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if force:
+            os.replace(temporary, path)
+        else:
+            try:
+                # Hard-linking commits the staged file without overwriting a
+                # concurrently created target. The link operation is atomic.
+                os.link(temporary, path)
+            except FileExistsError:
+                raise FileExistsError(f"Refusing to overwrite existing file: {path}") from None
+        committed = path.stat()
+        return committed.st_dev, committed.st_ino
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _unlink_if_same_file(path: Path, identity: tuple[int, int]) -> None:
+    """Remove a partial output only when it is still the file this process wrote."""
+    try:
+        current = path.stat()
+    except FileNotFoundError:
+        return
+    if (current.st_dev, current.st_ino) == identity:
+        path.unlink()
 
 
 def create_idea_graph(
@@ -456,8 +495,13 @@ def create_idea_graph(
         graph_url=graph_url,
         summary=summary,
     )
-    _write_new(output_path, html_content, force=force)
-    _write_new(note_path, note_content, force=force)
+    output_identity = _write_new(output_path, html_content, force=force)
+    try:
+        _write_new(note_path, note_content, force=force)
+    except Exception:
+        if not force:
+            _unlink_if_same_file(output_path, output_identity)
+        raise
     return note_path, output_path
 
 

--- a/graphify/idea.py
+++ b/graphify/idea.py
@@ -455,18 +455,12 @@ def _write_new(path: Path, content: str, *, force: bool) -> None:
                 }
                 if error.errno not in unsupported:
                     raise
-                try:
-                    # Some removable/network filesystems cannot create hard
-                    # links. O_EXCL preserves the no-overwrite guarantee there.
-                    target_fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
-                except FileExistsError:
-                    raise FileExistsError(
-                        f"Refusing to overwrite existing file: {path}"
-                    ) from None
-                with os.fdopen(target_fd, "w", encoding="utf-8") as target:
-                    target.write(content)
-                    target.flush()
-                    os.fsync(target.fileno())
+                raise OSError(
+                    error.errno,
+                    "Filesystem does not support atomic no-overwrite publication; "
+                    "rerun with --force to allow atomic replacement.",
+                    path,
+                ) from error
     finally:
         temporary.unlink(missing_ok=True)
 

--- a/graphify/idea.py
+++ b/graphify/idea.py
@@ -152,6 +152,10 @@ def _obsidian_uri(vault: Path, note_path: Path) -> str:
     return f"obsidian://open?{query}"
 
 
+def _identifier(value: Any) -> str:
+    return "" if value is None else str(value).strip()
+
+
 def cytoscape_elements(
     response: Mapping[str, Any],
     *,
@@ -187,7 +191,10 @@ def cytoscape_elements(
     for item in graph["nodes"]:
         if not isinstance(item, Mapping):
             continue
-        key = str(item.get("key") or item.get("id") or "").strip()
+        key_value = item.get("key")
+        if key_value is None:
+            key_value = item.get("id")
+        key = _identifier(key_value)
         if not key:
             continue
         attrs = item.get("attributes")
@@ -226,8 +233,8 @@ def cytoscape_elements(
     for item in graph["edges"]:
         if not isinstance(item, Mapping):
             continue
-        source_key = str(item.get("source") or "").strip()
-        target_key = str(item.get("target") or "").strip()
+        source_key = _identifier(item.get("source"))
+        target_key = _identifier(item.get("target"))
         source = f"concept:{source_key}"
         target = f"concept:{target_key}"
         if source not in concept_ids or target not in concept_ids:

--- a/graphify/idea.py
+++ b/graphify/idea.py
@@ -146,6 +146,13 @@ def _safe_infranodus_url(value: str) -> str:
     return value
 
 
+def _safe_obsidian_uri(value: str) -> str:
+    parsed = urllib.parse.urlparse(value)
+    if parsed.scheme.lower() != "obsidian" or not value.lower().startswith("obsidian://"):
+        return ""
+    return value
+
+
 def _obsidian_uri(vault: Path, note_path: Path) -> str:
     relative = note_path.relative_to(vault).with_suffix("").as_posix()
     query = urllib.parse.urlencode({"vault": vault.name, "file": relative})
@@ -164,10 +171,7 @@ def cytoscape_elements(
     note_uri: str,
 ) -> list[dict[str, Any]]:
     """Convert an InfraNodus Graphology graph to Cytoscape elements."""
-    if (
-        urllib.parse.urlparse(note_uri).scheme.lower() != "obsidian"
-        or not note_uri.lower().startswith("obsidian://")
-    ):
+    if not _safe_obsidian_uri(note_uri):
         raise ValueError("Node note URI must use the obsidian:// scheme.")
     graph = _graphology_graph(response)
     graph_url, _summary = _response_metadata(response)
@@ -323,8 +327,20 @@ def render_note(
 
 def render_cytoscape_html(title: str, elements: list[dict[str, Any]]) -> str:
     safe_title = html.escape(title)
+    safe_elements: list[dict[str, Any]] = []
+    for element in elements:
+        safe_element = dict(element)
+        data = element.get("data")
+        if isinstance(data, Mapping):
+            safe_data = dict(data)
+            if "note_uri" in safe_data:
+                safe_data["note_uri"] = _safe_obsidian_uri(str(data.get("note_uri") or ""))
+            if "graph_url" in safe_data:
+                safe_data["graph_url"] = _safe_infranodus_url(str(data.get("graph_url") or ""))
+            safe_element["data"] = safe_data
+        safe_elements.append(safe_element)
     # Keep untrusted graph content entirely out of executable script syntax.
-    elements_payload = base64.b64encode(json.dumps(elements).encode("utf-8")).decode("ascii")
+    elements_payload = base64.b64encode(json.dumps(safe_elements).encode("utf-8")).decode("ascii")
     return f"""<!doctype html>
 <html lang="en">
 <head>

--- a/graphify/idea.py
+++ b/graphify/idea.py
@@ -138,6 +138,8 @@ def _response_metadata(response: Mapping[str, Any]) -> tuple[str, Mapping[str, A
 def _safe_infranodus_url(value: str) -> str:
     if not value:
         return ""
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in value):
+        return ""
     parsed = urllib.parse.urlparse(value)
     hostname = (parsed.hostname or "").lower()
     if parsed.scheme != "https" or not (
@@ -148,6 +150,8 @@ def _safe_infranodus_url(value: str) -> str:
 
 
 def _safe_obsidian_uri(value: str) -> str:
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in value):
+        return ""
     parsed = urllib.parse.urlparse(value)
     if parsed.scheme.lower() != "obsidian" or not value.lower().startswith("obsidian://"):
         return ""
@@ -483,6 +487,8 @@ def create_idea_graph(
     """Create an Obsidian source note and local Cytoscape graph for one idea."""
     if not text.strip():
         raise ValueError("Idea text cannot be empty.")
+    if response is not None and not isinstance(response, Mapping):
+        raise ValueError("InfraNodus response must be a JSON object.")
     vault = vault.expanduser().resolve()
     if not vault.is_dir():
         raise ValueError(f"Obsidian vault does not exist or is not a directory: {vault}")
@@ -560,7 +566,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--force", action="store_true")
     args = parser.parse_args(argv)
 
-    if bool(args.text) == bool(args.file):
+    if (args.text is None) == (args.file is None):
         parser.error("provide exactly one of idea text or --file")
     text = args.text
     if args.file:

--- a/graphify/idea.py
+++ b/graphify/idea.py
@@ -1,0 +1,529 @@
+"""Turn a personal idea into an Obsidian note and clickable Cytoscape graph."""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from graphify.exporters.base import COMMUNITY_COLORS
+from graphify.security import _build_opener
+
+
+INFRANODUS_ENDPOINT = "https://infranodus.com/api/v1/graphAndStatements"
+_MAX_RESPONSE_BYTES = 20 * 1024 * 1024
+
+
+def _safe_stem(value: str) -> str:
+    stem = re.sub(r'[\\/:*?"<>|#^[\]]', "", value).strip().strip(".")
+    stem = re.sub(r"\s+", " ", stem)
+    if not stem:
+        raise ValueError("Idea title must contain at least one letter or number.")
+    encoded = stem.encode("utf-8")
+    if len(encoded) > 180:
+        stem = encoded[:180].decode("utf-8", "ignore").rstrip()
+    return stem
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug[:80] or "idea"
+
+
+def _default_title(text: str) -> str:
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "Idea")
+    words = first_line.split()
+    return " ".join(words[:8]) + ("..." if len(words) > 8 else "")
+
+
+def _yaml_string(value: str) -> str:
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def request_infranodus(
+    text: str,
+    title: str,
+    *,
+    api_key: str | None = None,
+    ai_topics: bool = True,
+    save: bool = False,
+    timeout: float = 60,
+) -> dict[str, Any]:
+    """Analyze text with InfraNodus without exposing the API key to generated HTML."""
+    query = urllib.parse.urlencode(
+        {
+            "doNotSave": str(not save).lower(),
+            "addStats": "true",
+            "includeStatements": "false",
+            "includeGraphSummary": "true",
+            "extendedGraphSummary": "true",
+            "includeGraph": "true",
+            "compactGraph": "true",
+        }
+    )
+    payload = json.dumps(
+        {"name": _slug(title), "text": text, "aiTopics": ai_topics},
+        ensure_ascii=False,
+    ).encode("utf-8")
+    headers = {"Content-Type": "application/json", "User-Agent": "graphify/idea"}
+    if api_key:
+        headers["Authorization"] = api_key
+
+    request = urllib.request.Request(
+        f"{INFRANODUS_ENDPOINT}?{query}",
+        data=payload,
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with _build_opener().open(request, timeout=timeout) as response:
+            raw = response.read(_MAX_RESPONSE_BYTES + 1)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"InfraNodus request failed with HTTP {exc.code}.") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"InfraNodus request failed: {exc.reason}") from exc
+
+    if len(raw) > _MAX_RESPONSE_BYTES:
+        raise RuntimeError("InfraNodus response exceeded the 20 MiB safety limit.")
+    try:
+        result = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("InfraNodus returned an invalid JSON response.") from exc
+    if not isinstance(result, dict):
+        raise RuntimeError("InfraNodus returned an unexpected response shape.")
+    return result
+
+
+def _graphology_graph(response: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Locate the Graphology graph across documented InfraNodus response shapes."""
+    entry = response.get("entriesAndGraphOfContext", response)
+    if not isinstance(entry, Mapping):
+        raise ValueError("InfraNodus response has no entriesAndGraphOfContext object.")
+
+    graph = entry.get("graph")
+    if not isinstance(graph, Mapping):
+        graph = response.get("graph")
+    if not isinstance(graph, Mapping):
+        raise ValueError("InfraNodus response does not contain a graph.")
+
+    nested = graph.get("graphologyGraph")
+    if isinstance(nested, Mapping):
+        graph = nested
+    if not isinstance(graph.get("nodes"), list) or not isinstance(graph.get("edges"), list):
+        raise ValueError("InfraNodus graph must contain nodes and edges arrays.")
+    return graph
+
+
+def _response_metadata(response: Mapping[str, Any]) -> tuple[str, Mapping[str, Any]]:
+    entry = response.get("entriesAndGraphOfContext", response)
+    if not isinstance(entry, Mapping):
+        return "", {}
+    graph_url = _safe_infranodus_url(
+        str(entry.get("graphUrl") or response.get("graphUrl") or "")
+    )
+    summary = entry.get("extendedGraphSummary")
+    return graph_url, summary if isinstance(summary, Mapping) else {}
+
+
+def _safe_infranodus_url(value: str) -> str:
+    if not value:
+        return ""
+    parsed = urllib.parse.urlparse(value)
+    hostname = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not (
+        hostname == "infranodus.com" or hostname.endswith(".infranodus.com")
+    ):
+        return ""
+    return value
+
+
+def _obsidian_uri(vault: Path, note_path: Path) -> str:
+    relative = note_path.relative_to(vault).with_suffix("").as_posix()
+    query = urllib.parse.urlencode({"vault": vault.name, "file": relative})
+    return f"obsidian://open?{query}"
+
+
+def cytoscape_elements(
+    response: Mapping[str, Any],
+    *,
+    title: str,
+    idea_text: str,
+    note_uri: str,
+) -> list[dict[str, Any]]:
+    """Convert an InfraNodus Graphology graph to Cytoscape elements."""
+    graph = _graphology_graph(response)
+    graph_url, _summary = _response_metadata(response)
+    elements: list[dict[str, Any]] = [
+        {
+            "data": {
+                "id": "idea",
+                "label": title,
+                "kind": "idea",
+                "content": idea_text,
+                "community": -1,
+                "color": "#f59e0b",
+                "note_uri": note_uri,
+                "graph_url": graph_url,
+            }
+        }
+    ]
+
+    concept_ids: set[str] = set()
+    ranked: list[tuple[float, str]] = []
+    for item in graph["nodes"]:
+        if not isinstance(item, Mapping):
+            continue
+        key = str(item.get("key") or item.get("id") or "").strip()
+        if not key:
+            continue
+        attrs = item.get("attributes")
+        attrs = attrs if isinstance(attrs, Mapping) else {}
+        concept_id = f"concept:{key}"
+        concept_ids.add(concept_id)
+        try:
+            community = int(attrs.get("community", 0))
+        except (TypeError, ValueError):
+            community = 0
+        degree = attrs.get("weighedDegree", attrs.get("degree", 0))
+        try:
+            rank = float(degree)
+        except (TypeError, ValueError):
+            rank = 0.0
+        ranked.append((rank, concept_id))
+        elements.append(
+            {
+                "data": {
+                    "id": concept_id,
+                    "label": key,
+                    "kind": "concept",
+                    "community": community,
+                    "degree": rank,
+                    "color": COMMUNITY_COLORS[community % len(COMMUNITY_COLORS)],
+                    "note_uri": note_uri,
+                    "graph_url": graph_url,
+                }
+            }
+        )
+
+    edge_index = 0
+    for item in graph["edges"]:
+        if not isinstance(item, Mapping):
+            continue
+        source = f"concept:{item.get('source', '')}"
+        target = f"concept:{item.get('target', '')}"
+        if source not in concept_ids or target not in concept_ids:
+            continue
+        attrs = item.get("attributes")
+        attrs = attrs if isinstance(attrs, Mapping) else {}
+        elements.append(
+            {
+                "data": {
+                    "id": f"edge:{edge_index}",
+                    "source": source,
+                    "target": target,
+                    "weight": attrs.get("weight", 1),
+                    "kind": "infranodus",
+                }
+            }
+        )
+        edge_index += 1
+
+    # Make the original thought a visible graph participant, not just a page title.
+    for index, (_rank, concept_id) in enumerate(sorted(ranked, reverse=True)[:8]):
+        elements.append(
+            {
+                "data": {
+                    "id": f"idea-edge:{index}",
+                    "source": "idea",
+                    "target": concept_id,
+                    "weight": 1,
+                    "kind": "idea-context",
+                }
+            }
+        )
+    return elements
+
+
+def _summary_markdown(summary: Mapping[str, Any]) -> list[str]:
+    lines: list[str] = []
+    for key, heading in (
+        ("mainTopics", "Main topics"),
+        ("mainConcepts", "Main concepts"),
+        ("contentGaps", "Content gaps"),
+        ("conceptualGateways", "Conceptual gateways"),
+    ):
+        values = summary.get(key)
+        if not isinstance(values, list) or not values:
+            continue
+        lines.extend(["", f"## {heading}"])
+        for value in values[:12]:
+            if isinstance(value, Mapping):
+                label = value.get("name") or value.get("label") or value.get("text")
+                value = label if label is not None else json.dumps(value, ensure_ascii=False)
+            lines.append(f"- {value}")
+    return lines
+
+
+def render_note(
+    *,
+    title: str,
+    idea_text: str,
+    html_path: Path,
+    graph_url: str,
+    summary: Mapping[str, Any],
+) -> str:
+    lines = [
+        "---",
+        "type: graphify-idea",
+        f"cytoscape_graph: {_yaml_string(html_path.resolve().as_uri())}",
+        f"infranodus_graph: {_yaml_string(graph_url)}",
+        "tags:",
+        "  - graphify/idea",
+        "  - infranodus",
+        "---",
+        "",
+        f"# {title}",
+        "",
+        idea_text.strip(),
+        "",
+        "## Explore",
+        f"- [Open the clickable Cytoscape graph]({html_path.resolve().as_uri()})",
+    ]
+    if graph_url:
+        lines.append(f"- [Open this analysis in InfraNodus]({graph_url})")
+    lines.extend(_summary_markdown(summary))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_cytoscape_html(title: str, elements: list[dict[str, Any]]) -> str:
+    safe_title = html.escape(title)
+    elements_json = json.dumps(elements, ensure_ascii=False).replace("</", "<\\/")
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{safe_title} - idea graph</title>
+<script src="https://unpkg.com/cytoscape@3.33.1/dist/cytoscape.min.js"
+        integrity="sha384-lXrzMjLDk3q9l0I/kjqjMcDgfFnHvWTDeWP3DmMqoeOq49/qa8drmlP3OBWN9dQ3"
+        crossorigin="anonymous"></script>
+<style>
+* {{ box-sizing: border-box; }}
+body {{ margin: 0; height: 100vh; display: grid; grid-template-columns: 1fr 320px;
+  background: #0f172a; color: #e2e8f0; font: 14px system-ui, sans-serif; }}
+#cy {{ min-width: 0; }}
+aside {{ padding: 20px; background: #111827; border-left: 1px solid #334155; overflow: auto; }}
+h1 {{ font-size: 17px; margin: 0 0 16px; }}
+#details {{ color: #cbd5e1; line-height: 1.55; }}
+.meta {{ color: #94a3b8; margin: 8px 0; }}
+a {{ display: inline-block; margin: 12px 8px 0 0; padding: 8px 10px; border-radius: 6px;
+  background: #2563eb; color: white; text-decoration: none; }}
+.hint {{ color: #64748b; font-size: 12px; margin-top: 20px; }}
+</style>
+</head>
+<body>
+<div id="cy"></div>
+<aside>
+  <h1>{safe_title}</h1>
+  <div id="details">Click a node to inspect it.</div>
+  <div class="hint">The gold diamond is your original idea. Its strongest InfraNodus concepts
+  are connected directly. Use the Obsidian button to return to the source note.</div>
+</aside>
+<script>
+const elements = {elements_json};
+const cy = cytoscape({{
+  container: document.getElementById('cy'),
+  elements,
+  style: [
+    {{ selector: 'node', style: {{
+      'background-color': 'data(color)', 'label': 'data(label)', 'color': '#e2e8f0',
+      'font-size': 11, 'text-valign': 'bottom', 'text-margin-y': 7,
+      'width': 'mapData(degree, 0, 20, 18, 48)', 'height': 'mapData(degree, 0, 20, 18, 48)'
+    }} }},
+    {{ selector: 'node[kind = "idea"]', style: {{
+      'shape': 'diamond', 'width': 64, 'height': 64, 'font-size': 14, 'font-weight': 'bold'
+    }} }},
+    {{ selector: 'edge', style: {{
+      'line-color': '#475569', 'width': 'mapData(weight, 1, 10, 1, 5)',
+      'curve-style': 'bezier', 'opacity': 0.65
+    }} }},
+    {{ selector: 'edge[kind = "idea-context"]', style: {{
+      'line-color': '#f59e0b', 'width': 2, 'opacity': 0.85
+    }} }},
+    {{ selector: ':selected', style: {{ 'border-width': 4, 'border-color': '#f8fafc' }} }}
+  ],
+  layout: {{ name: 'cose', animate: false, randomize: true, nodeRepulsion: 8500 }}
+}});
+
+function esc(value) {{
+  return String(value ?? '').replace(/[&<>"']/g, ch => ({{
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }})[ch]);
+}}
+cy.on('tap', 'node', event => {{
+  const data = event.target.data();
+  const content = data.content ? `<p>${{esc(data.content)}}</p>` : '';
+  const degree = data.kind === 'concept' ? `<div class="meta">Weighted degree: ${{esc(data.degree)}}</div>` : '';
+  const infra = data.graph_url
+    ? `<a href="${{esc(data.graph_url)}}" target="_blank" rel="noopener">Open InfraNodus</a>` : '';
+  document.getElementById('details').innerHTML = `
+    <strong>${{esc(data.label)}}</strong>${{content}}${{degree}}
+    <a href="${{esc(data.note_uri)}}">Open in Obsidian</a>${{infra}}`;
+}});
+</script>
+</body>
+</html>
+"""
+
+
+def _write_new(path: Path, content: str, *, force: bool) -> None:
+    if path.exists() and not force:
+        raise FileExistsError(f"Refusing to overwrite existing file: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(content, encoding="utf-8")
+    temporary.replace(path)
+
+
+def create_idea_graph(
+    *,
+    text: str,
+    title: str,
+    vault: Path,
+    folder: str = "Ideas",
+    output_path: Path | None = None,
+    response: Mapping[str, Any] | None = None,
+    api_key: str | None = None,
+    ai_topics: bool = True,
+    save_infranodus: bool = False,
+    force: bool = False,
+) -> tuple[Path, Path]:
+    """Create an Obsidian source note and local Cytoscape graph for one idea."""
+    if not text.strip():
+        raise ValueError("Idea text cannot be empty.")
+    vault = vault.expanduser().resolve()
+    if not vault.is_dir():
+        raise ValueError(f"Obsidian vault does not exist or is not a directory: {vault}")
+
+    safe_title = _safe_stem(title)
+    folder_path = Path(folder)
+    if folder_path.is_absolute():
+        raise ValueError("Obsidian folder must be relative to the vault.")
+    note_dir = (vault / folder_path).resolve()
+    try:
+        note_dir.relative_to(vault)
+    except ValueError:
+        raise ValueError("Obsidian folder must stay inside the vault.") from None
+    note_path = note_dir / f"{safe_title}.md"
+    output_path = (
+        output_path.expanduser()
+        if output_path is not None
+        else Path("graphify-out") / "ideas" / f"{_slug(safe_title)}.html"
+    )
+    output_path = output_path.resolve()
+    if note_path.exists() and not force:
+        raise FileExistsError(f"Refusing to overwrite existing file: {note_path}")
+    if output_path.exists() and not force:
+        raise FileExistsError(f"Refusing to overwrite existing file: {output_path}")
+
+    result = dict(response) if response is not None else request_infranodus(
+        text,
+        safe_title,
+        api_key=api_key,
+        ai_topics=ai_topics,
+        save=save_infranodus,
+    )
+    note_uri = _obsidian_uri(vault, note_path)
+    graph_url, summary = _response_metadata(result)
+    elements = cytoscape_elements(
+        result,
+        title=safe_title,
+        idea_text=text.strip(),
+        note_uri=note_uri,
+    )
+    html_content = render_cytoscape_html(safe_title, elements)
+    note_content = render_note(
+        title=safe_title,
+        idea_text=text,
+        html_path=output_path,
+        graph_url=graph_url,
+        summary=summary,
+    )
+    _write_new(output_path, html_content, force=force)
+    _write_new(note_path, note_content, force=force)
+    return note_path, output_path
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="graphify idea",
+        description="Turn an idea into an Obsidian note and clickable InfraNodus/Cytoscape graph.",
+    )
+    parser.add_argument("text", nargs="?", help="idea text (or use --file)")
+    parser.add_argument("--file", type=Path, help="read idea text from a UTF-8 file")
+    parser.add_argument("--title", help="note and graph title (defaults to the first eight words)")
+    parser.add_argument(
+        "--vault",
+        type=Path,
+        help="Obsidian vault path (or set GRAPHIFY_OBSIDIAN_VAULT)",
+    )
+    parser.add_argument("--folder", default="Ideas", help="folder inside the vault (default: Ideas)")
+    parser.add_argument("--output", type=Path, help="Cytoscape HTML output path")
+    parser.add_argument("--response", type=Path, help="use an existing InfraNodus JSON response")
+    parser.add_argument("--api-key-env", default="INFRANODUS_API_KEY")
+    parser.add_argument("--no-ai-topics", action="store_true")
+    parser.add_argument("--save-infranodus", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args(argv)
+
+    if bool(args.text) == bool(args.file):
+        parser.error("provide exactly one of idea text or --file")
+    text = args.text
+    if args.file:
+        try:
+            text = args.file.expanduser().read_text(encoding="utf-8")
+        except OSError as exc:
+            parser.error(f"could not read idea file: {exc}")
+    assert text is not None
+
+    vault = args.vault or (
+        Path(os.environ["GRAPHIFY_OBSIDIAN_VAULT"])
+        if os.environ.get("GRAPHIFY_OBSIDIAN_VAULT")
+        else None
+    )
+    if vault is None:
+        parser.error("--vault is required unless GRAPHIFY_OBSIDIAN_VAULT is set")
+
+    response = None
+    if args.response:
+        try:
+            response = json.loads(args.response.expanduser().read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            parser.error(f"could not read InfraNodus response: {exc}")
+
+    title = args.title or _default_title(text)
+    try:
+        note_path, html_path = create_idea_graph(
+            text=text,
+            title=title,
+            vault=vault,
+            folder=args.folder,
+            output_path=args.output,
+            response=response,
+            api_key=os.environ.get(args.api_key_env),
+            ai_topics=not args.no_ai_topics,
+            save_infranodus=args.save_infranodus,
+            force=args.force,
+        )
+    except (ValueError, FileExistsError, RuntimeError) as exc:
+        parser.error(str(exc))
+
+    print(f"Obsidian note: {note_path}")
+    print(f"Clickable graph: {html_path}")

--- a/graphify/idea.py
+++ b/graphify/idea.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import html
 import json
 import os
@@ -315,8 +316,8 @@ def render_note(
 
 def render_cytoscape_html(title: str, elements: list[dict[str, Any]]) -> str:
     safe_title = html.escape(title)
-    # ASCII escaping also protects JS line parsing from literal U+2028/U+2029.
-    elements_json = json.dumps(elements).replace("</", "<\\/")
+    # Keep untrusted graph content entirely out of executable script syntax.
+    elements_payload = base64.b64encode(json.dumps(elements).encode("utf-8")).decode("ascii")
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -349,7 +350,7 @@ a {{ display: inline-block; margin: 12px 8px 0 0; padding: 8px 10px; border-radi
   are connected directly. Use the Obsidian button to return to the source note.</div>
 </aside>
 <script>
-const elements = {elements_json};
+const elements = JSON.parse(atob('{elements_payload}'));
 const cy = cytoscape({{
   container: document.getElementById('cy'),
   elements,
@@ -553,7 +554,7 @@ def main(argv: list[str] | None = None) -> None:
             save_infranodus=args.save_infranodus,
             force=args.force,
         )
-    except (ValueError, FileExistsError, RuntimeError) as exc:
+    except (ValueError, OSError, RuntimeError) as exc:
         parser.error(str(exc))
 
     print(f"Obsidian note: {note_path}")

--- a/graphify/idea.py
+++ b/graphify/idea.py
@@ -225,8 +225,10 @@ def cytoscape_elements(
     for item in graph["edges"]:
         if not isinstance(item, Mapping):
             continue
-        source = f"concept:{item.get('source', '')}"
-        target = f"concept:{item.get('target', '')}"
+        source_key = str(item.get("source") or "").strip()
+        target_key = str(item.get("target") or "").strip()
+        source = f"concept:{source_key}"
+        target = f"concept:{target_key}"
         if source not in concept_ids or target not in concept_ids:
             continue
         attrs = item.get("attributes")
@@ -393,7 +395,7 @@ cy.on('tap', 'node', event => {{
 """
 
 
-def _write_new(path: Path, content: str, *, force: bool) -> tuple[int, int]:
+def _write_new(path: Path, content: str, *, force: bool) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, temporary_name = tempfile.mkstemp(
         dir=path.parent,
@@ -415,20 +417,8 @@ def _write_new(path: Path, content: str, *, force: bool) -> tuple[int, int]:
                 os.link(temporary, path)
             except FileExistsError:
                 raise FileExistsError(f"Refusing to overwrite existing file: {path}") from None
-        committed = path.stat()
-        return committed.st_dev, committed.st_ino
     finally:
         temporary.unlink(missing_ok=True)
-
-
-def _unlink_if_same_file(path: Path, identity: tuple[int, int]) -> None:
-    """Remove a partial output only when it is still the file this process wrote."""
-    try:
-        current = path.stat()
-    except FileNotFoundError:
-        return
-    if (current.st_dev, current.st_ino) == identity:
-        path.unlink()
 
 
 def create_idea_graph(
@@ -495,13 +485,10 @@ def create_idea_graph(
         graph_url=graph_url,
         summary=summary,
     )
-    output_identity = _write_new(output_path, html_content, force=force)
-    try:
-        _write_new(note_path, note_content, force=force)
-    except Exception:
-        if not force:
-            _unlink_if_same_file(output_path, output_identity)
-        raise
+    # The note is the durable source of truth. Publish it first so a later HTML
+    # filesystem failure never loses the captured idea or requires racy rollback.
+    _write_new(note_path, note_content, force=force)
+    _write_new(output_path, html_content, force=force)
     return note_path, output_path
 
 

--- a/graphify/idea.py
+++ b/graphify/idea.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import errno
 import html
 import json
 import os
@@ -441,6 +442,27 @@ def _write_new(path: Path, content: str, *, force: bool) -> None:
                 os.link(temporary, path)
             except FileExistsError:
                 raise FileExistsError(f"Refusing to overwrite existing file: {path}") from None
+            except OSError as error:
+                unsupported = {
+                    errno.EPERM,
+                    errno.EXDEV,
+                    getattr(errno, "ENOTSUP", errno.EOPNOTSUPP),
+                    errno.EOPNOTSUPP,
+                }
+                if error.errno not in unsupported:
+                    raise
+                try:
+                    # Some removable/network filesystems cannot create hard
+                    # links. O_EXCL preserves the no-overwrite guarantee there.
+                    target_fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
+                except FileExistsError:
+                    raise FileExistsError(
+                        f"Refusing to overwrite existing file: {path}"
+                    ) from None
+                with os.fdopen(target_fd, "w", encoding="utf-8") as target:
+                    target.write(content)
+                    target.flush()
+                    os.fsync(target.fileno())
     finally:
         temporary.unlink(missing_ok=True)
 

--- a/graphify/security.py
+++ b/graphify/security.py
@@ -240,7 +240,8 @@ class _NoFileRedirectHandler(urllib.request.HTTPRedirectHandler):
         return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
-def _build_opener() -> urllib.request.OpenerDirector:
+def build_safe_opener() -> urllib.request.OpenerDirector:
+    """Build a urllib opener with DNS-rebinding and redirect SSRF guards."""
     # build_opener replaces the default HTTP(S)Handlers with our SSRF-guarded
     # subclasses, so every connection resolves+validates DNS once and connects
     # to that exact IP. Thread-safe: no process-global state is mutated.
@@ -249,6 +250,10 @@ def _build_opener() -> urllib.request.OpenerDirector:
         _SSRFGuardedHTTPSHandler,
         _NoFileRedirectHandler,
     )
+
+
+# Backward-compatible alias for callers/tests that used the original private helper.
+_build_opener = build_safe_opener
 
 
 # ---------------------------------------------------------------------------
@@ -272,7 +277,7 @@ def safe_fetch(url: str, max_bytes: int = _MAX_FETCH_BYTES, timeout: int = 30) -
         OSError               - size cap exceeded
     """
     validate_url(url)
-    opener = _build_opener()
+    opener = build_safe_opener()
     req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 graphify/1.0"})
 
     with opener.open(req, timeout=timeout) as resp:

--- a/graphify/security.py
+++ b/graphify/security.py
@@ -239,7 +239,14 @@ class _NoFileRedirectHandler(urllib.request.HTTPRedirectHandler):
         validate_url(newurl)          # raises ValueError if scheme is wrong
         old_origin = urllib.parse.urlsplit(req.full_url)
         new_origin = urllib.parse.urlsplit(newurl)
-        if req.has_header("Authorization") and (
+        request_headers = {
+            header.lower()
+            for header in (*req.headers, *req.unredirected_hdrs)
+        }
+        has_credentials = bool(
+            request_headers & {"authorization", "cookie", "proxy-authorization"}
+        )
+        if has_credentials and (
             old_origin.scheme.lower(),
             old_origin.hostname,
             old_origin.port,
@@ -248,7 +255,7 @@ class _NoFileRedirectHandler(urllib.request.HTTPRedirectHandler):
             new_origin.hostname,
             new_origin.port,
         ):
-            raise ValueError("Blocked cross-origin redirect for authenticated request.")
+            raise ValueError("Blocked cross-origin redirect for credentialed request.")
         return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 

--- a/graphify/security.py
+++ b/graphify/security.py
@@ -237,7 +237,27 @@ class _NoFileRedirectHandler(urllib.request.HTTPRedirectHandler):
 
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         validate_url(newurl)          # raises ValueError if scheme is wrong
+        old_origin = urllib.parse.urlsplit(req.full_url)
+        new_origin = urllib.parse.urlsplit(newurl)
+        if req.has_header("Authorization") and (
+            old_origin.scheme.lower(),
+            old_origin.hostname,
+            old_origin.port,
+        ) != (
+            new_origin.scheme.lower(),
+            new_origin.hostname,
+            new_origin.port,
+        ):
+            raise ValueError("Blocked cross-origin redirect for authenticated request.")
         return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+class _SchemeValidationHandler(urllib.request.BaseHandler):
+    """Reject non-HTTP(S) requests before protocol-specific handlers run."""
+
+    def default_open(self, req):
+        validate_url(req.full_url)
+        return None
 
 
 def build_safe_opener() -> urllib.request.OpenerDirector:
@@ -246,6 +266,7 @@ def build_safe_opener() -> urllib.request.OpenerDirector:
     # subclasses, so every connection resolves+validates DNS once and connects
     # to that exact IP. Thread-safe: no process-global state is mutated.
     return urllib.request.build_opener(
+        _SchemeValidationHandler,
         _SSRFGuardedHTTPHandler,
         _SSRFGuardedHTTPSHandler,
         _NoFileRedirectHandler,

--- a/tests/test_idea.py
+++ b/tests/test_idea.py
@@ -4,10 +4,17 @@ import json
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
-from graphify.idea import create_idea_graph, cytoscape_elements
+from graphify.idea import (
+    _safe_stem,
+    _write_new,
+    create_idea_graph,
+    cytoscape_elements,
+    render_cytoscape_html,
+)
 
 
 def _response():
@@ -65,6 +72,62 @@ def test_cytoscape_elements_include_clickable_idea_and_concepts():
     assert any(item["data"].get("kind") == "idea-context" for item in elements)
 
 
+def test_cytoscape_elements_reject_non_obsidian_note_uri():
+    with pytest.raises(ValueError, match="obsidian"):
+        cytoscape_elements(
+            _response(),
+            title="Tool library",
+            idea_text="Neighbors share tools.",
+            note_uri="javascript:alert(1)",
+        )
+
+
+def test_cytoscape_elements_accept_weighted_degree_spelling():
+    response = _response()
+    attributes = response["entriesAndGraphOfContext"]["graph"]["graphologyGraph"]["nodes"][0][
+        "attributes"
+    ]
+    attributes.pop("weighedDegree")
+    attributes["weightedDegree"] = 11
+
+    elements = cytoscape_elements(
+        response,
+        title="Tool library",
+        idea_text="Neighbors share tools.",
+        note_uri="obsidian://open?vault=Notes&file=Ideas%2FTool+library",
+    )
+
+    tools = next(item["data"] for item in elements if item["data"]["id"] == "concept:tools")
+    assert tools["degree"] == 11
+
+
+def test_render_cytoscape_html_escapes_script_breakouts_and_js_line_separators():
+    elements = [
+        {
+            "data": {
+                "id": "idea",
+                "content": "</script><img src=x onerror=alert(1)>\u2028next",
+            }
+        }
+    ]
+
+    output = render_cytoscape_html("Safe", elements)
+
+    assert "</script><img" not in output
+    assert "\\u2028" in output
+    assert "\u2028" not in output
+
+
+@pytest.mark.parametrize("title", ["---", "...", "@@@"])
+def test_safe_stem_rejects_titles_without_letters_or_numbers(title):
+    with pytest.raises(ValueError, match="letter or number"):
+        _safe_stem(title)
+
+
+def test_safe_stem_accepts_non_ascii_letters():
+    assert _safe_stem("アイデア") == "アイデア"
+
+
 def test_create_idea_graph_writes_obsidian_note_and_cytoscape_html(tmp_path):
     vault = tmp_path / "Notes"
     vault.mkdir()
@@ -104,6 +167,58 @@ def test_create_idea_graph_refuses_to_overwrite_note(tmp_path):
             response=_response(),
         )
     assert note.read_text() == "personal content"
+
+
+def test_write_new_uses_unique_temp_file_and_preserves_existing_target(tmp_path):
+    target = tmp_path / "idea.html"
+    target.write_text("original")
+    stale_temp = tmp_path / ".idea.html.tmp"
+    stale_temp.symlink_to(tmp_path / "outside")
+
+    with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+        _write_new(target, "replacement", force=False)
+
+    assert target.read_text() == "original"
+    assert stale_temp.is_symlink()
+    assert not (tmp_path / "outside").exists()
+    assert list(tmp_path.glob(".idea.html.*.tmp")) == []
+
+
+def test_write_new_atomically_creates_new_target(tmp_path):
+    target = Path(tmp_path) / "idea.html"
+
+    _write_new(target, "content", force=False)
+
+    assert target.read_text() == "content"
+
+
+def test_create_idea_graph_rolls_back_owned_output_when_note_commit_fails(
+    tmp_path, monkeypatch
+):
+    import graphify.idea as idea_module
+
+    vault = tmp_path / "Notes"
+    vault.mkdir()
+    output = tmp_path / "idea.html"
+    original_write = idea_module._write_new
+
+    def fail_note(path, content, *, force):
+        if path.suffix == ".md":
+            raise FileExistsError("concurrent note")
+        return original_write(path, content, force=force)
+
+    monkeypatch.setattr(idea_module, "_write_new", fail_note)
+
+    with pytest.raises(FileExistsError, match="concurrent note"):
+        create_idea_graph(
+            text="New text",
+            title="Tool library",
+            vault=vault,
+            output_path=output,
+            response=_response(),
+        )
+
+    assert not output.exists()
 
 
 def test_create_idea_graph_blocks_folder_escape(tmp_path):

--- a/tests/test_idea.py
+++ b/tests/test_idea.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import errno
 import json
 import os
 import re
@@ -258,6 +259,20 @@ def test_write_new_atomically_creates_new_target(tmp_path):
     _write_new(target, "content", force=False)
 
     assert target.read_text() == "content"
+
+
+def test_write_new_falls_back_when_filesystem_rejects_hard_links(tmp_path, monkeypatch):
+    target = tmp_path / "idea.html"
+
+    def reject_hard_link(source, destination):
+        raise OSError(errno.EOPNOTSUPP, "hard links unsupported")
+
+    monkeypatch.setattr("graphify.idea.os.link", reject_hard_link)
+
+    _write_new(target, "content", force=False)
+
+    assert target.read_text() == "content"
+    assert list(tmp_path.glob(".idea.html.*.tmp")) == []
 
 
 def test_create_idea_graph_preserves_note_when_html_commit_fails(tmp_path, monkeypatch):

--- a/tests/test_idea.py
+++ b/tests/test_idea.py
@@ -121,6 +121,29 @@ def test_cytoscape_elements_normalize_edge_endpoint_keys():
     assert graph_edge["target"] == "concept:neighbors"
 
 
+def test_cytoscape_elements_preserve_numeric_zero_node_ids():
+    response = _response()
+    graph = response["entriesAndGraphOfContext"]["graph"]["graphologyGraph"]
+    graph["nodes"] = [
+        {"key": 0, "attributes": {"degree": 1}},
+        {"key": 1, "attributes": {"degree": 1}},
+    ]
+    graph["edges"] = [{"source": 0, "target": 1, "attributes": {"weight": 1}}]
+
+    elements = cytoscape_elements(
+        response,
+        title="Numbered concepts",
+        idea_text="Connect zero to one.",
+        note_uri="obsidian://open?vault=Notes&file=Ideas%2FNumbers",
+    )
+
+    ids = {item["data"]["id"] for item in elements}
+    assert {"concept:0", "concept:1"} <= ids
+    edge = next(item["data"] for item in elements if item["data"].get("kind") == "infranodus")
+    assert edge["source"] == "concept:0"
+    assert edge["target"] == "concept:1"
+
+
 def test_render_cytoscape_html_escapes_script_breakouts_and_js_line_separators():
     elements = [
         {

--- a/tests/test_idea.py
+++ b/tests/test_idea.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from graphify.idea import create_idea_graph, cytoscape_elements
+
+
+def _response():
+    return {
+        "entriesAndGraphOfContext": {
+            "graphUrl": "https://infranodus.com/example",
+            "extendedGraphSummary": {
+                "mainTopics": [{"name": "shared tools"}],
+                "contentGaps": ["trust and maintenance"],
+            },
+            "graph": {
+                "graphologyGraph": {
+                    "nodes": [
+                        {
+                            "key": "tools",
+                            "attributes": {
+                                "community": 0,
+                                "degree": 3,
+                                "weighedDegree": 7,
+                            },
+                        },
+                        {
+                            "key": "neighbors",
+                            "attributes": {
+                                "community": 1,
+                                "degree": 2,
+                                "weighedDegree": 4,
+                            },
+                        },
+                    ],
+                    "edges": [
+                        {
+                            "source": "tools",
+                            "target": "neighbors",
+                            "attributes": {"weight": 3},
+                        }
+                    ],
+                }
+            },
+        }
+    }
+
+
+def test_cytoscape_elements_include_clickable_idea_and_concepts():
+    elements = cytoscape_elements(
+        _response(),
+        title="Tool library",
+        idea_text="Neighbors share tools.",
+        note_uri="obsidian://open?vault=Notes&file=Ideas%2FTool+library",
+    )
+    nodes = {item["data"]["id"]: item["data"] for item in elements if "source" not in item["data"]}
+    assert nodes["idea"]["kind"] == "idea"
+    assert nodes["idea"]["note_uri"].startswith("obsidian://open")
+    assert nodes["concept:tools"]["graph_url"] == "https://infranodus.com/example"
+    assert any(item["data"].get("kind") == "idea-context" for item in elements)
+
+
+def test_create_idea_graph_writes_obsidian_note_and_cytoscape_html(tmp_path):
+    vault = tmp_path / "Notes"
+    vault.mkdir()
+    output = tmp_path / "idea.html"
+
+    note, graph = create_idea_graph(
+        text="Neighbors share tools and teach repair skills.",
+        title="Tool library",
+        vault=vault,
+        output_path=output,
+        response=_response(),
+    )
+
+    assert note == vault / "Ideas" / "Tool library.md"
+    assert graph == output
+    note_text = note.read_text()
+    graph_text = graph.read_text()
+    assert "Open the clickable Cytoscape graph" in note_text
+    assert "shared tools" in note_text
+    assert "cytoscape@3.33.1" in graph_text
+    assert "obsidian://open" in graph_text
+    assert "concept:tools" in graph_text
+
+
+def test_create_idea_graph_refuses_to_overwrite_note(tmp_path):
+    vault = tmp_path / "Notes"
+    note = vault / "Ideas" / "Tool library.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("personal content")
+
+    with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+        create_idea_graph(
+            text="New text",
+            title="Tool library",
+            vault=vault,
+            output_path=tmp_path / "idea.html",
+            response=_response(),
+        )
+    assert note.read_text() == "personal content"
+
+
+def test_create_idea_graph_blocks_folder_escape(tmp_path):
+    vault = tmp_path / "Notes"
+    vault.mkdir()
+
+    with pytest.raises(ValueError, match="inside the vault"):
+        create_idea_graph(
+            text="New text",
+            title="Tool library",
+            vault=vault,
+            folder="../outside",
+            output_path=tmp_path / "idea.html",
+            response=_response(),
+        )
+
+
+def test_untrusted_graph_url_is_not_rendered(tmp_path):
+    vault = tmp_path / "Notes"
+    vault.mkdir()
+    response = _response()
+    response["entriesAndGraphOfContext"]["graphUrl"] = "javascript:alert(1)"
+
+    note, graph = create_idea_graph(
+        text="New text",
+        title="Tool library",
+        vault=vault,
+        output_path=tmp_path / "idea.html",
+        response=response,
+    )
+
+    assert "javascript:" not in note.read_text()
+    assert "javascript:" not in graph.read_text()
+
+
+def test_idea_cli_supports_offline_infranodus_response(tmp_path):
+    vault = tmp_path / "Notes"
+    vault.mkdir()
+    response_path = tmp_path / "response.json"
+    response_path.write_text(json.dumps(_response()))
+    output = tmp_path / "clickable.html"
+    env = dict(os.environ)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "graphify",
+            "idea",
+            "Neighbors share tools and teach repair skills.",
+            "--title",
+            "Tool library",
+            "--vault",
+            str(vault),
+            "--response",
+            str(response_path),
+            "--output",
+            str(output),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (vault / "Ideas" / "Tool library.md").exists()
+    assert output.exists()
+    assert "Clickable graph:" in result.stdout

--- a/tests/test_idea.py
+++ b/tests/test_idea.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import base64
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -132,8 +134,8 @@ def test_render_cytoscape_html_escapes_script_breakouts_and_js_line_separators()
     output = render_cytoscape_html("Safe", elements)
 
     assert "</script><img" not in output
-    assert "\\u2028" in output
     assert "\u2028" not in output
+    assert "const elements = JSON.parse(atob('" in output
 
 
 @pytest.mark.parametrize("title", ["---", "...", "@@@"])
@@ -166,8 +168,12 @@ def test_create_idea_graph_writes_obsidian_note_and_cytoscape_html(tmp_path):
     assert "Open the clickable Cytoscape graph" in note_text
     assert "shared tools" in note_text
     assert "cytoscape@3.33.1" in graph_text
-    assert "obsidian://open" in graph_text
-    assert "concept:tools" in graph_text
+    payload_match = re.search(r"atob\('([^']+)'\)", graph_text)
+    assert payload_match is not None
+    payload = json.loads(base64.b64decode(payload_match.group(1)))
+    payload_text = json.dumps(payload)
+    assert "obsidian://open" in payload_text
+    assert "concept:tools" in payload_text
 
 
 def test_create_idea_graph_refuses_to_overwrite_note(tmp_path):
@@ -304,3 +310,31 @@ def test_idea_cli_supports_offline_infranodus_response(tmp_path):
     assert (vault / "Ideas" / "Tool library.md").exists()
     assert output.exists()
     assert "Clickable graph:" in result.stdout
+
+
+def test_idea_cli_reports_filesystem_errors(tmp_path, monkeypatch, capsys):
+    import graphify.idea as idea_module
+
+    vault = tmp_path / "Notes"
+    vault.mkdir()
+    response_path = tmp_path / "response.json"
+    response_path.write_text(json.dumps(_response()))
+
+    def fail_write(**_kwargs):
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(idea_module, "create_idea_graph", fail_write)
+
+    with pytest.raises(SystemExit) as exc:
+        idea_module.main(
+            [
+                "New idea",
+                "--vault",
+                str(vault),
+                "--response",
+                str(response_path),
+            ]
+        )
+
+    assert exc.value.code == 2
+    assert "permission denied" in capsys.readouterr().err

--- a/tests/test_idea.py
+++ b/tests/test_idea.py
@@ -336,6 +336,40 @@ def test_untrusted_graph_url_is_not_rendered(tmp_path):
     assert "javascript:" not in graph.read_text()
 
 
+def test_graph_url_with_control_characters_is_not_rendered(tmp_path):
+    vault = tmp_path / "Notes"
+    vault.mkdir()
+    response = _response()
+    response["entriesAndGraphOfContext"]["graphUrl"] = (
+        "https://infranodus.com/example\njavascript:alert(1)"
+    )
+
+    note, graph = create_idea_graph(
+        text="New text",
+        title="Tool library",
+        vault=vault,
+        output_path=tmp_path / "idea.html",
+        response=response,
+    )
+
+    assert "javascript:" not in note.read_text()
+    assert "javascript:" not in graph.read_text()
+
+
+def test_create_idea_graph_rejects_non_object_response(tmp_path):
+    vault = tmp_path / "Notes"
+    vault.mkdir()
+
+    with pytest.raises(ValueError, match="JSON object"):
+        create_idea_graph(
+            text="New text",
+            title="Tool library",
+            vault=vault,
+            output_path=tmp_path / "idea.html",
+            response=[],
+        )
+
+
 def test_idea_cli_supports_offline_infranodus_response(tmp_path):
     vault = tmp_path / "Notes"
     vault.mkdir()

--- a/tests/test_idea.py
+++ b/tests/test_idea.py
@@ -261,7 +261,7 @@ def test_write_new_atomically_creates_new_target(tmp_path):
     assert target.read_text() == "content"
 
 
-def test_write_new_falls_back_when_filesystem_rejects_hard_links(tmp_path, monkeypatch):
+def test_write_new_reports_filesystem_without_hard_links(tmp_path, monkeypatch):
     target = tmp_path / "idea.html"
 
     def reject_hard_link(source, destination):
@@ -269,9 +269,10 @@ def test_write_new_falls_back_when_filesystem_rejects_hard_links(tmp_path, monke
 
     monkeypatch.setattr("graphify.idea.os.link", reject_hard_link)
 
-    _write_new(target, "content", force=False)
+    with pytest.raises(OSError, match="atomic no-overwrite publication"):
+        _write_new(target, "content", force=False)
 
-    assert target.read_text() == "content"
+    assert not target.exists()
     assert list(tmp_path.glob(".idea.html.*.tmp")) == []
 
 

--- a/tests/test_idea.py
+++ b/tests/test_idea.py
@@ -101,6 +101,24 @@ def test_cytoscape_elements_accept_weighted_degree_spelling():
     assert tools["degree"] == 11
 
 
+def test_cytoscape_elements_normalize_edge_endpoint_keys():
+    response = _response()
+    edge = response["entriesAndGraphOfContext"]["graph"]["graphologyGraph"]["edges"][0]
+    edge["source"] = " tools "
+    edge["target"] = " neighbors "
+
+    elements = cytoscape_elements(
+        response,
+        title="Tool library",
+        idea_text="Neighbors share tools.",
+        note_uri="obsidian://open?vault=Notes&file=Ideas%2FTool+library",
+    )
+
+    graph_edge = next(item["data"] for item in elements if item["data"].get("kind") == "infranodus")
+    assert graph_edge["source"] == "concept:tools"
+    assert graph_edge["target"] == "concept:neighbors"
+
+
 def test_render_cytoscape_html_escapes_script_breakouts_and_js_line_separators():
     elements = [
         {
@@ -192,9 +210,7 @@ def test_write_new_atomically_creates_new_target(tmp_path):
     assert target.read_text() == "content"
 
 
-def test_create_idea_graph_rolls_back_owned_output_when_note_commit_fails(
-    tmp_path, monkeypatch
-):
+def test_create_idea_graph_preserves_note_when_html_commit_fails(tmp_path, monkeypatch):
     import graphify.idea as idea_module
 
     vault = tmp_path / "Notes"
@@ -202,14 +218,14 @@ def test_create_idea_graph_rolls_back_owned_output_when_note_commit_fails(
     output = tmp_path / "idea.html"
     original_write = idea_module._write_new
 
-    def fail_note(path, content, *, force):
-        if path.suffix == ".md":
-            raise FileExistsError("concurrent note")
+    def fail_html(path, content, *, force):
+        if path.suffix == ".html":
+            raise FileExistsError("concurrent graph")
         return original_write(path, content, force=force)
 
-    monkeypatch.setattr(idea_module, "_write_new", fail_note)
+    monkeypatch.setattr(idea_module, "_write_new", fail_html)
 
-    with pytest.raises(FileExistsError, match="concurrent note"):
+    with pytest.raises(FileExistsError, match="concurrent graph"):
         create_idea_graph(
             text="New text",
             title="Tool library",
@@ -218,6 +234,7 @@ def test_create_idea_graph_rolls_back_owned_output_when_note_commit_fails(
             response=_response(),
         )
 
+    assert (vault / "Ideas" / "Tool library.md").exists()
     assert not output.exists()
 
 

--- a/tests/test_idea.py
+++ b/tests/test_idea.py
@@ -161,6 +161,27 @@ def test_render_cytoscape_html_escapes_script_breakouts_and_js_line_separators()
     assert "const elements = JSON.parse(atob('" in output
 
 
+def test_render_cytoscape_html_sanitizes_node_links_at_render_boundary():
+    elements = [
+        {
+            "data": {
+                "id": "unsafe",
+                "label": "Unsafe",
+                "note_uri": "javascript:alert(1)",
+                "graph_url": "https://infranodus.com.evil.example/graph",
+            }
+        }
+    ]
+
+    output = render_cytoscape_html("Unsafe links", elements)
+    payload_match = re.search(r"atob\('([^']+)'\)", output)
+    assert payload_match is not None
+    payload = json.loads(base64.b64decode(payload_match.group(1)))
+
+    assert payload[0]["data"]["note_uri"] == ""
+    assert payload[0]["data"]["graph_url"] == ""
+
+
 @pytest.mark.parametrize("title", ["---", "...", "@@@"])
 def test_safe_stem_rejects_titles_without_letters_or_numbers(title):
     with pytest.raises(ValueError, match="letter or number"):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from graphify.security import (
+    _MAX_FETCH_BYTES,
+    _MAX_GRAPH_FILE_BYTES,
+    _MAX_TEXT_BYTES,
+    _METADATA_MAX_LIST_ITEMS,
+    _METADATA_MAX_VALUE_LEN,
+    _max_graph_file_bytes,
+    _sanitize_metadata_string,
+    _sanitize_metadata_value,
+    build_safe_opener,
     check_graph_file_size_cap,
     sanitize_label,
     sanitize_metadata,
@@ -17,14 +27,6 @@ from graphify.security import (
     safe_fetch_text,
     validate_graph_path,
     validate_url,
-    _MAX_FETCH_BYTES,
-    _MAX_GRAPH_FILE_BYTES,
-    _MAX_TEXT_BYTES,
-    _max_graph_file_bytes,
-    _METADATA_MAX_LIST_ITEMS,
-    _METADATA_MAX_VALUE_LEN,
-    _sanitize_metadata_string,
-    _sanitize_metadata_value,
 )
 
 
@@ -77,6 +79,32 @@ def test_safe_fetch_rejects_file_url():
 def test_safe_fetch_rejects_ftp_url():
     with pytest.raises(ValueError, match="ftp"):
         safe_fetch("ftp://example.com/file.zip")
+
+
+def test_build_safe_opener_rejects_file_url():
+    with pytest.raises(ValueError, match="file"):
+        build_safe_opener().open("file:///etc/passwd")
+
+
+def test_authenticated_redirect_must_stay_on_same_origin():
+    from graphify.security import _NoFileRedirectHandler
+
+    request = urllib.request.Request(
+        "https://infranodus.com/api",
+        headers={"Authorization": "secret"},
+    )
+    handler = _NoFileRedirectHandler()
+    with patch("graphify.security.validate_url", return_value="https://example.com/"):
+        with pytest.raises(ValueError, match="cross-origin"):
+            handler.redirect_request(
+                request,
+                None,
+                302,
+                "Found",
+                {},
+                "https://example.com/redirect",
+            )
+
 
 def test_safe_fetch_returns_bytes(tmp_path):
     mock_resp = _make_mock_response(b"hello world")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -86,12 +86,13 @@ def test_build_safe_opener_rejects_file_url():
         build_safe_opener().open("file:///etc/passwd")
 
 
-def test_authenticated_redirect_must_stay_on_same_origin():
+@pytest.mark.parametrize("header", ["Authorization", "Cookie", "Proxy-Authorization"])
+def test_credentialed_redirect_must_stay_on_same_origin(header):
     from graphify.security import _NoFileRedirectHandler
 
     request = urllib.request.Request(
         "https://infranodus.com/api",
-        headers={"Authorization": "secret"},
+        headers={header: "secret"},
     )
     handler = _NoFileRedirectHandler()
     with patch("graphify.security.validate_url", return_value="https://example.com/"):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -80,7 +80,7 @@ def test_safe_fetch_rejects_ftp_url():
 
 def test_safe_fetch_returns_bytes(tmp_path):
     mock_resp = _make_mock_response(b"hello world")
-    with patch("graphify.security._build_opener") as mock_opener_fn:
+    with patch("graphify.security.build_safe_opener") as mock_opener_fn:
         mock_opener = MagicMock()
         mock_opener.open.return_value = mock_resp
         mock_opener_fn.return_value = mock_opener
@@ -89,7 +89,7 @@ def test_safe_fetch_returns_bytes(tmp_path):
 
 def test_safe_fetch_raises_on_non_2xx():
     mock_resp = _make_mock_response(b"Not Found", status=404)
-    with patch("graphify.security._build_opener") as mock_opener_fn:
+    with patch("graphify.security.build_safe_opener") as mock_opener_fn:
         mock_opener = MagicMock()
         mock_opener.open.return_value = mock_resp
         mock_opener_fn.return_value = mock_opener
@@ -107,7 +107,7 @@ def test_safe_fetch_raises_on_size_exceeded():
     # Return the chunk twice so total > max_bytes=65536
     mock_resp.read.side_effect = [big_chunk, big_chunk, b""]
 
-    with patch("graphify.security._build_opener") as mock_opener_fn:
+    with patch("graphify.security.build_safe_opener") as mock_opener_fn:
         mock_opener = MagicMock()
         mock_opener.open.return_value = mock_resp
         mock_opener_fn.return_value = mock_opener
@@ -122,7 +122,7 @@ def test_safe_fetch_raises_on_size_exceeded():
 def test_safe_fetch_text_decodes_utf8():
     content = "héllo wörld".encode("utf-8")
     mock_resp = _make_mock_response(content)
-    with patch("graphify.security._build_opener") as mock_opener_fn:
+    with patch("graphify.security.build_safe_opener") as mock_opener_fn:
         mock_opener = MagicMock()
         mock_opener.open.return_value = mock_resp
         mock_opener_fn.return_value = mock_opener
@@ -132,7 +132,7 @@ def test_safe_fetch_text_decodes_utf8():
 def test_safe_fetch_text_replaces_bad_bytes():
     bad = b"hello \xff world"
     mock_resp = _make_mock_response(bad)
-    with patch("graphify.security._build_opener") as mock_opener_fn:
+    with patch("graphify.security.build_safe_opener") as mock_opener_fn:
         mock_opener = MagicMock()
         mock_opener.open.return_value = mock_resp
         mock_opener_fn.return_value = mock_opener


### PR DESCRIPTION
Personal ideas currently require separate manual steps to capture in Obsidian, analyze in InfraNodus, and visualize interactively. This adds a single `graphify idea` workflow that turns an idea into an Obsidian note and a clickable Cytoscape graph.

## What changed

- Sends idea text to InfraNodus with `doNotSave=true` by default and keeps the API token out of generated browser content.
- Converts the returned Graphology structure into Cytoscape elements, including a gold root node for the original idea and links to its strongest concepts.
- Generates an Obsidian note with links to the local visualization and the InfraNodus analysis.
- Supports saved InfraNodus JSON responses for offline and reproducible workflows.
- Protects vault content with overwrite guards, path containment checks, response size limits, safe external URLs, and atomic file writes.
- Documents the command and adds CLI, rendering, security, and offline-response coverage.

## Validation

- `uv run --frozen pytest -q tests/test_idea.py tests/test_architecture_doc.py tests/test_cli_export.py`
- `uv run --frozen ruff check graphify/idea.py graphify/cli.py graphify/__main__.py tests/test_idea.py`