### PR TITLE
docs: clarify build_merge persistence contract

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -1619,7 +1619,10 @@ def build_merge(
     dedup_llm_backend: str | None = None,
     root: str | Path | None = None,
 ) -> nx.Graph:
-    """Load existing graph.json, merge new chunks into it, and save back.
+    """Merge new chunks with an existing graph.json, when present.
+
+    Returns the merged graph without writing it to ``graph_path``. The caller
+    is responsible for persistence.
 
     Re-extracted files REPLACE their prior contribution per tier (#2333/#2336):
     a source_file present in new_chunks has its existing nodes/edges dropped


### PR DESCRIPTION
## Summary

- clarify that `build_merge` returns the merged graph without writing to `graph_path`
- state that persistence remains the caller's responsibility

Fixes #2831

## Result

The documented contract now matches the existing behavior: a merge can return a graph with 2 nodes while the input `graph.json` remains byte-identical with its original 1 node.

## Testing

- `uv run --frozen pytest -q tests/test_build.py tests/test_build_merge_hyperedges_and_prune.py tests/test_build_merge_shrink_guard.py --tb=short` (102 passed)
- `uv run --frozen pytest tests/ -q --tb=short --ignore=tests/test_ollama_retry_cap.py` (4570 passed, 73 skipped; optional `openai` dependency unavailable locally)
- `uv run --frozen python -m tools.skillgen --check` (134 artifacts matched)
