### PR TITLE
fix(sql): walk into BEGIN;...COMMIT; transaction blocks (#2953)

### DIFF
--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -398,7 +398,14 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
         if stmt.type == "statement":
             for child in stmt.children:
                 walk(child)
-        elif stmt.type in ("fb_proc_or_trigger", "set_term", "declare_external_function", "ERROR"):
+        elif stmt.type in ("fb_proc_or_trigger", "set_term", "declare_external_function",
+                            "ERROR", "transaction"):
+            # `transaction` wraps BEGIN/START TRANSACTION ... COMMIT/ROLLBACK
+            # blocks in its own top-level node (#2953), so statements inside
+            # never reach the `stmt.type == "statement"` branch above and were
+            # silently dropped. walk() has no special case for "transaction"
+            # either, so it falls through to its generic per-child recursion,
+            # which reaches the nested `statement` nodes normally.
             walk(stmt)
 
     # Global regex fallback: catch any REFERENCES missed due to ERROR nodes in the parse tree

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -487,6 +487,28 @@ def test_sql_no_dangling_edges():
     for e in r["edges"]:
         assert e["source"] in node_ids, f"dangling source: {e['source']}"
 
+def test_sql_transaction_block_is_not_dropped(tmp_path):
+    """#2953: statements wrapped in BEGIN; ... COMMIT; land under a top-level
+    `transaction` node, not `statement`, and were silently skipped entirely."""
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "con_transaccion.sql"
+    p.write_text(
+        "BEGIN;\n"
+        "CREATE TABLE gamma (id INT PRIMARY KEY);\n"
+        "CREATE TABLE delta (id INT PRIMARY KEY, gamma_id INT REFERENCES gamma(id));\n"
+        "COMMIT;\n"
+    )
+    r = extract_sql(p)
+    labels = [n["label"] for n in r["nodes"]]
+    assert "gamma" in labels
+    assert "delta" in labels
+    # Both tables get real source info, not a sourceless _ref_stub
+    by_label = {n["label"]: n for n in r["nodes"]}
+    assert by_label["gamma"]["source_location"] == "L2"
+    assert by_label["delta"]["source_location"] == "L3"
+    fk_edges = [e for e in r["edges"] if e["relation"] == "references"]
+    assert len(fk_edges) == 1
+
 def test_sql_cte_is_not_read_as_a_table():
     """#2577: a name bound by WITH ... AS (...) is scoped to its statement, not a table.
 


### PR DESCRIPTION
Fixes #2953 — SQL statements wrapped in BEGIN; ... COMMIT; transaction blocks were silently dropped, with zero nodes extracted and no error surfaced.

Root cause: tree-sitter-sql wraps a transaction block in its own top-level transaction node instead of statement. The extractor's root dispatch loop only walked children of type statement (plus a few special cases like ERROR), so transaction never matched and everything inside — tables, views, functions, triggers — was skipped. Any REFERENCES pointing at one of those tables also fell back to a sourceless stub instead of resolving to the real node, matching the "empty source_file/source_location" symptom described in the issue.

Fix: route transaction through the same generic walk() used everywhere else — it already recurses into whatever children it finds, so no new logic is needed, just letting the node through.

Test plan:

-  Reproduced the issue's minimal repro — confirmed 0 table nodes before the fix, 3 nodes (file + gamma + delta) with correct source_location after
-  Added a regression test (test_sql_transaction_block_is_not_dropped) following the existing conventions in tests/test_multilang.py
-  ROLLBACK instead of COMMIT
-  Views, functions, and triggers inside a transaction, not just tables
-  Multiple separate transaction blocks in one file, with an FK reference resolving across them
-  PL/pgSQL function bodies (the ERROR-node regex recovery path) nested inside a transaction — no interference
-  The issue's exact combination — schema-qualified names, IF NOT EXISTS, CHECK, ALTER TABLE, all transaction-wrapped
-  Checked for double-emission between the AST walk and the existing raw-text regex fallbacks — none found
-  Ran a synthetic 8-file, 52-table, cross-file-FK migration corpus (mirroring the issue's "59 CREATE TABLEs across 8 migrations") through the real extract() pipeline — all tables and FK edges present, zero dangling edges
-  Full test suite: 4585 passed; 12 pre-existing failures (missing optional deps in a fresh venv) confirmed identical on unmodified v8, unrelated to this change