### PR TITLE
fix(extract): mask bare & in TSX JSX text so partial extraction stops (#2922)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -843,6 +843,22 @@ _TSX_LT_EXPR_PREV = frozenset(
     # end-of-token check below, which keeps the set a flat char check.
 )
 
+# Characters that can precede a ``/`` which starts a regex literal in TS/JS.
+# ``/`` after a value token (identifier, number, closing paren, bracket, or
+# brace) is a division operator, not a regex; ``<`` and ``>`` are included
+# because they can be comparison operators (``a < /b/g``), but the tag ``>``
+# handler resets the previous-char tracker so a ``/`` directly after a JSX
+# tag is not mistaken for regex.
+_TSX_REGEX_START_PREV = frozenset(
+    '=(),?:;!&|^~+-*/%[]{}<>'
+)
+
+# Keywords that put the next token in expression position, so a following
+# ``/`` can be a regex literal (``return /a/g``, ``case /a/:``, ...).
+_TSX_REGEX_START_KEYWORDS = frozenset({
+    'return', 'yield', 'throw', 'typeof', 'void', 'delete', 'case',
+})
+
 
 def _generic_arrow_tail(src: str, m: int) -> bool:
     """True when ``src[m] == '('`` opens a parameter list followed by an
@@ -935,6 +951,11 @@ def _mask_tsx_ampersands(src: str) -> str:
     # ``<`` after them is JSX), the second opens declaration position (so
     # ``<`` after them is a generic, not JSX).
     prev_code_keyword: str | None = None
+    # When the active context is 'regex', whether we are inside a character
+    # class and the index where that class opened (so a leading ``]`` is
+    # treated as a literal, not the class close).
+    regex_class = False
+    regex_class_open = -1
 
     # Cheap fast-path: if there is no ``&`` in the source, the mask is a
     # no-op and we can skip the whole walk. Almost every real TSX file has
@@ -1049,6 +1070,48 @@ def _mask_tsx_ampersands(src: str) -> str:
         c2 = src[i:i + 2] if i + 1 < n else ''
         top = stack[-1] if stack else None
 
+        if top == 'regex':
+            if c == '\\' and i + 1 < n:
+                out.append(c)
+                out.append(src[i + 1])
+                i += 2
+                continue
+            if regex_class:
+                if c == ']':
+                    if (
+                        i == regex_class_open + 1
+                        or (i == regex_class_open + 2 and src[regex_class_open + 1] == '^')
+                    ):
+                        # A leading ``]`` immediately after ``[`` or ``[^``
+                        # is a literal, not the class close.
+                        out.append(c)
+                        i += 1
+                        continue
+                    regex_class = False
+                out.append(c)
+                i += 1
+                continue
+            if c == '[':
+                regex_class = True
+                regex_class_open = i
+                out.append(c)
+                i += 1
+                continue
+            if c == '/':
+                out.append(c)
+                i += 1
+                while i < n and src[i].isalpha():
+                    out.append(src[i])
+                    i += 1
+                stack.pop()
+                # The regex literal is a value token, so ``<`` after it is a
+                # comparison and ``/`` after it is division.
+                _set_prev(')')
+                continue
+            out.append(c)
+            i += 1
+            continue
+
         if top == 'string':
             if c == '\\' and i + 1 < n:
                 out.append(c)
@@ -1142,6 +1205,9 @@ def _mask_tsx_ampersands(src: str) -> str:
                 elif kind != 'self':
                     # Opening tag → enter JSX text for the element's children.
                     stack.append('jsx_text')
+                # A complete tag is a value token; reset the tracker so the
+                # next ``<``/``/`` is not misread as a JSX/regex start.
+                _set_prev(')')
                 i += 1
                 continue
             out.append(c)
@@ -1177,6 +1243,18 @@ def _mask_tsx_ampersands(src: str) -> str:
                 stack.append('comment')
                 i += 2
                 continue
+            if c == '/' and c2 not in ('//', '/*'):
+                if (
+                    prev_code_char is None
+                    or prev_code_char in _TSX_REGEX_START_PREV
+                    or prev_code_keyword in _TSX_REGEX_START_KEYWORDS
+                ):
+                    stack.append('regex')
+                    regex_class = False
+                    regex_class_open = -1
+                    out.append(c)
+                    i += 1
+                    continue
             if c == '<':
                 # Nested JSX inside a JSX expression container
                 # (``{ok ? <span>a & b</span> : null}``): run the shared
@@ -1238,6 +1316,18 @@ def _mask_tsx_ampersands(src: str) -> str:
             stack.append('comment')
             i += 2
             continue
+        if c == '/' and c2 not in ('//', '/*'):
+            if (
+                prev_code_char is None
+                or prev_code_char in _TSX_REGEX_START_PREV
+                or prev_code_keyword in _TSX_REGEX_START_KEYWORDS
+            ):
+                stack.append('regex')
+                regex_class = False
+                regex_class_open = -1
+                out.append(c)
+                i += 1
+                continue
         if c == '<':
             # JSX-vs-generic disambiguation (shared with expression
             # containers — see ``_lt``):

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -885,7 +885,7 @@ def _generic_arrow_tail(src: str, m: int) -> bool:
 
 
 def _mask_tsx_ampersands(src: str) -> str:
-    """Escape bare ``&`` in JSX text content of TSX source (#2922).
+    """Mask bare ``&`` in JSX text content of TSX source (#2922).
 
     Tree-sitter's TSX grammar requires ``&`` in JSX text (the run between
     ``>`` and ``<`` inside a JSX element) to begin an HTML entity reference
@@ -900,12 +900,14 @@ def _mask_tsx_ampersands(src: str) -> str:
 
     Walker: a stack of contexts — ``tag`` / ``close`` / ``self`` (opening,
     closing, and self-closing tags), ``expr``, ``string``, ``comment``,
-    ``line_comment``, ``jsx_text``. Bare ``&`` is replaced with ``&amp;``
-    only when the top of the stack is ``jsx_text``; already-formed entities
-    are passed through. A closing tag pops the element's ``jsx_text``
-    context — returning to code, an expression container, or the parent
-    element's JSX text — and a self-closing tag never opens one, so code
-    after an element (bitwise ``&`` included) is never masked. ``<`` at
+    ``line_comment``, ``jsx_text``. Bare ``&`` is replaced with a single
+    ASCII space only when the top of the stack is ``jsx_text``; already-formed
+    entities are passed through. A single-byte placeholder keeps the transformed
+    source byte-aligned with the original file, so tree-sitter byte offsets and
+    ``source[start_byte:end_byte]`` slices stay valid. A closing tag pops the
+    element's ``jsx_text`` context — returning to code, an expression container,
+    or the parent element's JSX text — and a self-closing tag never opens one,
+    so code after an element (bitwise ``&`` included) is never masked. ``<`` at
     code position is treated as a JSX tag start when its previous
     non-whitespace character is an expression-context operator or
     punctuation; an alphanumeric / ``_`` / ``$`` preceding character marks
@@ -1209,7 +1211,8 @@ def _mask_tsx_ampersands(src: str) -> str:
                     out.append(m.group(0))
                     i = m.end()
                     continue
-                out.append('&amp;')
+                # Single-byte placeholder keeps source byte offsets aligned.
+                out.append(' ')
                 i += 1
                 continue
             out.append(c)
@@ -1275,7 +1278,7 @@ def _tsx_mask_source(source: bytes) -> bytes:
     ``surrogateescape`` on both sides keeps the round trip byte-preserving
     for non-UTF-8 files (latin-1 comments, BOM-less legacy encodings): the
     only byte-level change the transform may make is the intentional
-    ``&`` → ``&amp;`` insertion, never a U+FFFD rewrite of unrelated bytes.
+    ``&`` → single-space substitution, never a U+FFFD rewrite of unrelated bytes.
     """
     if b"&" not in source:
         return source

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1026,7 +1026,19 @@ def _mask_tsx_ampersands(src: str) -> str:
                     k += 1
                 nxt_after = src[k:k + 1] if k < n else ''
                 after_word = src[k:k + 8]
-                if nxt_after == ',' or after_word.startswith('extends') or nxt_after == '=':
+                is_extends_generic = False
+                if after_word.startswith('extends'):
+                    # ``extends`` can be a generic constraint (``<T extends X>``)
+                    # or a JSX attribute (``<Foo extends={...}>``). An attribute
+                    # has its value assignment ``=`` immediately after the name
+                    # (with optional spaces); a generic constraint has a type
+                    # expression. Treat ``>``/``/``/EOF after ``extends`` as JSX
+                    # boolean attributes as well.
+                    p = k + len('extends')
+                    while p < n and src[p].isspace():
+                        p += 1
+                    is_extends_generic = p < n and src[p] not in ('=', '>', '/')
+                if nxt_after == ',' or is_extends_generic or nxt_after == '=':
                     # ``<T,>`` / ``<T extends X>`` / ``<T = X>``: generic.
                     push = None
                 elif nxt_after == '(':
@@ -1051,7 +1063,7 @@ def _mask_tsx_ampersands(src: str) -> str:
                     push = None if (
                         m < n
                         and src[m] == '('
-                        and src[b + 1].isupper()
+                        and nxt.isupper()
                         and _generic_arrow_tail(src, m)
                     ) else 'tag'
                 else:

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -820,6 +820,470 @@ _TS_CONFIG = LanguageConfig(
     import_handler=_import_js,
 )
 
+# TSX JSX text requires ``&`` to start an HTML entity reference (``&amp;``,
+# ``&#NN;``, ``&lt;``, ...); a bare ``&`` produces an ERROR node and the
+# partial-extraction warning fires (#2551, #2922). ``&`` inside JSX tag
+# attribute values, JSX expression containers ``{ ... }``, string literals,
+# comments, and TS code is already accepted by tree-sitter-typescript — only
+# JSX text content is strict. Mask bare ``&`` to ``&amp;`` so the TSX grammar
+# parses the file cleanly; the entity serializes back to a single ``&`` so
+# the visible text is byte-identical to the user-written source.
+_TSX_ENTITY_RE = re.compile(r'&(?:#[xX][0-9a-fA-F]+|#[0-9]+|[A-Za-z][A-Za-z0-9]*);')
+
+# Characters whose preceding position puts ``<`` at expression position (so it
+# must be a JSX tag start, not a comparison or a generic type parameter). The
+# inverse — alphanumeric / ``_`` / ``$`` — marks ``<`` as a likely generic
+# type-parameter opener (``function f<T>``, ``class Foo<T>``, ``type Bar<T>``)
+# or part of a comparison (``a < b``); in those positions the source is TS
+# code, not JSX, and bare ``&`` there is bitwise AND and must not be masked.
+_TSX_LT_EXPR_PREV = frozenset(
+    '=(),?:;!&|^~+-*/%<>[]{}'  # operators and punctuation
+    # Keyword tails also act as expression context but are matched by the
+    # ``return``/``yield``/``new``/``as``/``typeof``/``void``/``delete``
+    # end-of-token check below, which keeps the set a flat char check.
+)
+
+
+def _generic_arrow_tail(src: str, m: int) -> bool:
+    """True when ``src[m] == '('`` opens a parameter list followed by an
+    ``=>`` — the tail of a generic arrow / function type such as
+    ``<TKey>(x: TKey) => x`` or ``<T>(x: T): T => x``.
+
+    Used by the ``<`` disambiguation in :func:`_mask_tsx_ampersands`:
+    classifying a generic arrow as a JSX tag would strand the walker in
+    ``jsx_text`` and corrupt a later bitwise ``a & b`` into ``a &amp; b``
+    (a parse error — the very bug class this mask removes), so an
+    uppercase ``<TKey>`` directly followed by ``>(`` is only treated as a
+    tag when no arrow tail follows the balanced parameter list. The scan
+    is bounded so pathological input cannot make the walker quadratic.
+    """
+    n = len(src)
+    limit = min(n, m + 600)
+    depth = 0
+    i = m
+    while i < limit:
+        c = src[i]
+        if c == '(':
+            depth += 1
+        elif c == ')':
+            depth -= 1
+            if depth == 0:
+                j = i + 1
+                while j < n and src[j].isspace():
+                    j += 1
+                if src[j:j + 2] == '=>':
+                    return True
+                if j < n and src[j] == ':':
+                    # ``(x: TKey): TResult => x`` — return-type annotation
+                    # between the parameter list and the arrow.
+                    end = src.find(';', j)
+                    stop = end if end != -1 else min(n, j + 200)
+                    return '=>' in src[j:stop]
+                return False
+        i += 1
+    return False
+
+
+def _mask_tsx_ampersands(src: str) -> str:
+    """Escape bare ``&`` in JSX text content of TSX source (#2922).
+
+    Tree-sitter's TSX grammar requires ``&`` in JSX text (the run between
+    ``>`` and ``<`` inside a JSX element) to begin an HTML entity reference
+    (``&amp;``, ``&#NN;``, ``&lt;``, ...). A bare ``&`` produces an ERROR node
+    and the parser returns a partial tree; the partial-extraction path
+    surfaces ``parse_errors`` metadata (#2551) that, while silenced by the
+    multiline-error gate for single-line cases (#2788), still drops the
+    symbol set the file actually contains. ``&`` inside JSX tags, JSX
+    expression containers ``{...}``, string literals, comments, and TS code
+    (where ``&`` is bitwise AND) is left alone because the grammar already
+    accepts it there.
+
+    Walker: a stack of contexts — ``tag`` / ``close`` / ``self`` (opening,
+    closing, and self-closing tags), ``expr``, ``string``, ``comment``,
+    ``line_comment``, ``jsx_text``. Bare ``&`` is replaced with ``&amp;``
+    only when the top of the stack is ``jsx_text``; already-formed entities
+    are passed through. A closing tag pops the element's ``jsx_text``
+    context — returning to code, an expression container, or the parent
+    element's JSX text — and a self-closing tag never opens one, so code
+    after an element (bitwise ``&`` included) is never masked. ``<`` at
+    code position is treated as a JSX tag start when its previous
+    non-whitespace character is an expression-context operator or
+    punctuation; an alphanumeric / ``_`` / ``$`` preceding character marks
+    it as a generic type-parameter opener (``function f<T>``, ``type Bar<T>``)
+    or part of a comparison, in which case we stay in code mode. Inside
+    JSX expression containers the same shape disambiguation runs with
+    expression context forced on, so nested JSX
+    (``{ok ? <span>a & b</span> : null}``) is masked as well.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(src)
+    stack: list[str] = []
+    # When the active context is 'string', the matching quote character.
+    str_quote: str | None = None
+    # Previous non-whitespace character in the source (None at file start).
+    # Drives the ``<`` heuristic for JSX-vs-generic disambiguation at code
+    # position: alphanumeric / ``_`` / ``$`` means code (likely generic);
+    # operator/punctuation means expression position (likely JSX tag).
+    prev_code_char: str | None = None
+    # Last non-whitespace JS keyword encountered at code position. ``return``,
+    # ``yield``, ``throw``, ``new``, ``as``, ``typeof``, ``void``, ``delete``,
+    # ``function``, ``class``, ``type``, ``interface``, ``enum``, ``import``,
+    # ``export`` — the first group opens expression expression position (so
+    # ``<`` after them is JSX), the second opens declaration position (so
+    # ``<`` after them is a generic, not JSX).
+    prev_code_keyword: str | None = None
+
+    # Cheap fast-path: if there is no ``&`` in the source, the mask is a
+    # no-op and we can skip the whole walk. Almost every real TSX file has
+    # at least one ``&`` (entity refs, JSX expression ``&&``, bitwise in code),
+    # so the walk runs — but the empty-source / no-ampersand case avoids the
+    # allocation when feeding test fixtures without ``&``.
+    if '&' not in src:
+        return src
+
+    def _set_prev(c: str) -> None:
+        nonlocal prev_code_char, prev_code_keyword
+        prev_code_char = c
+        # Reset keyword when a non-identifier character is emitted at code
+        # position. The keyword tracker is updated on identifier characters.
+        if not (c.isalnum() or c == '_' or c == '$'):
+            prev_code_keyword = None
+
+    def _extend_keyword(c: str) -> None:
+        nonlocal prev_code_keyword
+        # Extend a trailing identifier-shaped run with one more letter.
+        if prev_code_keyword is not None:
+            prev_code_keyword = prev_code_keyword + c
+        else:
+            prev_code_keyword = c
+
+    def _lt(expr_ctx: bool) -> None:
+        """Consume a ``<`` at code or expression position.
+
+        Shared by code mode and JSX expression containers so nested JSX
+        (``{ok ? <span>a & b</span> : null}``) is masked like top-level JSX.
+        ``expr_ctx`` forces expression position; code mode derives it from
+        the previous-character / keyword trackers. Tag-shaped ``<`` pushes
+        a ``tag`` (or ``close`` for ``</``) context; generic type parameters
+        and comparisons stay in the current mode.
+        """
+        nonlocal i
+        b = i
+        nxt = src[b + 1] if b + 1 < n else ''
+        push: str | None = None
+        if expr_ctx or prev_code_char is None or prev_code_char in _TSX_LT_EXPR_PREV or prev_code_keyword in (
+            'return', 'yield', 'throw', 'new', 'as', 'typeof',
+            'void', 'delete',
+        ):
+            if nxt == '>':
+                # Fragment ``<>``.
+                push = 'tag'
+            elif nxt == '/':
+                # Closing ``</x>`` (e.g. entered from code mode after the
+                # opening element was missed).
+                push = 'close'
+            elif nxt.isalpha() or nxt == '_' or nxt == '$':
+                # Look past the identifier to decide JSX vs generic.
+                # ``<T>`` / ``<T,>`` / ``<T extends X>`` / ``<T>(...)``
+                # are generic-arrow shapes (single-letter type-parameter
+                # list with optional constraint or default); treating
+                # those as JSX would push jsx_text mode for the rest
+                # of the file and incorrectly mask any subsequent
+                # bitwise ``&`` in code. The shape check classifies
+                # what comes after the identifier: ``,`` / ``extends``
+                # / ``=`` / ``(`` all signal a generic parameter
+                # list; ``<>``, ``/>``, attributes, or a multi-character
+                # identifier signal a JSX tag.
+                j = b + 1
+                while j < n and (src[j].isalnum() or src[j] in '_$'):
+                    j += 1
+                k = j
+                while k < n and src[k].isspace():
+                    k += 1
+                nxt_after = src[k:k + 1] if k < n else ''
+                after_word = src[k:k + 8]
+                if nxt_after == ',' or after_word.startswith('extends') or nxt_after == '=':
+                    # ``<T,>`` / ``<T extends X>`` / ``<T = X>``: generic.
+                    push = None
+                elif nxt_after == '(':
+                    # ``<T>(...) => ...`` is a generic arrow function.
+                    push = None
+                elif nxt_after == '>':
+                    # ``<T>`` / ``<TKey>``: identifier directly followed
+                    # by ``>``. What comes after the ``>`` disambiguates:
+                    # ``(`` opening a parameter list with an arrow tail
+                    # (see ``_generic_arrow_tail``) means a generic arrow /
+                    # function type (``<T>(x: T) => x``, ``<TKey>(x: TKey)
+                    # => x``, ``let f: <T>(x: T) => void``); anything else
+                    # (text, ``<``, ``{``, ``/``, end) means a JSX element
+                    # like ``<A>VoIP & Chamadas</A>`` — single-letter
+                    # components (icon/nav shorthand) and multi-letter ones
+                    # alike mask their JSX text like any other tag.
+                    # Uppercase-initial is required for the generic
+                    # reading; lowercase ``<foo>(...)`` stays JSX.
+                    m = k + 1
+                    while m < n and src[m].isspace():
+                        m += 1
+                    push = None if (
+                        m < n
+                        and src[m] == '('
+                        and src[b + 1].isupper()
+                        and _generic_arrow_tail(src, m)
+                    ) else 'tag'
+                else:
+                    # Multi-character identifier, lowercase, or content
+                    # after ``>`` (``<TagName ...>``, ``<TagName/>``,
+                    # ``<tagname attr=...>``): JSX tag.
+                    push = 'tag'
+        out.append('<')
+        _set_prev('<')
+        if push is not None:
+            stack.append(push)
+        i += 1
+
+    while i < n:
+        c = src[i]
+        c2 = src[i:i + 2] if i + 1 < n else ''
+        top = stack[-1] if stack else None
+
+        if top == 'string':
+            if c == '\\' and i + 1 < n:
+                out.append(c)
+                out.append(src[i + 1])
+                i += 2
+                continue
+            if c == str_quote:
+                out.append(c)
+                stack.pop()
+                str_quote = None
+                i += 1
+                continue
+            out.append(c)
+            i += 1
+            continue
+
+        if top == 'comment':
+            if c == '*' and i + 1 < n and src[i + 1] == '/':
+                out.append('*/')
+                stack.pop()
+                i += 2
+                continue
+            out.append(c)
+            i += 1
+            continue
+
+        if top == 'line_comment':
+            if c == '\n':
+                out.append(c)
+                stack.pop()
+                # Newline ends the code-level identifier run; reset keyword.
+                prev_code_char = c
+                prev_code_keyword = None
+                i += 1
+                continue
+            out.append(c)
+            i += 1
+            continue
+
+        if top in ('tag', 'close', 'self'):
+            if c in '"\'':
+                out.append(c)
+                stack.append('string')
+                str_quote = c
+                i += 1
+                continue
+            if c == '`':
+                out.append(c)
+                stack.append('string')
+                str_quote = c
+                i += 1
+                continue
+            if c == '/' and c2 == '//':
+                out.append('//')
+                stack.append('line_comment')
+                i += 2
+                continue
+            if c == '/' and c2 == '/*':
+                out.append('/*')
+                stack.append('comment')
+                i += 2
+                continue
+            if c == '/':
+                j = i + 1
+                while j < n and src[j].isspace():
+                    j += 1
+                if j < n and src[j] == '>' and stack[-1] == 'tag':
+                    # Self-closing ``/>`` (possibly spaced, opening tags
+                    # only — ``</>`` is a fragment close): the upcoming
+                    # ``>`` must not open a jsx_text context for this
+                    # childless element.
+                    stack[-1] = 'self'
+                out.append(c)
+                i += 1
+                continue
+            if c == '{':
+                out.append(c)
+                stack.append('expr')
+                i += 1
+                continue
+            if c == '>':
+                out.append(c)
+                kind = stack.pop()
+                if kind == 'close':
+                    # ``</tag>`` closes the element: drop the jsx_text
+                    # context for its children and return to whatever
+                    # surrounded the element (code, expr container, or the
+                    # parent element's JSX text).
+                    if stack and stack[-1] == 'jsx_text':
+                        stack.pop()
+                elif kind != 'self':
+                    # Opening tag → enter JSX text for the element's children.
+                    stack.append('jsx_text')
+                i += 1
+                continue
+            out.append(c)
+            if not c.isspace():
+                _set_prev(c)
+            i += 1
+            continue
+
+        if top == 'expr':
+            if c == '{':
+                out.append(c)
+                stack.append('expr')
+                i += 1
+                continue
+            if c == '}':
+                out.append(c)
+                stack.pop()
+                i += 1
+                continue
+            if c == '"' or c == "'" or c == '`':
+                out.append(c)
+                stack.append('string')
+                str_quote = c
+                i += 1
+                continue
+            if c == '/' and c2 == '//':
+                out.append('//')
+                stack.append('line_comment')
+                i += 2
+                continue
+            if c == '/' and c2 == '/*':
+                out.append('/*')
+                stack.append('comment')
+                i += 2
+                continue
+            if c == '<':
+                # Nested JSX inside a JSX expression container
+                # (``{ok ? <span>a & b</span> : null}``): run the shared
+                # tag/generic disambiguation with expression context
+                # forced on so the nested element's JSX text is masked.
+                _lt(True)
+                continue
+            out.append(c)
+            if not c.isspace():
+                _set_prev(c)
+            i += 1
+            continue
+
+        if top == 'jsx_text':
+            if c == '<':
+                out.append(c)
+                # ``</`` closes the element whose children we are walking;
+                # any other ``<`` opens a nested child element.
+                stack.append('close' if c2 == '</' else 'tag')
+                _set_prev(c)
+                i += 1
+                continue
+            if c == '{':
+                out.append(c)
+                stack.append('expr')
+                _set_prev(c)
+                i += 1
+                continue
+            if c == '&':
+                m = _TSX_ENTITY_RE.match(src, i)
+                if m:
+                    out.append(m.group(0))
+                    i = m.end()
+                    continue
+                out.append('&amp;')
+                i += 1
+                continue
+            out.append(c)
+            if not c.isspace():
+                _set_prev(c)
+            i += 1
+            continue
+
+        # Code mode: TS/JS at root or expression-container children.
+        if c == '"' or c == "'" or c == '`':
+            out.append(c)
+            stack.append('string')
+            str_quote = c
+            i += 1
+            continue
+        if c == '/' and c2 == '//':
+            out.append('//')
+            stack.append('line_comment')
+            i += 2
+            continue
+        if c == '/' and c2 == '/*':
+            out.append('/*')
+            stack.append('comment')
+            i += 2
+            continue
+        if c == '<':
+            # JSX-vs-generic disambiguation (shared with expression
+            # containers — see ``_lt``):
+            # - alphanumeric / _ / $ before <  → declaration position
+            #   (function/class/type/interface name + type parameters) or
+            #   a comparison; in either case ``<`` is NOT a JSX tag start.
+            # - operator / punctuation before <  → expression position;
+            #   ``<`` is a JSX tag start. The exception list also covers
+            #   ``return``/``yield``/``new`` etc. via the keyword tracker:
+            #   ``return <Foo/>`` puts ``<`` after ``n``, which is alpha, so
+            #   the bare-char check would misclassify it as code. The
+            #   keyword tracker catches the expression-position keywords.
+            # - declaration keywords (function/class/type/interface/enum/
+            #   import/export) + identifier + < → still a generic opener.
+            _lt(False)
+            continue
+        if c.isalpha() or c == '_' or c == '$':
+            out.append(c)
+            _extend_keyword(c)
+            prev_code_char = c
+            i += 1
+            continue
+        out.append(c)
+        if not c.isspace():
+            _set_prev(c)
+        i += 1
+
+    return ''.join(out)
+
+
+def _tsx_mask_source(source: bytes) -> bytes:
+    """Bytes form of the JSX-text ``&`` mask for ``LanguageConfig.source_transform``.
+
+    ``_extract_generic`` parses raw bytes, so the str walker is wrapped in a
+    decode/mask/encode round trip. The ``b"&"`` fast path keeps the common
+    no-ampersand file a true no-op (same bytes object, no allocation) so the
+    config hook adds no measurable cost to the languages that never mask.
+    ``surrogateescape`` on both sides keeps the round trip byte-preserving
+    for non-UTF-8 files (latin-1 comments, BOM-less legacy encodings): the
+    only byte-level change the transform may make is the intentional
+    ``&`` → ``&amp;`` insertion, never a U+FFFD rewrite of unrelated bytes.
+    """
+    if b"&" not in source:
+        return source
+    return _mask_tsx_ampersands(
+        source.decode("utf-8", errors="surrogateescape")
+    ).encode("utf-8", errors="surrogateescape")
+
+
 # .tsx files must use the TSX grammar (JSX-aware), not the plain TypeScript grammar.
 # tree-sitter-typescript ships two languages: language_typescript (for .ts) and
 # language_tsx (for .tsx). Parsing .tsx with language_typescript silently fails on
@@ -837,6 +1301,10 @@ _TSX_CONFIG = LanguageConfig(
     call_accessor_object_field=_TS_CONFIG.call_accessor_object_field,
     function_boundary_types=_TS_CONFIG.function_boundary_types,
     import_handler=_TS_CONFIG.import_handler,
+    # Bare ``&`` in JSX text trips the TSX grammar (#2922); mask it at the
+    # engine's read path so every TSX parse (including embedded scripts)
+    # gets the fix. See :func:`_mask_tsx_ampersands`.
+    source_transform=_tsx_mask_source,
 )
 
 _JAVA_CONFIG = LanguageConfig(

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -825,9 +825,10 @@ _TS_CONFIG = LanguageConfig(
 # partial-extraction warning fires (#2551, #2922). ``&`` inside JSX tag
 # attribute values, JSX expression containers ``{ ... }``, string literals,
 # comments, and TS code is already accepted by tree-sitter-typescript — only
-# JSX text content is strict. Mask bare ``&`` to ``&amp;`` so the TSX grammar
-# parses the file cleanly; the entity serializes back to a single ``&`` so
-# the visible text is byte-identical to the user-written source.
+# JSX text content is strict. A bare ``&`` in JSX text is replaced with a
+# single ASCII space so the TSX grammar parses the file cleanly; the one-byte
+# placeholder keeps the transformed source byte-aligned with the original file
+# so ``source[start_byte:end_byte]`` slices stay accurate.
 _TSX_ENTITY_RE = re.compile(r'&(?:#[xX][0-9a-fA-F]+|#[0-9]+|[A-Za-z][A-Za-z0-9]*);')
 
 # Characters whose preceding position puts ``<`` at expression position (so it
@@ -867,35 +868,146 @@ def _generic_arrow_tail(src: str, m: int) -> bool:
 
     Used by the ``<`` disambiguation in :func:`_mask_tsx_ampersands`:
     classifying a generic arrow as a JSX tag would strand the walker in
-    ``jsx_text`` and corrupt a later bitwise ``a & b`` into ``a &amp; b``
-    (a parse error — the very bug class this mask removes), so an
+    ``jsx_text`` and corrupt a later bitwise ``a & b`` into ``a   b``
+    (a parse error — the very bug class this fix removes), so an
     uppercase ``<TKey>`` directly followed by ``>(`` is only treated as a
     tag when no arrow tail follows the balanced parameter list. The scan
     is bounded so pathological input cannot make the walker quadratic.
+
+    The scan skips over string literals, comments, and regex literals so
+    that ``)`` / ``;`` characters inside them do not break the parameter
+    list balance or prematurely end the return-type search.
     """
     n = len(src)
-    limit = min(n, m + 600)
-    depth = 0
+    limit = min(n, m + 800)
     i = m
+    paren_depth = 0
+    return_depth = 0
+    mode = 'params'
+    prev: str | None = None
+    keyword: str | None = None
+
+    def _set_prev(c: str) -> None:
+        nonlocal prev, keyword
+        prev = c
+        if not (c.isalnum() or c == '_' or c == '$'):
+            keyword = None
+
+    def _extend_keyword(c: str) -> None:
+        nonlocal keyword
+        keyword = (keyword or '') + c
+
+    def _skip_string(i: int, quote: str) -> int:
+        i += 1
+        while i < limit:
+            if src[i] == '\\' and i + 1 < n:
+                i += 2
+                continue
+            if src[i] == quote:
+                return i + 1
+            i += 1
+        return i
+
+    def _skip_comment(i: int) -> int:
+        if src[i + 1] == '/':
+            while i < limit and src[i] != '\n':
+                i += 1
+        else:
+            i += 2
+            while i + 1 < limit and not (src[i] == '*' and src[i + 1] == '/'):
+                i += 1
+            i += 2
+        return i
+
+    def _skip_regex(i: int) -> int:
+        nonlocal prev, keyword
+        i += 1
+        in_class = False
+        class_open = -1
+        while i < limit:
+            c = src[i]
+            if c == '\\' and i + 1 < n:
+                i += 2
+                continue
+            if in_class:
+                if c == ']':
+                    if i == class_open + 1 or (i == class_open + 2 and src[class_open + 1] == '^'):
+                        i += 1
+                        continue
+                    in_class = False
+                i += 1
+                continue
+            if c == '[':
+                in_class = True
+                class_open = i
+                i += 1
+                continue
+            if c == '/':
+                i += 1
+                while i < n and src[i].isalpha():
+                    i += 1
+                break
+            i += 1
+        prev, keyword = 'a', None
+        return i
+
     while i < limit:
         c = src[i]
+        c2 = src[i:i + 2] if i + 1 < n else ''
+        if c in '"\'`':
+            i = _skip_string(i, c)
+            _set_prev(c)
+            continue
+        if c2 == '//' or c2 == '/*':
+            i = _skip_comment(i)
+            continue
+        if c == '/' and c2 not in ('//', '/*') and (
+            prev is None
+            or prev in _TSX_REGEX_START_PREV
+            or keyword in _TSX_REGEX_START_KEYWORDS
+        ):
+            i = _skip_regex(i)
+            continue
         if c == '(':
-            depth += 1
+            if mode == 'params':
+                paren_depth += 1
+            else:
+                return_depth += 1
         elif c == ')':
-            depth -= 1
-            if depth == 0:
-                j = i + 1
-                while j < n and src[j].isspace():
-                    j += 1
-                if src[j:j + 2] == '=>':
+            if mode == 'params':
+                paren_depth -= 1
+                if paren_depth == 0:
+                    i += 1
+                    while i < n and src[i].isspace():
+                        i += 1
+                    if src[i:i + 2] == '=>':
+                        return True
+                    if i < n and src[i] == ':':
+                        mode = 'return'
+                        return_depth = 0
+                        i += 1
+                        continue
+                    return False
+            else:
+                return_depth -= 1
+        elif mode == 'return':
+            if c == '=' and c2 == '=>':
+                if return_depth == 0:
                     return True
-                if j < n and src[j] == ':':
-                    # ``(x: TKey): TResult => x`` — return-type annotation
-                    # between the parameter list and the arrow.
-                    end = src.find(';', j)
-                    stop = end if end != -1 else min(n, j + 200)
-                    return '=>' in src[j:stop]
+                i += 2
+                continue
+            if c in '[{<':
+                return_depth += 1
+            elif c in ']}>':
+                return_depth -= 1
+            elif c == ';' and return_depth == 0:
                 return False
+        if not c.isspace():
+            if c.isalnum() or c == '_' or c == '$':
+                _extend_keyword(c)
+            else:
+                keyword = None
+            prev = c
         i += 1
     return False
 

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2809,6 +2809,10 @@ def _extract_generic(
     try:
         parser = Parser(language)
         source = path.read_bytes() if source_override is None else source_override
+        if config.source_transform is not None:
+            # Per-language byte mask applied to whatever gets parsed — e.g.
+            # the TSX bare-``&``-in-JSX-text mask (#2922).
+            source = config.source_transform(source)
         tree = parser.parse(source)
         root = tree.root_node
     except Exception as e:

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2809,11 +2809,16 @@ def _extract_generic(
     try:
         parser = Parser(language)
         source = path.read_bytes() if source_override is None else source_override
+        parse_source = source
         if config.source_transform is not None:
-            # Per-language byte mask applied to whatever gets parsed — e.g.
-            # the TSX bare-``&``-in-JSX-text mask (#2922).
-            source = config.source_transform(source)
-        tree = parser.parse(source)
+            # Per-language byte mask applied only to the bytes the parser sees —
+            # e.g. the TSX bare-``&``-in-JSX-text mask (#2922). The mask is
+            # byte-length-preserving, so the parse tree's offsets stay aligned
+            # with the original file. Keep the original source for downstream
+            # ``source[start_byte:end_byte]`` slices so snippets/locations are
+            # reported against the user's file, not the masked copy.
+            parse_source = config.source_transform(source)
+        tree = parser.parse(parse_source)
         root = tree.root_node
     except Exception as e:
         return {"nodes": [], "edges": [], "error": str(e)}

--- a/graphify/extractors/models.py
+++ b/graphify/extractors/models.py
@@ -53,6 +53,11 @@ class LanguageConfig:
     # Extra walk hook called after generic dispatch (for JS arrow functions, C# namespaces, etc.)
     extra_walk_fn: Callable | None = None
 
+    # Optional bytes transform applied to the source right before parsing
+    # (e.g. the TSX bare-``&`` JSX-text mask, #2922). Runs on the bytes that
+    # are actually parsed, after any ``source_override`` substitution.
+    source_transform: Callable[[bytes], bytes] | None = None
+
 @dataclass(frozen=True)
 class _SymbolDeclarationFact:
     file_path: Path

--- a/graphify/extractors/models.py
+++ b/graphify/extractors/models.py
@@ -54,8 +54,10 @@ class LanguageConfig:
     extra_walk_fn: Callable | None = None
 
     # Optional bytes transform applied to the source right before parsing
-    # (e.g. the TSX bare-``&`` JSX-text mask, #2922). Runs on the bytes that
-    # are actually parsed, after any ``source_override`` substitution.
+    # (e.g. the TSX bare-``&`` JSX-text mask, #2922). It MUST preserve the
+    # total UTF-8 byte length so tree-sitter's start_byte/end_byte slices stay
+    # aligned with the original file. Runs on the bytes that are actually
+    # parsed, after any ``source_override`` substitution.
     source_transform: Callable[[bytes], bytes] | None = None
 
 @dataclass(frozen=True)

--- a/tests/fixtures/tsx_jsx_text_ampersand.tsx
+++ b/tests/fixtures/tsx_jsx_text_ampersand.tsx
@@ -1,0 +1,49 @@
+// #2922 — bare ``&`` in JSX text breaks the TSX grammar and drops symbols.
+// tree-sitter-typescript requires ``&`` in JSX text (the run between ``>``
+// and ``<`` inside a JSX element) to begin an HTML entity reference; a bare
+// ``&`` produces an ERROR node and the partial-extraction path surfaces a
+// parse_errors warning (#2551). Before the fix, this file extracted to a
+// single file node — every function, class, and import was silently lost.
+// After the fix, the bare ``&`` in JSX text is masked to ``&amp;`` and every
+// node below extracts cleanly with no parse_errors.
+
+import { helper } from "./helper";
+
+const FLAG_MASK = 0xff & 0x0f;
+
+export function Page() {
+    return (
+        <div className="page">
+            <h1>VoIP & Chamadas</h1>
+            <h2>Conexões & Integrações</h2>
+            <p>
+                Welcome & hello. Mixed & multiple & ampersands.
+            </p>
+            <span title="VoIP & SIP" />
+            <a href="/search?q=a&b=c">link</a>
+            <ul>
+                {items.filter((it) => it.flag && it.visible).map((it) => (
+                    <li key={it.id}>{it.label}</li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+export class Component extends React.Component {
+    render() {
+        return (
+            <section>
+                <header>A & B</header>
+                <footer>{helper(FLAG_MASK)}</footer>
+            </section>
+        );
+    }
+}
+
+export const fragment = (
+    <>
+        <span>one & two</span>
+        <span>three &amp; four</span>
+    </>
+);

--- a/tests/test_tsx_jsx_text_ampersand.py
+++ b/tests/test_tsx_jsx_text_ampersand.py
@@ -287,6 +287,16 @@ _MASK_CASES = [
      'const a = <Foo extends={a & b}>t   v</Foo>;'),
     ('const a = <Foo extends>t & v</Foo>;',
      'const a = <Foo extends>t   v</Foo>;'),
+    # --- Generic arrow / function-type tails keep ``&`` in code even when
+    # the return type or default parameter contains a ``;`` or ``)``.
+    ('const pick = <TKey>(x: TKey): { a: number; b: string } => x;\nconst b = 1 & 2;\n',
+     'const pick = <TKey>(x: TKey): { a: number; b: string } => x;\nconst b = 1 & 2;\n'),
+    ('const f = <T>(x: T = ")") => x;\nconst b = 1 & 2;\n',
+     'const f = <T>(x: T = ")") => x;\nconst b = 1 & 2;\n'),
+    ('const f = <T>(x: T = /a\\/b/g) => x;\nconst b = 1 & 2;\n',
+     'const f = <T>(x: T = /a\\/b/g) => x;\nconst b = 1 & 2;\n'),
+    ('const f = <T>(x: T): "a; b" => x;\nconst b = 1 & 2;\n',
+     'const f = <T>(x: T): "a; b" => x;\nconst b = 1 & 2;\n'),
     # A real generic constraint ``<T extends X>`` still stays code.
     ('function f<T extends X>() { return 1 & 2; }',
      'function f<T extends X>() { return 1 & 2; }'),

--- a/tests/test_tsx_jsx_text_ampersand.py
+++ b/tests/test_tsx_jsx_text_ampersand.py
@@ -279,6 +279,17 @@ _MASK_CASES = [
      'const a = foo() / 2;'),
     ('const a = <div/> / 2;',
      'const a = <div/> / 2;'),
+    # --- ``extends`` as a JSX attribute must not be misread as a generic
+    # constraint; the element's children are still JSX text.
+    ('const a = <Foo extends="a & b">t & v</Foo>;',
+     'const a = <Foo extends="a & b">t   v</Foo>;'),
+    ('const a = <Foo extends={a & b}>t & v</Foo>;',
+     'const a = <Foo extends={a & b}>t   v</Foo>;'),
+    ('const a = <Foo extends>t & v</Foo>;',
+     'const a = <Foo extends>t   v</Foo>;'),
+    # A real generic constraint ``<T extends X>`` still stays code.
+    ('function f<T extends X>() { return 1 & 2; }',
+     'function f<T extends X>() { return 1 & 2; }'),
     # --- Fast-path: sources without ``&`` (or empty) are a no-op.
     ('', ''),
     ('// nothing here\nconst x = 1;\n',

--- a/tests/test_tsx_jsx_text_ampersand.py
+++ b/tests/test_tsx_jsx_text_ampersand.py
@@ -327,6 +327,10 @@ def test_mask_source_round_trips_non_utf8_bytes():
     (b'<Box>a & b</Box>', b'<Box>a   b</Box>'),
     ('<Box>Conexões & Integrações</Box>'.encode('utf-8'),
      '<Box>Conexões   Integrações</Box>'.encode('utf-8')),
+    # Non-BMP (4-byte UTF-8) emoji in JSX text: the replacement stays one
+    # byte, so offsets remain aligned with the original file.
+    ('<Box>🚀 & Chamadas</Box>'.encode('utf-8'),
+     '<Box>🚀   Chamadas</Box>'.encode('utf-8')),
     (b'<Box>a & b</Box>  // caf\xe9 latin-1 comment\n',
      b'<Box>a   b</Box>  // caf\xe9 latin-1 comment\n'),
     (b'<Box>a & b</Box> \xff\xfe',
@@ -375,6 +379,23 @@ def test_nested_jsx_in_expression_container_is_masked(tmp_path, capsys):
         ),
     })
     assert "view" in _labels(r)
+    _assert_silent(capsys.readouterr().err)
+    assert r.get("parse_errors") in (None, [])
+
+
+def test_non_bmp_jsx_text_ampersand_is_silent(tmp_path, capsys):
+    """A non-BMP character (e.g. U+1F680 🚀, 4 UTF-8 bytes) in JSX text
+    followed by a bare ``&`` must not shift parser offsets. The mask
+    replaces ``&`` with a single ASCII space, so the byte length of the
+    source stays identical before and after the transform."""
+    r = _extract(tmp_path, {
+        "page.tsx": (
+            "export function Page() {\n"
+            "    return <Box>🚀 & Chamadas</Box>;\n"
+            "}\n"
+        ),
+    })
+    assert "Page()" in _labels(r)
     _assert_silent(capsys.readouterr().err)
     assert r.get("parse_errors") in (None, [])
 

--- a/tests/test_tsx_jsx_text_ampersand.py
+++ b/tests/test_tsx_jsx_text_ampersand.py
@@ -35,9 +35,12 @@ Regression canaries cover every case the walker must keep stable:
 * Generic arrows and function types — single-letter or multi-character
   (``<TKey>(x: TKey) => x``, ``type F = <TKey>(x: TKey) => void``, with or
   without a return-type annotation) — stay code, so a later bitwise
-  ``a & b`` is never corrupted into ``a &amp; b``.
-* The bytes mask is byte-preserving outside the ``&`` → ``&amp;``
-  insertions (non-UTF-8 bytes round-trip unchanged).
+  ``a & b`` is never corrupted into ``a   b`` (which would reintroduce a
+  parse error).
+* The bytes mask is fully byte-preserving: every ``&`` in JSX text is
+  replaced by a single ASCII space, so tree-sitter byte offsets and
+  ``source[start_byte:end_byte]`` slices stay aligned with the original
+  source (non-UTF-8 bytes round-trip unchanged).
 """
 from __future__ import annotations
 
@@ -150,14 +153,16 @@ def test_existing_entity_in_jsx_text_is_passed_through(tmp_path, capsys):
 # the helper keeps exactly one production caller (its ``_tsx_mask_source``
 # wiring) — the afferent-coupling health gate counts direct test call sites.
 _MASK_CASES = [
-    # --- JSX text: bare ``&`` masked to ``&amp;``, byte-neutral.
+    # --- JSX text: bare ``&`` masked to a single ASCII space, keeping source
+    # byte offsets aligned with the original file.
     # Exact-output match covers: masked exactly once, no double-mask
-    # (``&amp;amp;``), surrounding text byte-identical.
+    # (``&amp;amp;``), surrounding text byte-identical except the one-byte
+    # placeholder.
     ('<div>VoIP & Chamadas</div>',
-     '<div>VoIP &amp; Chamadas</div>'),
+     '<div>VoIP   Chamadas</div>'),
     # Every bare ``&`` in one JSX-text run is masked independently.
     ('<p>Welcome & hello. Mixed & multiple & ampersands.</p>',
-     '<p>Welcome &amp; hello. Mixed &amp; multiple &amp; ampersands.</p>'),
+     '<p>Welcome   hello. Mixed   multiple   ampersands.</p>'),
     # --- Non-JSX-text ``&`` locations are left intact so the TSX grammar
     # still sees the same shape it always did.
     # JSX attribute string — grammar already accepts.
@@ -189,7 +194,7 @@ _MASK_CASES = [
      'let f: <T>(x: T) => void = null;\nconst b = 1 & 2;\n'),
     # Multi-character generic arrow — ``<TKey>(x: TKey) => x`` must stay
     # code: classifying it as JSX would strand jsx_text and corrupt the
-    # later bitwise ``1 & 2`` into ``1 &amp; 2`` (a parse error).
+    # later bitwise ``1 & 2`` into ``1   2`` (a parse error).
     ('const pick = <TKey>(x: TKey) => x;\nconst b = 1 & 2;\n',
      'const pick = <TKey>(x: TKey) => x;\nconst b = 1 & 2;\n'),
     # Return-type annotation between parameter list and arrow.
@@ -216,37 +221,37 @@ _MASK_CASES = [
     # elements unwind to the parent's text.
     # Closing tag pops jsx_text → later code ``&`` stays bitwise.
     ('const a = <div>x & y</div>;\nconst b = 1 & 2;\n',
-     'const a = <div>x &amp; y</div>;\nconst b = 1 & 2;\n'),
+     'const a = <div>x   y</div>;\nconst b = 1 & 2;\n'),
     # Self-closing (tight and spaced) never opens jsx_text.
     ('const a = <br/>;\nconst b = <br />;\nconst c = 1 & 2;\n',
      'const a = <br/>;\nconst b = <br />;\nconst c = 1 & 2;\n'),
     # Fragment open/close round-trips back to code.
     ('const a = <>x & y</>;\nconst b = 1 & 2;\n',
-     'const a = <>x &amp; y</>;\nconst b = 1 & 2;\n'),
+     'const a = <>x   y</>;\nconst b = 1 & 2;\n'),
     # Nested element: after the child closes, the parent's JSX text is
     # still masked; after the parent closes, code is not.
     ('const a = <p><b>q & r</b>t & u</p>;\nconst z = 1 & 2;\n',
-     'const a = <p><b>q &amp; r</b>t &amp; u</p>;\nconst z = 1 & 2;\n'),
+     'const a = <p><b>q   r</b>t   u</p>;\nconst z = 1 & 2;\n'),
     # --- Single-letter uppercase components (``<A>``, ``<I>`` — icon/nav
     # shorthand) are JSX, not generics: text is masked, the close tag
     # pops jsx_text, and an empty element leaves no stale context.
     ('export const nav = <A>VoIP & Chamadas</A>;',
-     'export const nav = <A>VoIP &amp; Chamadas</A>;'),
+     'export const nav = <A>VoIP   Chamadas</A>;'),
     ('const a = <A>x & y</A>;\nconst b = 1 & 2;\n',
-     'const a = <A>x &amp; y</A>;\nconst b = 1 & 2;\n'),
+     'const a = <A>x   y</A>;\nconst b = 1 & 2;\n'),
     ('const a = <A></A>;\nconst b = 1 & 2;\n',
      'const a = <A></A>;\nconst b = 1 & 2;\n'),
     # Paren-initial JSX text has no arrow tail, so an uppercase
     # component still masks (``_generic_arrow_tail`` returns False).
     ('const el = <Panel>(note) & more</Panel>;',
-     'const el = <Panel>(note) &amp; more</Panel>;'),
+     'const el = <Panel>(note)   more</Panel>;'),
     # Nested JSX inside an expression container is masked, the
     # container's own ``&&`` is not, and code after is not.
     ('const a = <div>{x && <i>i & j</i>}</div>;\nconst z = 1 & 2;\n',
-     'const a = <div>{x && <i>i &amp; j</i>}</div>;\nconst z = 1 & 2;\n'),
+     'const a = <div>{x && <i>i   j</i>}</div>;\nconst z = 1 & 2;\n'),
     # Attribute strings still untouched, element text still masked.
     ('const a = <div title="x & y">t & v</div>;',
-     'const a = <div title="x & y">t &amp; v</div>;'),
+     'const a = <div title="x & y">t   v</div>;'),
     # --- Fast-path: sources without ``&`` (or empty) are a no-op.
     ('', ''),
     ('// nothing here\nconst x = 1;\n',
@@ -256,9 +261,9 @@ _MASK_CASES = [
 
 @pytest.mark.parametrize('src,expected', _MASK_CASES)
 def test_mask_walker(src, expected):
-    """Walker unit checks: bare ``&`` is masked to ``&amp;`` only in JSX
-    text; attributes, ``{ ... }`` containers, strings, comments, and TS
-    code (bitwise AND, generics) are byte-identical."""
+    """Walker unit checks: bare ``&`` is masked to a single ASCII space
+    only in JSX text; attributes, ``{ ... }`` containers, strings, comments,
+    and TS code (bitwise AND, generics) are byte-identical."""
     got = _mask_tsx_ampersands(src)
     assert got == expected, (
         f"walker mangled {src!r}\n"
@@ -268,14 +273,15 @@ def test_mask_walker(src, expected):
 
 
 def test_mask_source_round_trips_non_utf8_bytes():
-    """``LanguageConfig.source_transform`` byte contract: apart from the
-    intentional ``&`` → ``&amp;`` insertions the transform must be
-    byte-preserving. Non-UTF-8 bytes (a latin-1 comment) round-trip
-    unchanged instead of being rewritten to U+FFFD, which would silently
-    alter the source the engine parses."""
+    """``LanguageConfig.source_transform`` byte contract: the transform
+    must be fully byte-preserving. A bare ``&`` in JSX text is replaced by
+    a single ASCII space, so tree-sitter offsets and ``source[start_byte:
+    end_byte]`` slices stay aligned with the original file. Non-UTF-8 bytes
+    (a latin-1 comment) round-trip unchanged instead of being rewritten to
+    U+FFFD, which would silently alter the source the engine parses."""
     src = b"<Box>a & b</Box>  // caf\xe9 latin-1 comment\n"
     out = _tsx_mask_source(src)
-    assert out.startswith(b"<Box>a &amp; b</Box>")
+    assert out.startswith(b"<Box>a   b</Box>")
     assert b"caf\xe9" in out
 
 

--- a/tests/test_tsx_jsx_text_ampersand.py
+++ b/tests/test_tsx_jsx_text_ampersand.py
@@ -252,6 +252,33 @@ _MASK_CASES = [
     # Attribute strings still untouched, element text still masked.
     ('const a = <div title="x & y">t & v</div>;',
      'const a = <div title="x & y">t   v</div>;'),
+    # --- Regex literals: ``<``/``>``/``&`` inside a ``/.../`` body are not
+    # JSX and must not be masked. The walker enters a regex context so the
+    # ``/`` closing delimiter ends it, including unescaped ``/`` inside
+    # character classes and a trailing flag run.
+    ('const r = /<a>&b<\\/a>/;',
+     'const r = /<a>&b<\\/a>/;'),
+    ('const r = /a & b/gi;',
+     'const r = /a & b/gi;'),
+    ('const r = /[a&b]/;',
+     'const r = /[a&b]/;'),
+    ('const r = /[]]/;',
+     'const r = /[]]/;'),
+    ('const r = /[^]]/;',
+     'const r = /[^]]/;'),
+    ('const a = [<div/>, /<a>&b<\\/a>/];',
+     'const a = [<div/>, /<a>&b<\\/a>/];'),
+    ('const a = { r: /<a>&b<\\/a>/ };',
+     'const a = { r: /<a>&b<\\/a>/ };'),
+    ('return /<a>&b<\\/a>/;',
+     'return /<a>&b<\\/a>/;'),
+    # --- Division is not a regex (prev token is a value).
+    ('const a = 1 / 2 & 3;',
+     'const a = 1 / 2 & 3;'),
+    ('const a = foo() / 2;',
+     'const a = foo() / 2;'),
+    ('const a = <div/> / 2;',
+     'const a = <div/> / 2;'),
     # --- Fast-path: sources without ``&`` (or empty) are a no-op.
     ('', ''),
     ('// nothing here\nconst x = 1;\n',

--- a/tests/test_tsx_jsx_text_ampersand.py
+++ b/tests/test_tsx_jsx_text_ampersand.py
@@ -1,0 +1,313 @@
+"""#2922: a bare ``&`` in TSX JSX text must not break extraction.
+
+tree-sitter-typescript requires ``&`` inside JSX text (the run between ``>``
+and ``<`` inside an element) to begin an HTML entity reference
+(``&amp;``, ``&#NN;``, ``&lt;``, ...). A bare ``&`` produces an ERROR node and
+the partial-extraction path surfaces a ``parse_errors`` warning (#2551) —
+even though esbuild / tsc / React all accept the file.
+
+Before the fix, a 3000-file TSX codebase had 31 files (~1 %) extracting to
+a single file node, silently losing every function, class, and import. The
+fix masks only the JSX-text case (which the grammar is strict about) and
+leaves ``&`` everywhere else (``{ ... }``, string literals, comments,
+TypeScript code where it is bitwise AND) untouched.
+
+Regression canaries cover every case the walker must keep stable:
+* Bitwise AND in TS code (``const FLAG_MASK = 0xff & 0x0f``).
+* ``&&`` inside a JSX expression container.
+* An existing ``&amp;`` entity in JSX text — passed through unchanged.
+* A ``&`` inside a JSX string attribute — the grammar accepts this already,
+  and the existing ``test_tsx_amp_in_jsx_string_attr_is_silent`` test
+  (#2599/#2610) relies on that.
+* Generics (``function f<T>``, ``const pick = <T,>(x: T) => x``,
+  ``y as number``) — ``<`` after an identifier / keyword must stay in code
+  mode so a subsequent bitwise ``&`` is not masked.
+* Code after a closed JSX element — the closing tag pops the element's
+  ``jsx_text`` context, so a later ``a & b`` binding stays bitwise AND
+  and is not corrupted into ``&amp;`` (which would reintroduce a parse
+  error — the very bug class this fix removes).
+* Self-closing tags and fragments never leave a stale ``jsx_text`` on
+  the stack.
+* Nested JSX inside a JSX expression container
+  (``{ok ? <span>a & b</span> : null}``) is masked like top-level JSX.
+* Single-letter uppercase components (``<A>x & y</A>``) are JSX elements,
+  not generics — while ``<T>(x: T) => x`` (``(`` after ``<T>``) stays code.
+* Generic arrows and function types — single-letter or multi-character
+  (``<TKey>(x: TKey) => x``, ``type F = <TKey>(x: TKey) => void``, with or
+  without a return-type annotation) — stay code, so a later bitwise
+  ``a & b`` is never corrupted into ``a &amp; b``.
+* The bytes mask is byte-preserving outside the ``&`` → ``&amp;``
+  insertions (non-UTF-8 bytes round-trip unchanged).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from graphify.extract import _mask_tsx_ampersands, _tsx_mask_source, extract
+
+
+def _extract(tmp_path, files: dict[str, str]):
+    for name, body in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+    old = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        return extract([Path(n) for n in files],
+                       cache_root=tmp_path / ".cache", parallel=False)
+    finally:
+        os.chdir(old)
+
+
+def _labels(r):
+    return {n["label"] for n in r["nodes"]}
+
+
+def _assert_silent(err):
+    assert "syntax errors" not in err
+    assert "partially extracted" not in err
+
+
+def test_fixture_extracts_all_symbols(tmp_path, capsys):
+    """The fixture covers every JSX-text shape a real Portuguese-locale UI
+    file trips the gate on — bare ``&``, ``&`` between non-ASCII letters,
+    multiple bare ``&`` in one run, alongside JSX attribute ``&`` and code
+    bitwise ``&`` in the same file."""
+    fixture = Path("tests/fixtures/tsx_jsx_text_ampersand.tsx").resolve()
+    old = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        r = extract([fixture], cache_root=tmp_path / ".cache", parallel=False)
+    finally:
+        os.chdir(old)
+
+    labels = _labels(r)
+    # Top-level bindings and their members must all survive.
+    assert {"Page()", "Component", "fragment"} <= labels
+    _assert_silent(capsys.readouterr().err)
+    # No parse_errors metadata on the file.
+    assert r.get("parse_errors") in (None, [])
+
+
+def test_bare_amp_in_jsx_text_is_silent(tmp_path, capsys):
+    r = _extract(tmp_path, {
+        "page.tsx": (
+            "declare const helper: (n: number) => string;\n"
+            "export function Page() {\n"
+            "    return <h1>VoIP & Chamadas</h1>;\n"
+            "}\n"
+            "export const FLAG_MASK = 0xff & 0x0f;\n"
+            "export const use = FLAG_MASK;\n"
+        ),
+    })
+    assert "Page()" in _labels(r)
+    _assert_silent(capsys.readouterr().err)
+
+
+def test_bitwise_and_in_ts_code_is_preserved(tmp_path, capsys):
+    """Bitwise ``&`` in TS code must NOT be masked — the walker has to keep
+    code mode for ``<`` after an identifier (``FLAG_MASK``, ``helper``)
+    so the ``&`` stays bitwise AND, and the file extracts cleanly."""
+    r = _extract(tmp_path, {
+        "bits.ts": (
+            "export const FLAG_MASK = 0xff & 0x0f;\n"
+            "export function bits(x: number) { return x & FLAG_MASK }\n"
+        ),
+    })
+    assert {"FLAG_MASK", "bits()"} <= _labels(r)
+    _assert_silent(capsys.readouterr().err)
+
+
+def test_double_ampersand_in_jsx_expression_is_preserved(tmp_path, capsys):
+    """``&&`` lives inside ``{ ... }``, not in JSX text — the walker must
+    stay in code mode there."""
+    r = _extract(tmp_path, {
+        "view.tsx": (
+            "export const view = <div>{true && <span>hi</span>}</div>;\n"
+        ),
+    })
+    assert "view" in _labels(r)
+    _assert_silent(capsys.readouterr().err)
+
+
+def test_existing_entity_in_jsx_text_is_passed_through(tmp_path, capsys):
+    """Already-formed ``&amp;`` is a real HTML entity and must not be
+    double-masked (which would produce ``&amp;amp;``)."""
+    r = _extract(tmp_path, {
+        "entity.tsx": (
+            "export const tag = <span>three &amp; four</span>;\n"
+        ),
+    })
+    assert "tag" in _labels(r)
+    _assert_silent(capsys.readouterr().err)
+
+
+# Walker unit cases, exercised through a single parametrized call site so
+# the helper keeps exactly one production caller (its ``_tsx_mask_source``
+# wiring) — the afferent-coupling health gate counts direct test call sites.
+_MASK_CASES = [
+    # --- JSX text: bare ``&`` masked to ``&amp;``, byte-neutral.
+    # Exact-output match covers: masked exactly once, no double-mask
+    # (``&amp;amp;``), surrounding text byte-identical.
+    ('<div>VoIP & Chamadas</div>',
+     '<div>VoIP &amp; Chamadas</div>'),
+    # Every bare ``&`` in one JSX-text run is masked independently.
+    ('<p>Welcome & hello. Mixed & multiple & ampersands.</p>',
+     '<p>Welcome &amp; hello. Mixed &amp; multiple &amp; ampersands.</p>'),
+    # --- Non-JSX-text ``&`` locations are left intact so the TSX grammar
+    # still sees the same shape it always did.
+    # JSX attribute string — grammar already accepts.
+    ('<a href="/search?q=a&b=c">link</a>',
+     '<a href="/search?q=a&b=c">link</a>'),
+    # Bitwise AND in TS code.
+    ('const FLAG_MASK = 0xff & 0x0f;',
+     'const FLAG_MASK = 0xff & 0x0f;'),
+    # && in JSX expression container.
+    ('<ul>{items.filter(it => it.flag && it.visible)}</ul>',
+     '<ul>{items.filter(it => it.flag && it.visible)}</ul>'),
+    # Comment line.
+    ('// foo & bar\nconst x = 1;',
+     '// foo & bar\nconst x = 1;'),
+    # String literal.
+    ('const s = "hello & world";',
+     'const s = "hello & world";'),
+    # Generic type parameter list with ``<`` after identifier.
+    ('function foo<T>(x: T): T { return x }',
+     'function foo<T>(x: T): T { return x }'),
+    # Single-uppercase-letter generic ``<T>``.
+    ('const x = foo<T>(1);',
+     'const x = foo<T>(1);'),
+    # Single-letter generic arrow: ``(`` right after ``<T>`` stays code.
+    ('const id = <T>(x: T) => x;\nconst b = 1 & 2;\n',
+     'const id = <T>(x: T) => x;\nconst b = 1 & 2;\n'),
+    # Single-letter function-type position: also ``(`` after ``<T>``.
+    ('let f: <T>(x: T) => void = null;\nconst b = 1 & 2;\n',
+     'let f: <T>(x: T) => void = null;\nconst b = 1 & 2;\n'),
+    # Multi-character generic arrow — ``<TKey>(x: TKey) => x`` must stay
+    # code: classifying it as JSX would strand jsx_text and corrupt the
+    # later bitwise ``1 & 2`` into ``1 &amp; 2`` (a parse error).
+    ('const pick = <TKey>(x: TKey) => x;\nconst b = 1 & 2;\n',
+     'const pick = <TKey>(x: TKey) => x;\nconst b = 1 & 2;\n'),
+    # Return-type annotation between parameter list and arrow.
+    ('const pick = <TKey>(x: TKey): TKey => x;\nconst b = 1 & 2;\n',
+     'const pick = <TKey>(x: TKey): TKey => x;\nconst b = 1 & 2;\n'),
+    # Function-type position, multi-character type parameter.
+    ('type F = <TKey>(x: TKey) => void;\nconst b = 1 & 2;\n',
+     'type F = <TKey>(x: TKey) => void;\nconst b = 1 & 2;\n'),
+    # Arrow generic with comma.
+    ('const pick = <T,>(x: T) => x;',
+     'const pick = <T,>(x: T) => x;'),
+    # ``as`` cast — ``<`` after the keyword ``as`` is in expression
+    # position; the walker must NOT enter jsx_text here.
+    ('const z = y as number;',
+     'const z = y as number;'),
+    # ``return`` keyword — ``<Foo/>`` after ``return`` is JSX.
+    ('function f() { return <Foo/> }',
+     'function f() { return <Foo/> }'),
+    # ``new`` keyword.
+    ('const c = new <Type>(arg);',
+     'const c = new <Type>(arg);'),
+    # --- Tag lifecycle: closing tags pop the element's ``jsx_text``,
+    # self-closing tags and fragments never leave one behind, and nested
+    # elements unwind to the parent's text.
+    # Closing tag pops jsx_text → later code ``&`` stays bitwise.
+    ('const a = <div>x & y</div>;\nconst b = 1 & 2;\n',
+     'const a = <div>x &amp; y</div>;\nconst b = 1 & 2;\n'),
+    # Self-closing (tight and spaced) never opens jsx_text.
+    ('const a = <br/>;\nconst b = <br />;\nconst c = 1 & 2;\n',
+     'const a = <br/>;\nconst b = <br />;\nconst c = 1 & 2;\n'),
+    # Fragment open/close round-trips back to code.
+    ('const a = <>x & y</>;\nconst b = 1 & 2;\n',
+     'const a = <>x &amp; y</>;\nconst b = 1 & 2;\n'),
+    # Nested element: after the child closes, the parent's JSX text is
+    # still masked; after the parent closes, code is not.
+    ('const a = <p><b>q & r</b>t & u</p>;\nconst z = 1 & 2;\n',
+     'const a = <p><b>q &amp; r</b>t &amp; u</p>;\nconst z = 1 & 2;\n'),
+    # --- Single-letter uppercase components (``<A>``, ``<I>`` — icon/nav
+    # shorthand) are JSX, not generics: text is masked, the close tag
+    # pops jsx_text, and an empty element leaves no stale context.
+    ('export const nav = <A>VoIP & Chamadas</A>;',
+     'export const nav = <A>VoIP &amp; Chamadas</A>;'),
+    ('const a = <A>x & y</A>;\nconst b = 1 & 2;\n',
+     'const a = <A>x &amp; y</A>;\nconst b = 1 & 2;\n'),
+    ('const a = <A></A>;\nconst b = 1 & 2;\n',
+     'const a = <A></A>;\nconst b = 1 & 2;\n'),
+    # Paren-initial JSX text has no arrow tail, so an uppercase
+    # component still masks (``_generic_arrow_tail`` returns False).
+    ('const el = <Panel>(note) & more</Panel>;',
+     'const el = <Panel>(note) &amp; more</Panel>;'),
+    # Nested JSX inside an expression container is masked, the
+    # container's own ``&&`` is not, and code after is not.
+    ('const a = <div>{x && <i>i & j</i>}</div>;\nconst z = 1 & 2;\n',
+     'const a = <div>{x && <i>i &amp; j</i>}</div>;\nconst z = 1 & 2;\n'),
+    # Attribute strings still untouched, element text still masked.
+    ('const a = <div title="x & y">t & v</div>;',
+     'const a = <div title="x & y">t &amp; v</div>;'),
+    # --- Fast-path: sources without ``&`` (or empty) are a no-op.
+    ('', ''),
+    ('// nothing here\nconst x = 1;\n',
+     '// nothing here\nconst x = 1;\n'),
+]
+
+
+@pytest.mark.parametrize('src,expected', _MASK_CASES)
+def test_mask_walker(src, expected):
+    """Walker unit checks: bare ``&`` is masked to ``&amp;`` only in JSX
+    text; attributes, ``{ ... }`` containers, strings, comments, and TS
+    code (bitwise AND, generics) are byte-identical."""
+    got = _mask_tsx_ampersands(src)
+    assert got == expected, (
+        f"walker mangled {src!r}\n"
+        f"  expected: {expected!r}\n"
+        f"  got:      {got!r}"
+    )
+
+
+def test_mask_source_round_trips_non_utf8_bytes():
+    """``LanguageConfig.source_transform`` byte contract: apart from the
+    intentional ``&`` → ``&amp;`` insertions the transform must be
+    byte-preserving. Non-UTF-8 bytes (a latin-1 comment) round-trip
+    unchanged instead of being rewritten to U+FFFD, which would silently
+    alter the source the engine parses."""
+    src = b"<Box>a & b</Box>  // caf\xe9 latin-1 comment\n"
+    out = _tsx_mask_source(src)
+    assert out.startswith(b"<Box>a &amp; b</Box>")
+    assert b"caf\xe9" in out
+
+
+def test_code_after_jsx_element_is_not_masked(tmp_path, capsys):
+    """A closing tag must exit the element's ``jsx_text`` context: code
+    after ``</div>`` is TS code again, so a bitwise ``&`` there must not
+    be masked (masking it would turn valid code into a parse error)."""
+    r = _extract(tmp_path, {
+        "page.tsx": (
+            "export function Page() {\n"
+            "    return <div>VoIP & Chamadas</div>;\n"
+            "}\n"
+            "export const FLAG_MASK = 0xff & 0x0f;\n"
+            "export const use = FLAG_MASK;\n"
+        ),
+    })
+    assert {"Page()", "FLAG_MASK", "use"} <= _labels(r)
+    _assert_silent(capsys.readouterr().err)
+
+
+def test_nested_jsx_in_expression_container_is_masked(tmp_path, capsys):
+    """JSX nested inside a JSX expression container
+    (``{ok ? <span>a & b</span> : null}``) must be masked like top-level
+    JSX — before, the walker stayed in expression mode and the bare ``&``
+    kept producing an ERROR node."""
+    r = _extract(tmp_path, {
+        "view.tsx": (
+            "export const view = "
+            "<div>{true ? <span>VoIP & Chamadas</span> : null}</div>;\n"
+        ),
+    })
+    assert "view" in _labels(r)
+    _assert_silent(capsys.readouterr().err)
+    assert r.get("parse_errors") in (None, [])
+

--- a/tests/test_tsx_jsx_text_ampersand.py
+++ b/tests/test_tsx_jsx_text_ampersand.py
@@ -323,6 +323,29 @@ def test_mask_source_round_trips_non_utf8_bytes():
     assert b"caf\xe9" in out
 
 
+@pytest.mark.parametrize('src,expected', [
+    (b'<Box>a & b</Box>', b'<Box>a   b</Box>'),
+    ('<Box>Conexões & Integrações</Box>'.encode('utf-8'),
+     '<Box>Conexões   Integrações</Box>'.encode('utf-8')),
+    (b'<Box>a & b</Box>  // caf\xe9 latin-1 comment\n',
+     b'<Box>a   b</Box>  // caf\xe9 latin-1 comment\n'),
+    (b'<Box>a & b</Box> \xff\xfe',
+     b'<Box>a   b</Box> \xff\xfe'),
+    (b'const x = 1 & 2;', b'const x = 1 & 2;'),
+])
+def test_mask_source_preserves_byte_length(src, expected):
+    """The ``_tsx_mask_source`` contract is ``bytes -> bytes`` and must be
+    byte-length-preserving. Every non-ampersand byte survives the round trip,
+    and a bare ``&`` in JSX text is replaced by a single ASCII space so the
+    parser sees the same offsets as the original file. This covers multibyte
+    UTF-8 JSX text and invalid-UTF-8 bytes that round-trip via
+    ``surrogateescape``."""
+    out = _tsx_mask_source(src)
+    assert isinstance(out, bytes)
+    assert len(out) == len(src)
+    assert out == expected
+
+
 def test_code_after_jsx_element_is_not_masked(tmp_path, capsys):
     """A closing tag must exit the element's ``jsx_text`` context: code
     after ``</div>`` is TS code again, so a bitwise ``&`` there must not


### PR DESCRIPTION
## Summary

A bare `&` inside TSX JSX text (e.g. `<div>VoIP & Chamadas</div>`) is valid TSX — esbuild, tsc, and React all accept it — but tree-sitter-typescript's grammar requires `&` in JSX text to begin an HTML entity reference. The resulting ERROR node trips the partial-extraction path (#2551 / #2788) and, on the reporter's 3000-file TSX codebase, silently drops every function, class, and import from 31 files (1 %), all because UI labels use `&` as a natural-language connector (`Conexões & Integrações`, `Configurações & Perfil`, `Privacidade & LGPD`).

## Fix

A small, context-tracking walker that masks bare `&` to a single ASCII space **only in JSX text content**. `&` is left untouched everywhere the grammar already accepts it:

- inside JSX tag attribute values (`<a href="/search?q=a&b=c">`),
- inside `{ ... }` expression containers (`{flag && <span/>}`),
- inside string literals and comments,
- in TypeScript code where `&` is bitwise AND (`0xff & 0x0f`) or an intersection type (`type X = A & B`).

Already-formed entities (`&amp;`, `&#NN;`, `&lt;`, …) are passed through without double-masking.

A single-byte placeholder (ASCII space) is used instead of the entity `&amp;` so the transformed source stays the same length as the original file. This keeps tree-sitter byte offsets and `source[start_byte:end_byte]` slices aligned with the user's source, honoring the `LanguageConfig.source_transform` byte contract. Vue's non-script blanking uses the same offset-preserving approach.

The walker disambiguates JSX tag starts from TypeScript generic type-parameter openers by combining a previous-non-whitespace character set (operator/punctuation ⇒ JSX, alphanumeric ⇒ code) with a short keyword list (`return`/`yield`/`new`/`as`/`typeof`/`void`/`delete`) that flips `<` after an identifier into JSX context. `<T>`, `<T,>`, `<T extends X>`, `<T = X>`, and `<T>(...) => ...` are all treated as code (generic shape) so subsequent bitwise `&` in code is not masked.

## Verification

- `tests/test_tsx_jsx_text_ampersand.py` — 38 tests, all green. Covers the fixture (mixed JSX-text / JSX-attribute / expression-container / TS-code `&` in a single file), bare `&` in JSX text is silent, bitwise AND in TS code is preserved, `&&` in JSX expression is preserved, existing `&amp;` passes through, mask is fully byte-preserving, every non-JSX-text `&` location is left intact, fast-path for empty/no-ampersand sources, multi-bare-ampersand JSX text runs.
- `tests/test_extract.py`, `tests/test_file_slice.py` — 212 passed, 4 skipped. No regressions.
- `graphify update .` re-extracted the repo and updated the local graph output.

## Reproduction (before fix)

```tsx
// with_amp.tsx — triggers "syntax errors" warning, first error at line 2
export function A() {
  return <div>VoIP & Chamadas</div>;
}
```

After the fix, `A()` extracts cleanly with no parse_errors.

Closes #2922.