### PR TITLE
Report edge loss on rebuild: the node-only shrink guard misses a 12% edge drop

### DIFF
--- a/graphify/skill-agents.md
+++ b/graphify/skill-agents.md
@@ -427,11 +427,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/graphify/skill-aider.md
+++ b/graphify/skill-aider.md
@@ -422,10 +422,38 @@ questions = suggest_questions(G, communities, labels)
 # Persist the graph first and only write the report/analysis if it actually
 # persisted - to_json refuses to shrink an existing graph.json (#479), and a
 # report describing a graph we did not write would be a lie (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (fewer nodes than the existing graph). Run a full rebuild to be safe.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report)
 

--- a/graphify/skill-amp.md
+++ b/graphify/skill-amp.md
@@ -427,11 +427,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/graphify/skill-claw.md
+++ b/graphify/skill-claw.md
@@ -430,11 +430,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -427,11 +427,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/graphify/skill-copilot.md
+++ b/graphify/skill-copilot.md
@@ -430,11 +430,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/graphify/skill-devin.md
+++ b/graphify/skill-devin.md
@@ -487,10 +487,38 @@ questions = suggest_questions(G, communities, labels)
 # Persist the graph first and only write the report/analysis if it actually
 # persisted - to_json refuses to shrink an existing graph.json (#479), and a
 # report describing a graph we did not write would be a lie (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (fewer nodes than the existing graph). Run a full rebuild to be safe.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report)
 

--- a/graphify/skill-droid.md
+++ b/graphify/skill-droid.md
@@ -427,11 +427,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/graphify/skill-kilo.md
+++ b/graphify/skill-kilo.md
@@ -430,11 +430,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/graphify/skill-kiro.md
+++ b/graphify/skill-kiro.md
@@ -430,11 +430,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -422,11 +422,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/graphify/skill-pi.md
+++ b/graphify/skill-pi.md
@@ -430,11 +430,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/graphify/skill-trae.md
+++ b/graphify/skill-trae.md
@@ -428,11 +428,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/graphify/skill-vscode.md
+++ b/graphify/skill-vscode.md
@@ -426,11 +426,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/graphify/skill-windows.md
+++ b/graphify/skill-windows.md
@@ -452,11 +452,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding="utf-8")
 analysis = {

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -430,11 +430,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-agents.md
+++ b/tools/skillgen/expected/graphify__skill-agents.md
@@ -427,11 +427,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-aider.md
+++ b/tools/skillgen/expected/graphify__skill-aider.md
@@ -422,10 +422,38 @@ questions = suggest_questions(G, communities, labels)
 # Persist the graph first and only write the report/analysis if it actually
 # persisted - to_json refuses to shrink an existing graph.json (#479), and a
 # report describing a graph we did not write would be a lie (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (fewer nodes than the existing graph). Run a full rebuild to be safe.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report)
 

--- a/tools/skillgen/expected/graphify__skill-amp.md
+++ b/tools/skillgen/expected/graphify__skill-amp.md
@@ -427,11 +427,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-claw.md
+++ b/tools/skillgen/expected/graphify__skill-claw.md
@@ -430,11 +430,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-codex.md
+++ b/tools/skillgen/expected/graphify__skill-codex.md
@@ -427,11 +427,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-copilot.md
+++ b/tools/skillgen/expected/graphify__skill-copilot.md
@@ -430,11 +430,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-devin.md
+++ b/tools/skillgen/expected/graphify__skill-devin.md
@@ -487,10 +487,38 @@ questions = suggest_questions(G, communities, labels)
 # Persist the graph first and only write the report/analysis if it actually
 # persisted - to_json refuses to shrink an existing graph.json (#479), and a
 # report describing a graph we did not write would be a lie (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (fewer nodes than the existing graph). Run a full rebuild to be safe.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report)
 

--- a/tools/skillgen/expected/graphify__skill-droid.md
+++ b/tools/skillgen/expected/graphify__skill-droid.md
@@ -427,11 +427,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-kilo.md
+++ b/tools/skillgen/expected/graphify__skill-kilo.md
@@ -430,11 +430,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-kiro.md
+++ b/tools/skillgen/expected/graphify__skill-kiro.md
@@ -430,11 +430,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-opencode.md
+++ b/tools/skillgen/expected/graphify__skill-opencode.md
@@ -422,11 +422,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-pi.md
+++ b/tools/skillgen/expected/graphify__skill-pi.md
@@ -430,11 +430,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-trae.md
+++ b/tools/skillgen/expected/graphify__skill-trae.md
@@ -428,11 +428,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-vscode.md
+++ b/tools/skillgen/expected/graphify__skill-vscode.md
@@ -426,11 +426,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill-windows.md
+++ b/tools/skillgen/expected/graphify__skill-windows.md
@@ -452,11 +452,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding="utf-8")
 analysis = {

--- a/tools/skillgen/expected/graphify__skill.md
+++ b/tools/skillgen/expected/graphify__skill.md
@@ -430,11 +430,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/fragments/core/aider.md
+++ b/tools/skillgen/fragments/core/aider.md
@@ -422,10 +422,38 @@ questions = suggest_questions(G, communities, labels)
 # Persist the graph first and only write the report/analysis if it actually
 # persisted - to_json refuses to shrink an existing graph.json (#479), and a
 # report describing a graph we did not write would be a lie (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (fewer nodes than the existing graph). Run a full rebuild to be safe.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report)
 

--- a/tools/skillgen/fragments/core/core.md
+++ b/tools/skillgen/fragments/core/core.md
@@ -365,11 +365,39 @@ questions = suggest_questions(G, communities, labels)
 # nothing) when the new graph is smaller than the existing graph.json. Only write
 # GRAPH_REPORT.md + the analysis sidecar when the graph was actually written, so
 # they never describe a graph that graph.json doesn't contain (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (existing graph has more nodes; #479).')
     print('If this shrink is intentional (you deleted files), re-run a full build with --force.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report, encoding=\"utf-8\")
 analysis = {

--- a/tools/skillgen/fragments/core/devin.md
+++ b/tools/skillgen/fragments/core/devin.md
@@ -487,10 +487,38 @@ questions = suggest_questions(G, communities, labels)
 # Persist the graph first and only write the report/analysis if it actually
 # persisted - to_json refuses to shrink an existing graph.json (#479), and a
 # report describing a graph we did not write would be a lie (#1392).
+# Read the previous graph's counts BEFORE it is overwritten. The #479 guard
+# compares NODES only, so a rebuild that gains nodes and loses edges passes it
+# silently: measured on a real corpus, 2,100 -> 2,172 nodes (+72) while edges
+# went 3,378 -> 2,978 (-12%), and the guard passed.
+_prev_n = _prev_e = None
+_prev_path = Path('graphify-out/graph.json')
+if _prev_path.is_file():
+    try:
+        with _prev_path.open('rb') as _fh:
+            _prev = json.loads(_fh.read())
+        _prev_n = len(_prev.get('nodes', []))
+        # to_json writes node_link_data(G, edges='links'); its TypeError fallback
+        # can emit 'edges' instead, so accept either key.
+        _prev_e = len(_prev.get('links', _prev.get('edges', [])))
+    except Exception:
+        _prev_n = _prev_e = None
+
 wrote = to_json(G, communities, 'graphify-out/graph.json')
 if not wrote:
     print('ERROR: refused to shrink graphify-out/graph.json (fewer nodes than the existing graph). Run a full rebuild to be safe.')
     raise SystemExit(1)
+# Edge side of the same guard. Reported, not fatal: an edge drop can be legitimate
+# (files deleted, a noisy extractor tightened), and a guard that aborted here would
+# be switched off during exactly the rebuild it should be watching.
+if _prev_e:
+    _new_n, _new_e = G.number_of_nodes(), G.number_of_edges()
+    if _new_e < _prev_e:
+        _pct = (_prev_e - _new_e) * 100.0 / _prev_e
+        print(f'EDGE LOSS: {_prev_e} -> {_new_e} edges (-{_pct:.1f}%) while nodes went {_prev_n} -> {_new_n}. The #479 guard compares nodes and did not see this.')
+        if _new_n >= _prev_n:
+            print('  Nodes did not shrink, so relations were lost, not content. Node ids that are not stable across passes are the usual cause: cached edges point at nodes the new pass renamed.')
+
 report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report)
 

--- a/tools/skillgen/gen.py
+++ b/tools/skillgen/gen.py
@@ -1142,6 +1142,42 @@ def _is_community_label_export_fix_line(line: str) -> bool:
     )
 
 
+def _is_edge_loss_guard_fix_line(line: str) -> bool:
+    """Whether a line is part of the edge-side companion to the #479 guard.
+
+    ``to_json``'s #479 guard compares NODES only, so a rebuild that gains nodes
+    and loses edges is written silently. Step 4 now reads the previous graph's
+    node and edge counts before overwriting it and reports an edge drop as a
+    proportion. Reported, not fatal: an edge drop can be legitimate, and a guard
+    that aborted here would be switched off during exactly the rebuild it should
+    be watching. The ``try:``/``except Exception:`` pair belongs to the
+    defensive read of the existing graph.json, which must not crash a build when
+    that file is corrupt or mid-write.
+    """
+    s = line.strip()
+    return (
+        "_prev_n" in line
+        or "_prev_e" in line
+        or "_prev_path" in line
+        or "_prev = json.loads" in line
+        or "_new_n" in line
+        or "_new_e" in line
+        or "_pct" in line
+        or "EDGE LOSS:" in line
+        or "Nodes did not shrink" in line
+        or "Read the previous graph's counts" in line
+        or "compares NODES only" in line
+        or "silently: measured on a real corpus" in line
+        or "went 3,378 -> 2,978" in line
+        or "to_json writes node_link_data" in line
+        or "can emit 'edges' instead" in line
+        or "Edge side of the same guard" in line
+        or "files deleted, a noisy extractor tightened" in line
+        or "be switched off during exactly the rebuild" in line
+        or s == "try:"
+        or s == "except Exception:"
+    )
+
 # Every line that may differ between a rendered monolith and its pristine v8
 # baseline. Each predicate documents one sanctioned change-class; a blank line is
 # allowed because the multi-line fix blocks insert spacing. Anything else failing
@@ -1163,6 +1199,7 @@ _SANCTIONED_MONOLITH_DIFFS = (
     _is_uv_from_interpreter_fix_line,
     _is_semantic_cache_scope_fix_line,
     _is_community_label_export_fix_line,
+    _is_edge_loss_guard_fix_line,
 )
 
 


### PR DESCRIPTION
## The node-only shrink guard passes a rebuild that loses 12% of its edges

`to_json`'s #479 guard refuses to write when the new graph has fewer **nodes**
than the existing one. It does not look at edges, so a rebuild that gains nodes
and loses relations is written silently.

Measured on a real corpus:

```
nodes  2,100 -> 2,172   (+72)
edges  3,378 -> 2,978   (-400, -11.8%)
```

The guard passed. The graph still answers, but every traversal query returns a
shorter path or none, and nothing in the output says why.

### What this changes

Step 4 reads the previous graph's node and edge counts *before* the write, and
after the write reports an edge drop as a proportion, alongside the node delta.

**Reported, not fatal, and that is deliberate.** An edge drop can be legitimate:
files deleted, a noisy extractor tightened. A guard that aborted here would be
switched off during exactly the rebuild it should be watching. It prints at the
point of writing rather than leaving it to a later step, so the number is in
front of whoever is looking at the rebuild.

When nodes did **not** shrink, it adds the diagnosis, because that case has one
common cause worth naming: node ids that are not stable across passes, so cached
edges point at nodes the new pass renamed.

### Which key it reads

`to_json` writes `node_link_data(G, edges="links")`, with a `TypeError` fallback
to the networkx default. The read takes `links` first and falls back to `edges`,
so it works against both shapes. Reading only `edges` returns 0 on every graph
the primary path writes, and the guard would never fire.

### Where the change lives

In `tools/skillgen/fragments/core/{core,aider,devin}.md`, so all sixteen
committed skill bodies get it from one edit. `graphify/skill*.md` and
`tools/skillgen/expected/` in this diff are regenerated output
(`python -m tools.skillgen` then `--bless`).

`aider` and `devin` are monoliths under `--monolith-roundtrip`, which requires
every added line to match a documented change-class, so this adds one predicate,
`_is_edge_loss_guard_fix_line`, alongside the existing ones. If you would rather
the monoliths stay frozen, dropping that predicate and reverting those two
fragments leaves the other fourteen platforms covered.

Verified locally: `--check`, `--audit-coverage`, `--schema-singleton`,
`--monolith-roundtrip` and `--always-on-roundtrip` all pass, the sixteen
rendered Python bodies compile, and the guard was exercised against a stubbed
graph for six cases — the measured regression under both key shapes, an edge
gain, a legitimate corpus shrink, a first build, and a corrupt `graph.json`
(which must not crash the build).

### Why it is in the skill body rather than in `to_json`

Following the existing #479 guard, which lives there too. If you would rather
have it inside `build.to_json` as a returned warning, say which shape you prefer
and I will re-cut the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
