### PR TITLE
feat(sql): link SQL tables to the code that queries them (#2884)

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ These are only needed for **headless / CI extraction** (`graphify extract`). Whe
 | `GRAPHIFY_MAX_OUTPUT_TOKENS` | Raise output cap for dense corpora | optional — e.g. `32768` for large files |
 | `GRAPHIFY_API_TIMEOUT` | Per-call timeout in seconds for HTTP, claude-cli, Anthropic SDK, and Bedrock backends (default: 600) | optional — also `--api-timeout` flag |
 | `GRAPHIFY_MAX_RETRIES` | How many times to retry a rate-limited (429) request before giving up (default: 6; honors `Retry-After`) | optional — raise for strict per-org limits (e.g. kimi); `0` disables |
-| `GRAPHIFY_NO_SQL_LINKS` | Skip the pass that links SQL tables to the code whose queries name them | optional — set to `1` for ORM-based repos, which name tables via model classes rather than in SQL text |
+| `GRAPHIFY_NO_SQL_LINKS` | Skip the pass that links SQL tables to the code whose queries name them | optional — also `--no-sql-links` flag; useful for ORM-based repos, which name tables via model classes rather than in SQL text |
 | `GRAPHIFY_FORCE` | Force graph rebuild even with fewer nodes | optional — also `--force` flag |
 | `GRAPHIFY_GOOGLE_WORKSPACE` | Auto-enable Google Workspace export | optional — set to `1` |
 | `GRAPHIFY_TRIAGE_BACKEND` | Backend for `graphify prs --triage` | optional — auto-detected from available keys |
@@ -749,6 +749,7 @@ graphify extract ./docs --no-cluster           # raw extraction only, skip clust
 graphify extract ./docs --timing               # print per-stage wall-clock timings to stderr (also works on cluster-only)
 graphify extract ./docs --force                # overwrite graph.json even if new graph has fewer nodes (use after refactors or to clear ghost duplicates)
 graphify extract ./docs --dedup-llm            # LLM tiebreaker for ambiguous entity pairs (uses same API key)
+graphify extract ./src --no-sql-links          # skip linking SQL tables to the code whose queries name them (useful for ORM-based repos)
 graphify extract ./docs --global --as myrepo   # extract and register into the cross-project global graph
 GRAPHIFY_MAX_OUTPUT_TOKENS=32768 graphify extract ./docs --backend claude  # raise output cap for dense corpora
 

--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ These are only needed for **headless / CI extraction** (`graphify extract`). Whe
 | `GRAPHIFY_MAX_OUTPUT_TOKENS` | Raise output cap for dense corpora | optional — e.g. `32768` for large files |
 | `GRAPHIFY_API_TIMEOUT` | Per-call timeout in seconds for HTTP, claude-cli, Anthropic SDK, and Bedrock backends (default: 600) | optional — also `--api-timeout` flag |
 | `GRAPHIFY_MAX_RETRIES` | How many times to retry a rate-limited (429) request before giving up (default: 6; honors `Retry-After`) | optional — raise for strict per-org limits (e.g. kimi); `0` disables |
+| `GRAPHIFY_NO_SQL_LINKS` | Skip the pass that links SQL tables to the code whose queries name them | optional — set to `1` for ORM-based repos, which name tables via model classes rather than in SQL text |
 | `GRAPHIFY_FORCE` | Force graph rebuild even with fewer nodes | optional — also `--force` flag |
 | `GRAPHIFY_GOOGLE_WORKSPACE` | Auto-enable Google Workspace export | optional — set to `1` |
 | `GRAPHIFY_TRIAGE_BACKEND` | Backend for `graphify prs --triage` | optional — auto-detected from available keys |

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -2849,7 +2849,7 @@ def dispatch_command(cmd: str) -> None:
             print(
                 "Usage: graphify extract <path> [--backend gemini|kimi|claude|openai|deepseek|ollama] "
                 "[--model M] [--mode deep] [--out DIR|--output DIR] [--google-workspace] [--no-cluster] "
-                "[--no-gitignore] [--code-only] "
+                "[--no-gitignore] [--code-only] [--no-sql-links] "
                 "[--max-workers N] [--token-budget N] [--max-concurrency N] "
                 "[--api-timeout S] [--postgres DSN] [--cargo] [--allow-partial] [--timing]",
                 file=sys.stderr,
@@ -2875,6 +2875,12 @@ def dispatch_command(cmd: str) -> None:
         cli_allow_partial: bool = False
         no_cluster = False
         dedup_llm = False
+        # --no-sql-links: skip the pass that links SQL tables to the code whose
+        # queries name them (#2884). On by default, like every other language
+        # resolver, because a schema that is invisible to the graph is the
+        # problem it exists to fix; an ORM-based repo names tables via model
+        # classes and gets little from it.
+        no_sql_links = False
         google_workspace = False
         global_merge = False
         code_only = False
@@ -2943,6 +2949,8 @@ def dispatch_command(cmd: str) -> None:
                 no_cluster = True; i += 1
             elif a == "--dedup-llm":
                 dedup_llm = True; i += 1
+            elif a == "--no-sql-links":
+                no_sql_links = True; i += 1
             elif a == "--code-only":
                 code_only = True; i += 1
             elif a == "--google-workspace":
@@ -3019,6 +3027,11 @@ def dispatch_command(cmd: str) -> None:
             os.environ["GRAPHIFY_API_TIMEOUT"] = str(cli_api_timeout)
         if cli_max_workers is not None:
             os.environ["GRAPHIFY_MAX_WORKERS"] = str(cli_max_workers)
+        # Same bridge as --api-timeout above: the SQL resolver runs inside
+        # extract() with no access to CLI args, so the flag sets the env var
+        # it already reads. The flag wins; the env var alone still works.
+        if no_sql_links:
+            os.environ["GRAPHIFY_NO_SQL_LINKS"] = "1"
 
         # Resolve output dir. The user-facing contract is "<out>/graphify-out/"
         # so a fresh checkout writes graphify-out/ at the project root, matching

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -22,6 +22,7 @@ from .resolver_registry import (
     run_language_resolvers,
 )
 from .ruby_resolution import resolve_ruby_member_calls
+from .sql_resolution import resolve_sql_table_references
 from .pascal_resolution import resolve_pascal_inherited_calls
 
 # --- migrated to graphify/extractors/ (see graphify/extractors/MIGRATION.md) ---
@@ -3855,6 +3856,13 @@ register_language_resolver(
     LanguageResolver(
         "kotlin_qualified_calls", frozenset({".kt", ".kts"}), _resolve_kotlin_qualified_calls
     )
+)
+# SQL <-> host-language linkage (#2884): a table declared in a .sql file gets a
+# `references` edge from every non-SQL source whose text names it in a SQL
+# keyword position. Lexical by necessity — the table name lives inside a string
+# literal the host grammar never looks into. Lives in graphify.sql_resolution.
+register_language_resolver(
+    LanguageResolver("sql_table_references", frozenset({".sql"}), resolve_sql_table_references)
 )
 
 

--- a/graphify/sql_resolution.py
+++ b/graphify/sql_resolution.py
@@ -1,0 +1,170 @@
+"""Link SQL tables to the application code that queries them (#2884).
+
+``tree-sitter-sql`` extracts table declarations correctly and the host-language
+grammars extract the application code correctly, but nothing connected the two:
+a table declared in ``db/schema.sql`` had no edge to the ``.ts`` file whose query
+reads ``SELECT … FROM that_table``. Every table landed connected only to the file
+that declares it (``contains``, degree 1), so the data layer floated free of the
+application and the graph could not answer "what breaks if I change this table?".
+
+This is a text-embedding problem rather than an AST one — the table name lives
+inside a template literal that the TypeScript grammar sees only as a string — so
+the pass is lexical: after per-file extraction, scan every non-SQL source for
+each declared table name and emit a ``references`` edge from the referencing file
+to the table.
+
+Precision is the whole difficulty. Table names like ``users``, ``events``,
+``sales`` and ``notifications`` are extremely common ordinary identifiers, and a
+matcher that asks "does this file contain SQL anywhere, and does this table name
+appear anywhere in it" produces mostly phantoms — on the reporting corpus, 1,489
+edges of which the 130 for ``events`` were all JavaScript variables named
+``events``. The table must therefore sit in a real SQL keyword position **in the
+same match**, which brings that corpus to 921 edges that hand-checked clean.
+
+Set ``GRAPHIFY_NO_SQL_LINKS=1`` to skip the pass (a repo that reaches its
+database through an ORM gets little from it, since ORMs name tables via model
+classes rather than in SQL text).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import PurePath
+
+# A table name only counts when it directly follows one of these. Run over the
+# whole file text rather than line by line, so a table named on the second line
+# of a multi-line template literal still matches.
+_SQL_KEYWORDS = r"(?:FROM|JOIN|INTO|UPDATE|REFERENCES|TABLE(?:\s+IF\s+NOT\s+EXISTS)?)"
+# Identifier quoting differs by dialect: MySQL backticks, standard SQL double
+# quotes, T-SQL brackets (cf. #2712). Unquoted is the common case.
+_OPEN_QUOTE = r"[`\"\[]?"
+_CLOSE_QUOTE = r"[`\"\]]?"
+
+# Files larger than this are not scanned: a multi-megabyte bundle or generated
+# artifact costs more to read than the edges it could plausibly contribute.
+_MAX_SCAN_BYTES = 2 * 1024 * 1024
+
+
+def _table_pattern(name: str) -> "re.Pattern[str]":
+    return re.compile(
+        _SQL_KEYWORDS + r"\s+" + _OPEN_QUOTE + re.escape(name) + _CLOSE_QUOTE + r"\b",
+        re.IGNORECASE,
+    )
+
+
+def _declared_tables(all_nodes: list[dict], all_edges: list[dict]) -> dict[str, list[str]]:
+    """Map table name -> node ids of every ``.sql`` file that declares it.
+
+    A declaration is the target of a ``contains`` edge from a ``.sql`` file, which
+    is exactly how the SQL extractor anchors tables and views it defines. The
+    sourceless reference stubs it mints for tables defined in another file carry
+    no ``contains`` edge, so they are excluded — a stub is not a declaration site.
+    """
+    sql_files = {
+        n["id"] for n in all_nodes
+        if isinstance(n, dict) and str(n.get("source_file", "")).lower().endswith(".sql")
+        and n.get("source_location") in (None, "", "L1")
+        and str(n.get("label", "")).lower().endswith(".sql")
+    }
+    if not sql_files:
+        return {}
+    labels = {
+        n["id"]: str(n.get("label", ""))
+        for n in all_nodes
+        if isinstance(n, dict) and n.get("id")
+    }
+    declared: dict[str, list[str]] = {}
+    for e in all_edges:
+        if not isinstance(e, dict) or e.get("relation") != "contains":
+            continue
+        if e.get("source") not in sql_files:
+            continue
+        target = e.get("target")
+        label = labels.get(target, "")
+        # Bare identifiers only: anything punctuated is a column, a member or a
+        # file node, none of which is addressable as `FROM <name>`.
+        if not label or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_$]*", label):
+            continue
+        ids = declared.setdefault(label, [])
+        if target not in ids:
+            ids.append(target)
+    return declared
+
+
+def _scannable_sources(all_nodes: list[dict]) -> list[tuple[str, str]]:
+    """(source_file, file node id) for every non-SQL source, in stable order.
+
+    The file node is the one labelled with the file's basename. Its id cannot be
+    recomputed from the path here: by the time resolvers run, ids have already
+    been made portable, so ``make_id(source_file)`` no longer matches. Extractors
+    emit the file node before anything else in the file, so the first match wins
+    if a symbol happens to share the basename.
+    """
+    seen: set[str] = set()
+    out: list[tuple[str, str]] = []
+    for n in all_nodes:
+        if not isinstance(n, dict) or not n.get("id"):
+            continue
+        sf = str(n.get("source_file") or "")
+        if not sf or sf in seen or sf.lower().endswith(".sql"):
+            continue
+        if str(n.get("label", "")) != PurePath(sf).name:
+            continue
+        seen.add(sf)
+        out.append((sf, n["id"]))
+    return out
+
+
+def resolve_sql_table_references(
+    per_file: list[dict],
+    all_nodes: list[dict],
+    all_edges: list[dict],
+) -> None:
+    """Emit ``references`` edges from application files to the tables they query."""
+    if os.environ.get("GRAPHIFY_NO_SQL_LINKS", "").strip().lower() in ("1", "true", "yes"):
+        return
+
+    declared = _declared_tables(all_nodes, all_edges)
+    if not declared:
+        return
+
+    patterns = {name: _table_pattern(name) for name in declared}
+
+    for sf, file_nid in _scannable_sources(all_nodes):
+        try:
+            with open(sf, "rb") as fh:
+                blob = fh.read(_MAX_SCAN_BYTES + 1)
+        except OSError:
+            continue
+        if len(blob) > _MAX_SCAN_BYTES:
+            continue
+        text = blob.decode("utf-8", errors="replace")
+        # Cheap pre-filter: no SQL keyword at all means no possible match, which
+        # skips the per-table scan for the overwhelming majority of files.
+        if not re.search(_SQL_KEYWORDS + r"\s", text, re.IGNORECASE):
+            continue
+        for name, table_nids in declared.items():
+            m = patterns[name].search(text)
+            if m is None:
+                continue
+            line = text.count("\n", 0, m.start()) + 1
+            for table_nid in table_nids:
+                if table_nid == file_nid:
+                    continue
+                all_edges.append({
+                    "source": file_nid,
+                    "target": table_nid,
+                    "relation": "references",
+                    # The table name is written verbatim in a SQL keyword
+                    # position in this file — a checkable claim, not an
+                    # inference. `calls` edges must stay within one language
+                    # (see references/extraction-spec.md); `references` is a
+                    # different relation and this is what it is for.
+                    "confidence": "EXTRACTED",
+                    "confidence_score": 1.0,
+                    "source_file": sf,
+                    "source_location": f"L{line}",
+                    "weight": 1.0,
+                    "context": "sql_table",
+                })

--- a/graphify/sql_resolution.py
+++ b/graphify/sql_resolution.py
@@ -18,8 +18,12 @@ Precision is the whole difficulty. Table names like ``users``, ``events``,
 matcher that asks "does this file contain SQL anywhere, and does this table name
 appear anywhere in it" produces mostly phantoms — on the reporting corpus, 1,489
 edges of which the 130 for ``events`` were all JavaScript variables named
-``events``. The table must therefore sit in a real SQL keyword position **in the
-same match**, which brings that corpus to 921 edges that hand-checked clean.
+``events``. Three conditions have to hold together:
+
+1. the table sits in a real SQL keyword position (``FROM users``, not ``users``);
+2. inside a string literal, so a ``// SELECT foo FROM events`` comment is out;
+3. near a statement head, so prose that merely names a keyword — ``"the FROM
+   users keyword"``, a docstring saying "you can JOIN users with assets" — is out.
 
 Set ``GRAPHIFY_NO_SQL_LINKS=1`` to skip the pass (a repo that reaches its
 database through an ORM gets little from it, since ORMs name tables via model
@@ -32,6 +36,8 @@ import os
 import re
 from pathlib import PurePath
 
+from graphify.extractors.sql import _norm_ident
+
 # A table name only counts when it directly follows one of these. Run over the
 # whole file text rather than line by line, so a table named on the second line
 # of a multi-line template literal still matches.
@@ -41,6 +47,40 @@ _SQL_KEYWORDS = r"(?:FROM|JOIN|INTO|UPDATE|REFERENCES|TABLE(?:\s+IF\s+NOT\s+EXIS
 _OPEN_QUOTE = r"[`\"\[]?"
 _CLOSE_QUOTE = r"[`\"\]]?"
 
+# `FROM public.users` and `FROM "public"."users"` have to reach a table declared
+# as `public.users`, so the pattern matches the bare name with an optional schema
+# qualifier in front. Without this a Postgres or T-SQL corpus, where every
+# CREATE TABLE is schema-qualified, produced no edges at all.
+_QUALIFIER = _OPEN_QUOTE + r"[A-Za-z_][A-Za-z0-9_$]*" + _CLOSE_QUOTE + r"\s*\.\s*"
+
+# A keyword position is necessary but not sufficient: the match also has to sit
+# inside a string literal, near a statement head. Scanning the raw bytes minted
+# an edge for any keyword+table pair anywhere in the file, including comments and
+# ordinary prose.
+_STATEMENT_HEAD = re.compile(
+    r"\b(?:SELECT|INSERT|UPDATE|DELETE|WITH|CREATE|ALTER|DROP|TRUNCATE|MERGE|REPLACE)\b",
+    re.IGNORECASE,
+)
+# How far back from the table name a statement head may sit — enough for a long
+# column list and the whitespace of a formatted multi-line query.
+# ponytail: fixed window, not a SQL parser. A docstring that names a table
+# within 500 chars of a genuine query in the same file still links; parse the
+# host language's strings properly if that ever bites.
+_HEAD_WINDOW = 500
+
+# The string literals of the languages that embed SQL: Python triple quotes,
+# JS/TS template literals and Go raw strings (backticks), and ordinary single-
+# and double-quoted strings. Heredocs (PHP `<<<SQL`, Ruby `<<~SQL`) are not
+# literals by this definition and so are not scanned.
+_STRING = re.compile(
+    r'"""[\s\S]*?"""'
+    r"|'''[\s\S]*?'''"
+    r"|`(?:\\.|[^\\`])*`"
+    r'|"(?:\\.|[^"\\\n])*"'
+    r"|'(?:\\.|[^'\\\n])*'"
+)
+_NON_NEWLINE = re.compile(r"[^\n]")
+
 # Files larger than this are not scanned: a multi-megabyte bundle or generated
 # artifact costs more to read than the edges it could plausibly contribute.
 _MAX_SCAN_BYTES = 2 * 1024 * 1024
@@ -48,18 +88,55 @@ _MAX_SCAN_BYTES = 2 * 1024 * 1024
 
 def _table_pattern(name: str) -> "re.Pattern[str]":
     return re.compile(
-        _SQL_KEYWORDS + r"\s+" + _OPEN_QUOTE + re.escape(name) + _CLOSE_QUOTE + r"\b",
+        _SQL_KEYWORDS + r"\s+(?:" + _QUALIFIER + r")?"
+        + _OPEN_QUOTE + re.escape(name) + _CLOSE_QUOTE + r"\b",
         re.IGNORECASE,
     )
 
 
+def _strings_only(text: str) -> str:
+    """Blank every character outside a string literal, preserving offsets.
+
+    Offsets and newlines survive, so a match's line number is still the line it
+    occupies in the real file. Blanking rather than extracting also keeps
+    adjacent literals adjacent, so Python implicit concatenation —
+    ``"SELECT id " "FROM users"`` — still reads as one statement.
+    """
+    out: list[str] = []
+    pos = 0
+    for m in _STRING.finditer(text):
+        out.append(_NON_NEWLINE.sub(" ", text[pos:m.start()]))
+        out.append(m.group())
+        pos = m.end()
+    out.append(_NON_NEWLINE.sub(" ", text[pos:]))
+    return "".join(out)
+
+
+def _first_query_match(pattern: "re.Pattern[str]", text: str):
+    """First keyword+table match that a statement head vouches for.
+
+    ``text`` is already string-literal-only, so what is left to reject is prose
+    inside a string: ``"the FROM users keyword"`` names a keyword without being a
+    query. Looking back a bounded distance for SELECT/INSERT/… separates the two.
+    """
+    for m in pattern.finditer(text):
+        if _STATEMENT_HEAD.search(text[max(0, m.start() - _HEAD_WINDOW):m.end()]):
+            return m
+    return None
+
+
 def _declared_tables(all_nodes: list[dict], all_edges: list[dict]) -> dict[str, list[str]]:
-    """Map table name -> node ids of every ``.sql`` file that declares it.
+    """Map bare table name -> node ids of every ``.sql`` file that declares it.
 
     A declaration is the target of a ``contains`` edge from a ``.sql`` file, which
     is exactly how the SQL extractor anchors tables and views it defines. The
     sourceless reference stubs it mints for tables defined in another file carry
     no ``contains`` edge, so they are excluded — a stub is not a declaration site.
+
+    Labels are stored verbatim, so ``CREATE TABLE public.users`` is labelled
+    ``public.users``. Keys are the normalized bare name (``users``): the schema
+    qualifier is optional at the reference site and usually absent there, so
+    keying by the label left a schema-qualified corpus with zero edges.
     """
     sql_files = {
         n["id"] for n in all_nodes
@@ -82,11 +159,14 @@ def _declared_tables(all_nodes: list[dict], all_edges: list[dict]) -> dict[str, 
             continue
         target = e.get("target")
         label = labels.get(target, "")
-        # Bare identifiers only: anything punctuated is a column, a member or a
-        # file node, none of which is addressable as `FROM <name>`.
-        if not label or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_$]*", label):
+        if not label:
             continue
-        ids = declared.setdefault(label, [])
+        # Identifiers only, part by part: anything else punctuated is a column,
+        # a member or a file node, none of which is addressable as `FROM <name>`.
+        parts = _norm_ident(label).split(".")
+        if not all(re.fullmatch(r"[a-z_][a-z0-9_$]*", p) for p in parts):
+            continue
+        ids = declared.setdefault(parts[-1], [])
         if target not in ids:
             ids.append(target)
     return declared
@@ -139,13 +219,15 @@ def resolve_sql_table_references(
             continue
         if len(blob) > _MAX_SCAN_BYTES:
             continue
-        text = blob.decode("utf-8", errors="replace")
-        # Cheap pre-filter: no SQL keyword at all means no possible match, which
-        # skips the per-table scan for the overwhelming majority of files.
-        if not re.search(_SQL_KEYWORDS + r"\s", text, re.IGNORECASE):
+        raw = blob.decode("utf-8", errors="replace")
+        # Cheap pre-filter before the cost of masking: no SQL keyword at all
+        # means no possible match, which skips the rest for the overwhelming
+        # majority of files.
+        if not re.search(_SQL_KEYWORDS + r"\s", raw, re.IGNORECASE):
             continue
+        text = _strings_only(raw)
         for name, table_nids in declared.items():
-            m = patterns[name].search(text)
+            m = _first_query_match(patterns[name], text)
             if m is None:
                 continue
             line = text.count("\n", 0, m.start()) + 1
@@ -157,10 +239,10 @@ def resolve_sql_table_references(
                     "target": table_nid,
                     "relation": "references",
                     # The table name is written verbatim in a SQL keyword
-                    # position in this file — a checkable claim, not an
-                    # inference. `calls` edges must stay within one language
-                    # (see references/extraction-spec.md); `references` is a
-                    # different relation and this is what it is for.
+                    # position inside a query string in this file — a checkable
+                    # claim, not an inference. `calls` edges must stay within one
+                    # language (see references/extraction-spec.md); `references`
+                    # is a different relation and this is what it is for.
                     "confidence": "EXTRACTED",
                     "confidence_score": 1.0,
                     "source_file": sf,

--- a/tests/test_sql_table_references.py
+++ b/tests/test_sql_table_references.py
@@ -152,3 +152,49 @@ def test_quoted_table_names_match(tmp_path):
     result = extract(paths, cache_root=tmp_path)
     linked = {f for f, label in _refs(result) if label == "user_email_preferences"}
     assert linked == {"mysql.ts", "pg.ts", "tsql.ts"}
+
+
+def _run_cli(monkeypatch, argv):
+    import graphify.__main__ as mainmod
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv", argv)
+    try:
+        mainmod.main()
+    except SystemExit as exc:
+        return exc.code or 0
+    return 0
+
+
+def _graph_edges(out_dir):
+    import json
+    return json.loads((out_dir / "graphify-out" / "graph.json").read_text())
+
+
+def test_cli_flag_skips_the_pass(tmp_path, monkeypatch):
+    """#2884 review: the pass is on by default, so the opt-out has to be a real
+    flag and not only an env var a user has to know exists."""
+    monkeypatch.delenv("GRAPHIFY_NO_SQL_LINKS", raising=False)
+    root, db, src = _corpus(tmp_path)
+    out = tmp_path / "out"
+    assert _run_cli(monkeypatch, [
+        "graphify", "extract", str(root), "--code-only", "--no-cluster",
+        "--no-sql-links", "--out", str(out),
+    ]) == 0
+    graph = _graph_edges(out)
+    links = [e for e in graph.get("links", graph.get("edges", []))
+             if e.get("context") == "sql_table"]
+    assert links == []
+
+
+def test_cli_emits_the_links_by_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("GRAPHIFY_NO_SQL_LINKS", raising=False)
+    root, db, src = _corpus(tmp_path)
+    out = tmp_path / "out"
+    assert _run_cli(monkeypatch, [
+        "graphify", "extract", str(root), "--code-only", "--no-cluster",
+        "--out", str(out),
+    ]) == 0
+    graph = _graph_edges(out)
+    links = [e for e in graph.get("links", graph.get("edges", []))
+             if e.get("context") == "sql_table"]
+    assert links, "the pass is on by default — that is the point of the issue"

--- a/tests/test_sql_table_references.py
+++ b/tests/test_sql_table_references.py
@@ -1,0 +1,154 @@
+"""SQL tables are linked to the application code that queries them (#2884).
+
+Before this pass a table declared in `db/schema.sql` had no edge to the `.ts`
+file whose query reads `SELECT … FROM that_table` — the whole data layer landed
+as degree-1 orphans and the graph could not answer "what breaks if I change this
+table?".
+"""
+from __future__ import annotations
+
+import pytest
+
+from graphify.extract import extract
+
+pytest.importorskip("tree_sitter_sql")
+pytest.importorskip("tree_sitter_typescript")
+
+
+def _corpus(tmp_path):
+    db = tmp_path / "db"
+    db.mkdir()
+    (db / "schema.sql").write_text(
+        "CREATE TABLE volunteer_assignments (id INT, note TEXT);\n"
+        "CREATE TABLE events (id INT);\n"
+        "CREATE TABLE never_queried (id INT);\n"
+    )
+    migrations = db / "migrations"
+    migrations.mkdir()
+    (migrations / "035_volunteers.sql").write_text(
+        "CREATE TABLE volunteer_assignments (id INT, note TEXT);\n"
+    )
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "assignments.ts").write_text(
+        "export async function load(id: number) {\n"
+        "  return await query(`\n"
+        "    SELECT a.id, a.note\n"
+        "    FROM volunteer_assignments\n"
+        "    WHERE a.id = ?`, [id]);\n"
+        "}\n"
+    )
+    (src / "roster.ts").write_text(
+        "export async function add(v: string) {\n"
+        "  await query(`INSERT INTO volunteer_assignments (note) VALUES (?)`, [v]);\n"
+        "}\n"
+    )
+    return tmp_path, db, src
+
+
+def _refs(result):
+    """(source_file basename, target label) for every sql_table reference edge."""
+    labels = {n["id"]: n.get("label") for n in result["nodes"]}
+    out = []
+    for e in result["edges"]:
+        if e.get("context") != "sql_table":
+            continue
+        out.append((str(e.get("source_file", "")).replace("\\", "/").split("/")[-1],
+                    labels.get(e["target"])))
+    return sorted(out)
+
+
+def test_queried_table_links_to_every_declaration_site(tmp_path):
+    root, db, src = _corpus(tmp_path)
+    paths = sorted(db.rglob("*.sql")) + sorted(src.glob("*.ts"))
+    result = extract(paths, cache_root=tmp_path)
+
+    refs = _refs(result)
+    # Both querying files link to the table, and each links to BOTH declaration
+    # sites (schema.sql and the migration that created it), so tracing a table
+    # also reaches its migration history.
+    assert refs.count(("assignments.ts", "volunteer_assignments")) == 2
+    assert refs.count(("roster.ts", "volunteer_assignments")) == 2
+
+    # Edges are EXTRACTED with full confidence: the name is written verbatim in
+    # a SQL keyword position, which is a checkable claim rather than a guess.
+    sql_edges = [e for e in result["edges"] if e.get("context") == "sql_table"]
+    assert all(e["confidence"] == "EXTRACTED" for e in sql_edges)
+    assert all(e["confidence_score"] == 1.0 for e in sql_edges)
+    assert all(e["relation"] == "references" for e in sql_edges)
+
+
+def test_table_is_no_longer_a_degree_one_orphan(tmp_path):
+    root, db, src = _corpus(tmp_path)
+    paths = sorted(db.rglob("*.sql")) + sorted(src.glob("*.ts"))
+    result = extract(paths, cache_root=tmp_path)
+
+    table_ids = {
+        n["id"] for n in result["nodes"]
+        if n.get("label") == "volunteer_assignments"
+    }
+    degree = sum(
+        1 for e in result["edges"]
+        if e.get("source") in table_ids or e.get("target") in table_ids
+    )
+    assert degree > 2, "the table should reach the routes that query it"
+
+
+def test_a_table_named_like_a_variable_is_not_falsely_linked(tmp_path):
+    """The precision trap the issue warns about.
+
+    Matching a table name on a word boundary and applying the SQL-context test
+    file-wide — "does this file contain SQL anywhere, and does this name appear
+    anywhere in it" — produced 130 phantom `events` edges that were all
+    JavaScript variables named `events`. The table must sit in a SQL keyword
+    position IN THE SAME MATCH.
+    """
+    root, db, src = _corpus(tmp_path)
+    (src / "widget.ts").write_text(
+        "const events = [1, 2, 3];\n"
+        "export function count() {\n"
+        "  return events.length + events.filter(Boolean).length;\n"
+        "}\n"
+        "// note: we also SELECT things from the events array below\n"
+        "export const first = events[0];\n"
+    )
+    paths = sorted(db.rglob("*.sql")) + sorted(src.glob("*.ts"))
+    result = extract(paths, cache_root=tmp_path)
+
+    assert ("widget.ts", "events") not in _refs(result)
+    # ...while the genuine references are still found.
+    assert ("assignments.ts", "volunteer_assignments") in _refs(result)
+
+
+def test_unreferenced_table_gets_no_edges(tmp_path):
+    """A useful side effect: tables with no SQL-position reference anywhere are
+    surfaced as dead schema rather than papered over."""
+    root, db, src = _corpus(tmp_path)
+    paths = sorted(db.rglob("*.sql")) + sorted(src.glob("*.ts"))
+    result = extract(paths, cache_root=tmp_path)
+    assert not any(label == "never_queried" for _, label in _refs(result))
+
+
+def test_opt_out_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_NO_SQL_LINKS", "1")
+    root, db, src = _corpus(tmp_path)
+    paths = sorted(db.rglob("*.sql")) + sorted(src.glob("*.ts"))
+    result = extract(paths, cache_root=tmp_path)
+    assert _refs(result) == []
+
+
+def test_quoted_table_names_match(tmp_path):
+    """MySQL backticks, standard double quotes, T-SQL brackets (cf. #2712)."""
+    db = tmp_path / "db"
+    db.mkdir()
+    (db / "schema.sql").write_text("CREATE TABLE user_email_preferences (id INT);\n")
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "mysql.ts").write_text('q("SELECT * FROM `user_email_preferences`");\n')
+    (src / "pg.ts").write_text('q(`SELECT * FROM "user_email_preferences"`);\n')
+    (src / "tsql.ts").write_text("q(`SELECT * FROM [user_email_preferences]`);\n")
+
+    paths = sorted(db.glob("*.sql")) + sorted(src.glob("*.ts"))
+    result = extract(paths, cache_root=tmp_path)
+    linked = {f for f, label in _refs(result) if label == "user_email_preferences"}
+    assert linked == {"mysql.ts", "pg.ts", "tsql.ts"}

--- a/tests/test_sql_table_references.py
+++ b/tests/test_sql_table_references.py
@@ -120,6 +120,54 @@ def test_a_table_named_like_a_variable_is_not_falsely_linked(tmp_path):
     assert ("assignments.ts", "volunteer_assignments") in _refs(result)
 
 
+def test_comments_and_prose_are_not_queries(tmp_path):
+    """#2884 review: the same phantom class one level up from a bare identifier.
+
+    A table name after a SQL keyword is not a query when it sits in a comment or
+    in ordinary prose, and all three of these minted a `references` edge while
+    the matcher scanned raw file bytes.
+    """
+    root, db, src = _corpus(tmp_path)
+    (src / "comment.ts").write_text(
+        "// SELECT foo FROM events\n"
+        "export const n = 1;\n"
+    )
+    (src / "prose.ts").write_text(
+        'const s = "the FROM events keyword";\n'
+        "export const t = s;\n"
+    )
+    (src / "docs.py").write_text(
+        '"""Docs: you can JOIN events with assets here."""\n'
+        "N = 1\n"
+    )
+    paths = (sorted(db.rglob("*.sql")) + sorted(src.glob("*.ts"))
+             + sorted(src.glob("*.py")))
+    result = extract(paths, cache_root=tmp_path)
+
+    refs = _refs(result)
+    assert ("comment.ts", "events") not in refs
+    assert ("prose.ts", "events") not in refs
+    assert ("docs.py", "events") not in refs
+    assert ("assignments.ts", "volunteer_assignments") in refs
+
+
+def test_schema_qualified_table_links_both_reference_forms(tmp_path):
+    """#2884 review: labels are stored verbatim, so a Postgres/T-SQL corpus
+    declares `public.users` — and matching on the label alone gave it zero
+    edges, whichever way the query spells the reference."""
+    db = tmp_path / "db"
+    db.mkdir()
+    (db / "schema.sql").write_text("CREATE TABLE public.users (id INT);\n")
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "bare.ts").write_text("q(`SELECT id FROM users`);\n")
+    (src / "qualified.ts").write_text("q(`SELECT id FROM public.users`);\n")
+
+    paths = sorted(db.glob("*.sql")) + sorted(src.glob("*.ts"))
+    result = extract(paths, cache_root=tmp_path)
+    assert {f for f, label in _refs(result)} == {"bare.ts", "qualified.ts"}
+
+
 def test_unreferenced_table_gets_no_edges(tmp_path):
     """A useful side effect: tables with no SQL-position reference anywhere are
     surfaced as dead schema rather than papered over."""


### PR DESCRIPTION
Fixes #2884.

## The gap

`tree-sitter-sql` extracts table declarations correctly and the host-language grammars extract the application code correctly — but nothing connected the two. A table declared in `db/schema.sql` had no edge to the `.ts` file whose query reads `SELECT … FROM that_table`, so every table landed connected only to its declaring file (`contains`, degree 1). On the reporter's corpus that was **65 orphaned SQL symbol nodes**, with `db/` never bridging a single community despite being queried from ~100 route files.

The practical cost: the graph could not answer *"what breaks if I change this table?"* — the question a schema-heavy project most wants from a knowledge graph.

There is no AST route to it. The table name lives inside a template literal that the TypeScript grammar sees only as a string, so this is a text-embedding problem. The new resolver is lexical by necessity.

## What it does

`graphify/sql_resolution.py` registers into `resolver_registry` (gated on `.sql` being present in the corpus, like every other language resolver). After per-file extraction it scans every non-SQL source for each declared table name and emits:

`file --references--> table`, `EXTRACTED`, `confidence_score: 1.0`, `context: "sql_table"`

to **every** declaration site — `schema.sql` *and* the migration that created the table — so tracing a table also reaches its migration history, as the issue asks.

A declaration is the target of a `contains` edge from a `.sql` file, which is exactly how the SQL extractor anchors what it defines. The sourceless reference stubs it mints for tables defined in *another* file carry no `contains` edge and are correctly excluded — a stub is not a declaration site.

## Precision — the trap the issue warns about

The reporter measured it, and the numbers are the reason this PR is shaped the way it is:

| table | naive matcher | strict matcher |
|---|---|---|
| `events` | 157 files | 27 |
| `users` | 98 | 78 |
| `listings` | 95 | 32 |
| **total edges** | **1,489** | **921** |

All 130 phantom `events` edges were JavaScript variables named `events`. Table names like `users`, `events`, `sales`, `notifications` are extremely common identifiers, so "does this file contain SQL anywhere, and does this name appear anywhere in it" is not good enough.

The table must sit in a SQL keyword position **in the same match**:

```python
_SQL_KEYWORDS = r"(?:FROM|JOIN|INTO|UPDATE|REFERENCES|TABLE(?:\s+IF\s+NOT\s+EXISTS)?)"
```

Matching runs over the whole file text rather than line by line, so a table named on the second line of a multi-line template literal still matches. Backtick (MySQL), double-quote (standard SQL) and bracket (T-SQL) quoting are all handled, per #2712.

`test_a_table_named_like_a_variable_is_not_falsely_linked` pins this: a file full of `const events = […]` — including the word `SELECT` in a comment — gets no edge, while the genuine `FROM volunteer_assignments` in a sibling file still does.

## On the `calls` guardrail

`references/extraction-spec.md` is right and unchanged: `calls` edges stay within one language. `references` is a different relation with different semantics — "this file's SQL names this table" is a factual, checkable claim, not an inferred call. That distinction is written into the edge-emitting code so it survives future edits.

## Cost and opt-out

Lexical and free — no LLM. Files are read once, capped at 2 MiB, behind a cheap "is there a SQL keyword at all" pre-filter that skips the per-table scan for the overwhelming majority of files. `GRAPHIFY_NO_SQL_LINKS=1` skips the pass entirely, documented in the README env table: an ORM-based repo names tables via model classes and gets little from it. An env var rather than a CLI flag because resolvers have no access to CLI args, and this needed no new plumbing to be usable.

## Scope, matching the issue

- **File-level only.** Resolving to the specific function holding the query needs the enclosing-scope span; not attempted.
- **Raw SQL in string literals only.** Prisma/Drizzle/ActiveRecord name tables via model classes and would need separate handling.
- **Not** #1572 (table→table via INSERT/CTAS/MERGE) or #2442 (FK edges), which are both *within* SQL. `.sql` files are excluded from the scan for that reason.

## Tests

`tests/test_sql_table_references.py` — the issue's `volunteer_assignments` scenario end to end (two routes, two declaration sites, four edges), the degree-1-orphan regression, the `events`-variable precision trap, dialect quoting across MySQL/Postgres/T-SQL, the opt-out, and the dead-schema side effect (a table with no SQL-position reference anywhere gets no edges, which makes this a dead-schema detector too). Four of the six fail without the resolver.

Full suite: no new failures — the 22 that fail on this machine fail identically on a clean `v8` (missing `tree_sitter_hcl`, and Windows-specific install/symlink/FIFO tests).