### PR TITLE
fix(php,swift): drop relative-scope type keywords so they stop minting god nodes

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -633,6 +633,16 @@ def _php_name_text(node, source: bytes) -> str | None:
         return None
     return _read_text(node, source).rsplit("\\", 1)[-1] or None
 
+# PHP's relative-scope type keywords resolve to a class only in the context of the
+# enclosing class -- `self`/`static` are the current class, `parent` is its base.
+# They are not referenceable types of their own, and since they are declared in no
+# file the stub rewire collapses every `: self` / `: static` return type across the
+# corpus (fluent setters and factories emit them constantly) onto a single global
+# node, manufacturing a false god node. Skip them. PHP keywords are
+# case-insensitive, so match on the casefolded text.
+_PHP_RELATIVE_TYPE_KEYWORDS = frozenset({"self", "static", "parent"})
+
+
 def _php_collect_type_refs(node, source: bytes, generic: bool, out: list[tuple[str, str]]) -> None:
     """Walk a PHP type expression; append (name, role) tuples."""
     if node is None:
@@ -644,13 +654,13 @@ def _php_collect_type_refs(node, source: bytes, generic: bool, out: list[tuple[s
         for c in node.children:
             if c.type in ("name", "qualified_name"):
                 text = _php_name_text(c, source)
-                if text:
+                if text and text.casefold() not in _PHP_RELATIVE_TYPE_KEYWORDS:
                     out.append((text, "generic_arg" if generic else "type"))
                 return
         return
     if t in ("name", "qualified_name"):
         text = _php_name_text(node, source)
-        if text:
+        if text and text.casefold() not in _PHP_RELATIVE_TYPE_KEYWORDS:
             out.append((text, "generic_arg" if generic else "type"))
         return
     if t in ("nullable_type", "union_type", "intersection_type", "optional_type"):
@@ -870,7 +880,7 @@ def _swift_collect_type_refs(node, source: bytes, generic: bool, out: list[tuple
         for c in node.children:
             if c.type == "type_identifier":
                 text = _read_text(c, source)
-                if text:
+                if text and text != "Self":
                     out.append((text, "generic_arg" if generic else "type"))
                 break
         for c in node.children:
@@ -881,7 +891,11 @@ def _swift_collect_type_refs(node, source: bytes, generic: bool, out: list[tuple
         return
     if t == "type_identifier":
         text = _read_text(node, source)
-        if text:
+        # `Self` is Swift's keyword alias for the enclosing type (common on
+        # `static func … -> Self` factories); it is declared nowhere, so emitting
+        # it collapses every such return type onto one global `self` stub -- a
+        # false god node. Skip it, mirroring the Rust/PHP relative-type handling.
+        if text and text != "Self":
             out.append((text, "generic_arg" if generic else "type"))
         return
     if t in ("optional_type", "implicitly_unwrapped_optional_type", "array_type",

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1095,6 +1095,36 @@ def test_php_call_edges_have_call_context():
     assert call_edges
     assert all(e.get("context") == "call" for e in call_edges)
 
+def test_php_relative_type_keywords_do_not_create_phantom_nodes(tmp_path):
+    """`: self` / `: static` / `: parent` are relative-scope keywords, not types.
+
+    Emitting them minted sourceless stubs that normalise to global `self` /
+    `static` / `parent` nodes, so every fluent setter and factory across the
+    corpus rewired onto three god nodes. PHP keywords are case-insensitive.
+    """
+    src = tmp_path / "builder.php"
+    src.write_text(
+        "<?php\n"
+        "class Builder {\n"
+        "    public function make(): self { return new Builder(); }\n"
+        "    public static function create(): STATIC { return new static(); }\n"
+        "    public function base(): parent { return $this; }\n"
+        "    public function real(): Response { return new Response(); }\n"
+        "}\n"
+    )
+    r = extract_php(src)
+    assert "error" not in r
+    labels = {l.casefold() for l in _labels(r)}
+    assert "self" not in labels
+    assert "static" not in labels
+    assert "parent" not in labels
+    assert not any(e["target"] in {"self", "static", "parent"} for e in r["edges"])
+    # A genuine class type in return position is still referenced.
+    assert ("real", "Response") in [
+        (s.strip("()").lstrip("."), t) for s, t, _ in _references(r)
+    ]
+
+
 def test_php_finds_static_property_access():
     r = extract_php(FIXTURES / "sample_php_static_prop.php")
     assert "uses_static_prop" in _relations(r)
@@ -1218,6 +1248,28 @@ def test_swift_no_dangling_edges():
         assert e["source"] in node_ids
         # #1327: targets must resolve to a node too, else build.py prunes the edge.
         assert e["target"] in node_ids, f"dangling target {e['target']} ({e['relation']})"
+
+
+def test_swift_self_return_type_does_not_create_phantom_node(tmp_path):
+    """`-> Self` on a Swift factory is the enclosing-type keyword, not a type.
+
+    Emitting it minted a sourceless stub normalising to a single global `self`
+    node that every `static func … -> Self` across the corpus rewired onto.
+    """
+    src = tmp_path / "shape.swift"
+    src.write_text(
+        "struct Circle {\n"
+        "    let r: Double\n"
+        "    static func unit() -> Self { return Circle(r: 1.0) }\n"
+        "    func grown() -> Circle { return Circle(r: r * 2) }\n"
+        "}\n"
+    )
+    r = extract_swift(src)
+    assert "error" not in r
+    assert "Self" not in _labels(r)
+    assert not any(e["target"] == "self" for e in r["edges"])
+    # A concrete return type is still referenced.
+    assert "Circle" in _labels(r)
 
 
 def test_swift_imports_survive_build():


### PR DESCRIPTION
## What

PHP's `self` / `static` / `parent` and Swift's `Self` in **type position** (return types, parameters, fields) are relative-scope keyword *aliases* for the enclosing class — they are not referenceable types of their own.

The type-reference walkers (`_php_collect_type_refs`, `_swift_collect_type_refs`) matched them as ordinary type names and emitted `references` edges. Because these names are declared in no file, `ensure_named_node` mints **sourceless stubs** whose ids normalise (via `ids.normalize_id`) to single global `self` / `static` / `parent` nodes. Fluent setters and factories return these constantly:

```php
public function withHeader($h): static { /* … */ return $this; }
public function build(): self { /* … */ }
```
```swift
static func make() -> Self { /* … */ }
```

So across a real corpus every such method rewires onto a handful of false **god nodes** — `static` and `self` become hubs wired to a large fraction of the classes in the project.

## Reproduce

```php
<?php
class Builder {
    public function make(): self { return new Builder(); }
    public static function create(): STATIC { return new static(); }
    public function base(): parent { return $this; }
}
```

Before this change `extract_php` returns nodes labelled `self`, `static`, `parent` and `references` edges pointing at them. Swift `-> Self` behaves the same way.

## Fix

Skip these keywords in the two walkers, mirroring how `primitive_type` is already skipped:

- PHP: `self` / `static` / `parent`, matched case-insensitively (PHP keywords are case-insensitive, e.g. `STATIC`).
- Swift: `Self`.

Genuine class types in the same positions are untouched.

## Tests

Adds `test_php_relative_type_keywords_do_not_create_phantom_nodes` and `test_swift_self_return_type_does_not_create_phantom_node`, each asserting no phantom node/edge is produced while a real return-type reference still resolves. Full suite is green locally apart from the pre-existing order-dependent flake `test_label_communities_batches_when_over_batch_size` (#2877), which passes in isolation and is unrelated.
