### PR TITLE
Add test coverage for paths.nfc()

### DIFF
--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -7,6 +7,7 @@ import pytest
 from graphify.paths import (
     _is_test_path,
     disambiguate_ambiguous_candidates,
+    nfc,
 )
 
 
@@ -144,3 +145,15 @@ def test_is_absolute_any_platform_is_host_independent():
     from graphify.paths import is_absolute_any_platform
     assert is_absolute_any_platform("/home/ci/x.md")
     assert is_absolute_any_platform("C:/Users/u/x.md")
+
+
+# --- NFC normalization for cross-platform path identity ---------------------
+# macOS reports filenames in NFD; manifests and graph source_file entries are
+# typically NFC. Path membership checks that skip normalization treat the same
+# file as two different paths (#2210, #2221/#2224).
+
+def test_nfc_normalizes_decomposed_unicode() -> None:
+    decomposed = "e\u0301"  # "e" + combining acute accent (NFD form)
+    composed = "\u00e9"  # "é" precomposed (NFC form)
+    assert nfc(decomposed) == composed
+    assert nfc(composed) == composed  # already-NFC input is a no-op


### PR DESCRIPTION
## Summary
- `graphify.paths.nfc()` normalizes path strings to NFC to keep macOS's NFD filenames matching NFC entries in manifests/graphs (see #2210, #2221/#2224), but had no direct unit test.
- Adds a small test asserting a decomposed (NFD) string normalizes to its precomposed (NFC) form, and that already-NFC input is a no-op.

## Test plan
- [x] `pytest tests/test_paths.py -v` — 50 passed locally