### PR TITLE
fix(extract): invalidate tsconfig alias/baseUrl caches per run

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -70,6 +70,7 @@ from graphify.extractors.resolution import (  # noqa: E402,F401
     _JS_PRIMITIVE_TYPES,
     _JS_RESOLVE_EXTS,
     _TSCONFIG_ALIAS_CACHE,
+    _TSCONFIG_BASEURL_CACHE,
     _VUE_SCRIPT_LANG_RE,
     _VUE_SCRIPT_RE,
     _WORKSPACE_MANIFEST_NAMES,
@@ -5523,6 +5524,14 @@ def extract(
     _raise_recursion_limit()
     # Workspace package manifests/globs can change during watch or repeated extraction.
     _WORKSPACE_PACKAGE_CACHE.clear()
+    # tsconfig/jsconfig compilerOptions are the same kind of state: keyed by
+    # config path with no mtime component, so an edit to `paths` or `baseUrl`
+    # was never observed again for the life of the process. `graphify watch`
+    # and the MCP server both call extract() repeatedly in one process, so
+    # every rebuild after the edit kept resolving through the stale alias map.
+    # Clearing per run, not per file, leaves within-run caching intact.
+    _TSCONFIG_ALIAS_CACHE.clear()
+    _TSCONFIG_BASEURL_CACHE.clear()
     _XAML_CSHARP_CLASS_CACHE.clear()
     _MD_LINK_INDEX_CACHE.clear()
 

--- a/tests/test_jsconfig_baseurl.py
+++ b/tests/test_jsconfig_baseurl.py
@@ -191,3 +191,63 @@ def test_tsconfig_wins_when_both_configs_present(tmp_path):
     targets = _targets(r)
     assert _cid(tmp_path, ts_hit) in targets
     assert _cid(tmp_path, tmp_path / "js_root" / "mods" / "W.js") not in targets
+
+
+# --- config edits must survive the per-process caches (#2917) ---------------
+#
+# `_TSCONFIG_ALIAS_CACHE` and `_TSCONFIG_BASEURL_CACHE` are keyed on the config
+# path with no mtime component. Every test above calls extract() exactly once
+# under its own tmp_path, so each gets a fresh cache key and the staleness never
+# shows. `graphify watch` and the MCP server are the opposite shape: one process,
+# one config path, many extract() calls — so an edit to compilerOptions was never
+# observed again for the life of the process. These two run extract() twice
+# against the SAME config path, which is the case that was unguarded.
+
+
+def test_edited_paths_alias_is_observed_by_a_later_extract(tmp_path):
+    """Editing `paths` mid-session must retarget the alias, not keep the old map."""
+    _write(tmp_path / "src" / "target.ts", "export function hit() { return 1; }\n")
+    _write(tmp_path / "lib" / "target.ts", "export function hit() { return 2; }\n")
+    importer = _write(tmp_path / "main.ts", "import { hit } from '@app/target';\nhit();\n")
+
+    def _run() -> set[str]:
+        return _targets(extract([importer], root=tmp_path))
+
+    _write(tmp_path / "tsconfig.json",
+           '{\n  "compilerOptions": {\n'
+           '    "baseUrl": ".",\n'
+           '    "paths": { "@app/*": ["src/*"] }\n'
+           '  }\n}\n')
+    assert _cid(tmp_path, tmp_path / "src" / "target.ts") in _run()
+
+    _write(tmp_path / "tsconfig.json",
+           '{\n  "compilerOptions": {\n'
+           '    "baseUrl": ".",\n'
+           '    "paths": { "@app/*": ["lib/*"] }\n'
+           '  }\n}\n')
+    second = _run()
+    assert _cid(tmp_path, tmp_path / "lib" / "target.ts") in second, (
+        "second extract() resolved @app/target through the alias map cached by the "
+        "first run, so the edited tsconfig was never read"
+    )
+    assert _cid(tmp_path, tmp_path / "src" / "target.ts") not in second
+
+
+def test_edited_baseurl_is_observed_by_a_later_extract(tmp_path):
+    """Same contract for the separately cached `baseUrl` root (#2153)."""
+    _write(tmp_path / "one" / "mods" / "Widget.js", "export default function Widget() {}\n")
+    _write(tmp_path / "two" / "mods" / "Widget.js", "export default function Widget() {}\n")
+    importer = _write(tmp_path / "packs" / "dashboard.js",
+                      "import Widget from 'mods/Widget.js';\nexport default Widget;\n")
+
+    def _run() -> set[str]:
+        return _targets(extract([importer], root=tmp_path))
+
+    _write(tmp_path / "jsconfig.json", '{\n  "compilerOptions": { "baseUrl": "one" }\n}\n')
+    assert _cid(tmp_path, tmp_path / "one" / "mods" / "Widget.js") in _run()
+
+    _write(tmp_path / "jsconfig.json", '{\n  "compilerOptions": { "baseUrl": "two" }\n}\n')
+    second = _run()
+    assert _cid(tmp_path, tmp_path / "two" / "mods" / "Widget.js") in second, (
+        "second extract() resolved through the baseUrl cached by the first run"
+    )


### PR DESCRIPTION
## The problem

`extract()` opens by resetting the process-global caches whose backing files can change
between runs:

```python
# Workspace package manifests/globs can change during watch or repeated extraction.
_WORKSPACE_PACKAGE_CACHE.clear()
_XAML_CSHARP_CLASS_CACHE.clear()
_MD_LINK_INDEX_CACHE.clear()
```

`_MD_LINK_INDEX_CACHE` spells the contract out:

> `extract()` clears it at the start of each run (beside `_WORKSPACE_PACKAGE_CACHE`) so a
> serial rerun in one process sees files created since the last run.

`_TSCONFIG_ALIAS_CACHE` and `_TSCONFIG_BASEURL_CACHE` are the same kind of state — keyed on
the config path string, no mtime component, no invalidation anywhere in the package — but
they were not in that block. A `tsconfig.json` is at least as mutable as a workspace
manifest, so an edit to `compilerOptions.paths` or `baseUrl` was never observed again for the
life of the process:

```python
key = str(config)
if key not in _TSCONFIG_ALIAS_CACHE:
    _TSCONFIG_ALIAS_CACHE[key] = _read_tsconfig_aliases(config, candidate, seen=set())
return _TSCONFIG_ALIAS_CACHE[key]
```

That matters for exactly the callers the neighbouring comment was written for — `graphify
watch`, the MCP server, and library code calling `extract()` in a loop. It fails silently:
imports keep resolving to the *previous* target directory, so the edges still exist and still
look plausible.

The existing suite could not catch it. `tests/test_jsconfig_baseurl.py` covers alias
precedence well, but every test calls `extract()` once under its own `tmp_path`, so each gets
a distinct config path and therefore a fresh cache key. The bug only appears when one process
extracts twice against the *same* config path.

## The change

Two `.clear()` calls, beside the three already there. Clearing per **run** rather than per
**file** keeps the within-run caching these exist for entirely intact — identical in shape and
cost to how `_WORKSPACE_PACKAGE_CACHE` is already handled.

## Tests

Two regression tests in `tests/test_jsconfig_baseurl.py`, both running `extract()` twice
against one config path:

- `test_edited_paths_alias_is_observed_by_a_later_extract` — retarget `@app/*` from `src/*`
  to `lib/*` between runs; the second run must resolve to `lib/`.
- `test_edited_baseurl_is_observed_by_a_later_extract` — same for `baseUrl`.

Both fail on `v8` before the change and pass after:

```
# without the two .clear() calls
FAILED tests/test_jsconfig_baseurl.py::test_edited_paths_alias_is_observed_by_a_later_extract
FAILED tests/test_jsconfig_baseurl.py::test_edited_baseurl_is_observed_by_a_later_extract
2 failed, 12 passed

# with
14 passed in 1.58s
```

I also drafted a third test for "a `tsconfig.json` added *after* the first run", expecting the
miss to have been cached as `{}` — it passed unchanged, because `_find_js_config` returning
`None` short-circuits before the cache is touched. That case was already safe, so the test was
dropped rather than shipped as a fix it does not test.

## Verification

Full suite, Windows 11 / Python 3.12.10, `v8` @ `b2cd362`:

| | failures | passed |
|---|---|---|
| `origin/v8` | 50 | 4511 |
| this branch | 50 | 4513 |

The two failure sets are **identical** (set-diff of the `FAILED` ids is empty in both
directions); the delta is the two new tests. The 50 pre-existing failures are
optional-dependency and platform ones — `terraform` needs `tree-sitter-hcl`, `skillgen` needs
full git history, and several are POSIX-only fixtures — none related to this change.

Fixes #2917.
