### PR TITLE
feat(extract): add --no-dedup so incremental merges can skip fuzzy dedup (#2881)

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,7 @@ graphify extract ./docs --no-cluster           # raw extraction only, skip clust
 graphify extract ./docs --timing               # print per-stage wall-clock timings to stderr (also works on cluster-only)
 graphify extract ./docs --force                # overwrite graph.json even if new graph has fewer nodes (use after refactors or to clear ghost duplicates)
 graphify extract ./docs --dedup-llm            # LLM tiebreaker for ambiguous entity pairs (uses same API key)
+graphify extract ./src --no-dedup              # skip entity dedup; on an incremental merge this also arms the shrink guard that refuses to drop untouched files' nodes
 graphify extract ./docs --global --as myrepo   # extract and register into the cross-project global graph
 GRAPHIFY_MAX_OUTPUT_TOKENS=32768 graphify extract ./docs --backend claude  # raise output cap for dense corpora
 

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -2849,7 +2849,7 @@ def dispatch_command(cmd: str) -> None:
             print(
                 "Usage: graphify extract <path> [--backend gemini|kimi|claude|openai|deepseek|ollama] "
                 "[--model M] [--mode deep] [--out DIR|--output DIR] [--google-workspace] [--no-cluster] "
-                "[--no-gitignore] [--code-only] "
+                "[--no-gitignore] [--code-only] [--no-dedup] "
                 "[--max-workers N] [--token-budget N] [--max-concurrency N] "
                 "[--api-timeout S] [--postgres DSN] [--cargo] [--allow-partial] [--timing]",
                 file=sys.stderr,
@@ -2875,6 +2875,13 @@ def dispatch_command(cmd: str) -> None:
         cli_allow_partial: bool = False
         no_cluster = False
         dedup_llm = False
+        # --no-dedup: skip entity deduplication entirely. On an incremental
+        # merge the fuzzy pass runs over the COMBINED node set (existing graph +
+        # new chunk), so a small diff merged into a large graph can collapse
+        # pre-existing nodes from files the diff never touched. Turning dedup
+        # off also arms build_merge's #479 shrink guard, which is disabled while
+        # dedup is on because fuzzy merging shrinks the graph legitimately (#2881).
+        no_dedup = False
         google_workspace = False
         global_merge = False
         code_only = False
@@ -2943,6 +2950,8 @@ def dispatch_command(cmd: str) -> None:
                 no_cluster = True; i += 1
             elif a == "--dedup-llm":
                 dedup_llm = True; i += 1
+            elif a == "--no-dedup":
+                no_dedup = True; i += 1
             elif a == "--code-only":
                 code_only = True; i += 1
             elif a == "--google-workspace":
@@ -3000,6 +3009,16 @@ def dispatch_command(cmd: str) -> None:
         if not has_path and cli_postgres_dsn is None:
             print("error: must specify a path to scan or a --postgres DSN", file=sys.stderr)
             sys.exit(1)
+
+        if no_dedup and dedup_llm:
+            # --dedup-llm is pass 3 of the dedup pipeline, so with dedup off it
+            # would be a silent no-op that still demands an API key.
+            print(
+                "error: --no-dedup and --dedup-llm are mutually exclusive "
+                "(--dedup-llm is a tiebreaker inside the dedup pass)",
+                file=sys.stderr,
+            )
+            sys.exit(2)
 
         _VALID_MODES = {"deep"}
         if extract_mode is not None and extract_mode not in _VALID_MODES:
@@ -3906,16 +3925,24 @@ def dispatch_command(cmd: str) -> None:
             for _src in list(excluded_files) + graph_stale_sources:
                 if _src not in _prune_sources:
                     _prune_sources.append(_src)
-            G = _build_merge(
-                [merged],
-                graph_path=existing_graph_path,
-                prune_sources=_prune_sources or None,
-                dedup=True,
-                dedup_llm_backend=dedup_backend,
-                root=target,
-            )
+            try:
+                G = _build_merge(
+                    [merged],
+                    graph_path=existing_graph_path,
+                    prune_sources=_prune_sources or None,
+                    dedup=not no_dedup,
+                    dedup_llm_backend=dedup_backend,
+                    root=target,
+                )
+            except ValueError as exc:
+                # --no-dedup arms build_merge's #479 shrink guard, which refuses
+                # to drop nodes belonging to files this run neither re-extracted
+                # nor pruned. Report the refusal instead of a traceback (#2881):
+                # graph.json on disk is untouched, so the old graph is intact.
+                print(f"[graphify extract] {exc}", file=sys.stderr)
+                sys.exit(1)
         else:
-            G = _build([merged], dedup=True, dedup_llm_backend=dedup_backend, root=target)
+            G = _build([merged], dedup=not no_dedup, dedup_llm_backend=dedup_backend, root=target)
         stages.mark("build")
         if G.number_of_nodes() == 0:
             print(

--- a/tests/test_no_dedup_flag.py
+++ b/tests/test_no_dedup_flag.py
@@ -1,0 +1,104 @@
+"""`graphify extract --no-dedup` (#2881).
+
+The incremental merge path hardcoded `dedup=True`, so fuzzy dedup always ran
+over the COMBINED node set (existing graph + new chunk). On a large graph a
+small diff could therefore collapse pre-existing nodes belonging to files the
+diff never touched, and the #479 shrink guard — the one thing that would have
+caught it — is deliberately skipped while dedup is on, because fuzzy merging
+shrinks the graph legitimately. There was no way to opt out from the CLI.
+"""
+from __future__ import annotations
+
+import graphify.__main__ as mainmod
+
+
+def _corpus(tmp_path):
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "main.go").write_text("package main\nfunc main() {}\n")
+    return corpus
+
+
+def _run(monkeypatch, argv):
+    """Run the CLI and return its exit code (0 when main() simply returns)."""
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv", argv)
+    try:
+        mainmod.main()
+    except SystemExit as exc:
+        return exc.code or 0
+    return 0
+
+
+def _capture_dedup(monkeypatch):
+    """Record the `dedup` kwarg both build entry points are called with."""
+    import graphify.build as buildmod
+
+    seen: dict[str, bool] = {}
+    real_build = buildmod.build
+    real_merge = buildmod.build_merge
+
+    def fake_build(chunks, *a, **kw):
+        seen["build"] = kw.get("dedup", True)
+        return real_build(chunks, *a, **kw)
+
+    def fake_merge(chunks, *a, **kw):
+        seen["build_merge"] = kw.get("dedup", True)
+        return real_merge(chunks, *a, **kw)
+
+    monkeypatch.setattr(buildmod, "build", fake_build)
+    monkeypatch.setattr(buildmod, "build_merge", fake_merge)
+    return seen
+
+
+def test_no_dedup_flag_disables_dedup(monkeypatch, tmp_path):
+    corpus = _corpus(tmp_path)
+    seen = _capture_dedup(monkeypatch)
+    code = _run(monkeypatch, [
+        "graphify", "extract", str(corpus), "--code-only",
+        "--no-dedup", "--out", str(tmp_path / "out"),
+    ])
+    assert code == 0
+    assert seen.get("build") is False
+
+
+def test_dedup_is_on_by_default(monkeypatch, tmp_path):
+    corpus = _corpus(tmp_path)
+    seen = _capture_dedup(monkeypatch)
+    code = _run(monkeypatch, [
+        "graphify", "extract", str(corpus), "--code-only",
+        "--out", str(tmp_path / "out"),
+    ])
+    assert code == 0
+    assert seen.get("build") is True
+
+
+def test_no_dedup_reaches_the_incremental_merge(monkeypatch, tmp_path):
+    corpus = _corpus(tmp_path)
+    out = tmp_path / "out"
+    # First run establishes graph.json, so the second run takes the
+    # build_merge (incremental) path rather than build().
+    assert _run(monkeypatch, [
+        "graphify", "extract", str(corpus), "--code-only",
+        "--out", str(out),
+    ]) == 0
+
+    (corpus / "other.go").write_text("package main\nfunc other() {}\n")
+    seen = _capture_dedup(monkeypatch)
+    assert _run(monkeypatch, [
+        "graphify", "extract", str(corpus), "--code-only",
+        "--no-dedup", "--out", str(out),
+    ]) == 0
+    assert seen.get("build_merge") is False, (
+        "the incremental path hardcoded dedup=True, which is the bug"
+    )
+
+
+def test_no_dedup_conflicts_with_dedup_llm(monkeypatch, tmp_path, capsys):
+    corpus = _corpus(tmp_path)
+    code = _run(monkeypatch, [
+        "graphify", "extract", str(corpus), "--code-only",
+        "--no-dedup", "--dedup-llm", "--out", str(tmp_path / "out"),
+    ])
+    assert code == 2
+    assert "mutually exclusive" in capsys.readouterr().err

--- a/tests/test_no_dedup_flag.py
+++ b/tests/test_no_dedup_flag.py
@@ -31,7 +31,19 @@ def _run(monkeypatch, argv):
 
 
 def _capture_dedup(monkeypatch):
-    """Record the `dedup` kwarg both build entry points are called with."""
+    """Record the `dedup` kwarg both build entry points are called with.
+
+    Patching `graphify.build` does reach the CLI's `_build` / `_build_merge`
+    aliases, even though it refers to them by those names: the
+
+        from graphify.build import build as _build, build_merge as _build_merge
+
+    is function-local to `dispatch_command`, so the alias is bound when the
+    command runs, which is after this patch is installed. A module-level import
+    would bind at import time and make the patch inert — `_assert_spied` below
+    turns that into a loud failure rather than a test that quietly asserts
+    nothing.
+    """
     import graphify.build as buildmod
 
     seen: dict[str, bool] = {}
@@ -51,6 +63,16 @@ def _capture_dedup(monkeypatch):
     return seen
 
 
+def _assert_spied(seen: dict, entry_point: str) -> None:
+    """Fail loudly if the spy never fired, so no assertion is vacuous."""
+    assert entry_point in seen, (
+        f"{entry_point}() was never called through the patched "
+        f"graphify.build symbol — the spy is inert and every dedup assertion "
+        f"below it would be vacuous. Did the CLI's import of it move to module "
+        f"scope, or did this run take a path that skips the build stage?"
+    )
+
+
 def test_no_dedup_flag_disables_dedup(monkeypatch, tmp_path):
     corpus = _corpus(tmp_path)
     seen = _capture_dedup(monkeypatch)
@@ -59,7 +81,8 @@ def test_no_dedup_flag_disables_dedup(monkeypatch, tmp_path):
         "--no-dedup", "--out", str(tmp_path / "out"),
     ])
     assert code == 0
-    assert seen.get("build") is False
+    _assert_spied(seen, "build")
+    assert seen["build"] is False
 
 
 def test_dedup_is_on_by_default(monkeypatch, tmp_path):
@@ -70,7 +93,8 @@ def test_dedup_is_on_by_default(monkeypatch, tmp_path):
         "--out", str(tmp_path / "out"),
     ])
     assert code == 0
-    assert seen.get("build") is True
+    _assert_spied(seen, "build")
+    assert seen["build"] is True
 
 
 def test_no_dedup_reaches_the_incremental_merge(monkeypatch, tmp_path):
@@ -89,7 +113,8 @@ def test_no_dedup_reaches_the_incremental_merge(monkeypatch, tmp_path):
         "graphify", "extract", str(corpus), "--code-only",
         "--no-dedup", "--out", str(out),
     ]) == 0
-    assert seen.get("build_merge") is False, (
+    _assert_spied(seen, "build_merge")
+    assert seen["build_merge"] is False, (
         "the incremental path hardcoded dedup=True, which is the bug"
     )
 


### PR DESCRIPTION
Fixes #2881.

Implements the issue's primary request: a CLI opt-out from entity dedup, so incremental updates on large graphs can skip the fuzzy pass and get the shrink guard for free.

## The gap

`build_merge()` already accepts `dedup: bool = True`, but the CLI hardcoded `dedup=True` on the incremental path (`cli.py`, the `if incremental_mode:` branch) with no flag to override it. That matters because the fuzzy pass runs over the **combined** node set — existing graph plus new chunk — so a small diff merged into a large graph compares every new node against every pre-existing one.

And as the issue points out, the safety net for exactly this case is inverted:

```python
# Safety check: refuse to SILENTLY drop nodes (#479, reworked in #2497)
if had_graph and not dedup:
```

The guard is **disabled** in the only mode reachable from the CLI, and **armed** in the mode that was unreachable from it.

## What this adds

`graphify extract <path> --no-dedup`:

- passes `dedup=False` to both `build()` (full build) and `build_merge()` (incremental merge);
- therefore arms build_merge's #479 shrink guard, which refuses to drop nodes from sources this run neither re-extracted nor pruned;
- surfaces that refusal as a clean `[graphify extract] …` error and exit 1 rather than an unhandled `ValueError` traceback. `graph.json` on disk is untouched when it fires, so the existing graph survives the refusal;
- is rejected together with `--dedup-llm` (exit 2). The LLM tiebreaker is pass 3 *inside* the dedup pipeline, so combining them would be a silent no-op that still demands an API key.

Documented in the README flag list and in `graphify extract`'s usage line.

## One note on the traced root cause

The issue was filed against 0.8.28, and on current `v8` both dedup passes now skip code symbols outright:

```python
# Code symbols are excluded from fuzzy matching too: two functions with
# similar long names in different files … must not be fuzzy-merged (#1205)
if _is_code(node):
    continue
```

So the specific losses reported — `AdminPanel.tsx`, `LoginModal.tsx`, Python builtins like `date`/`int` — should no longer be reachable through pass 2 on the current release; #1205, #1243, #2182, #1284 and #2576 each narrowed that path after 0.8.28. I have deliberately **not** claimed this PR fixes those merges, since I could not reproduce them on `v8`.

What is verifiably still true is the part this PR addresses: the incremental path had no opt-out, and the shrink guard was unreachable from the CLI. If the reporter still sees shrinkage on 0.9.x, `--no-dedup` now turns a silent 5-10% loss into a loud refusal naming the first unexplained node — which is the diagnostic the issue was missing.

## Not included

Scoping pass 2's candidate set to the current diff plus its direct neighbours (the issue's alternative suggestion). That changes dedup quality for every user on every run and wants its own benchmarking against the corpora that motivated the existing thresholds; it did not belong in the same change as an opt-out flag.

`graphify update` needs no flag: it routes through `watch._rebuild_code` → `build_from_json`, which never calls `deduplicate_entities`.

## Tests

`tests/test_no_dedup_flag.py` — the flag reaches `build()`, dedup stays on by default, the flag reaches `build_merge()` on a genuine second (incremental) run, and the `--dedup-llm` conflict exits 2. Three of the four fail without the change.