### PR TITLE
fix(csharp): walk generic type arguments in field position

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -3714,13 +3714,29 @@ def _extract_generic(
                             if name_node is not None:
                                 fields[_read_text(name_node, source)] = type_name
                 line = node.start_point[0] + 1
-                metadata = {"ref_token": type_name}
-                if qualified:
-                    metadata["qualified"] = True
-                if qualifier:
-                    metadata["ref_qualifier"] = qualifier
-                add_edge(parent_class_nid, ensure_named_node(type_name, line),
-                         "references", line, context="field", metadata=metadata)
+                # Walk the whole type expression rather than only its outer name, so
+                # `Box<Widget>` yields the Box field ref AND the Widget generic_arg ref.
+                # Reading just the outer name left every generic argument in field
+                # position unlinked -- `IDbContextFactory<SomeContext>` lost SomeContext,
+                # and `Mock<IThing>` lost IThing across entire test suites. The C#
+                # property_declaration handler below and the tree_sitter_java
+                # field_declaration handler beside it already do exactly this; C# fields
+                # were the odd one out.
+                refs: list[tuple[str, str, bool, str]] = []
+                _csharp_collect_type_refs(
+                    type_node, source, False, refs, csharp_type_params
+                )
+                for ref_name, role, ref_qualified, ref_qualifier in refs:
+                    ctx = "generic_arg" if role == "generic_arg" else "field"
+                    target_nid = ensure_named_node(ref_name, line)
+                    if target_nid != parent_class_nid:
+                        metadata = {"ref_token": ref_name}
+                        if ref_qualified:
+                            metadata["qualified"] = True
+                        if ref_qualifier:
+                            metadata["ref_qualifier"] = ref_qualifier
+                        add_edge(parent_class_nid, target_nid, "references",
+                                 line, context=ctx, metadata=metadata)
             return
 
         if (config.ts_module == "tree_sitter_c_sharp"

--- a/tests/test_csharp_field_generic_args.py
+++ b/tests/test_csharp_field_generic_args.py
@@ -1,0 +1,121 @@
+"""C# generic type arguments in FIELD position.
+
+The field_declaration handler read only the outer type name, so the inner argument of
+`Box<Widget>` produced no edge. Properties, return types and parameters already walked
+the full type expression via _csharp_collect_type_refs, which made fields the odd one
+out for two very common shapes: `IDbContextFactory<SomeContext>` lost SomeContext, and
+`Mock<IThing>` lost IThing across whole test suites.
+
+Missing edges here are silent -- `affected` returns a smaller, confident answer rather
+than an error -- so each case asserts the edge exists rather than asserting a count.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from graphify.extract import extract
+
+
+def _refs(tmp_path, files: dict[str, str]) -> set[tuple[str, str]]:
+    """Extract, returning {(source_label, target_label)} for `references` edges."""
+    for name, body in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+    old = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        r = extract([Path(n) for n in files], cache_root=tmp_path / ".cache")
+    finally:
+        os.chdir(old)
+    labels = {n["id"]: n.get("label", "") for n in r["nodes"]}
+    return {
+        (labels.get(e["source"], ""), labels.get(e["target"], ""))
+        for e in r["edges"]
+        if e["relation"] == "references"
+    }
+
+
+_TYPES = (
+    "public interface IThing { }\n"
+    "public class Box<T> { }\n"
+    "public class Outer { public class Inner { } }\n"
+)
+
+
+def test_field_generic_argument_produces_edge(tmp_path):
+    refs = _refs(tmp_path, {
+        "T.cs": _TYPES,
+        "P.cs": "public class Probe { private Box<IThing> _f = null!; }\n",
+    })
+    assert ("Probe", "Box") in refs, "outer field type must still be linked"
+    assert ("Probe", "IThing") in refs, "generic argument in field position must be linked"
+
+
+def test_field_matches_property_behaviour(tmp_path):
+    """A field and a property of the same type must produce the same references."""
+    refs = _refs(tmp_path, {
+        "T.cs": _TYPES,
+        "P.cs": (
+            "public class WithField { private Box<IThing> _f = null!; }\n"
+            "public class WithProp  { public Box<IThing> P { get; set; } = null!; }\n"
+        ),
+    })
+    field_targets = {t for s, t in refs if s == "WithField"}
+    prop_targets = {t for s, t in refs if s == "WithProp"}
+    assert field_targets == prop_targets, (
+        f"field and property disagree: field={field_targets} property={prop_targets}"
+    )
+
+
+def test_nested_generic_arguments(tmp_path):
+    refs = _refs(tmp_path, {
+        "T.cs": _TYPES,
+        "P.cs": "public class Probe { private Box<Box<IThing>> _f = null!; }\n",
+    })
+    assert ("Probe", "IThing") in refs, "innermost generic argument must be linked"
+
+
+def test_multiple_declarators_share_the_type(tmp_path):
+    refs = _refs(tmp_path, {
+        "T.cs": _TYPES,
+        "P.cs": "public class Probe { private Box<IThing> _a = null!, _b = null!; }\n",
+    })
+    assert ("Probe", "IThing") in refs
+
+
+def test_bare_type_parameter_is_not_fabricated(tmp_path):
+    """`T item` must not create a node for the type parameter itself."""
+    refs = _refs(tmp_path, {
+        "P.cs": "public class Probe<T> { private T _item = default!; }\n",
+    })
+    assert not any(t == "T" for _, t in refs), "type parameter must not become a node"
+
+
+def test_type_parameter_as_generic_argument_is_not_fabricated(tmp_path):
+    refs = _refs(tmp_path, {
+        "T.cs": _TYPES,
+        "P.cs": "public class Probe<T> { private Box<T> _f = null!; }\n",
+    })
+    assert ("Probe", "Box") in refs, "outer type is still a real reference"
+    assert not any(t == "T" for _, t in refs), "type parameter must not become a node"
+
+
+def test_predefined_types_are_not_fabricated(tmp_path):
+    refs = _refs(tmp_path, {
+        "T.cs": _TYPES,
+        "P.cs": "public class Probe { private Box<int> _f = null!; private string _s = \"\"; }\n",
+    })
+    assert not any(t in {"int", "string"} for _, t in refs), (
+        "builtin types must not become nodes"
+    )
+
+
+def test_plain_field_still_links(tmp_path):
+    """The non-generic path must be unchanged."""
+    refs = _refs(tmp_path, {
+        "T.cs": _TYPES,
+        "P.cs": "public class Probe { private IThing _f = null!; }\n",
+    })
+    assert ("Probe", "IThing") in refs


### PR DESCRIPTION
Fixes the field half of #2911.

## Problem

The `field_declaration` handler reads only the outer type name via `_read_csharp_type_name` and emits a single `references` edge, so the inner argument of `Box<Widget>` is never linked.

Properties, return types and parameters already walk the whole type expression through `_csharp_collect_type_refs`. That makes fields the odd one out — and the `property_declaration` handler's own comment points at exactly the siblings it was mirroring:

> Use `_csharp_collect_type_refs` (like the Java/PHP/Kotlin siblings) so `List<Widget>` yields both the List field ref and the Widget generic_arg ref.

The `tree_sitter_java` `field_declaration` handler immediately below does the same thing correctly. C# fields were simply never converted.

| position | before | after |
|---|---|---|
| property | `references[generic_arg]` | unchanged |
| return | `references[generic_arg]` | unchanged |
| parameter | `references[generic_arg]` | unchanged |
| **field** | **none** | `references[generic_arg]` |

## Why it matters

Two very common shapes lose their edge:

```csharp
private readonly IDbContextFactory<SomeContext> _factory;  // SomeContext: no edge
private readonly Mock<IThing> _mock;                       // IThing: no edge
```

Classic constructor injection stores its dependency in a **field**, so this is the same blind spot #2829 removed from primary constructors — just relocated to where the dependency is kept. Mock-based unit tests lose their subject across an entire suite.

The failure is silent. `affected` returns a smaller, confident answer rather than an error or a warning, which is the same reason #2829 was worth fixing.

## Fix

Route the field handler through `_csharp_collect_type_refs`, passing the in-scope type parameters as the skip set, mirroring the property handler exactly. The outer type still emits `context="field"`; arguments emit `context="generic_arg"`. The existing `csharp_field_types` receiver registration is untouched.

**Bonus:** this also stops fields fabricating nodes for predefined types. `private string _s` previously created a `string` node, because `_read_csharp_type_name` returns builtins while `_csharp_collect_type_refs` returns early on `predefined_type`. That aligns fields with the builtin-not-fabricated behaviour added for primary constructors in 1eb356cd.

## Verification

Eight regression tests in `tests/test_csharp_field_generic_args.py`, covering both directions — the argument is linked, a field and a property of the same type now agree, nested arguments resolve, and type parameters and builtins are still never fabricated.

| | |
|---|---|
| New tests on unpatched HEAD | **5 of 8 fail** |
| New tests with this patch | **8 of 8 pass** |
| C# suites (`-k csharp`) | 108 passed, 5 skipped |
| Full suite, baseline | 30 failed, 4,575 passed |
| Full suite, patched | 25 failed, 4,580 passed |

A set-difference of the failing test ids between the two full runs shows **nothing newly broken** — the delta is exactly the five new tests.

One caveat stated plainly: `test_labeling.py::test_label_communities_batches_when_over_batch_size` is flaky independently of this change. It fails intermittently on unpatched HEAD too (confirmed over repeated runs), so please don't read it either way.

## Scope

Deliberately field-only. #2911 also covers call-site type arguments (`services.AddScoped<IThing, Thing>()`), but that lives in the call-resolution path and overlaps #2676, which strips call-site type arguments to repair the callee match. The two want different things from the same tokens — one discards them, the other needs them emitted — so that half is better as its own change once #2676 settles. Happy to write it.
