### PR TITLE
docs: document GRAPHIFY_CLAUDE_CLI_MODEL in the env-var table

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ These are only needed for **headless / CI extraction** (`graphify extract`). Whe
 | `ANTHROPIC_API_KEY` | Claude (Anthropic) backend | `--backend claude` |
 | `ANTHROPIC_BASE_URL` | Anthropic-compatible endpoint URL (LiteLLM proxy, gateways, ...) | `--backend claude` (default: `https://api.anthropic.com`) |
 | `ANTHROPIC_MODEL` | Model name for the Claude backend — for custom endpoints, use the model name/alias your server exposes | `--backend claude` (default: `claude-sonnet-4-6`) |
+| `GRAPHIFY_CLAUDE_CLI_MODEL` | Model override for the `claude-cli` backend, passed through as `claude -p --model` (accepts `haiku`, `sonnet`, or a full model ID) | optional — `--backend claude-cli` (default: Opus, the CLI's own default; overkill for structured extraction, and for `graphify label`/`cluster-only` specifically, `haiku` is usually enough) |
 | `GEMINI_API_KEY` or `GOOGLE_API_KEY` | Google Gemini backend | `--backend gemini` |
 | `OPENAI_API_KEY` | OpenAI or OpenAI-compatible APIs | `--backend openai` (local servers accept any non-empty value) |
 | `OPENAI_BASE_URL` | OpenAI-compatible server URL (llama.cpp, vLLM, LM Studio, ...) | `--backend openai` (default: `https://api.openai.com/v1`) |
@@ -734,6 +735,7 @@ GRAPHIFY_OLLAMA_NUM_CTX=32768 graphify extract ./docs --backend ollama   # overr
 GRAPHIFY_OLLAMA_KEEP_ALIVE=0 graphify extract ./docs --backend ollama    # unload model after each chunk (saves VRAM on small GPUs)
 graphify extract ./docs --backend bedrock      # AWS Bedrock via IAM - no API key, uses AWS credential chain
 graphify extract ./docs --backend claude-cli   # route through Claude Code CLI - no API key, uses your Claude subscription
+GRAPHIFY_CLAUDE_CLI_MODEL=haiku graphify cluster-only ./docs --backend claude-cli   # cheaper model for community naming (claude-cli defaults to Opus)
 graphify extract ./docs --backend azure        # Azure OpenAI (set AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT)
 graphify extract ./docs --max-workers 16       # AST parallelism (also GRAPHIFY_MAX_WORKERS)
 graphify extract --postgres "postgresql://user:pass@host/db"   # introspect live PostgreSQL schema directly


### PR DESCRIPTION
Fixes #2861 (ask 1; a usage example is included too). Not included: ask 2 (surfacing it in `--help`) and ask 3 (changing the default model for labeling) are behavior changes, left for a separate PR.

## The gap

`GRAPHIFY_CLAUDE_CLI_MODEL` is read by the `claude-cli` backend (`graphify/llm.py:1571`) but wasn't documented anywhere. Since `claude-cli` defaults to Opus when the variable is unset, following the README as-is for `--backend claude-cli` silently spends Opus quota on jobs (like community naming via `cluster-only`) that a cheaper model handles fine.

## Change

- Adds a row to the environment-variables table next to `ANTHROPIC_MODEL`, noting the default (Opus) and that `haiku`/`sonnet` are usually enough, especially for `graphify label`/`cluster-only`.
- Adds a one-line usage example next to the other `claude-cli` example, showing `GRAPHIFY_CLAUDE_CLI_MODEL=haiku` on a `cluster-only` run — the exact scenario from the issue report.

Docs only, no code changes.