### PR TITLE
perf(detect): hoist per-pattern work out of the ignore-matching loop

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1331,14 +1331,20 @@ def _is_ignored(
         # keep it in the shared cache. It used to run for every target: on a repo with
         # ~55 patterns and ~14k targets that is ~770k redundant string splits.
         #
-        # Invalidate on pattern count: detect() appends patterns from nested .gitignore
-        # files *during* the walk (see ignore_patterns.extend below), so a frozen parse
-        # would silently stop applying the later ones.
+        # The entry is keyed on the pattern list's identity AND its length, and it
+        # keeps a reference to that list:
+        #   - length, because detect() appends patterns from nested .gitignore files
+        #     *during* the walk (see ignore_patterns.extend below), so a frozen parse
+        #     would silently stop applying the later ones;
+        #   - identity, because a caller may pass a different list of the same length
+        #     with the same _cache, and length alone would serve the wrong parse.
+        # Holding the list keeps it alive, so an `is` check cannot be fooled by a new
+        # list landing on a freed one's address (which `id()` alone would allow).
         prepared = None
         if _cache is not None:
             cached = _cache.get(_PREPARED_KEY)
-            if cached is not None and cached[0] == len(patterns):
-                prepared = cached[1]
+            if cached is not None and cached[0] is patterns and cached[1] == len(patterns):
+                prepared = cached[2]
         if prepared is None:
             prepared = []
             for _anchor, _pattern in patterns:
@@ -1350,7 +1356,7 @@ def _is_ignored(
                 prepared.append((_anchor, _negated, _raw.endswith("/"),
                                  "/" in _raw.rstrip("/"), _p))
             if _cache is not None:
-                _cache[_PREPARED_KEY] = (len(patterns), prepared)
+                _cache[_PREPARED_KEY] = (patterns, len(patterns), prepared)
 
         # relative_to() + _nfc() are the dominant cost in this loop and depend only on
         # the anchor (or on root), never on the individual pattern. Anchors are few,

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1277,6 +1277,12 @@ def _match_anchored_ignore_pattern(path: str, pattern: str) -> bool:
     return _matches(0, 0)
 
 
+# Sentinels for the per-scan caches in _is_ignored. A str key cannot collide with the
+# Path keys the ancestor memo uses.
+_PREPARED_KEY = "__prepared_patterns__"
+_UNSET = object()
+
+
 def _is_ignored(
     path: Path,
     root: Path,
@@ -1320,14 +1326,40 @@ def _is_ignored(
             return False
 
         result = False
-        for anchor, pattern in patterns:
-            negated = pattern.startswith("!")
-            raw = pattern[1:] if negated else pattern
-            directory_only = raw.endswith("/")
-            path_relative = "/" in raw.rstrip("/")
-            p = raw.strip("/")
-            if not p:
-                continue
+
+        # Pattern parsing does not depend on the target, so do it once per scan and
+        # keep it in the shared cache. It used to run for every target: on a repo with
+        # ~55 patterns and ~14k targets that is ~770k redundant string splits.
+        #
+        # Invalidate on pattern count: detect() appends patterns from nested .gitignore
+        # files *during* the walk (see ignore_patterns.extend below), so a frozen parse
+        # would silently stop applying the later ones.
+        prepared = None
+        if _cache is not None:
+            cached = _cache.get(_PREPARED_KEY)
+            if cached is not None and cached[0] == len(patterns):
+                prepared = cached[1]
+        if prepared is None:
+            prepared = []
+            for _anchor, _pattern in patterns:
+                _negated = _pattern.startswith("!")
+                _raw = _pattern[1:] if _negated else _pattern
+                _p = _raw.strip("/")
+                if not _p:
+                    continue
+                prepared.append((_anchor, _negated, _raw.endswith("/"),
+                                 "/" in _raw.rstrip("/"), _p))
+            if _cache is not None:
+                _cache[_PREPARED_KEY] = (len(patterns), prepared)
+
+        # relative_to() + _nfc() are the dominant cost in this loop and depend only on
+        # the anchor (or on root), never on the individual pattern. Anchors are few,
+        # patterns are many, so memoise per target.
+        rel_by_anchor: dict = {}
+        rel_root_cached = _UNSET
+        target_is_dir = None
+
+        for anchor, negated, directory_only, path_relative, p in prepared:
 
             # gitignore semantics: patterns from A/.gitignore apply ONLY to paths
             # under A. Matching non-anchored patterns against root-relative paths
@@ -1335,21 +1367,33 @@ def _is_ignored(
             # (detect() returned 0 files). The anchor dir itself is exempt — an
             # ignore file governs its directory's contents, not the directory.
             matched = False
-            try:
-                rel_anchor = _nfc(str(target.relative_to(anchor)).replace(os.sep, "/"))
-            except ValueError:
-                continue  # target outside this pattern's anchor: cannot match
+            if anchor in rel_by_anchor:
+                rel_anchor = rel_by_anchor[anchor]
+            else:
+                try:
+                    rel_anchor = _nfc(str(target.relative_to(anchor)).replace(os.sep, "/"))
+                except ValueError:
+                    rel_anchor = None  # target outside this anchor: cannot match
+                rel_by_anchor[anchor] = rel_anchor
+            if rel_anchor is None:
+                continue
             if rel_anchor != ".":
                 rel = rel_anchor
-                if not path_relative:
-                    try:
-                        if len(root.parts) > len(anchor.parts):
-                            rel = _nfc(str(target.relative_to(root)).replace(os.sep, "/"))
-                    except ValueError:
-                        pass
+                if not path_relative and len(root.parts) > len(anchor.parts):
+                    if rel_root_cached is _UNSET:
+                        try:
+                            rel_root_cached = _nfc(
+                                str(target.relative_to(root)).replace(os.sep, "/"))
+                        except ValueError:
+                            rel_root_cached = None
+                    if rel_root_cached is not None:
+                        rel = rel_root_cached
                 matched = _matches(rel, p, path_relative=path_relative)
-                if matched and directory_only and not target.is_dir():
-                    matched = False
+                if matched and directory_only:
+                    if target_is_dir is None:
+                        target_is_dir = target.is_dir()
+                    if not target_is_dir:
+                        matched = False
 
             if matched:
                 result = not negated  # last match wins; ! flips to un-ignore

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -3093,3 +3093,29 @@ def test_nested_gitignore_applies_when_patterns_grow_mid_walk(tmp_path):
     assert any("keep.py" in f for f in all_files)
     assert any("kept.py" in f for f in all_files)
     assert not any("skipped.py" in f for f in all_files)  # nested pattern applies too
+
+
+def test_prepared_pattern_cache_is_not_shared_across_pattern_lists(tmp_path):
+    """A shared _cache must not serve one pattern list's parse to another.
+
+    The per-scan parse cache is keyed on the pattern list, not just on its
+    length: detect() only ever grows one list (so length alone suffices there),
+    but _is_ignored takes both `patterns` and `_cache` as arguments, so any
+    other caller can hand it two different lists of equal length. Keyed on
+    length alone, the second call silently matches against the first list's
+    patterns.
+    """
+    (tmp_path / "a.log").write_text("noise")
+    (tmp_path / "b.tmp").write_text("noise")
+    (tmp_path / "c.log").write_text("noise")
+
+    logs = [(tmp_path, "*.log")]
+    temps = [(tmp_path, "*.tmp")]
+    cache: dict = {}
+
+    # First call fills the parse cache from `logs`.
+    assert _is_ignored(tmp_path / "a.log", tmp_path, logs, _cache=cache) is True
+
+    # Same length, different contents: `temps` must be parsed on its own.
+    assert _is_ignored(tmp_path / "b.tmp", tmp_path, temps, _cache=cache) is True
+    assert _is_ignored(tmp_path / "c.log", tmp_path, temps, _cache=cache) is False

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -3066,3 +3066,30 @@ def test_sensitive_env_template_inside_secrets_dir_still_dropped(path):
     """Stage 1 dir guard runs before the Stage 2 template exemption: anything
     under a secrets/credentials dir stays excluded, template suffix or not."""
     assert _is_sensitive(Path(path)), f"{path} is under a secrets dir, must stay excluded (#2184)"
+
+def test_nested_gitignore_applies_when_patterns_grow_mid_walk(tmp_path):
+    """Patterns from a nested .gitignore are appended while the walk is already
+    running, so any per-scan caching of the parsed pattern list must invalidate
+    when the list grows.
+
+    The root .gitignore matters: it makes the parse cache fill up early, before
+    the walk reaches pkg/sub. Without a root pattern _is_ignored returns before
+    touching the cache and the bug cannot reproduce.
+    """
+    (tmp_path / ".gitignore").write_text("*.log\n")
+    (tmp_path / "root.log").write_text("noise")
+    (tmp_path / "keep.py").write_text("x = 1")
+
+    deep = tmp_path / "pkg" / "sub"
+    deep.mkdir(parents=True)
+    (deep / "kept.py").write_text("y = 2")
+    (deep / "skipped.py").write_text("z = 3")
+    (deep / ".gitignore").write_text("skipped.py\n")
+
+    result = detect(tmp_path)
+    all_files = [f for files in result["files"].values() for f in files]
+
+    assert not any("root.log" in f for f in all_files)   # root pattern still applies
+    assert any("keep.py" in f for f in all_files)
+    assert any("kept.py" in f for f in all_files)
+    assert not any("skipped.py" in f for f in all_files)  # nested pattern applies too


### PR DESCRIPTION
## What

`_is_ignored` re-did the same work for every `(target, pattern)` pair, so the cost scaled with `patterns × targets` even though most of that work depends on neither the pattern nor the target:

- **pattern parsing** (`startswith("!")`, `endswith("/")`, `strip("/")`) does not depend on the target at all, yet ran once per target per pattern;
- **`target.relative_to(anchor)` + `_nfc()`** depend only on the anchor — anchors are few, patterns are many;
- **`target.relative_to(root)` + `_nfc()`** depend on neither;
- **`target.is_dir()`** (an `lstat`) ran for every directory-only pattern instead of once per target.

The parse is now done once per scan and kept in the shared cache, the relative paths are memoised per target, and `is_dir()` is lazy. No behaviour change intended.

## Numbers

Measured on an iOS repo: 3614 detected files, ~55 ignore patterns across four `.gitignore` files, 74k files on disk (60k of them under a git-ignored `.build/`).

| | before | after |
|---|---|---|
| `detect()` | 5.34s | **2.24s** (2.4×) |
| `graphify update .` | 13.05s | **9.89s** |

Profiling the original pointed at exactly this loop: 762k `Path.relative_to` calls, 4.6M `fnmatch`, 1.36M `lstat`, with `detect.py:_matches` at 5.8s cumulative.

## Correctness

`detect()` output is **byte-identical** before and after — I compared the full result dict (`files`, `ignored`, `unclassified`, …), not just counts. Counts alone would not have caught the bug below.

Full suite: **the same 25 pre-existing failures before and after**, no new ones. `tests/test_detect.py` and `tests/test_ignore_file_encoding.py`: 261 passed.

## The trap worth reviewing carefully

Caching the parse needs invalidation, because `detect()` appends patterns from nested `.gitignore` files **while the walk is already running** (`ignore_patterns.extend(...)` inside the walk loop). My first version cached the parse unconditionally and silently stopped applying the nested rules — and the detected **file count stayed the same**, so it looked fine.

The cache key is therefore `len(patterns)`, and `tests/test_detect.py::test_nested_gitignore_applies_when_patterns_grow_mid_walk` covers it. That test needs a root-level pattern in the fixture: without one, `_is_ignored` returns before touching the cache and the bug cannot reproduce. I verified the test fails with the guard removed and passes with it — an earlier version of the test passed in both directions and was worthless.

## Notes

- Two sentinels (`_PREPARED_KEY`, `_UNSET`) are module-level; the string cache key cannot collide with the `Path` keys the ancestor memo uses.
- The gain should scale with repo size — more patterns and more files both multiply into the removed work.
