### PR TITLE
fix(update): report forced graph shrink

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -962,6 +962,39 @@ def _check_shrink(
     return False
 
 
+def _force_shrink_summary(
+    force: bool,
+    existing_data: dict | None,
+    new_data: dict,
+) -> str | None:
+    """Describe a forced node-count shrink after graph.json is replaced."""
+    if not force or not existing_data:
+        return None
+    existing_nodes = existing_data.get("nodes", [])
+    new_nodes = new_data.get("nodes", [])
+    if len(new_nodes) >= len(existing_nodes):
+        return None
+    existing_edges = existing_data.get("links", existing_data.get("edges", []))
+    new_edges = new_data.get("links", new_data.get("edges", []))
+    node_delta = len(new_nodes) - len(existing_nodes)
+    edge_delta = len(new_edges) - len(existing_edges)
+    return (
+        "[graphify] --force: graph.json shrink: observed "
+        f"{len(existing_nodes):,} nodes / {len(existing_edges):,} edges; wrote "
+        f"{len(new_nodes):,} nodes / {len(new_edges):,} edges "
+        f"({node_delta:+,} nodes, {edge_delta:+,} edges)"
+    )
+
+
+def _emit_force_shrink_summary(summary: str | None) -> None:
+    """Write the receipt without letting a closed output stream abort a rebuild."""
+    if summary:
+        try:
+            print(summary)
+        except (OSError, ValueError):
+            pass
+
+
 def _report_for_compare(report_text: str) -> str:
     return re.sub(r"^- Built from commit: `[^`]+`\n?", "", report_text, flags=re.MULTILINE)
 
@@ -1567,6 +1600,8 @@ def _rebuild_code(
             }
             candidate_graph_text = _json_text(candidate_graph_data)
             same_graph = False
+            existing_payload = None
+            force_summary = None
             if existing_graph.exists():
                 try:
                     check_graph_file_size_cap(existing_graph)
@@ -1604,7 +1639,11 @@ def _rebuild_code(
                 # crash mid-write must not leave a truncated graph.json.
                 graph_tmp = out / ".graph.tmp.json"
                 graph_tmp.write_text(candidate_graph_text, encoding="utf-8")
+                force_summary = _force_shrink_summary(
+                    force, existing_payload, candidate_graph_data,
+                )
                 graph_tmp.replace(existing_graph)
+                _emit_force_shrink_summary(force_summary)
 
             # Write the user-supplied path only after the candidate graph is
             # accepted, so a refused shrink cannot mismatch graph and marker.
@@ -1771,6 +1810,7 @@ def _rebuild_code(
         candidate_graph_data = json.loads(graph_tmp.read_text(encoding="utf-8"))
         same_graph = False
         same_report = False
+        existing_payload = None
         if existing_graph.exists():
             try:
                 check_graph_file_size_cap(existing_graph)
@@ -1799,6 +1839,7 @@ def _rebuild_code(
             old_report = report_path.read_text(encoding="utf-8")
             same_report = _report_for_compare(old_report) == _report_for_compare(report)
         no_change = same_graph and same_report
+        force_summary = None
         if no_change:
             graph_tmp.unlink(missing_ok=True)
             print("[graphify watch] No code-graph changes detected; graph.json/GRAPH_REPORT.md left untouched.")
@@ -1817,7 +1858,11 @@ def _rebuild_code(
             (out / _HTML_STALE_MARKER).touch()
             from graphify.export import backup_if_protected as _backup
             _backup(out)
+            force_summary = _force_shrink_summary(
+                force, existing_payload, candidate_graph_data,
+            )
             graph_tmp.replace(existing_graph)
+            _emit_force_shrink_summary(force_summary)
             report_path.write_text(report, encoding="utf-8")
             labels_file.write_text(labels_json, encoding="utf-8")
             # Keep the membership signatures in step with the labels we just wrote.

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -13,6 +13,7 @@ from graphify.watch import (
     _WATCHED_EXTENSIONS,
     _rebuild_lock,
     _check_shrink,
+    _force_shrink_summary,
     _batch_triggers_rebuild,
     _batch_needs_llm_flag,
 )
@@ -1331,6 +1332,135 @@ def test_check_shrink_allows_force_override():
         new_data=_shrink_payload(1),
     )
     assert ok is True
+
+
+@pytest.mark.parametrize("edge_key", ["links", "edges"])
+def test_force_shrink_summary_reports_node_and_edge_deltas(edge_key):
+    existing = {"nodes": [{}] * 12_431, edge_key: [{}] * 48_002}
+    candidate = {"nodes": [{}] * 12_429, edge_key: [{}] * 47_996}
+
+    assert _force_shrink_summary(True, existing, candidate) == (
+        "[graphify] --force: graph.json shrink: observed "
+        "12,431 nodes / 48,002 edges; wrote 12,429 nodes / 47,996 edges "
+        "(-2 nodes, -6 edges)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("force", "existing", "candidate"),
+    [
+        (False, _shrink_payload(3), _shrink_payload(2)),
+        (True, {}, _shrink_payload(2)),
+        (True, _shrink_payload(2), _shrink_payload(2)),
+        (True, _shrink_payload(2), _shrink_payload(3)),
+    ],
+)
+def test_force_shrink_summary_skips_when_not_applicable(
+    force, existing, candidate
+):
+    assert _force_shrink_summary(force, existing, candidate) is None
+
+
+@pytest.mark.parametrize("no_cluster", [True, False], ids=["no-cluster", "clustered"])
+def test_rebuild_force_reports_persisted_graph_shrink(
+    tmp_path, capsys, no_cluster
+):
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    source = corpus / "app.py"
+    source.write_text(
+        "def alpha():\n    return beta()\n\ndef beta():\n    return 1\n",
+        encoding="utf-8",
+    )
+    assert _rebuild_code(corpus, no_cluster=no_cluster, acquire_lock=False) is True
+    graph_path = corpus / "graphify-out" / "graph.json"
+    before = json.loads(graph_path.read_text(encoding="utf-8"))
+    capsys.readouterr()
+
+    source.write_text("def alpha():\n    return 1\n", encoding="utf-8")
+    assert _rebuild_code(
+        corpus, force=True, no_cluster=no_cluster, acquire_lock=False,
+    ) is True
+    after = json.loads(graph_path.read_text(encoding="utf-8"))
+    assert len(after["nodes"]) < len(before["nodes"])
+
+    expected = (
+        "[graphify] --force: graph.json shrink: observed "
+        f"{len(before['nodes']):,} nodes / {len(before['links']):,} edges; wrote "
+        f"{len(after['nodes']):,} nodes / {len(after['links']):,} edges "
+        f"({len(after['nodes']) - len(before['nodes']):+,} nodes, "
+        f"{len(after['links']) - len(before['links']):+,} edges)"
+    )
+    assert capsys.readouterr().out.count(expected) == 1
+
+
+@pytest.mark.parametrize("error_type", [BrokenPipeError, ValueError])
+def test_rebuild_force_summary_output_failure_does_not_abort_sidecars(
+    tmp_path, monkeypatch, error_type
+):
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    source = corpus / "app.py"
+    source.write_text(
+        "def alpha():\n    return beta()\n\ndef beta():\n    return 1\n",
+        encoding="utf-8",
+    )
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+    graph_path = corpus / "graphify-out" / "graph.json"
+    report_path = corpus / "graphify-out" / "GRAPH_REPORT.md"
+    before_report = report_path.read_text(encoding="utf-8")
+    real_print = print
+
+    def fail_summary(*args, **kwargs):
+        if args and str(args[0]).startswith("[graphify] --force: graph.json shrink:"):
+            raise error_type
+        return real_print(*args, **kwargs)
+
+    monkeypatch.setattr("builtins.print", fail_summary)
+    source.write_text("def alpha():\n    return 1\n", encoding="utf-8")
+
+    assert _rebuild_code(corpus, force=True, acquire_lock=False) is True
+    assert report_path.read_text(encoding="utf-8") != before_report
+    assert not (graph_path.parent / ".graph.tmp.json").exists()
+
+
+@pytest.mark.parametrize(
+    ("no_cluster", "failing_sidecar"),
+    [(True, ".graphify_root"), (False, "GRAPH_REPORT.md")],
+    ids=["no-cluster", "clustered"],
+)
+def test_rebuild_force_reports_shrink_before_later_sidecar_failure(
+    tmp_path, monkeypatch, capsys, no_cluster, failing_sidecar
+):
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    source = corpus / "app.py"
+    source.write_text(
+        "def alpha():\n    return beta()\n\ndef beta():\n    return 1\n",
+        encoding="utf-8",
+    )
+    assert _rebuild_code(corpus, no_cluster=no_cluster, acquire_lock=False) is True
+    graph_path = corpus / "graphify-out" / "graph.json"
+    before = json.loads(graph_path.read_text(encoding="utf-8"))
+    real_write_text = Path.write_text
+
+    def fail_after_graph_replace(path, *args, **kwargs):
+        if path.name == failing_sidecar:
+            raise OSError("injected post-replace sidecar failure")
+        return real_write_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fail_after_graph_replace)
+    capsys.readouterr()
+    source.write_text("def alpha():\n    return 1\n", encoding="utf-8")
+
+    assert _rebuild_code(
+        corpus, force=True, no_cluster=no_cluster, acquire_lock=False,
+    ) is False
+    after = json.loads(graph_path.read_text(encoding="utf-8"))
+    assert len(after["nodes"]) < len(before["nodes"])
+    assert capsys.readouterr().out.count(
+        "[graphify] --force: graph.json shrink: observed "
+    ) == 1
 
 
 def test_check_shrink_allows_explicit_deletions(capsys):


### PR DESCRIPTION
## Summary

- report observed and written node and edge counts when `update --force` commits a smaller graph
- emit the receipt immediately after atomic graph replacement, without letting a closed output stream interrupt remaining rebuild work
- cover clustered and `--no-cluster` updates plus legacy `edges` payloads

Fixes #2833

## Result

```text
[graphify] --force: graph.json shrink: observed 12,431 nodes / 48,002 edges; wrote 12,429 nodes / 47,996 edges (-2 nodes, -6 edges)
```

## Testing

- `uv run pytest tests/test_watch.py::test_force_shrink_summary_reports_node_and_edge_deltas tests/test_watch.py::test_force_shrink_summary_skips_when_not_applicable tests/test_watch.py::test_rebuild_force_reports_persisted_graph_shrink tests/test_watch.py::test_rebuild_force_summary_output_failure_does_not_abort_sidecars tests/test_watch.py::test_rebuild_force_reports_shrink_before_later_sidecar_failure -q --tb=short` (12 passed)
- `uv run pytest tests/ -q --tb=short` (4893 passed, 11 skipped)
- `uv run ruff check graphify/watch.py tests/test_watch.py`
- `uv run python -m tools.skillgen --check`
- `uv run graphify update .`
