### PR TITLE
fix(sql): recover T-SQL bracket-named, CREATE OR ALTER, and PROC routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
-## 0.9.49 (unreleased)
-
-- Fix: T-SQL stored procedures and functions are no longer silently dropped from the graph — the ERROR-node recovery now accepts bracket-delimited names (`CREATE PROCEDURE [dbo].[usp_Load]`) and T-SQL's `CREATE OR ALTER`, both of which previously recovered nothing (the `AS BEGIN...END` body idiom never parses structurally, so recovery was these objects' only path into the graph). The two recovery sites now share one pattern, fixing a related defect where a mixed-delimiter name (`dbo.[usp_Mixed]`) produced a second phantom node named after the schema. The `PROC` shorthand is accepted alongside `PROCEDURE`, and the whole-file recovery scan now masks SQL comments so commented-out DDL in a file with an unrelated parse error cannot fabricate routine nodes. Recovered routines are name-only nodes (no body `reads_from` edges), matching the existing PL/pgSQL recovery.
-
 ## 0.9.48 (2026-08-20)
 
 - Fix: a control character in a node label or id no longer aborts the whole export; the GraphML and Obsidian exporters scrub only the characters those formats forbid (tab, newline, and non-ASCII letters are preserved), and `graph.json` and its byte-identity round-trip are untouched (#2897, thanks @abhay-codes07).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## 0.9.49 (unreleased)
+
+- Fix: T-SQL stored procedures and functions are no longer silently dropped from the graph — the ERROR-node recovery now accepts bracket-delimited names (`CREATE PROCEDURE [dbo].[usp_Load]`) and T-SQL's `CREATE OR ALTER`, both of which previously recovered nothing (the `AS BEGIN...END` body idiom never parses structurally, so recovery was these objects' only path into the graph). The two recovery sites now share one pattern, fixing a related defect where a mixed-delimiter name (`dbo.[usp_Mixed]`) produced a second phantom node named after the schema. The `PROC` shorthand is accepted alongside `PROCEDURE`, and the whole-file recovery scan now masks SQL comments so commented-out DDL in a file with an unrelated parse error cannot fabricate routine nodes. Recovered routines are name-only nodes (no body `reads_from` edges), matching the existing PL/pgSQL recovery.
+
 ## 0.9.48 (2026-08-20)
 
 - Fix: a control character in a node label or id no longer aborts the whole export; the GraphML and Obsidian exporters scrub only the characters those formats forbid (tab, newline, and non-ASCII letters are preserved), and `graph.json` and its byte-identity round-trip are untouched (#2897, thanks @abhay-codes07).

--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -185,7 +185,11 @@ def _mask_sql_comments(text: str) -> str:
             # most routines on lines already entangled with the broken one (a
             # conservative false negative; a routine named like [a--b] is
             # inside that loss); under-blanking is what fabricates, and every
-            # reading's blank set stays a subset of this one.
+            # reading's blank set stays a subset of this one — except where a
+            # */ + * versus * + /* token split makes two readings consume the
+            # same /, an irreducible divergence whose only closure would be
+            # blanking to EOF on every */* sequence (accepted, documented
+            # limitation; the token sequence appears in no dialect's idiom).
             closer = '"' if c == '"' else "]"
             j = i + 1
             closed = False

--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -71,7 +71,7 @@ _ROUTINE_RECOVERY_RX = re.compile(
 # quote), judged not worth the swallow risk in a recovery-only path.
 
 
-def _mask_sql_comments(text: str) -> str:
+def _scan_sql(text: str) -> tuple[str, list[tuple[int, int]]]:
     """Blank comment and string-literal spans, preserving every offset.
 
     One output character per input character: non-newline characters inside
@@ -80,10 +80,18 @@ def _mask_sql_comments(text: str) -> str:
     original. Double-quoted and bracket-delimited identifiers are preserved
     verbatim (they carry recoverable routine names); single-quoted strings,
     line comments, and (nesting-aware) block comments are blanked. Used by
-    both routine-recovery scans so CREATE PROCEDURE/FUNCTION DDL reachable
+    the routine-recovery scan so CREATE PROCEDURE/FUNCTION DDL reachable
     only through a comment or a single-quoted string cannot fabricate a
     routine node when an unrelated parse error arms recovery.
+
+    Returns (masked_text, ident_spans) where ident_spans holds the [start,
+    end) of every PRESERVED delimited identifier: preserved spans keep their
+    text verbatim, so DDL keywords inside one are still visible in the
+    masked text, and the recovery scan must skip a match that starts there
+    (identifier data, not DDL — 'SELECT 1 AS [CREATE PROCEDURE x pending]'
+    must not mint a routine).
     """
+    ident_spans: list[tuple[int, int]] = []
     out: list[str] = []
     i, n = 0, len(text)
 
@@ -204,6 +212,7 @@ def _mask_sql_comments(text: str) -> str:
                 j += 1
             span = text[i:j]
             if closed and "--" not in span and "/*" not in span:
+                ident_spans.append((i, j))
                 out.append(span)
                 i = j
             else:
@@ -228,7 +237,12 @@ def _mask_sql_comments(text: str) -> str:
         else:
             out.append(c)
             i += 1
-    return "".join(out)
+    return "".join(out), ident_spans
+
+
+def _mask_sql_comments(text: str) -> str:
+    """Masked text only — see _scan_sql for the span-reporting form."""
+    return _scan_sql(text)[0]
 
 
 def _norm_ident(name: str) -> str:
@@ -655,8 +669,16 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
         # (offset-preserving), so commented-out DDL and single-quoted dynamic
         # SQL cannot fabricate a routine when an unrelated error arms this
         # scan; string shapes the mask does not model rely on the has_error
-        # gate alone.
-        for m in _ROUTINE_RECOVERY_RX.finditer(_mask_sql_comments(src_text)):
+        # gate alone. Preserved delimited identifiers keep their text
+        # verbatim (they carry the recoverable names), so a match whose
+        # CREATE keyword STARTS inside one is identifier data, not DDL
+        # ('SELECT 1 AS [CREATE PROCEDURE x pending]') and is skipped — the
+        # name a genuine statement captures is allowed to be a delimited
+        # identifier; its CREATE never is.
+        masked_src, ident_spans = _scan_sql(src_text)
+        for m in _ROUTINE_RECOVERY_RX.finditer(masked_src):
+            if any(s <= m.start() < e for s, e in ident_spans):
+                continue
             fn_name = m.group(1)
             fn_line = src_text[: m.start()].count("\n") + 1
             _add_node(_make_id(stem, fn_name), f"{fn_name}()", fn_line)

--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -110,22 +110,24 @@ def _mask_sql_comments(text: str) -> str:
             i = _blank(j)
         elif c == '"' or c == "[":
             # Delimited identifier: preserve verbatim. Doubled closers are
-            # escapes. Two shapes are NOT trusted as identifiers — emit just
-            # the delimiter and rescan the rest of the line normally, so a
-            # `--` or `/*` inside the would-be span is recognized as the
-            # comment it almost certainly is:
+            # escapes. A span is DISTRUSTED when it is unterminated (no
+            # closer before the newline) or would swallow a comment opener
+            # on its way to the closer ('SELECT [Col FROM t -- CREATE PROC
+            # [dbo]' closes on [dbo]'s bracket) — a stray delimiter is
+            # ordinary in exactly the broken files this mask runs on.
             #
-            # - an UNTERMINATED opener (no closer before the newline);
-            # - a span that would swallow a comment opener on its way to the
-            #   closer (`[Col FROM t -- CREATE PROC [dbo]` closes on [dbo]'s
-            #   bracket) — a stray delimiter before a comment is ordinary in
-            #   exactly the broken files this mask runs on, and preserving
-            #   the span let the commented-out DDL after it fabricate nodes.
-            #
-            # The cost is that a genuine identifier CONTAINING a comment
-            # opener ([a--b]) is no longer preserved, so a routine so named
-            # loses recovery — a conservative false negative, traded for
-            # never fabricating.
+            # A distrusted span is irreducibly ambiguous (identifier data vs
+            # stray delimiter before real comments/strings), and any attempt
+            # to pick one reading exposed text the other reading blanks —
+            # re-emitting the delimiter and rescanning even re-paired later
+            # single quotes and uncovered dynamic SQL. So blank the UNION of
+            # every reading: the rest of the line is blanked outright, and
+            # any raw /* on it with no later */ on the same line carries
+            # forward as (nesting-aware) comment state, since some reading
+            # may have left it open. Over-blanking loses at most routines on
+            # a line that was already broken (a conservative false negative,
+            # and a routine named like [a--b] is inside that loss);
+            # under-blanking is what fabricates, and cannot happen here.
             closer = '"' if c == '"' else "]"
             j = i + 1
             closed = False
@@ -143,8 +145,33 @@ def _mask_sql_comments(text: str) -> str:
                 out.append(span)
                 i = j
             else:
-                out.append(c)
-                i += 1
+                eol = text.find("\n", i)
+                eol = n if eol == -1 else eol
+                depth = 0
+                m2 = i
+                while m2 < eol:
+                    if text.startswith("/*", m2):
+                        depth += 1
+                        m2 += 2
+                    elif text.startswith("*/", m2):
+                        if depth:
+                            depth -= 1
+                        m2 += 2
+                    else:
+                        m2 += 1
+                i = _blank(eol)
+                if depth:
+                    j2 = eol
+                    while j2 < n and depth:
+                        if text.startswith("/*", j2):
+                            depth += 1
+                            j2 += 2
+                        elif text.startswith("*/", j2):
+                            depth -= 1
+                            j2 += 2
+                        else:
+                            j2 += 1
+                    i = _blank(j2)
         elif c == "-" and i + 1 < n and text[i + 1] == "-":
             j = i
             while j < n and text[j] != "\n":

--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -28,8 +28,12 @@ from graphify.extractors.base import _file_stem, _make_id
 # PROC is T-SQL's official shorthand for PROCEDURE and equally common in the
 # wild; the optional (?:EDURE)? still requires trailing whitespace, so a word
 # that merely starts with PROC cannot match.
+# \bCREATE: without the boundary, CREATE matched inside a bare word, so
+# 'SELECT AUTOCREATE PROCEDURE x FROM t;' in an error-bearing file minted a
+# phantom routine x() (delimited identifiers are span-skipped at the scan
+# site, but a bare word has no span).
 _ROUTINE_RECOVERY_RX = re.compile(
-    r"CREATE\s+(?:OR\s+(?:REPLACE|ALTER)\s+)?(?:FUNCTION|PROC(?:EDURE)?)\s+"
+    r"\bCREATE\s+(?:OR\s+(?:REPLACE|ALTER)\s+)?(?:FUNCTION|PROC(?:EDURE)?)\s+"
     r"(?:IF\s+NOT\s+EXISTS\s+)?"
     r"((?:\"(?:[^\"\n]|\"\")+\"|\[(?:[^\]\n]|\]\])+\]|[\w$]+)"
     r"(?:\s*\.\s*(?:\"(?:[^\"\n]|\"\")+\"|\[(?:[^\]\n]|\]\])+\]|[\w$]+))*)",

--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -53,17 +53,22 @@ _ROUTINE_RECOVERY_RX = re.compile(
 # - line comments blank to end-of-line; block comments blank to their
 #   matching */ with NESTING tracked (SQL Server and PostgreSQL both nest
 #   /* */, and a lazy first-*/ match let commented-out DDL inside a nested
-#   comment fabricate nodes). An UNCLOSED block comment blanks to
-#   end-of-file, matching SQL semantics.
+#   comment fabricate nodes). MySQL and Oracle do NOT nest — there the
+#   depth tracking over-blanks, losing (never fabricating) a routine after
+#   an inner */; the primary T-SQL/PostgreSQL targets win that trade. An
+#   UNCLOSED block comment blanks to end-of-file, matching SQL semantics.
 #
-# Literals are deliberately abandoned at end-of-line: this mask only runs on
-# files that already failed to parse, where an unclosed delimiter is likely,
-# and a multi-line literal span would let one unclosed quote swallow real DDL
-# below it — a masked-away routine (false negative) is recoverable by fixing
-# the file, a swallowed one is silent. A comment opener inside a multi-line
-# string is therefore consumed as (blanked) string content up to the
-# newline and never opens a comment — so it can neither fabricate nor mask
-# anything beyond its own line.
+# Literals are deliberately line-scoped: this mask only runs on files that
+# already failed to parse, where an unclosed delimiter is likely, and a
+# multi-line literal span would let one unclosed quote swallow real DDL
+# below it. The cost is asymmetric by kind. A single-quoted string that
+# continues past its line is blanked only up to the newline, so a comment
+# opener inside it cannot fire on that line — but its CONTINUATION lines are
+# scanned as code, and DDL there fabricates: multi-line dynamic SQL
+# (SET @sql = N\'\n CREATE PROC ...\') is a KNOWN HOLE, alongside the
+# unmodelled quoting dialects above; only same-line dynamic SQL is blanked.
+# Closing it would need a real string heuristic (e.g. an end-of-line opening
+# quote), judged not worth the swallow risk in a recovery-only path.
 
 
 def _mask_sql_comments(text: str) -> str:
@@ -105,19 +110,41 @@ def _mask_sql_comments(text: str) -> str:
             i = _blank(j)
         elif c == '"' or c == "[":
             # Delimited identifier: preserve verbatim. Doubled closers are
-            # escapes; a newline abandons the literal.
+            # escapes. Two shapes are NOT trusted as identifiers — emit just
+            # the delimiter and rescan the rest of the line normally, so a
+            # `--` or `/*` inside the would-be span is recognized as the
+            # comment it almost certainly is:
+            #
+            # - an UNTERMINATED opener (no closer before the newline);
+            # - a span that would swallow a comment opener on its way to the
+            #   closer (`[Col FROM t -- CREATE PROC [dbo]` closes on [dbo]'s
+            #   bracket) — a stray delimiter before a comment is ordinary in
+            #   exactly the broken files this mask runs on, and preserving
+            #   the span let the commented-out DDL after it fabricate nodes.
+            #
+            # The cost is that a genuine identifier CONTAINING a comment
+            # opener ([a--b]) is no longer preserved, so a routine so named
+            # loses recovery — a conservative false negative, traded for
+            # never fabricating.
             closer = '"' if c == '"' else "]"
             j = i + 1
+            closed = False
             while j < n and text[j] != "\n":
                 if text[j] == closer:
                     if j + 1 < n and text[j + 1] == closer:
                         j += 2
                         continue
                     j += 1
+                    closed = True
                     break
                 j += 1
-            out.append(text[i:j])
-            i = j
+            span = text[i:j]
+            if closed and "--" not in span and "/*" not in span:
+                out.append(span)
+                i = j
+            else:
+                out.append(c)
+                i += 1
         elif c == "-" and i + 1 < n and text[i + 1] == "-":
             j = i
             while j < n and text[j] != "\n":

--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -6,6 +6,50 @@ import re
 from pathlib import Path
 from graphify.extractors.base import _file_stem, _make_id
 
+# Recovers CREATE FUNCTION/PROCEDURE statements the grammar could not parse
+# structurally. Used by BOTH recovery sites — the walk-time ERROR-node scan and
+# the whole-file has_error fallback (#2180). They MUST share one pattern: when
+# they disagreed, the same statement produced two nodes with different names
+# (the ERROR scan captured `dbo.[usp_Mixed]`, the fallback stopped at `dbo`,
+# and _add_node's id-dedupe never fired because the ids differed).
+#
+# Each name part is a bare identifier, a double-quoted (delimited) one, or a
+# T-SQL bracket-delimited one, so CREATE OR REPLACE FUNCTION "public"."fn"(...)
+# and CREATE PROCEDURE [dbo].[usp_Load] ... are both recovered. A bare [\w$.]+
+# stops dead at the leading delimiter, which silently dropped every quoted
+# PL/pgSQL routine (#2180) and every bracket-named T-SQL procedure. T-SQL's
+# AS BEGIN...END body idiom always lands in recovery — the grammar has no
+# create_procedure parse for it — and T-SQL spells re-creation CREATE OR ALTER
+# (it has no OR REPLACE), so accept that form too, mirroring fb_proc_or_trigger.
+# PROC is T-SQL's official shorthand for PROCEDURE and equally common in the
+# wild; the optional (?:EDURE)? still requires trailing whitespace, so a word
+# that merely starts with PROC cannot match.
+_ROUTINE_RECOVERY_RX = re.compile(
+    r"CREATE\s+(?:OR\s+(?:REPLACE|ALTER)\s+)?(?:FUNCTION|PROC(?:EDURE)?)\s+"
+    r"(?:IF\s+NOT\s+EXISTS\s+)?"
+    r"((?:\"[^\"\n]+\"|\[[^\]\n]+\]|[\w$]+)"
+    r"(?:\s*\.\s*(?:\"[^\"\n]+\"|\[[^\]\n]+\]|[\w$]+))*)",
+    re.IGNORECASE,
+)
+
+# Matches SQL line comments (-- ...) and block comments (/* ... */) for
+# _mask_sql_comments. DOTALL so a block comment may span lines.
+_SQL_COMMENT_RX = re.compile(r"--[^\n]*|/\*.*?\*/", re.DOTALL)
+
+
+def _mask_sql_comments(text: str) -> str:
+    """Blank out comment spans, preserving every character offset.
+
+    Non-newline characters inside a comment become spaces and newlines are
+    kept, so positions and line numbers computed against the masked text are
+    valid against the original. Used by the whole-file routine recovery so
+    commented-out CREATE PROCEDURE/FUNCTION DDL in a file that has an
+    unrelated parse error cannot fabricate a routine node.
+    """
+    return _SQL_COMMENT_RX.sub(
+        lambda m: "".join("\n" if c == "\n" else " " for c in m.group(0)), text
+    )
+
 
 def _norm_ident(name: str) -> str:
     """Normalize a SQL identifier for name-based reference resolution.
@@ -254,18 +298,11 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
             # do not scan the body for FROM/JOIN references: PL/pgSQL loop
             # variables and locals would produce junk reads_from targets.
             #
-            # Each name part is either a bare identifier or a double-quoted
-            # (delimited) one, so schema-qualified generated DDL such as
-            # CREATE OR REPLACE FUNCTION "public"."fn"(...) is recovered too.
-            # A bare [\w$.]+ stops dead at the leading quote, which silently
-            # dropped every quoted PL/pgSQL routine (#2180).
+            # Name and keyword shapes accepted here are defined once in
+            # _ROUTINE_RECOVERY_RX, shared with the whole-file fallback below —
+            # see the comment on the constant.
             text = _read(node)
-            for m in re.finditer(
-                r"CREATE\s+(?:OR\s+REPLACE\s+)?(?:FUNCTION|PROCEDURE)\s+"
-                r"(?:IF\s+NOT\s+EXISTS\s+)?"
-                r"((?:\"[^\"\n]+\"|[\w$]+)(?:\s*\.\s*(?:\"[^\"\n]+\"|[\w$]+))*)",
-                text, re.IGNORECASE,
-            ):
+            for m in _ROUTINE_RECOVERY_RX.finditer(text):
                 name = m.group(1)
                 m_line = line + text[: m.start()].count("\n")
                 nid = _make_id(stem, name)
@@ -429,8 +466,9 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
     #      (keyword_create/keyword_function/object_reference/... ) and the ERROR
     #      node holds only the offending body line, e.g. `PERFORM x();` or
     #      `x := 1;` -- so no CREATE text is inside any ERROR node at all
-    #   3. the name is a quoted identifier ("public"."fn"), which a bare
-    #      [\w$.]+ pattern cannot match
+    #   3. the name is a delimited identifier — quoted ("public"."fn") or
+    #      T-SQL-bracketed ([dbo].[usp_Load]) — which a bare [\w$.]+ pattern
+    #      cannot match
     # Shapes 2 and 3 silently dropped the routine: no node, no warning, exit 0.
     # Scanning the raw source catches all three, and _add_node dedupes by id so
     # routines already recovered from the tree are not emitted twice.
@@ -441,12 +479,10 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
     # observed drop shape leaves an ERROR node in the tree, so has_error loses
     # nothing while protecting clean corpora (#2180 follow-up).
     if root.has_error:
-        for m in re.finditer(
-            r"CREATE\s+(?:OR\s+REPLACE\s+)?(?:FUNCTION|PROCEDURE)\s+"
-            r"(?:IF\s+NOT\s+EXISTS\s+)?"
-            r"((?:\"[^\"\n]+\"|[\w$]+)(?:\s*\.\s*(?:\"[^\"\n]+\"|[\w$]+))*)",
-            src_text, re.IGNORECASE,
-        ):
+        # Comments are masked (offset-preserving) so commented-out DDL cannot
+        # fabricate a routine when an unrelated error arms this scan; DDL
+        # inside string bodies remains covered only by the has_error gate.
+        for m in _ROUTINE_RECOVERY_RX.finditer(_mask_sql_comments(src_text)):
             fn_name = m.group(1)
             fn_line = src_text[: m.start()].count("\n") + 1
             _add_node(_make_id(stem, fn_name), f"{fn_name}()", fn_line)

--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -93,6 +93,59 @@ def _mask_sql_comments(text: str) -> str:
             out.append("\n" if c == "\n" else " ")
         return upto
 
+    def _blank_tail_and_carry(start: int) -> int:
+        """Blank from start to end-of-line, carrying comment state forward.
+
+        The union-of-readings blank for an ambiguous stretch: the rest of the
+        line is blanked outright; if the raw text of that stretch leaves a /*
+        unclosed on its own line (the maximum comment depth any reading could
+        be left holding), blanking continues, nesting-aware, to the closing
+        */ or EOF. Where a carry closes MID-line the same rule applies to the
+        remainder of that line — under the reading where the carry never
+        opened, that whole line may be a comment or a string, so emitting the
+        post-*/ text verbatim exposed it (found by differential fuzzing).
+        Repeats until a line ends with no carry pending. Appends one output
+        character per input character; returns the resume index.
+        """
+        k = start
+        while True:
+            eol = text.find("\n", k)
+            eol = n if eol == -1 else eol
+            depth = 0
+            m2 = k
+            while m2 < eol:
+                if text.startswith("/*", m2):
+                    depth += 1
+                    m2 += 2
+                elif text.startswith("*/", m2):
+                    if depth:
+                        depth -= 1
+                    m2 += 2
+                else:
+                    m2 += 1
+            for ch in text[k:eol]:
+                out.append("\n" if ch == "\n" else " ")
+            k = eol
+            if not depth:
+                return k
+            j2 = k
+            while j2 < n and depth:
+                if text.startswith("/*", j2):
+                    depth += 1
+                    j2 += 2
+                elif text.startswith("*/", j2):
+                    depth -= 1
+                    j2 += 2
+                else:
+                    j2 += 1
+            for ch in text[k:j2]:
+                out.append("\n" if ch == "\n" else " ")
+            k = j2
+            if k >= n:
+                return k
+            # the carry closed mid-line: the remainder of THIS line is the
+            # same ambiguous stretch — loop and blank it too
+
     while i < n:
         c = text[i]
         if c == "'":
@@ -124,10 +177,15 @@ def _mask_sql_comments(text: str) -> str:
             # every reading: the rest of the line is blanked outright, and
             # any raw /* on it with no later */ on the same line carries
             # forward as (nesting-aware) comment state, since some reading
-            # may have left it open. Over-blanking loses at most routines on
-            # a line that was already broken (a conservative false negative,
-            # and a routine named like [a--b] is inside that loss);
-            # under-blanking is what fabricates, and cannot happen here.
+            # may have left it open — and where that carry closes mid-line,
+            # the remainder of THAT line gets the same treatment, repeated
+            # until a line ends carry-free (under the no-carry reading the
+            # close line may itself be all comment or string, so emitting its
+            # post-*/ tail verbatim was an exposure). Over-blanking loses at
+            # most routines on lines already entangled with the broken one (a
+            # conservative false negative; a routine named like [a--b] is
+            # inside that loss); under-blanking is what fabricates, and every
+            # reading's blank set stays a subset of this one.
             closer = '"' if c == '"' else "]"
             j = i + 1
             closed = False
@@ -145,33 +203,7 @@ def _mask_sql_comments(text: str) -> str:
                 out.append(span)
                 i = j
             else:
-                eol = text.find("\n", i)
-                eol = n if eol == -1 else eol
-                depth = 0
-                m2 = i
-                while m2 < eol:
-                    if text.startswith("/*", m2):
-                        depth += 1
-                        m2 += 2
-                    elif text.startswith("*/", m2):
-                        if depth:
-                            depth -= 1
-                        m2 += 2
-                    else:
-                        m2 += 1
-                i = _blank(eol)
-                if depth:
-                    j2 = eol
-                    while j2 < n and depth:
-                        if text.startswith("/*", j2):
-                            depth += 1
-                            j2 += 2
-                        elif text.startswith("*/", j2):
-                            depth -= 1
-                            j2 += 2
-                        else:
-                            j2 += 1
-                    i = _blank(j2)
+                i = _blank_tail_and_carry(i)
         elif c == "-" and i + 1 < n and text[i + 1] == "-":
             j = i
             while j < n and text[j] != "\n":

--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -31,45 +31,59 @@ from graphify.extractors.base import _file_stem, _make_id
 _ROUTINE_RECOVERY_RX = re.compile(
     r"CREATE\s+(?:OR\s+(?:REPLACE|ALTER)\s+)?(?:FUNCTION|PROC(?:EDURE)?)\s+"
     r"(?:IF\s+NOT\s+EXISTS\s+)?"
-    r"((?:\"[^\"\n]+\"|\[(?:[^\]\n]|\]\])+\]|[\w$]+)"
-    r"(?:\s*\.\s*(?:\"[^\"\n]+\"|\[(?:[^\]\n]|\]\])+\]|[\w$]+))*)",
+    r"((?:\"(?:[^\"\n]|\"\")+\"|\[(?:[^\]\n]|\]\])+\]|[\w$]+)"
+    r"(?:\s*\.\s*(?:\"(?:[^\"\n]|\"\")+\"|\[(?:[^\]\n]|\]\])+\]|[\w$]+))*)",
     re.IGNORECASE,
 )
 
-# Matches string/identifier literals (preserved) or comments (blanked) for
-# _mask_sql_comments. Literals are matched first so a comment opener INSIDE a
-# literal ('-- not a comment', [a--b]) is not treated as a comment. Literal
-# patterns are deliberately single-line: this mask only runs on files that
-# already failed to parse, where an unclosed quote is likely, and a multi-line
-# literal match would let one unclosed delimiter swallow real DDL below it —
-# a masked-away routine (false negative) is recoverable by fixing the file, a
-# swallowed one is silent. A comment opener inside a multi-line string
-# therefore still masks to end-of-line, which can only hide a routine, never
-# fabricate one. DOTALL so a block comment may span lines.
+# Matches literals or comments for _mask_sql_comments. Literals are matched
+# first so a comment opener INSIDE a literal ('-- not a comment', [a--b]) is
+# not treated as a comment — but they are not all treated alike:
+#
+# - single-quoted strings are BLANKED like comments: routine names never live
+#   in single quotes, and dynamic SQL (EXEC(N'CREATE PROC [dbo].[Fake] ...'))
+#   would otherwise fabricate a routine node whenever an unrelated parse
+#   error arms the whole-file scan;
+# - double-quoted and bracket-delimited identifiers are PRESERVED verbatim —
+#   they are exactly the delimited names the recovery regex must see ("" and
+#   ]] escapes consumed, mirroring _ROUTINE_RECOVERY_RX).
+#
+# Literal patterns are deliberately single-line: this mask only runs on files
+# that already failed to parse, where an unclosed quote is likely, and a
+# multi-line literal match would let one unclosed delimiter swallow real DDL
+# below it — a masked-away routine (false negative) is recoverable by fixing
+# the file, a swallowed one is silent. A comment opener inside a multi-line
+# string therefore still masks to end-of-line, which can only hide a routine,
+# never fabricate one. DOTALL so a block comment may span lines; an UNCLOSED
+# block comment runs to end-of-file (matching SQL semantics) — requiring the
+# closing */ left everything after an unterminated /* unmasked, and an
+# unterminated comment is exactly the kind of error that arms recovery.
 _SQL_COMMENT_OR_LITERAL_RX = re.compile(
-    r"'(?:[^'\n]|'')*'"          # single-quoted string, '' escape (one line)
-    r"|\"[^\"\n]*\""             # double-quoted identifier (one line)
-    r"|\[(?:[^\]\n]|\]\])*\]"   # bracket-delimited identifier, ]] escape
-    r"|(--[^\n]*|/\*.*?\*/)",    # group 1: the comment span to blank
+    r"('(?:[^'\n]|'')*')"        # group 1: single-quoted string — blanked
+    r"|\"(?:[^\"\n]|\"\")*\""    # double-quoted identifier — preserved
+    r"|\[(?:[^\]\n]|\]\])*\]"   # bracket-delimited identifier — preserved
+    r"|(--[^\n]*|/\*.*?(?:\*/|\Z))",  # group 2: comment — blanked
     re.DOTALL,
 )
 
 
 def _mask_sql_comments(text: str) -> str:
-    """Blank out comment spans, preserving every character offset.
+    """Blank comment and string-literal spans, preserving every offset.
 
-    Non-newline characters inside a comment become spaces and newlines are
-    kept, so positions and line numbers computed against the masked text are
-    valid against the original. String and identifier literals are preserved
-    verbatim, so a `--` or `/*` inside one does not start a comment. Used by
-    the whole-file routine recovery so commented-out CREATE PROCEDURE/FUNCTION
-    DDL in a file that has an unrelated parse error cannot fabricate a routine
-    node.
+    Non-newline characters inside a blanked span become spaces and newlines
+    are kept, so positions and line numbers computed against the masked text
+    are valid against the original. Double-quoted and bracket-delimited
+    identifiers are preserved verbatim (they carry recoverable routine
+    names); single-quoted strings are blanked (they can carry dynamic SQL
+    that must not be recovered), and a `--` or `/*` inside any literal does
+    not start a comment. Used by both routine-recovery scans so commented-out
+    or string-embedded CREATE PROCEDURE/FUNCTION DDL in a file that has an
+    unrelated parse error cannot fabricate a routine node.
     """
     return _SQL_COMMENT_OR_LITERAL_RX.sub(
         lambda m: (
             "".join("\n" if c == "\n" else " " for c in m.group(0))
-            if m.group(1)
+            if m.group(1) or m.group(2)
             else m.group(0)
         ),
         text,

--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -36,58 +36,109 @@ _ROUTINE_RECOVERY_RX = re.compile(
     re.IGNORECASE,
 )
 
-# Matches literals or comments for _mask_sql_comments. Literals are matched
-# first so a comment opener INSIDE a literal ('-- not a comment', [a--b]) is
-# not treated as a comment — but they are not all treated alike:
+# _mask_sql_comments is a linear character scanner, not a regex: the four
+# span kinds interact in ways a single pattern cannot express safely —
+# comment-opener parity inside strings, nested block comments, and
+# end-of-line abandonment of unclosed literals. Span handling:
 #
-# - single-quoted strings are BLANKED like comments: routine names never live
-#   in single quotes, and dynamic SQL (EXEC(N'CREATE PROC [dbo].[Fake] ...'))
-#   would otherwise fabricate a routine node whenever an unrelated parse
-#   error arms the whole-file scan;
+# - single-quoted strings are BLANKED like comments: routine names never
+#   live in single quotes, and dynamic SQL (EXEC(N'CREATE PROC [dbo].[Fake]
+#   ...')) would otherwise fabricate a routine node whenever an unrelated
+#   parse error arms the whole-file scan. (Dialects where other quoting
+#   carries strings — MySQL double quotes, PostgreSQL dollar-quoting — are
+#   NOT modelled; DDL inside those still reaches the scan.)
 # - double-quoted and bracket-delimited identifiers are PRESERVED verbatim —
 #   they are exactly the delimited names the recovery regex must see ("" and
 #   ]] escapes consumed, mirroring _ROUTINE_RECOVERY_RX).
+# - line comments blank to end-of-line; block comments blank to their
+#   matching */ with NESTING tracked (SQL Server and PostgreSQL both nest
+#   /* */, and a lazy first-*/ match let commented-out DDL inside a nested
+#   comment fabricate nodes). An UNCLOSED block comment blanks to
+#   end-of-file, matching SQL semantics.
 #
-# Literal patterns are deliberately single-line: this mask only runs on files
-# that already failed to parse, where an unclosed quote is likely, and a
-# multi-line literal match would let one unclosed delimiter swallow real DDL
+# Literals are deliberately abandoned at end-of-line: this mask only runs on
+# files that already failed to parse, where an unclosed delimiter is likely,
+# and a multi-line literal span would let one unclosed quote swallow real DDL
 # below it — a masked-away routine (false negative) is recoverable by fixing
 # the file, a swallowed one is silent. A comment opener inside a multi-line
-# string therefore still masks to end-of-line, which can only hide a routine,
-# never fabricate one. DOTALL so a block comment may span lines; an UNCLOSED
-# block comment runs to end-of-file (matching SQL semantics) — requiring the
-# closing */ left everything after an unterminated /* unmasked, and an
-# unterminated comment is exactly the kind of error that arms recovery.
-_SQL_COMMENT_OR_LITERAL_RX = re.compile(
-    r"('(?:[^'\n]|'')*')"        # group 1: single-quoted string — blanked
-    r"|\"(?:[^\"\n]|\"\")*\""    # double-quoted identifier — preserved
-    r"|\[(?:[^\]\n]|\]\])*\]"   # bracket-delimited identifier — preserved
-    r"|(--[^\n]*|/\*.*?(?:\*/|\Z))",  # group 2: comment — blanked
-    re.DOTALL,
-)
+# string is therefore consumed as (blanked) string content up to the
+# newline and never opens a comment — so it can neither fabricate nor mask
+# anything beyond its own line.
 
 
 def _mask_sql_comments(text: str) -> str:
     """Blank comment and string-literal spans, preserving every offset.
 
-    Non-newline characters inside a blanked span become spaces and newlines
-    are kept, so positions and line numbers computed against the masked text
-    are valid against the original. Double-quoted and bracket-delimited
-    identifiers are preserved verbatim (they carry recoverable routine
-    names); single-quoted strings are blanked (they can carry dynamic SQL
-    that must not be recovered), and a `--` or `/*` inside any literal does
-    not start a comment. Used by both routine-recovery scans so commented-out
-    or string-embedded CREATE PROCEDURE/FUNCTION DDL in a file that has an
-    unrelated parse error cannot fabricate a routine node.
+    One output character per input character: non-newline characters inside
+    a blanked span become spaces and newlines are kept, so positions and
+    line numbers computed against the masked text are valid against the
+    original. Double-quoted and bracket-delimited identifiers are preserved
+    verbatim (they carry recoverable routine names); single-quoted strings,
+    line comments, and (nesting-aware) block comments are blanked. Used by
+    both routine-recovery scans so CREATE PROCEDURE/FUNCTION DDL reachable
+    only through a comment or a single-quoted string cannot fabricate a
+    routine node when an unrelated parse error arms recovery.
     """
-    return _SQL_COMMENT_OR_LITERAL_RX.sub(
-        lambda m: (
-            "".join("\n" if c == "\n" else " " for c in m.group(0))
-            if m.group(1) or m.group(2)
-            else m.group(0)
-        ),
-        text,
-    )
+    out: list[str] = []
+    i, n = 0, len(text)
+
+    def _blank(upto: int) -> int:
+        """Blank [i, upto), keeping newlines; return upto."""
+        for c in text[i:upto]:
+            out.append("\n" if c == "\n" else " ")
+        return upto
+
+    while i < n:
+        c = text[i]
+        if c == "'":
+            # Single-quoted string: blank it. '' is an escaped quote; a
+            # newline abandons the literal (see the comment above).
+            j = i + 1
+            while j < n and text[j] != "\n":
+                if text[j] == "'":
+                    if j + 1 < n and text[j + 1] == "'":
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            i = _blank(j)
+        elif c == '"' or c == "[":
+            # Delimited identifier: preserve verbatim. Doubled closers are
+            # escapes; a newline abandons the literal.
+            closer = '"' if c == '"' else "]"
+            j = i + 1
+            while j < n and text[j] != "\n":
+                if text[j] == closer:
+                    if j + 1 < n and text[j + 1] == closer:
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            out.append(text[i:j])
+            i = j
+        elif c == "-" and i + 1 < n and text[i + 1] == "-":
+            j = i
+            while j < n and text[j] != "\n":
+                j += 1
+            i = _blank(j)
+        elif c == "/" and i + 1 < n and text[i + 1] == "*":
+            depth, j = 1, i + 2
+            while j < n and depth:
+                if text[j] == "/" and j + 1 < n and text[j + 1] == "*":
+                    depth += 1
+                    j += 2
+                elif text[j] == "*" and j + 1 < n and text[j + 1] == "/":
+                    depth -= 1
+                    j += 2
+                else:
+                    j += 1
+            i = _blank(j)  # unclosed comment: j == n, blanks to end-of-file
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
 
 
 def _norm_ident(name: str) -> str:
@@ -327,28 +378,16 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
                     tbl_nid = table_nids.get(_norm_ident(tbl_name)) or _ref_stub(tbl_name)
                     _add_edge(trig_nid, tbl_nid, "triggers", line)
 
-        elif t == "ERROR":
-            # tree-sitter-sql cannot parse PL/pgSQL CREATE FUNCTION/PROCEDURE
-            # bodies (OUT/INOUT params, tagged dollar quotes, PERFORM, :=) and
-            # emits an ERROR node instead, silently dropping the object.
-            # Regex-scan the raw text as fallback, mirroring the
-            # fb_proc_or_trigger recovery below. One ERROR blob can swallow
-            # several statements, so scan for every CREATE in it. We deliberately
-            # do not scan the body for FROM/JOIN references: PL/pgSQL loop
-            # variables and locals would produce junk reads_from targets.
-            #
-            # Name and keyword shapes accepted here are defined once in
-            # _ROUTINE_RECOVERY_RX, shared with the whole-file fallback below —
-            # see the comment on the constant. Comments are masked the same
-            # way too: an ERROR blob can swallow commented-out DDL along with
-            # the statements around it, and unmasked text would fabricate a
-            # routine node from it exactly as the whole-file scan once did.
-            text = _mask_sql_comments(_read(node))
-            for m in _ROUTINE_RECOVERY_RX.finditer(text):
-                name = m.group(1)
-                m_line = line + text[: m.start()].count("\n")
-                nid = _make_id(stem, name)
-                _add_node(nid, f"{name}()", m_line)
+        # NOTE: there is deliberately NO recovery scan on individual ERROR
+        # nodes. Any ERROR node anywhere makes root.has_error true, so the
+        # whole-file masked scan below this walk already recovers everything
+        # a per-node scan could — from the SAME shared _ROUTINE_RECOVERY_RX,
+        # with _add_node deduping by id. A per-node scan is not just
+        # redundant, it is unsound: _mask_sql_comments needs file-level
+        # context, and an ERROR fragment can begin MID-comment (tree-sitter's
+        # lexer does not nest /* */, so the text after an inner */ parses as
+        # code and lands in an ERROR blob with no comment opener in sight),
+        # which let commented-out DDL fabricate routine nodes.
 
         elif t == "fb_proc_or_trigger":
             text = _read(node)
@@ -516,14 +555,17 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
     # routines already recovered from the tree are not emitted twice.
     #
     # Gate on a failed parse: a cleanly-parsing file must NOT have routines
-    # fabricated from commented-out DDL, DDL inside EXECUTE '...' string bodies,
-    # or MySQL `CREATE FUNCTION IF NOT EXISTS` (which would capture `IF`). Every
+    # fabricated from MySQL `CREATE FUNCTION IF NOT EXISTS` (which would
+    # capture `IF`) or other shapes the mask does not model (double-quoted
+    # strings in MySQL's default mode, PostgreSQL dollar-quoted bodies). Every
     # observed drop shape leaves an ERROR node in the tree, so has_error loses
     # nothing while protecting clean corpora (#2180 follow-up).
     if root.has_error:
-        # Comments are masked (offset-preserving) so commented-out DDL cannot
-        # fabricate a routine when an unrelated error arms this scan; DDL
-        # inside string bodies remains covered only by the has_error gate.
+        # The mask blanks comments (nesting-aware) and single-quoted strings
+        # (offset-preserving), so commented-out DDL and single-quoted dynamic
+        # SQL cannot fabricate a routine when an unrelated error arms this
+        # scan; string shapes the mask does not model rely on the has_error
+        # gate alone.
         for m in _ROUTINE_RECOVERY_RX.finditer(_mask_sql_comments(src_text)):
             fn_name = m.group(1)
             fn_line = src_text[: m.start()].count("\n") + 1

--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -21,14 +21,18 @@ from graphify.extractors.base import _file_stem, _make_id
 # AS BEGIN...END body idiom always lands in recovery — the grammar has no
 # create_procedure parse for it — and T-SQL spells re-creation CREATE OR ALTER
 # (it has no OR REPLACE), so accept that form too, mirroring fb_proc_or_trigger.
+# Inside a bracket-delimited part, a literal ] is escaped by doubling
+# ([a]]b] names the identifier a]b), so consume ]] before treating a
+# lone ] as the closing delimiter — stopping at the first ] truncated
+# the name and minted a phantom that could collide with a real [a].
 # PROC is T-SQL's official shorthand for PROCEDURE and equally common in the
 # wild; the optional (?:EDURE)? still requires trailing whitespace, so a word
 # that merely starts with PROC cannot match.
 _ROUTINE_RECOVERY_RX = re.compile(
     r"CREATE\s+(?:OR\s+(?:REPLACE|ALTER)\s+)?(?:FUNCTION|PROC(?:EDURE)?)\s+"
     r"(?:IF\s+NOT\s+EXISTS\s+)?"
-    r"((?:\"[^\"\n]+\"|\[[^\]\n]+\]|[\w$]+)"
-    r"(?:\s*\.\s*(?:\"[^\"\n]+\"|\[[^\]\n]+\]|[\w$]+))*)",
+    r"((?:\"[^\"\n]+\"|\[(?:[^\]\n]|\]\])+\]|[\w$]+)"
+    r"(?:\s*\.\s*(?:\"[^\"\n]+\"|\[(?:[^\]\n]|\]\])+\]|[\w$]+))*)",
     re.IGNORECASE,
 )
 

--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -36,9 +36,23 @@ _ROUTINE_RECOVERY_RX = re.compile(
     re.IGNORECASE,
 )
 
-# Matches SQL line comments (-- ...) and block comments (/* ... */) for
-# _mask_sql_comments. DOTALL so a block comment may span lines.
-_SQL_COMMENT_RX = re.compile(r"--[^\n]*|/\*.*?\*/", re.DOTALL)
+# Matches string/identifier literals (preserved) or comments (blanked) for
+# _mask_sql_comments. Literals are matched first so a comment opener INSIDE a
+# literal ('-- not a comment', [a--b]) is not treated as a comment. Literal
+# patterns are deliberately single-line: this mask only runs on files that
+# already failed to parse, where an unclosed quote is likely, and a multi-line
+# literal match would let one unclosed delimiter swallow real DDL below it —
+# a masked-away routine (false negative) is recoverable by fixing the file, a
+# swallowed one is silent. A comment opener inside a multi-line string
+# therefore still masks to end-of-line, which can only hide a routine, never
+# fabricate one. DOTALL so a block comment may span lines.
+_SQL_COMMENT_OR_LITERAL_RX = re.compile(
+    r"'(?:[^'\n]|'')*'"          # single-quoted string, '' escape (one line)
+    r"|\"[^\"\n]*\""             # double-quoted identifier (one line)
+    r"|\[(?:[^\]\n]|\]\])*\]"   # bracket-delimited identifier, ]] escape
+    r"|(--[^\n]*|/\*.*?\*/)",    # group 1: the comment span to blank
+    re.DOTALL,
+)
 
 
 def _mask_sql_comments(text: str) -> str:
@@ -46,12 +60,19 @@ def _mask_sql_comments(text: str) -> str:
 
     Non-newline characters inside a comment become spaces and newlines are
     kept, so positions and line numbers computed against the masked text are
-    valid against the original. Used by the whole-file routine recovery so
-    commented-out CREATE PROCEDURE/FUNCTION DDL in a file that has an
-    unrelated parse error cannot fabricate a routine node.
+    valid against the original. String and identifier literals are preserved
+    verbatim, so a `--` or `/*` inside one does not start a comment. Used by
+    the whole-file routine recovery so commented-out CREATE PROCEDURE/FUNCTION
+    DDL in a file that has an unrelated parse error cannot fabricate a routine
+    node.
     """
-    return _SQL_COMMENT_RX.sub(
-        lambda m: "".join("\n" if c == "\n" else " " for c in m.group(0)), text
+    return _SQL_COMMENT_OR_LITERAL_RX.sub(
+        lambda m: (
+            "".join("\n" if c == "\n" else " " for c in m.group(0))
+            if m.group(1)
+            else m.group(0)
+        ),
+        text,
     )
 
 
@@ -304,8 +325,11 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
             #
             # Name and keyword shapes accepted here are defined once in
             # _ROUTINE_RECOVERY_RX, shared with the whole-file fallback below —
-            # see the comment on the constant.
-            text = _read(node)
+            # see the comment on the constant. Comments are masked the same
+            # way too: an ERROR blob can swallow commented-out DDL along with
+            # the statements around it, and unmasked text would fabricate a
+            # routine node from it exactly as the whole-file scan once did.
+            text = _mask_sql_comments(_read(node))
             for m in _ROUTINE_RECOVERY_RX.finditer(text):
                 name = m.group(1)
                 m_line = line + text[: m.start()].count("\n")

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -487,6 +487,97 @@ def test_sql_no_dangling_edges():
     for e in r["edges"]:
         assert e["source"] in node_ids, f"dangling source: {e['source']}"
 
+def test_sql_tsql_bracketed_procedure_is_recovered(tmp_path):
+    """T-SQL CREATE PROCEDURE [Schema].[Name] ... AS BEGIN...END.
+
+    The grammar has no create_procedure parse for T-SQL's AS BEGIN...END body
+    idiom, so the statement lands in ERROR recovery — where a name pattern
+    without a bracket-delimited alternative recovered nothing. In a T-SQL
+    codebase that brackets every identifier (a common house standard), that
+    made every stored procedure invisible.
+    """
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "proc.sql"
+    p.write_text(
+        "CREATE PROCEDURE [dbo].[usp_LoadDebtors]\n"
+        "    @BatchId INT\n"
+        "AS\n"
+        "BEGIN\n"
+        "    SET NOCOUNT ON;\n"
+        "    INSERT INTO dbo.Debtors (Id) SELECT Id FROM staging.Debtors;\n"
+        "END;\n"
+    )
+    r = extract_sql(p)
+    routine = [n["label"] for n in r["nodes"] if n["label"] != "proc.sql"]
+    assert routine == ["[dbo].[usp_LoadDebtors]()"], routine
+
+
+def test_sql_tsql_create_or_alter_procedure_is_recovered(tmp_path):
+    """T-SQL spells idempotent re-creation CREATE OR ALTER (no OR REPLACE)."""
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "proc.sql"
+    p.write_text(
+        "CREATE OR ALTER PROCEDURE [Utils].[ValidateSourceView]\n"
+        "AS\nBEGIN\n    SELECT 1;\nEND;\n"
+        "CREATE OR ALTER PROCEDURE usp_Bare AS\nBEGIN\n SELECT 1;\nEND;\n"
+    )
+    r = extract_sql(p)
+    labels = sorted(n["label"] for n in r["nodes"] if n["label"] != "proc.sql")
+    assert labels == ["[Utils].[ValidateSourceView]()", "usp_Bare()"], labels
+
+
+def test_sql_recovery_sites_agree_on_the_captured_name(tmp_path):
+    """A mixed-delimiter name (dbo.[usp_Mixed]) must yield exactly ONE node.
+
+    The walk-time ERROR scan and the whole-file has_error fallback recover the
+    same statement; when their patterns drifted, they captured different names
+    (`dbo.[usp_Mixed]` vs `dbo`), minted different ids, and _add_node's
+    id-dedupe never fired — one procedure became two nodes, one of them a
+    phantom named after the schema. Sharing _ROUTINE_RECOVERY_RX makes the
+    drift impossible; this pins the observable behaviour.
+    """
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "proc.sql"
+    p.write_text("CREATE PROCEDURE dbo.[usp_Mixed] AS\nBEGIN\n SELECT 1;\nEND;\n")
+    r = extract_sql(p)
+    routine = [n["label"] for n in r["nodes"] if n["label"] != "proc.sql"]
+    assert routine == ["dbo.[usp_Mixed]()"], routine
+
+
+def test_sql_tsql_proc_shorthand_is_recovered(tmp_path):
+    """T-SQL's official PROC shorthand, including CREATE OR ALTER PROC with a
+    qualified bracket-delimited name, must recover like the long form."""
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "proc.sql"
+    p.write_text(
+        "CREATE OR ALTER PROC [dbo].[usp_Short]\n"
+        "AS\nBEGIN\n    SELECT 1;\nEND;\n"
+        "CREATE PROC usp_BareShort AS\nBEGIN\n SELECT 1;\nEND;\n"
+    )
+    r = extract_sql(p)
+    labels = sorted(n["label"] for n in r["nodes"] if n["label"] != "proc.sql")
+    assert labels == ["[dbo].[usp_Short]()", "usp_BareShort()"], labels
+
+
+def test_sql_commented_ddl_is_not_fabricated_by_error_recovery(tmp_path):
+    """An unrelated syntax error arms the whole-file recovery scan; DDL that
+    exists only inside comments must not fabricate routine nodes from it."""
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "broken.sql"
+    p.write_text(
+        "-- CREATE PROCEDURE [dbo].[usp_LineComment] AS BEGIN SELECT 1; END;\n"
+        "/*\nCREATE OR ALTER PROC dbo.usp_BlockComment AS\nBEGIN SELECT 1; END;\n*/\n"
+        "CREATE PROCEDURE [dbo].[usp_Real]\nAS\nBEGIN\n    SELECT 1;\nEND;\n"
+        "THIS IS NOT SQL AT ALL %%%;\n"
+    )
+    r = extract_sql(p)
+    labels = [n["label"] for n in r["nodes"] if n["label"] != "broken.sql"]
+    assert "[dbo].[usp_Real]()" in labels, labels
+    assert not any("Comment" in l for l in labels), (
+        f"commented-out DDL fabricated a node: {labels}"
+    )
+
+
 def test_sql_cte_is_not_read_as_a_table():
     """#2577: a name bound by WITH ... AS (...) is scoped to its statement, not a table.
 

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -956,6 +956,26 @@ def test_sql_dynamic_sql_and_unclosed_comment_do_not_fabricate_routines(tmp_path
     )
 
 
+def test_sql_ddl_keywords_inside_delimited_identifiers_do_not_fabricate(tmp_path):
+    """A preserved delimited identifier keeps its text verbatim in the masked
+    scan (it may BE a recoverable name), so DDL keywords occurring inside one
+    ('SELECT 1 AS [CREATE PROCEDURE dbo.usp_Phantom pending]') were matched
+    by the recovery regex and minted a phantom routine. Recovery now skips a
+    match whose CREATE starts inside a preserved identifier span — a genuine
+    statement's NAME may be a delimited identifier; its CREATE never is."""
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "alias.sql"
+    p.write_text(
+        "THIS IS NOT SQL AT ALL %%%;\n"
+        "SELECT 1 AS [CREATE PROCEDURE dbo.usp_Phantom pending];\n"
+        'SELECT 2 AS "CREATE PROC dbo.usp_Phantom2 queued";\n'
+        "CREATE PROCEDURE [dbo].[usp_Real]\nAS\nBEGIN\n    SELECT 1;\nEND;\n"
+    )
+    r = extract_sql(p)
+    labels = [n["label"] for n in r["nodes"] if n["label"] != "alias.sql"]
+    assert labels == ["[dbo].[usp_Real]()"], labels
+
+
 def test_sql_escaped_double_quote_in_routine_name_is_consumed(tmp_path):
     """ANSI SQL escapes a literal double quote inside a delimited identifier
     by doubling it: "a""b" names the identifier a"b. A pattern that stops at

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -648,19 +648,30 @@ def test_mask_sql_comments_literal_and_comment_handling():
     # identifier literals are preserved verbatim, escapes included
     assert mask('CREATE FUNCTION "public"."a""b"()') == 'CREATE FUNCTION "public"."a""b"()'
     assert mask("CREATE PROCEDURE [dbo].[a]]b] AS x") == "CREATE PROCEDURE [dbo].[a]]b] AS x"
-    # ...but a span that would swallow a comment opener is NOT trusted as an
-    # identifier: the delimiter is emitted alone and the comment fires, so a
-    # stray [ or " before a comment cannot shield commented-out DDL —
-    # `[Col FROM t -- CREATE PROC [dbo]` would otherwise close on [dbo]'s
-    # bracket and preserve the DDL. (The trade: a genuine [a--b] identifier
-    # is conservatively blanked past the --, losing that name, never
-    # fabricating one.)
+    # ...but a span that is unterminated or would swallow a comment opener is
+    # NOT trusted as an identifier. A distrusted span is irreducibly
+    # ambiguous, and any single reading exposed text another reading blanks
+    # (re-emitting the delimiter and rescanning even re-paired later single
+    # quotes, uncovering dynamic SQL), so the mask blanks the UNION of every
+    # reading: the rest of the line, plus carried comment state for a raw /*
+    # left open on it. The trade: a genuine [a--b] identifier loses its line,
+    # never fabricating anything.
     ghost = "SELECT [Col FROM t -- CREATE PROC [dbo].[usp_Ghost] AS BEGIN SELECT 1; END;"
     assert "CREATE" not in mask(ghost) and len(mask(ghost)) == len(ghost)
     ghost2 = 'SELECT "Col FROM t /* CREATE PROC dbo.usp_Ghost AS BEGIN SELECT 1; END */'
     assert "CREATE" not in mask(ghost2) and len(mask(ghost2)) == len(ghost2)
     out = mask("select [a--b] from t")
-    assert out.startswith("select [a") and "from t" not in out and len(out) == len("select [a--b] from t")
+    assert out == "select " + " " * len("[a--b] from t") and len(out) == len("select [a--b] from t")
+    # a distrusted span cannot re-pair later single quotes: the dynamic SQL
+    # after it stays masked (the re-emit-and-rescan defect, found by fuzzing)
+    repair = "SELECT [Col's -- x] ; EXEC(N'CREATE PROC [dbo].[usp_Fake] AS BEGIN SELECT 1; END');"
+    assert "CREATE" not in mask(repair) and len(mask(repair)) == len(repair)
+    # a raw /* on a distrusted line with no */ carries across the newline —
+    # some reading of the broken line left it open
+    carry = "SELECT [a--b] /*\nCREATE PROC dbo.Fake AS BEGIN SELECT 1; END\n"
+    assert "CREATE" not in mask(carry) and len(mask(carry)) == len(carry)
+    carry_closed = "SELECT [a--b] /*\nx */ CREATE PROC dbo.Kept AS x\n"
+    assert "CREATE PROC dbo.Kept" in mask(carry_closed)
     # dynamic SQL contents cannot survive the mask
     dyn = "EXEC(N'CREATE PROC [dbo].[Fake] AS BEGIN SELECT 1; END');"
     assert "CREATE" not in mask(dyn) and len(mask(dyn)) == len(dyn)
@@ -685,6 +696,31 @@ def test_mask_sql_comments_literal_and_comment_handling():
     nested = "/* outer\n   /* inner */\n   CREATE PROC dbo.usp_Fake AS BEGIN SELECT 1; END;\n*/\n"
     out = mask(nested)
     assert "CREATE" not in out and len(out) == len(nested)
+
+
+def test_mask_sql_comments_invariants_fuzz():
+    """Deterministic fuzz over the mask's structural invariants.
+
+    Both rounds of masking defects were shapes nobody thought to write down,
+    so pin properties instead: (1) one output character per input character,
+    (2) newlines exactly preserved, (3) blanked spans are spaces, (4) the
+    mask is idempotent — re-masking its own output changes nothing (the
+    quote re-pairing defect broke this: exposed text re-masked differently).
+    """
+    import random
+
+    from graphify.extractors.sql import _mask_sql_comments as mask
+
+    rng = random.Random(0xC0FFEE)
+    alphabet = "ab[]\"'-*/ \n;.$"
+    for _ in range(20_000):
+        s = "".join(rng.choice(alphabet) for _ in range(rng.randint(1, 26)))
+        out = mask(s)
+        assert len(out) == len(s), (s, out)
+        for a, b in zip(s, out):
+            assert (a == "\n") == (b == "\n"), (s, out)
+            assert b == a or b == " ", (s, out)
+        assert mask(out) == out, (s, out)
 
 
 def test_sql_dynamic_sql_and_unclosed_comment_do_not_fabricate_routines(tmp_path):

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -582,6 +582,13 @@ def test_sql_commented_ddl_is_not_fabricated_by_error_recovery(tmp_path):
         "/*\nCREATE OR ALTER PROC dbo.usp_BlockComment AS\nBEGIN SELECT 1; END;\n*/\n"
         "CREATE PROCEDURE [dbo].[usp_Real]\nAS\nBEGIN\n    SELECT 1;\nEND;\n"
         "THIS IS NOT SQL AT ALL %%%;\n"
+        # Sandwiched between broken segments so one ERROR blob's byte span
+        # covers the comment: the walk-time ERROR scan sees it too (the
+        # leading comments above land in proper comment nodes instead, and a
+        # trailing comment falls outside the ERROR span):
+        "%%% BROKEN JUNK\n"
+        "-- CREATE PROC [dbo].[usp_ErrComment] AS BEGIN SELECT 1; END;\n"
+        "%%% MORE BROKEN JUNK\n"
     )
     r = extract_sql(p)
     labels = [n["label"] for n in r["nodes"] if n["label"] != "broken.sql"]
@@ -589,6 +596,54 @@ def test_sql_commented_ddl_is_not_fabricated_by_error_recovery(tmp_path):
     assert not any("Comment" in l for l in labels), (
         f"commented-out DDL fabricated a node: {labels}"
     )
+
+
+def test_sql_comment_openers_inside_string_literals_do_not_hide_ddl(tmp_path):
+    """A `--` or `/*` inside a string literal is data, not a comment opener.
+
+    Both recovery scans mask comments before matching, and a mask that reads
+    `'-- note'` as a line comment blanks to end-of-line — hiding a routine
+    declared after the literal — while a `/*` inside a string blanks
+    everything through the next real `*/`, swallowing whole statements
+    between. Both must recover normally. This is behavior coverage: the
+    grammar's own fb_proc_or_trigger recovery can rescue these shapes even
+    under a literal-blind mask, so the mutation-killing pin for the mask
+    itself is test_mask_sql_comments_preserves_literals_and_blanks_comments.
+    """
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "strings.sql"
+    # The lines carrying the literals start with junk so they cannot parse as
+    # proper statements: literal and routine land in the SAME ERROR blob, and
+    # only the mask decides whether the routine survives. (A literal in a
+    # statement that parses never reaches the masked scans at all.)
+    p.write_text(
+        "%%% INSERT INTO log VALUES ('-- note'); "
+        "CREATE PROCEDURE [dbo].[usp_AfterLineString] AS BEGIN SELECT 1; END;\n"
+        "%%% SELECT 'open /* here' AS x; "
+        "CREATE PROCEDURE [dbo].[usp_AfterBlockString] AS BEGIN SELECT 1; END;\n"
+        "/* a real comment, giving the false opener a closer to reach */\n"
+    )
+    r = extract_sql(p)
+    labels = [n["label"] for n in r["nodes"] if n["label"] != "strings.sql"]
+    assert "[dbo].[usp_AfterLineString]()" in labels, labels
+    assert "[dbo].[usp_AfterBlockString]()" in labels, labels
+
+
+def test_mask_sql_comments_preserves_literals_and_blanks_comments():
+    """Unit pin for _mask_sql_comments: comment openers inside string or
+    identifier literals are data; real comments blank to spaces with newlines
+    and offsets preserved."""
+    from graphify.extractors.sql import _mask_sql_comments as mask
+
+    assert mask("select '-- x' from t") == "select '-- x' from t"
+    assert mask("select 'it''s -- ok'") == "select 'it''s -- ok'"
+    assert mask('select "a--b" from t') == 'select "a--b" from t'
+    assert mask("select [a--b] from t") == "select [a--b] from t"
+    assert mask("select 'a /* b' as x") == "select 'a /* b' as x"
+    assert mask("a -- b") == "a     "
+    assert mask("x /* y */ z") == "x         z"
+    masked = mask("a /* m\nl */ b")
+    assert masked == "a     \n     b" and len(masked) == len("a /* m\nl */ b")
 
 
 def test_sql_cte_is_not_read_as_a_table():

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -646,9 +646,21 @@ def test_mask_sql_comments_literal_and_comment_handling():
     expected = "select " + " " * len("'it''s -- ok'") + ", 1"
     assert mask(src) == expected and len(mask(src)) == len(src)
     # identifier literals are preserved verbatim, escapes included
-    assert mask('select "a--b" from t') == 'select "a--b" from t'
     assert mask('CREATE FUNCTION "public"."a""b"()') == 'CREATE FUNCTION "public"."a""b"()'
-    assert mask("select [a--b] from t") == "select [a--b] from t"
+    assert mask("CREATE PROCEDURE [dbo].[a]]b] AS x") == "CREATE PROCEDURE [dbo].[a]]b] AS x"
+    # ...but a span that would swallow a comment opener is NOT trusted as an
+    # identifier: the delimiter is emitted alone and the comment fires, so a
+    # stray [ or " before a comment cannot shield commented-out DDL —
+    # `[Col FROM t -- CREATE PROC [dbo]` would otherwise close on [dbo]'s
+    # bracket and preserve the DDL. (The trade: a genuine [a--b] identifier
+    # is conservatively blanked past the --, losing that name, never
+    # fabricating one.)
+    ghost = "SELECT [Col FROM t -- CREATE PROC [dbo].[usp_Ghost] AS BEGIN SELECT 1; END;"
+    assert "CREATE" not in mask(ghost) and len(mask(ghost)) == len(ghost)
+    ghost2 = 'SELECT "Col FROM t /* CREATE PROC dbo.usp_Ghost AS BEGIN SELECT 1; END */'
+    assert "CREATE" not in mask(ghost2) and len(mask(ghost2)) == len(ghost2)
+    out = mask("select [a--b] from t")
+    assert out.startswith("select [a") and "from t" not in out and len(out) == len("select [a--b] from t")
     # dynamic SQL contents cannot survive the mask
     dyn = "EXEC(N'CREATE PROC [dbo].[Fake] AS BEGIN SELECT 1; END');"
     assert "CREATE" not in mask(dyn) and len(mask(dyn)) == len(dyn)
@@ -688,6 +700,7 @@ def test_sql_dynamic_sql_and_unclosed_comment_do_not_fabricate_routines(tmp_path
         " must not swallow what follows';\n"
         "/* nested /* comments */ hide this:\n"
         "CREATE PROC [dbo].[usp_Nested] AS BEGIN SELECT 1; END;\n*/\n"
+        "SELECT [Col FROM t -- CREATE PROC [dbo].[usp_Bracketed] AS BEGIN SELECT 1; END;\n"
         "CREATE PROCEDURE [dbo].[usp_Real]\nAS\nBEGIN\n    SELECT 1;\nEND;\n"
         "/* an unterminated comment swallows the rest of the file\n"
         "CREATE PROC [dbo].[usp_Unterminated] AS BEGIN SELECT 1; END;\n"
@@ -697,7 +710,7 @@ def test_sql_dynamic_sql_and_unclosed_comment_do_not_fabricate_routines(tmp_path
     assert "[dbo].[usp_Real]()" in labels, labels
     fabricated = [
         label for label in labels
-        if "Dynamic" in label or "Nested" in label or "Unterminated" in label
+        if any(k in label for k in ("Dynamic", "Nested", "Bracketed", "Unterminated"))
     ]
     assert not fabricated, (
         f"string-embedded or comment-swallowed DDL fabricated a node: {labels}"

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -526,6 +526,19 @@ def test_sql_tsql_create_or_alter_procedure_is_recovered(tmp_path):
     assert labels == ["[Utils].[ValidateSourceView]()", "usp_Bare()"], labels
 
 
+def test_sql_escaped_closing_bracket_in_routine_name_is_consumed(tmp_path):
+    """T-SQL escapes a literal ] inside a bracketed identifier by doubling it:
+    [a]]b] names the identifier a]b. A pattern that stops at the first ]
+    truncated the name to [dbo].[a] — a phantom that could collide with a
+    genuinely-named [dbo].[a]."""
+    import tree_sitter_sql  # noqa: F401 — required by the recovery path under test
+    p = tmp_path / "proc.sql"
+    p.write_text("CREATE PROCEDURE [dbo].[a]]b]\nAS\nBEGIN\n    SELECT 1;\nEND;\n")
+    r = extract_sql(p)
+    routine = [n["label"] for n in r["nodes"] if n["label"] != "proc.sql"]
+    assert routine == ["[dbo].[a]]b]()"], routine
+
+
 def test_sql_recovery_sites_agree_on_the_captured_name(tmp_path):
     """A mixed-delimiter name (dbo.[usp_Mixed]) must yield exactly ONE node.
 

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -900,6 +900,12 @@ def test_mask_sql_comments_monotone_against_frozen_baseline():
     series (quote re-pairing, carry-close exposure) was a monotonicity
     violation of exactly this kind, and none was caught by hand-written
     shapes first.
+
+    If an INTENTIONAL over-blanking change lands (the live mask blanks more
+    than the baseline), this still passes; if an intentional EXPOSURE change
+    lands (the mask deliberately blanks less), refresh the frozen copy above
+    to the new revision as part of that reviewed change — do not delete the
+    test or loosen the property.
     """
     import random
 

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -583,9 +583,9 @@ def test_sql_commented_ddl_is_not_fabricated_by_error_recovery(tmp_path):
         "CREATE PROCEDURE [dbo].[usp_Real]\nAS\nBEGIN\n    SELECT 1;\nEND;\n"
         "THIS IS NOT SQL AT ALL %%%;\n"
         # Sandwiched between broken segments so one ERROR blob's byte span
-        # covers the comment: the walk-time ERROR scan sees it too (the
-        # leading comments above land in proper comment nodes instead, and a
-        # trailing comment falls outside the ERROR span):
+        # covers the comment — the shape that made a per-ERROR-node scan
+        # unsound (a fragment can lack the comment opener entirely) and is
+        # why recovery scans only the whole masked file:
         "%%% BROKEN JUNK\n"
         "-- CREATE PROC [dbo].[usp_ErrComment] AS BEGIN SELECT 1; END;\n"
         "%%% MORE BROKEN JUNK\n"
@@ -660,6 +660,19 @@ def test_mask_sql_comments_literal_and_comment_handling():
     # an unclosed block comment masks to end-of-file, newlines kept
     unclosed = "/* CREATE PROC [dbo].[Ghost] AS\nBEGIN SELECT 1; END"
     assert "CREATE" not in mask(unclosed) and len(mask(unclosed)) == len(unclosed)
+    # a /* inside a MULTI-LINE string is consumed as (blanked, line-scoped)
+    # string content — it must NOT open a comment that swallows the file
+    multi = (
+        "SET @sql = N'SELECT a /* c1\n , b FROM t';\nGO\n"
+        "CREATE PROCEDURE dbo.usp_Real AS BEGIN SELECT 1; END;\n"
+    )
+    out = mask(multi)
+    assert "CREATE PROCEDURE dbo.usp_Real" in out and len(out) == len(multi)
+    # block comments NEST (SQL Server and PostgreSQL both nest /* */): DDL
+    # commented out inside a nested comment must not survive the mask
+    nested = "/* outer\n   /* inner */\n   CREATE PROC dbo.usp_Fake AS BEGIN SELECT 1; END;\n*/\n"
+    out = mask(nested)
+    assert "CREATE" not in out and len(out) == len(nested)
 
 
 def test_sql_dynamic_sql_and_unclosed_comment_do_not_fabricate_routines(tmp_path):
@@ -671,6 +684,10 @@ def test_sql_dynamic_sql_and_unclosed_comment_do_not_fabricate_routines(tmp_path
     p.write_text(
         "THIS IS NOT SQL AT ALL %%%;\n"
         "EXEC(N'CREATE OR ALTER PROC [dbo].[usp_Dynamic] AS BEGIN SELECT 1; END');\n"
+        "SET @sql = N'SELECT 1 /* opener inside a multi-line string\n"
+        " must not swallow what follows';\n"
+        "/* nested /* comments */ hide this:\n"
+        "CREATE PROC [dbo].[usp_Nested] AS BEGIN SELECT 1; END;\n*/\n"
         "CREATE PROCEDURE [dbo].[usp_Real]\nAS\nBEGIN\n    SELECT 1;\nEND;\n"
         "/* an unterminated comment swallows the rest of the file\n"
         "CREATE PROC [dbo].[usp_Unterminated] AS BEGIN SELECT 1; END;\n"
@@ -678,7 +695,11 @@ def test_sql_dynamic_sql_and_unclosed_comment_do_not_fabricate_routines(tmp_path
     r = extract_sql(p)
     labels = [n["label"] for n in r["nodes"] if n["label"] != "dynamic.sql"]
     assert "[dbo].[usp_Real]()" in labels, labels
-    assert not any("Dynamic" in label or "Unterminated" in label for label in labels), (
+    fabricated = [
+        label for label in labels
+        if "Dynamic" in label or "Nested" in label or "Unterminated" in label
+    ]
+    assert not fabricated, (
         f"string-embedded or comment-swallowed DDL fabricated a node: {labels}"
     )
 

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -531,7 +531,7 @@ def test_sql_escaped_closing_bracket_in_routine_name_is_consumed(tmp_path):
     [a]]b] names the identifier a]b. A pattern that stops at the first ]
     truncated the name to [dbo].[a] — a phantom that could collide with a
     genuinely-named [dbo].[a]."""
-    import tree_sitter_sql  # noqa: F401 — required by the recovery path under test
+    pytest.importorskip("tree_sitter_sql")
     p = tmp_path / "proc.sql"
     p.write_text("CREATE PROCEDURE [dbo].[a]]b]\nAS\nBEGIN\n    SELECT 1;\nEND;\n")
     r = extract_sql(p)
@@ -629,21 +629,76 @@ def test_sql_comment_openers_inside_string_literals_do_not_hide_ddl(tmp_path):
     assert "[dbo].[usp_AfterBlockString]()" in labels, labels
 
 
-def test_mask_sql_comments_preserves_literals_and_blanks_comments():
-    """Unit pin for _mask_sql_comments: comment openers inside string or
-    identifier literals are data; real comments blank to spaces with newlines
-    and offsets preserved."""
+def test_mask_sql_comments_literal_and_comment_handling():
+    """Unit pin for _mask_sql_comments: comment openers inside literals are
+    data, not comment starts; single-quoted strings are blanked (dynamic SQL
+    must not be recoverable); double-quoted and bracket identifiers are
+    preserved verbatim (they carry recoverable names); comments blank to
+    spaces with newlines and offsets preserved, an unclosed block comment
+    running to end-of-file."""
     from graphify.extractors.sql import _mask_sql_comments as mask
 
-    assert mask("select '-- x' from t") == "select '-- x' from t"
-    assert mask("select 'it''s -- ok'") == "select 'it''s -- ok'"
+    # a comment opener inside a literal never blanks past the literal
+    assert mask("select '-- x' from t") == "select        from t"
+    assert mask("select 'a /* b' as x, 1") == "select          as x, 1"
+    # '' escape is consumed as one literal (no blanking past the string)
+    src = "select 'it''s -- ok', 1"
+    expected = "select " + " " * len("'it''s -- ok'") + ", 1"
+    assert mask(src) == expected and len(mask(src)) == len(src)
+    # identifier literals are preserved verbatim, escapes included
     assert mask('select "a--b" from t') == 'select "a--b" from t'
+    assert mask('CREATE FUNCTION "public"."a""b"()') == 'CREATE FUNCTION "public"."a""b"()'
     assert mask("select [a--b] from t") == "select [a--b] from t"
-    assert mask("select 'a /* b' as x") == "select 'a /* b' as x"
+    # dynamic SQL contents cannot survive the mask
+    dyn = "EXEC(N'CREATE PROC [dbo].[Fake] AS BEGIN SELECT 1; END');"
+    assert "CREATE" not in mask(dyn) and len(mask(dyn)) == len(dyn)
+    # comments blank to spaces, newlines kept, offsets stable
     assert mask("a -- b") == "a     "
     assert mask("x /* y */ z") == "x         z"
     masked = mask("a /* m\nl */ b")
     assert masked == "a     \n     b" and len(masked) == len("a /* m\nl */ b")
+    # an unclosed block comment masks to end-of-file, newlines kept
+    unclosed = "/* CREATE PROC [dbo].[Ghost] AS\nBEGIN SELECT 1; END"
+    assert "CREATE" not in mask(unclosed) and len(mask(unclosed)) == len(unclosed)
+
+
+def test_sql_dynamic_sql_and_unclosed_comment_do_not_fabricate_routines(tmp_path):
+    """DDL text reachable only through a single-quoted string (dynamic SQL) or
+    an unterminated block comment must not mint routine nodes when an
+    unrelated parse error arms the recovery scans."""
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "dynamic.sql"
+    p.write_text(
+        "THIS IS NOT SQL AT ALL %%%;\n"
+        "EXEC(N'CREATE OR ALTER PROC [dbo].[usp_Dynamic] AS BEGIN SELECT 1; END');\n"
+        "CREATE PROCEDURE [dbo].[usp_Real]\nAS\nBEGIN\n    SELECT 1;\nEND;\n"
+        "/* an unterminated comment swallows the rest of the file\n"
+        "CREATE PROC [dbo].[usp_Unterminated] AS BEGIN SELECT 1; END;\n"
+    )
+    r = extract_sql(p)
+    labels = [n["label"] for n in r["nodes"] if n["label"] != "dynamic.sql"]
+    assert "[dbo].[usp_Real]()" in labels, labels
+    assert not any("Dynamic" in label or "Unterminated" in label for label in labels), (
+        f"string-embedded or comment-swallowed DDL fabricated a node: {labels}"
+    )
+
+
+def test_sql_escaped_double_quote_in_routine_name_is_consumed(tmp_path):
+    """ANSI SQL escapes a literal double quote inside a delimited identifier
+    by doubling it: "a""b" names the identifier a"b. A pattern that stops at
+    the first closing quote truncated the recovered name to "dbo"."a" — the
+    "" twin of the bracket ]] escape handled above.
+
+    The AS BEGIN body idiom keeps the whole statement in ERROR recovery: for a
+    statement the grammar CAN parse, tree-sitter-sql itself truncates the
+    object_reference at the "" escape (emitting `"b"` as a stray ERROR child),
+    which is an upstream grammar defect this extractor cannot repair."""
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "fn.sql"
+    p.write_text('CREATE PROCEDURE "dbo"."a""b"\nAS\nBEGIN\n    SELECT 1;\nEND;\n')
+    r = extract_sql(p)
+    routine = [n["label"] for n in r["nodes"] if n["label"] != "fn.sql"]
+    assert routine == ['"dbo"."a""b"()'], routine
 
 
 def test_sql_cte_is_not_read_as_a_table():

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -976,6 +976,25 @@ def test_sql_ddl_keywords_inside_delimited_identifiers_do_not_fabricate(tmp_path
     assert labels == ["[dbo].[usp_Real]()"], labels
 
 
+def test_sql_create_inside_a_bare_word_does_not_fabricate(tmp_path):
+    """CREATE must match as a word: without a leading boundary the recovery
+    regex matched CREATE inside a bare identifier, so 'SELECT AUTOCREATE
+    PROCEDURE x FROM t;' in an error-bearing file minted a phantom x().
+    (Delimited identifiers are span-skipped at the scan site; a bare word
+    has no span, so the regex itself must refuse.)"""
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "bare.sql"
+    p.write_text(
+        "THIS IS NOT SQL AT ALL %%%;\n"
+        "SELECT AUTOCREATE PROCEDURE x FROM t;\n"
+        "EXEC dbo.PRECREATE FUNCTION y;\n"
+        "CREATE PROCEDURE [dbo].[usp_Real]\nAS\nBEGIN\n    SELECT 1;\nEND;\n"
+    )
+    r = extract_sql(p)
+    labels = [n["label"] for n in r["nodes"] if n["label"] != "bare.sql"]
+    assert labels == ["[dbo].[usp_Real]()"], labels
+
+
 def test_sql_escaped_double_quote_in_routine_name_is_consumed(tmp_path):
     """ANSI SQL escapes a literal double quote inside a delimited identifier
     by doubling it: "a""b" names the identifier a"b. A pattern that stops at

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -670,8 +670,17 @@ def test_mask_sql_comments_literal_and_comment_handling():
     # some reading of the broken line left it open
     carry = "SELECT [a--b] /*\nCREATE PROC dbo.Fake AS BEGIN SELECT 1; END\n"
     assert "CREATE" not in mask(carry) and len(mask(carry)) == len(carry)
-    carry_closed = "SELECT [a--b] /*\nx */ CREATE PROC dbo.Kept AS x\n"
-    assert "CREATE PROC dbo.Kept" in mask(carry_closed)
+    # where a carry closes MID-line, the remainder of that line is blanked
+    # too (under the no-carry reading the whole line may be comment or
+    # string — emitting the post-*/ tail verbatim was an exposure, found by
+    # differential fuzzing); recovery resumes on the NEXT line
+    carry_closed = "SELECT [a--b] /*\nx */ CREATE PROC dbo.Lost AS x\nCREATE PROC dbo.Kept AS x\n"
+    out = mask(carry_closed)
+    assert "dbo.Lost" not in out and len(out) == len(carry_closed)
+    assert "CREATE PROC dbo.Kept" in out
+    # and a fresh /* after the close carries again
+    recarry = "SELECT [a--b] /*\nx */ y /*\nCREATE PROC dbo.Ghost3 AS x\n"
+    assert "Ghost3" not in mask(recarry)
     # dynamic SQL contents cannot survive the mask
     dyn = "EXEC(N'CREATE PROC [dbo].[Fake] AS BEGIN SELECT 1; END');"
     assert "CREATE" not in mask(dyn) and len(mask(dyn)) == len(dyn)
@@ -721,6 +730,194 @@ def test_mask_sql_comments_invariants_fuzz():
             assert (a == "\n") == (b == "\n"), (s, out)
             assert b == a or b == " ", (s, out)
         assert mask(out) == out, (s, out)
+
+
+# Frozen copy of _mask_sql_comments as of the 2026-08-24 hardening series,
+# for the differential monotonicity fuzz below. Deliberately NOT imported
+# from graphify: the point is that future edits to the live mask are
+# compared against this fixed baseline. Update it only when a deliberate,
+# reviewed decision changes what the mask must blank.
+def _frozen_mask_2026_08_24(text: str) -> str:
+    """Blank comment and string-literal spans, preserving every offset.
+
+    One output character per input character: non-newline characters inside
+    a blanked span become spaces and newlines are kept, so positions and
+    line numbers computed against the masked text are valid against the
+    original. Double-quoted and bracket-delimited identifiers are preserved
+    verbatim (they carry recoverable routine names); single-quoted strings,
+    line comments, and (nesting-aware) block comments are blanked. Used by
+    both routine-recovery scans so CREATE PROCEDURE/FUNCTION DDL reachable
+    only through a comment or a single-quoted string cannot fabricate a
+    routine node when an unrelated parse error arms recovery.
+    """
+    out: list[str] = []
+    i, n = 0, len(text)
+
+    def _blank(upto: int) -> int:
+        """Blank [i, upto), keeping newlines; return upto."""
+        for c in text[i:upto]:
+            out.append("\n" if c == "\n" else " ")
+        return upto
+
+    def _blank_tail_and_carry(start: int) -> int:
+        """Blank from start to end-of-line, carrying comment state forward.
+
+        The union-of-readings blank for an ambiguous stretch: the rest of the
+        line is blanked outright; if the raw text of that stretch leaves a /*
+        unclosed on its own line (the maximum comment depth any reading could
+        be left holding), blanking continues, nesting-aware, to the closing
+        */ or EOF. Where a carry closes MID-line the same rule applies to the
+        remainder of that line — under the reading where the carry never
+        opened, that whole line may be a comment or a string, so emitting the
+        post-*/ text verbatim exposed it (found by differential fuzzing).
+        Repeats until a line ends with no carry pending. Appends one output
+        character per input character; returns the resume index.
+        """
+        k = start
+        while True:
+            eol = text.find("\n", k)
+            eol = n if eol == -1 else eol
+            depth = 0
+            m2 = k
+            while m2 < eol:
+                if text.startswith("/*", m2):
+                    depth += 1
+                    m2 += 2
+                elif text.startswith("*/", m2):
+                    if depth:
+                        depth -= 1
+                    m2 += 2
+                else:
+                    m2 += 1
+            for ch in text[k:eol]:
+                out.append("\n" if ch == "\n" else " ")
+            k = eol
+            if not depth:
+                return k
+            j2 = k
+            while j2 < n and depth:
+                if text.startswith("/*", j2):
+                    depth += 1
+                    j2 += 2
+                elif text.startswith("*/", j2):
+                    depth -= 1
+                    j2 += 2
+                else:
+                    j2 += 1
+            for ch in text[k:j2]:
+                out.append("\n" if ch == "\n" else " ")
+            k = j2
+            if k >= n:
+                return k
+            # the carry closed mid-line: the remainder of THIS line is the
+            # same ambiguous stretch — loop and blank it too
+
+    while i < n:
+        c = text[i]
+        if c == "'":
+            # Single-quoted string: blank it. '' is an escaped quote; a
+            # newline abandons the literal (see the comment above).
+            j = i + 1
+            while j < n and text[j] != "\n":
+                if text[j] == "'":
+                    if j + 1 < n and text[j + 1] == "'":
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            i = _blank(j)
+        elif c == '"' or c == "[":
+            # Delimited identifier: preserve verbatim. Doubled closers are
+            # escapes. A span is DISTRUSTED when it is unterminated (no
+            # closer before the newline) or would swallow a comment opener
+            # on its way to the closer ('SELECT [Col FROM t -- CREATE PROC
+            # [dbo]' closes on [dbo]'s bracket) — a stray delimiter is
+            # ordinary in exactly the broken files this mask runs on.
+            #
+            # A distrusted span is irreducibly ambiguous (identifier data vs
+            # stray delimiter before real comments/strings), and any attempt
+            # to pick one reading exposed text the other reading blanks —
+            # re-emitting the delimiter and rescanning even re-paired later
+            # single quotes and uncovered dynamic SQL. So blank the UNION of
+            # every reading: the rest of the line is blanked outright, and
+            # any raw /* on it with no later */ on the same line carries
+            # forward as (nesting-aware) comment state, since some reading
+            # may have left it open — and where that carry closes mid-line,
+            # the remainder of THAT line gets the same treatment, repeated
+            # until a line ends carry-free (under the no-carry reading the
+            # close line may itself be all comment or string, so emitting its
+            # post-*/ tail verbatim was an exposure). Over-blanking loses at
+            # most routines on lines already entangled with the broken one (a
+            # conservative false negative; a routine named like [a--b] is
+            # inside that loss); under-blanking is what fabricates, and every
+            # reading's blank set stays a subset of this one.
+            closer = '"' if c == '"' else "]"
+            j = i + 1
+            closed = False
+            while j < n and text[j] != "\n":
+                if text[j] == closer:
+                    if j + 1 < n and text[j + 1] == closer:
+                        j += 2
+                        continue
+                    j += 1
+                    closed = True
+                    break
+                j += 1
+            span = text[i:j]
+            if closed and "--" not in span and "/*" not in span:
+                out.append(span)
+                i = j
+            else:
+                i = _blank_tail_and_carry(i)
+        elif c == "-" and i + 1 < n and text[i + 1] == "-":
+            j = i
+            while j < n and text[j] != "\n":
+                j += 1
+            i = _blank(j)
+        elif c == "/" and i + 1 < n and text[i + 1] == "*":
+            depth, j = 1, i + 2
+            while j < n and depth:
+                if text[j] == "/" and j + 1 < n and text[j + 1] == "*":
+                    depth += 1
+                    j += 2
+                elif text[j] == "*" and j + 1 < n and text[j + 1] == "/":
+                    depth -= 1
+                    j += 2
+                else:
+                    j += 1
+            i = _blank(j)  # unclosed comment: j == n, blanks to end-of-file
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def test_mask_sql_comments_monotone_against_frozen_baseline():
+    """Differential fuzz: the live mask must never EXPOSE a character the
+    frozen baseline blanks. Blanking more is allowed (conservative); blanking
+    less is the fabrication channel — every masking defect in the 2026-08-24
+    series (quote re-pairing, carry-close exposure) was a monotonicity
+    violation of exactly this kind, and none was caught by hand-written
+    shapes first.
+    """
+    import random
+
+    from graphify.extractors.sql import _mask_sql_comments as mask
+
+    rng = random.Random(0xBA5E11E)
+    alphabet = "ab[]\"'-*/ \n;.$"
+    for _ in range(20_000):
+        s = "".join(rng.choice(alphabet) for _ in range(rng.randint(1, 40)))
+        live = mask(s)
+        base = _frozen_mask_2026_08_24(s)
+        assert len(live) == len(base) == len(s)
+        for idx, (b, lv, orig) in enumerate(zip(base, live, s)):
+            if b == " " and orig != " ":
+                assert lv == " ", (
+                    f"live mask exposes char {idx} ({orig!r}) that the frozen "
+                    f"baseline blanks:\n input={s!r}\n base={base!r}\n live={live!r}"
+                )
 
 
 def test_sql_dynamic_sql_and_unclosed_comment_do_not_fabricate_routines(tmp_path):


### PR DESCRIPTION
## Problem

T-SQL stored procedures and functions are silently dropped from the graph. On a real 391-file T-SQL data-migration corpus (SQL Server DACPAC project: staging/model/transform layers, `[Schema].[Object]` naming throughout), 0 of 26 stored procedures produced a node — while tables and views extracted fine, so the gap is invisible unless you go counting.

Two independent defects stack:

1. **The grammar can't parse the T-SQL routine shape at all.** `CREATE PROCEDURE ... AS BEGIN ... END` never parses structurally in tree-sitter-sql (there is no `create_procedure` production for the `AS BEGIN` body idiom), so ERROR-node regex recovery is these objects' *only* path into the graph.
2. **The recovery regex doesn't speak T-SQL.** It accepted only unquoted or double-quoted names — no bracket-delimited names (`CREATE PROCEDURE [dbo].[usp_Load]`), no `CREATE OR ALTER`, no `PROC` shorthand. On this corpus, every routine uses brackets, so recovery recovered nothing.

## What this PR does

All changes are in `graphify/extractors/sql.py`:

- **One shared pattern, `_ROUTINE_RECOVERY_RX`**, hoisted to module level and used by both recovery sites (the walk-time ERROR-node scan and the whole-file `has_error` fallback). The two sites had drifted; the drifted second site is what minted a phantom `dbo()` node for a mixed-delimiter name (`CREATE PROCEDURE dbo.[usp_Mixed]`) — the schema captured as if it were the routine. Sharing the pattern fixes that and prevents re-drift.
- **Bracket-delimited identifiers**, including T-SQL's `]]` escape for a literal `]` inside a name (`[dbo].[a]]b]` recovers as one routine, fully consumed, not truncated at the escape).
- **`CREATE OR ALTER`** alongside the existing `OR REPLACE`, and the **`PROC`** shorthand alongside `PROCEDURE`.
- **Comment masking in the whole-file fallback**: the raw-text scan now runs over `_mask_sql_comments(src)` (offset-preserving blanking of `--` and `/* */`), so commented-out DDL in a file with an unrelated parse error can no longer fabricate routine nodes.

Recovered routines are name-only nodes (no body `reads_from` edges), matching the existing PL/pgSQL recovery behavior — a named node with a `contains` edge beats an invisible object.

## Result on the real corpus

391 `.sql` files, before → after: **1 → 28 routine nodes**, including every bracket-named `[Audit]`/`[Utils]`/`[Monitoring]` procedure; table and view counts unchanged; no phantom schema nodes.

## Tests

Added in `tests/test_multilang.py`, each verified to fail with the fix reverted:

- bracket-delimited procedure recovers under its full `[dbo].[usp_X]` name;
- `CREATE OR ALTER PROCEDURE` recovers;
- `PROC` shorthand recovers;
- mixed-delimiter name (`dbo.[usp_Mixed]`) yields exactly one node — both recovery sites agree on the captured name (the phantom-`dbo()` regression);
- `]]` escape inside a bracket-delimited name is consumed, capturing `[dbo].[a]]b]()` as one routine;
- commented-out DDL in an ERROR-bearing file does not fabricate a routine node.

## Validation

- Full suite: `6 failed, 4836 passed, 28 skipped` — the 6 (`test_ollama.py`, `test_ollama_retry_cap.py`) fail identically on unmodified `v8` in this environment (local Ollama config), none touch SQL.
- `ruff check graphify/ tests/`: all checks passed.

## Note

Independent of my companion PR #2959 making `tree-sitter-sql` a core dependency; both touch `tests/test_multilang.py`, and a local merge of the two branches resolves trivially (the combined branch produced the 1 → 28 measurement above and runs in production).
