### PR TITLE
fix(rust): drop the `Self` keyword from type references so it stops minting a god node

### DIFF
--- a/graphify/extractors/rust.py
+++ b/graphify/extractors/rust.py
@@ -15,7 +15,14 @@ def _rust_collect_type_refs(node, source: bytes, generic: bool, out: list[tuple[
         return
     if t == "type_identifier":
         text = _read_text(node, source)
-        if text:
+        # `Self` is the keyword alias for the enclosing impl/trait type, not a
+        # referenceable type of its own. It is not declared in any file, so
+        # ensure_named_node mints a SOURCELESS stub whose id normalises to a
+        # single global `self` node -- and every `fn new() -> Self`,
+        # `fn build(self) -> Self`, `&Self`, etc. across the corpus rewires onto
+        # that one stub, manufacturing a false god node wired to every
+        # constructor. Skip it like the primitive types above.
+        if text and text != "Self":
             out.append((text, "generic_arg" if generic else "type"))
         return
     if t == "scoped_type_identifier":

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -336,6 +336,31 @@ def test_rust_no_dangling_edges():
             assert e["source"] in node_ids
 
 
+def test_rust_self_return_type_does_not_create_phantom_node(tmp_path):
+    """`-> Self` is the enclosing-type keyword, not a referenceable type.
+
+    Emitting it minted a SOURCELESS stub whose id normalises to a single
+    global `self` node, so every constructor and builder across a crate
+    rewired onto it -- a false god node. The keyword must be skipped.
+    """
+    src = tmp_path / "shape.rs"
+    src.write_text(
+        "pub struct Circle { r: f64 }\n"
+        "impl Circle {\n"
+        "    pub fn new(r: f64) -> Self { Circle { r } }\n"
+        "    pub fn scaled(&self, k: f64) -> Self { Circle { r: self.r * k } }\n"
+        "}\n"
+    )
+    r = extract_rust(src)
+    assert "error" not in r
+    # No node is the bare `Self` keyword...
+    assert "Self" not in _labels(r)
+    # ...and nothing references the normalised `self` stub id.
+    assert not any(e["target"] == "self" for e in r["edges"])
+    # The genuine type is still extracted.
+    assert "Circle" in _labels(r)
+
+
 def test_rust_trait_impl_emits_implements():
     r = extract_rust(FIXTURES / "sample.rs")
     assert ("DataProcessor", "Processor") in _edge_labels(r, "implements")


### PR DESCRIPTION
## What

The Rust extractor treats the `Self` keyword in type position as an ordinary type reference, which manufactures a false god node.

`_rust_collect_type_refs` matches `Self` as a plain `type_identifier` and emits it as a referenced type. Because `Self` is never *declared* in any file, `ensure_named_node` mints a **sourceless stub** whose id normalises (via `ids.normalize_id`) to a single global `self` node. Every `fn new() -> Self`, builder method returning `-> Self`, and `&Self` parameter/field across the whole crate then rewires onto that one stub — so `self` becomes a hub wired to essentially every constructor in the codebase.

`Self` is a keyword *alias* for the enclosing impl/trait type; it is not a referenceable type of its own, so no node should be emitted for it (just like the `primitive_type` case already returns early).

## Reproduce

```rust
// shape.rs
pub struct Circle { r: f64 }
impl Circle {
    pub fn new(r: f64) -> Self { Circle { r } }
    pub fn scaled(&self, k: f64) -> Self { Circle { r: self.r * k } }
}
```

Before this change `extract_rust` returns a node labelled `Self` and `references` edges pointing at the normalised `self` id. In a real multi-impl crate all of those collapse onto one global node.

## Fix

Skip `Self` in the `type_identifier` branch of `_rust_collect_type_refs`, exactly like the primitive types above it. Genuine types are untouched, and associated types such as `Self::Item` (which arrive as `scoped_type_identifier`, resolving to `Item`) keep resolving as before.

## Tests

Adds `test_rust_self_return_type_does_not_create_phantom_node` asserting no `Self` node and no edge targeting the `self` stub, while the real type is still extracted. Full suite is green locally (only the pre-existing order-dependent flake in `test_label_communities_batches_when_over_batch_size`, #2877, is unrelated).
