### PR TITLE
JS/TS: factory object literal is keyed on the class, so sibling methods collide (#2745 follow-up)

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -4443,12 +4443,22 @@ def _extract_generic(
                         owner_nid = function_owner_nid
                     elif tgt[0] == "object" and tgt[1] in object_bindings:
                         object_name = tgt[1]
-                        owner_nid = _make_id(function_owner_nid, object_name)
+                        # Namespace the object by the function it is declared in,
+                        # NOT by `function_owner_nid`. The two differ for a method:
+                        # `this.X = fn` belongs to the class, but `const api = {}`
+                        # is a local of the method. Keying the object on the class
+                        # merged the factory objects of two sibling methods that
+                        # picked the same local name, so the second method's
+                        # members hung off the first method's node and the
+                        # `contains` edge was emitted once per method — the very
+                        # duplication `contained_owners` exists to prevent (it is
+                        # scoped to one function, so it cannot see the sibling).
+                        owner_nid = _make_id(func_nid, object_name)
                         owner_line = object_bindings[object_name].start_point[0] + 1
                         add_node(owner_nid, object_name, owner_line)
                         if owner_nid not in contained_owners:
                             contained_owners.add(owner_nid)
-                            add_edge(function_owner_nid, owner_nid, "contains", owner_line)
+                            add_edge(func_nid, owner_nid, "contains", owner_line)
                     else:
                         continue
                     m_name = tgt[2]

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -934,6 +934,112 @@ def test_extract_js_factory_object_contains_edge_not_duplicated(tmp_path):
     assert len(methods) == 4
 
 
+def test_extract_js_factory_objects_in_sibling_methods_stay_separate(tmp_path):
+    """Two methods of one class that build same-named local factory objects must
+    get one node each.
+
+    The object is a local of the method, so it has to be namespaced by the
+    method. Namespacing it by the enclosing class instead collapsed both
+    `const api = {}` locals onto a single node: `.get()` and `.put()` hung off
+    the same object and the second method's object never appeared at all.
+    """
+    from graphify.extract import extract_js
+    f = tmp_path / "registry.js"
+    f.write_text(
+        "class Registry {\n"
+        "  buildRead() {\n"
+        "    const api = {};\n"
+        "    api.get = function () { return 1; };\n"
+        "    return api;\n"
+        "  }\n"
+        "  buildWrite() {\n"
+        "    const api = {};\n"
+        "    api.put = function () { return 2; };\n"
+        "    return api;\n"
+        "  }\n"
+        "}\n"
+    )
+    result = extract_js(f)
+    by_label = {}
+    for n in result["nodes"]:
+        by_label.setdefault(n["label"], []).append(n)
+
+    api_nodes = by_label.get("api", [])
+    assert len(api_nodes) == 2, (
+        "each method's local object needs its own node, got "
+        f"{[n['id'] for n in api_nodes]}"
+    )
+
+    edges = {(e["source"], e["relation"], e["target"]) for e in result["edges"]}
+    read_nid = by_label[".buildRead()"][0]["id"]
+    write_nid = by_label[".buildWrite()"][0]["id"]
+    read_api = next(n["id"] for n in api_nodes
+                    if (read_nid, "contains", n["id"]) in edges)
+    write_api = next(n["id"] for n in api_nodes
+                     if (write_nid, "contains", n["id"]) in edges)
+    assert read_api != write_api
+
+    # Each object owns only its own method.
+    assert (read_api, "method", by_label[".get()"][0]["id"]) in edges
+    assert (write_api, "method", by_label[".put()"][0]["id"]) in edges
+    assert (read_api, "method", by_label[".put()"][0]["id"]) not in edges
+    assert (write_api, "method", by_label[".get()"][0]["id"]) not in edges
+
+
+def test_extract_js_factory_contains_edge_not_duplicated_across_methods(tmp_path):
+    """`contained_owners` is scoped to one function, so it cannot dedup across
+    sibling methods. With the object keyed on the class, both methods minted the
+    same owner id and emitted the identical `contains` edge twice."""
+    from graphify.extract import extract_js
+    f = tmp_path / "dup.js"
+    f.write_text(
+        "class Builder {\n"
+        "  one() {\n"
+        "    const api = {};\n"
+        "    api.a = () => 1;\n"
+        "    return api;\n"
+        "  }\n"
+        "  two() {\n"
+        "    const api = {};\n"
+        "    api.b = () => 2;\n"
+        "    return api;\n"
+        "  }\n"
+        "}\n"
+    )
+    result = extract_js(f)
+    contains = [(e["source"], e["target"]) for e in result["edges"]
+                if e["relation"] == "contains"]
+    assert len(contains) == len(set(contains)), (
+        f"duplicate contains edges: {contains}"
+    )
+
+
+def test_extract_js_this_assignment_still_belongs_to_the_class(tmp_path):
+    """Control: `this.X = fn` keeps its class-level owner.
+
+    Only the object-literal arm moves to the function; `this` in a constructor
+    really does refer to the instance, so both methods must land on the class.
+    """
+    from graphify.extract import extract_js
+    f = tmp_path / "self.js"
+    f.write_text(
+        "class Handler {\n"
+        "  constructor() {\n"
+        "    this.onOpen = function () { return 1; };\n"
+        "  }\n"
+        "  wire() {\n"
+        "    this.onClose = function () { return 2; };\n"
+        "  }\n"
+        "}\n"
+    )
+    result = extract_js(f)
+    by_label = {n["label"]: n["id"] for n in result["nodes"]}
+    cls = by_label["Handler"]
+    edges = {(e["source"], e["relation"], e["target"]) for e in result["edges"]}
+    assert (cls, "method", by_label[".onOpen()"]) in edges
+    assert (cls, "method", by_label[".onClose()"]) in edges
+
+
 def test_extract_js_factory_object_arrow_assigned_methods(tmp_path):
     """Arrow functions assigned to a factory object are captured just like
     function expressions (the dominant modern factory shape)."""


### PR DESCRIPTION
Follow-up to #2745 (v0.9.47). The feature is right; only its owner id is scoped one level too wide.

## Problem

`_js_member_assignment_target`'s new `("object", …)` arm mints the owner as
`_make_id(function_owner_nid, object_name)`, and a few lines up:

```python
function_owner_nid = parent_class_nid if parent_class_nid else func_nid
```

For a **method**, `function_owner_nid` is the enclosing class. But `const api = {}`
is a local of the method, not a member of the class, so two sibling methods that
pick the same local name collapse onto one node.

```js
class Registry {
  buildRead() {
    const api = {};
    api.get = function () { return 1; };
    return api;
  }
  buildWrite() {
    const api = {};
    api.put = function () { return 2; };
    return api;
  }
}
```

0.9.48 (`extract_js`, node/edge dump):

```
NODE factory_registry_api                 'api'            L3
NODE factory_registry_api_get             '.get()'         L4
NODE factory_registry_api_put             '.put()'         L9

EDGE factory_registry     -contains-> factory_registry_api      L3
EDGE factory_registry_api -method->   factory_registry_api_get  L4
EDGE factory_registry     -contains-> factory_registry_api      L8   <-- duplicate
EDGE factory_registry_api -method->   factory_registry_api_put  L9
```

Two things go wrong:

1. **One node for two objects.** `add_node` is first-wins, so the graph represents
   both factory objects as the single `api` node owning both `.get()` and `.put()`,
   keeping `buildRead`'s line (L3), while `buildWrite`'s distinct local object is
   absent. `buildWrite` is left with no edge to any object node at all — its only
   edge is `Registry -method-> buildWrite`.
2. **The `contains` edge is emitted twice.** That is the duplication
   `contained_owners` was added to prevent — but that set is created per function
   node, so it cannot see the sibling method. The 0.9.47 release note states the
   guarantee as "the factory's `contains` edge is emitted once no matter how many
   methods hang off the object"; that holds for a plain function, not for a method.

## Fix

Key the object on `func_nid`. One line plus the comment explaining why the two ids
differ here.

`this.X = fn` deliberately keeps `function_owner_nid` — `this` really is the
instance, so those members do belong to the class. Only the object-literal arm moves.

## Tests

Three added next to the existing #2745 tests.

| test | without fix | with fix |
|---|---|---|
| `..._factory_objects_in_sibling_methods_stay_separate` | FAIL | pass |
| `..._factory_contains_edge_not_duplicated_across_methods` | FAIL | pass |
| `..._this_assignment_still_belongs_to_the_class` (control) | pass | pass |

Verified by reverting `graphify/extractors/engine.py` to `upstream/v8` and re-running
(`2 failed, 1 passed`), then restoring (`3 passed`).

The control passes both ways on purpose: it is there to catch a fix that moves the
`this` arm along with the object arm.

Two existing behaviours are already covered by #2745's own tests and stay green —
a plain function's factory object, and the single-`contains` guarantee within one
function. My repro's second control (same class, objects named `reader`/`writer`)
was already correct on 0.9.48 and is unchanged by the patch, which isolates the
trigger to *same local name in sibling methods*.

## Field measurement: zero occurrences

I could not find a real-world hit. Extracting with 0.9.48 and with the patch over
six JS corpora gives identical node and edge counts:

| corpus | files | nodes | edges | change |
|---|---|---|---|---|
| mongoose `lib/` | 264 | 2105 | 3872 | none |
| playwright `lib/` | 27 | 4399 | 10526 | none |
| eslint `lib/` | 388 | 3729 | 5876 | none |
| @hapi/hapi `lib/` | 19 | 347 | 534 | none |
| handlebars `lib/` | 34 | 164 | 349 | none |
| a local Hapi/Mongoose app `src/` | 52 | 1080 | 2893 | none |

The 12-line repro above, run through the same harness in the same invocation, does
change (7 nodes / 1 duplicate `contains` → 8 nodes / 0), so the harness does
distinguish the two versions — the zeros are data, not a broken measurement. I also
re-ran mongoose and playwright against virgin cache roots to rule out a cache hit
replaying one version's result for the other; identical.

The reason is scope, not rarity of factories: the feature only looks at direct
children of the function body, and the common shapes in these packages are inline
object literals (`const api = { get() {…} }`, still #2419) and `return { get, put }`.

So this is a correctness fix with no measured impact on existing graphs. Prioritise
accordingly — I am reporting it because it is one line and it breaks an invariant the
release note states, not because I can show it biting anyone today.

## Full suite

25 tests already fail on a clean `upstream/v8` in my environment (`test_skillgen`,
`test_terraform`, `test_ollama_retry_cap`, `test_install_references`, `test_labeling`
— none touch the JS extractor). The patch introduces no new failure: comparing the
failing sets, nothing is in the patched run that is not in the baseline run.

One caveat so the counts are not mistaken for an improvement:
`test_labeling.py::test_label_communities_batches_when_over_batch_size` appeared in
one patched full-suite run and not another. Run in isolation it fails deterministically
both with and without the patch, so it flakes on suite order, not on this change.
