### PR TITLE
i18n: honor source-content language for extraction labels

### DIFF
--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -236,6 +236,8 @@ Output exactly this JSON (no other text):
 {"nodes":[{"id":"filestem_entityname","label":"Human Readable Name","file_type":"code|document|paper|image","source_file":"relative/path","source_location":null,"source_url":null,"captured_at":null,"author":null,"contributor":null}],"edges":[{"source":"node_id","target":"node_id","relation":"calls|implements|references|cites|conceptually_related_to|shares_data_with|semantically_similar_to","confidence":"EXTRACTED|INFERRED|AMBIGUOUS","confidence_score":1.0,"source_file":"relative/path","source_location":null,"weight":1.0}],"hyperedges":[{"id":"snake_case_id","label":"Human Readable Label","nodes":["node_id1","node_id2","node_id3"],"relation":"participate_in|implement|form","confidence":"EXTRACTED|INFERRED","confidence_score":0.75,"source_file":"relative/path"}],"input_tokens":0,"output_tokens":0}
 ```
 
+LANGUAGE RULE: Write all human-readable text (node labels, hyperedge labels) in the dominant language of the source content. Chinese source content MUST produce Chinese labels with verbatim Chinese concepts (e.g. 道德义务论, 绝对命令) — do NOT translate them to English. Node IDs stay ASCII per the format rules above.
+
 **Step B3 - Collect, cache, and merge**
 
 Wait for all subagents. For each result:

--- a/skills/graphify/skill.md
+++ b/skills/graphify/skill.md
@@ -233,6 +233,8 @@ Output exactly this JSON (no other text):
 {"nodes":[{"id":"filestem_entityname","label":"Human Readable Name","file_type":"code|document|paper|image","source_file":"relative/path","source_location":null,"source_url":null,"captured_at":null,"author":null,"contributor":null}],"edges":[{"source":"node_id","target":"node_id","relation":"calls|implements|references|cites|conceptually_related_to|shares_data_with|semantically_similar_to","confidence":"EXTRACTED|INFERRED|AMBIGUOUS","confidence_score":1.0,"source_file":"relative/path","source_location":null,"weight":1.0}],"hyperedges":[{"id":"snake_case_id","label":"Human Readable Label","nodes":["node_id1","node_id2","node_id3"],"relation":"participate_in|implement|form","confidence":"EXTRACTED|INFERRED","confidence_score":0.75,"source_file":"relative/path"}],"input_tokens":0,"output_tokens":0}
 ```
 
+LANGUAGE RULE: Write all human-readable text (node labels, hyperedge labels) in the dominant language of the source content. Chinese source content MUST produce Chinese labels with verbatim Chinese concepts (e.g. 道德义务论, 绝对命令) — do NOT translate them to English. Node IDs stay ASCII per the format rules above.
+
 **Step B3 - Collect, cache, and merge**
 
 Wait for all subagents. For each result:


### PR DESCRIPTION
### Problem

`_EXTRACTION_SYSTEM` (graphify/llm.py) is entirely English and code-oriented, and
nothing in it tells the model what language to write labels in. LLMs follow the
system prompt's language, so non-English corpora get English labels.

Reproduced with a 4-document Chinese corpus (deepseek-v4-flash / qwen via
OpenAI-compatible endpoint), graphifyy 0.9.16:

- Before: 28 nodes, **0/28 Chinese labels** (e.g. Chinese notes on Kantian ethics
  produced "Kantian Deontology", "Categorical Imperative", ...). Hyperedge labels
  likewise English.
- After appending the language rule below: **27/27 Chinese labels**, and edges
  even improved (17 → 21).

### Proposal

Append a language rule to the extraction system prompt. Two variants; either works.

**Minimal (always-on, recommended)** — models are good at detecting the dominant
language, no config surface needed:

```
LANGUAGE RULE: Write all human-readable text (node labels, hyperedge labels) in
the dominant language of the source content. Chinese source content MUST produce
Chinese labels with verbatim Chinese concepts (e.g. 道德义务论, 绝对命令) — do NOT
translate them to English. Node IDs stay ASCII per the format rules above.
```

**Configurable** — `GRAPHIFY_LABEL_LANGUAGE=auto|zh-CN|en|...`, default `auto`
(= the rule above); an explicit value pins the label language regardless of
source language (useful for bilingual corpora where the user wants uniform labels).

### Notes

- Node IDs intentionally stay ASCII (`[a-z0-9_]`); this change only affects
  human-readable labels.
- Existing graphs keep their labels until rebuilt — no migration concern.
- Happy to open the PR with tests if you tell me which variant you prefer.

## Suggested patch (minimal variant)

```diff
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ _EXTRACTION_SYSTEM tail @@
 ...],"input_tokens":0,"output_tokens":0}
+
+LANGUAGE RULE: Write all human-readable text (node labels, hyperedge labels) in
+the dominant language of the source content. Chinese source content MUST produce
+Chinese labels with verbatim Chinese concepts (e.g. 道德义务论, 绝对命令) — do NOT
+translate them to English. Node IDs stay ASCII per the format rules above.
 """
```
