### PR TITLE
test: skip POSIX-only fixtures on Windows instead of failing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import socket
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -44,6 +46,96 @@ def requires_symlinks(_can_symlink) -> None:
         pytest.skip(
             "symlink creation unavailable on this machine "
             "(Windows requires an elevated shell or Developer Mode)"
+        )
+
+
+@pytest.fixture(scope="session")
+def _can_mkfifo() -> bool:
+    """Whether this machine can create a FIFO (#2919).
+
+    Probed, not inferred from ``sys.platform``, for the same reason as
+    ``_can_symlink``: ``os.mkfifo`` is absent on Windows, but it can also fail
+    on a POSIX host whose temp dir sits on a filesystem that has no FIFOs
+    (some network and container mounts). Either way an ``AttributeError`` or
+    ``OSError`` raised while *building the fixture* says nothing about the code
+    under test.
+    """
+    if not hasattr(os, "mkfifo"):
+        return False
+    with tempfile.TemporaryDirectory() as d:
+        try:
+            os.mkfifo(Path(d) / "probe-fifo")
+        except (OSError, NotImplementedError):
+            return False
+        return True
+
+
+@pytest.fixture
+def requires_fifo(_can_mkfifo) -> None:
+    """Skip a test whose fixture is a named pipe when the platform has none."""
+    if not _can_mkfifo:
+        pytest.skip("named pipes (os.mkfifo) unavailable on this platform")
+
+
+@pytest.fixture(scope="session")
+def _can_bind_unix_socket() -> bool:
+    """Whether this machine can bind an ``AF_UNIX`` socket to a path (#2919).
+
+    Windows 10+ does support ``AF_UNIX``, and CPython exposes it on some
+    builds, so this cannot be decided from the platform name either — probe and
+    let the hosts that can do it keep the coverage.
+    """
+    if not hasattr(socket, "AF_UNIX"):
+        return False
+    with tempfile.TemporaryDirectory() as d:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.bind(str(Path(d) / "probe.sock"))
+        except (OSError, NotImplementedError):
+            return False
+        finally:
+            sock.close()
+        return True
+
+
+@pytest.fixture
+def requires_unix_socket(_can_bind_unix_socket) -> None:
+    """Skip a test that must bind an AF_UNIX socket where that is unsupported."""
+    if not _can_bind_unix_socket:
+        pytest.skip("AF_UNIX sockets unavailable on this platform")
+
+
+@pytest.fixture(scope="session")
+def _can_delete_cwd() -> bool:
+    """Whether a directory can be removed while it is a process's CWD (#2919).
+
+    POSIX unlinks the directory entry and leaves the process sitting on an
+    orphaned inode — the state a detached hook inherits, and the one
+    ``_rebuild_code`` has to survive. Windows keeps an open handle on the CWD,
+    so ``rmdir`` raises ``PermissionError: [WinError 32]`` and the scenario
+    cannot be constructed at all. The failure is in the fixture, not the code.
+    """
+    old = Path.cwd()
+    with tempfile.TemporaryDirectory() as d:
+        probe = Path(d) / "probe-cwd"
+        probe.mkdir()
+        try:
+            os.chdir(probe)
+            probe.rmdir()
+        except OSError:
+            return False
+        finally:
+            os.chdir(old)
+        return True
+
+
+@pytest.fixture
+def requires_deletable_cwd(_can_delete_cwd) -> None:
+    """Skip a test that must delete its own CWD where the OS forbids it."""
+    if not _can_delete_cwd:
+        pytest.skip(
+            "cannot remove a directory that is the process CWD on this platform "
+            "(Windows holds an open handle: WinError 32)"
         )
 
 

--- a/tests/test_non_regular_files.py
+++ b/tests/test_non_regular_files.py
@@ -34,7 +34,7 @@ def test_regular_source_file_is_accepted(tree):
     assert _is_regular_file(tree / "src" / "module.py") is True
 
 
-def test_fifo_is_rejected(tree):
+def test_fifo_is_rejected(tree, requires_fifo):
     """The shape that hangs the whole run."""
     fifo = tree / "src" / "pipe.py"
     os.mkfifo(fifo)
@@ -42,7 +42,7 @@ def test_fifo_is_rejected(tree):
     assert _is_regular_file(fifo) is False
 
 
-def test_unix_socket_is_rejected(tree):
+def test_unix_socket_is_rejected(tree, requires_unix_socket):
     sock_path = tree / "src" / "sock.py"
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
@@ -58,14 +58,14 @@ def test_directory_named_like_a_source_file_is_rejected(tree):
     assert _is_regular_file(d) is False
 
 
-def test_symlink_to_a_regular_file_is_accepted(tree):
+def test_symlink_to_a_regular_file_is_accepted(tree, requires_symlinks):
     target = tree / "src" / "module.py"
     link = tree / "src" / "alias.py"
     link.symlink_to(target)
     assert _is_regular_file(link) is True
 
 
-def test_symlink_pointing_at_a_fifo_is_rejected(tree):
+def test_symlink_pointing_at_a_fifo_is_rejected(tree, requires_fifo, requires_symlinks):
     """A link to a FIFO blocks exactly like the FIFO, so stat must follow it."""
     fifo = tree / "src" / "real.py"
     os.mkfifo(fifo)
@@ -74,7 +74,7 @@ def test_symlink_pointing_at_a_fifo_is_rejected(tree):
     assert _is_regular_file(link) is False
 
 
-def test_broken_symlink_is_rejected_without_raising(tree):
+def test_broken_symlink_is_rejected_without_raising(tree, requires_symlinks):
     link = tree / "src" / "dangling.py"
     link.symlink_to(tree / "src" / "does-not-exist.py")
     assert _is_regular_file(link) is False

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -651,7 +651,9 @@ def test_graphify_root_preserves_absolute_when_user_supplied(tmp_path):
     )
 
 
-def test_rebuild_code_deleted_cwd_without_repo_root_returns_false(tmp_path, monkeypatch, capsys):
+def test_rebuild_code_deleted_cwd_without_repo_root_returns_false(
+    tmp_path, monkeypatch, capsys, requires_deletable_cwd
+):
     """Detached hooks can inherit a CWD that no longer exists.
 
     Without GRAPHIFY_REPO_ROOT, the rebuild should fail cleanly before creating
@@ -675,7 +677,9 @@ def test_rebuild_code_deleted_cwd_without_repo_root_returns_false(tmp_path, monk
     assert "current working directory no longer exists" in out
 
 
-def test_rebuild_code_deleted_cwd_uses_graphify_repo_root(tmp_path, monkeypatch):
+def test_rebuild_code_deleted_cwd_uses_graphify_repo_root(
+    tmp_path, monkeypatch, requires_deletable_cwd
+):
     """GRAPHIFY_REPO_ROOT lets detached hook rebuilds recover from a deleted CWD."""
     from graphify.watch import _rebuild_code
 


### PR DESCRIPTION
Fixes #2919.

## The problem

Five tests construct their fixture out of POSIX-only OS behaviour with no platform guard, so
on Windows they fail *before the code under test is reached*:

```
tests/test_non_regular_files.py::test_fifo_is_rejected
    AttributeError: module 'os' has no attribute 'mkfifo'
tests/test_non_regular_files.py::test_unix_socket_is_rejected
    AttributeError: module 'socket' has no attribute 'AF_UNIX'
tests/test_non_regular_files.py::test_symlink_pointing_at_a_fifo_is_rejected
    AttributeError: module 'os' has no attribute 'mkfifo'
tests/test_watch.py::test_rebuild_code_deleted_cwd_without_repo_root_returns_false
    PermissionError: [WinError 32] ... '...\gone'
tests/test_watch.py::test_rebuild_code_deleted_cwd_uses_graphify_repo_root
    PermissionError: [WinError 32] ... '...\gone'
```

The last two come from

```python
os.chdir(gone)
gone.rmdir()      # POSIX unlinks a live CWD; Windows holds an open handle on it
```

which is the exact state the test wants (`_rebuild_code` surviving a detached hook's deleted
CWD) — and which Windows cannot be made to enter at all.

This is the argument `#2642` already made for symlinks:

> A plain non-elevated Windows shell raises `OSError: [WinError 1314]`, which pytest reports as
> a FAILURE — 15 of them, drowning out real defects — when what it means is "unsupported here".

`tests/test_watch.py` already skips ten tests with `fcntl-only (POSIX)`, so the practice is
settled; these five were simply missed.

## The change

Extends the `_can_symlink` / `requires_symlinks` pair in `tests/conftest.py` with siblings for
the three capabilities involved:

| fixture | guards |
|---|---|
| `requires_fifo` | `os.mkfifo` |
| `requires_unix_socket` | binding an `AF_UNIX` socket |
| `requires_deletable_cwd` | removing a directory that is the process CWD |

Each is **probed**, not inferred from `sys.platform` — `#2642`'s reasoning applies unchanged:
Windows 10+ does support `AF_UNIX` and CPython exposes it on some builds, and a POSIX host can
lack FIFOs when its temp dir is on a filesystem that has none. Hosts that *can* do these things
keep the coverage.

They live in `conftest.py` beside `_can_symlink` rather than in the two test files, so the
"probe the capability, don't guess from the platform name" doctrine stays in one place and the
next test needing a FIFO finds it.

Also adds the **existing** `requires_symlinks` fixture to the two symlink tests in
`test_non_regular_files.py` that never took it — `test_symlink_to_a_regular_file_is_accepted`
and `test_broken_symlink_is_rejected_without_raising`. They pass on a Windows box with
Developer Mode enabled and raise `WinError 1314` on one without, which is precisely the case
that fixture exists for.

## Verification

Windows 11 / Python 3.12.10, `v8` @ `b2cd362`.

Targeted:

```
$ pytest tests/test_non_regular_files.py tests/test_watch.py -q -rs
120 passed, 17 skipped
  SKIPPED tests/test_non_regular_files.py:37: named pipes (os.mkfifo) unavailable on this platform
  SKIPPED tests/test_non_regular_files.py:45: AF_UNIX sockets unavailable on this platform
  SKIPPED tests/test_non_regular_files.py:68: named pipes (os.mkfifo) unavailable on this platform
  SKIPPED tests/test_watch.py:654: cannot remove a directory that is the process CWD on this
                                   platform (Windows holds an open handle: WinError 32)
  SKIPPED tests/test_watch.py:680: (same)
```

Full suite, before and after:

| | failures | passed | skipped |
|---|---|---|---|
| `origin/v8` | 50 | 4511 | 216 |
| this branch | 44 | 4512 | 221 |

Set-diff of the `FAILED` ids: **no new failures**. The six that stopped failing are the five
guarded here plus `test_incremental_mtime_collision.py::test_same_size_rewrite_in_one_tick_is_requeued`,
which is an unrelated timing-sensitive test that happened to pass on this run — not something
this PR fixes.

Tests only — no change under `graphify/`. On Linux every probe succeeds, nothing skips, and CI
behaviour is unchanged.
