### PR TITLE
fix(skills): stamp manifest from semantic-only result (#2844)

### DIFF
--- a/graphify/skills/agents/references/update.md
+++ b/graphify/skills/agents/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/amp/references/update.md
+++ b/graphify/skills/amp/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/claude/references/update.md
+++ b/graphify/skills/claude/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/claw/references/update.md
+++ b/graphify/skills/claw/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/codex/references/update.md
+++ b/graphify/skills/codex/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/copilot/references/update.md
+++ b/graphify/skills/copilot/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/droid/references/update.md
+++ b/graphify/skills/droid/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/kilo/references/update.md
+++ b/graphify/skills/kilo/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/kiro/references/update.md
+++ b/graphify/skills/kiro/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/opencode/references/update.md
+++ b/graphify/skills/opencode/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/pi/references/update.md
+++ b/graphify/skills/pi/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/trae/references/update.md
+++ b/graphify/skills/trae/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/vscode/references/update.md
+++ b/graphify/skills/vscode/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/graphify/skills/windows/references/update.md
+++ b/graphify/skills/windows/references/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tests/test_skillgen.py
+++ b/tests/test_skillgen.py
@@ -687,6 +687,27 @@ def test_generated_runbooks_pass_root_to_save_manifest():
     assert checked >= 4, f"expected save_manifest calls across the runbooks, found {checked}"
 
 
+def test_update_runbooks_stamp_manifest_from_semantic_only():
+    """#2844: --update must stamp semantic_hash from .graphify_semantic.json only.
+
+    Passing the AST+semantic merge marks docs with heading nodes as semantically
+    done even when no subagent extracted them.
+    """
+    targets = sorted((REPO_ROOT / "graphify" / "skills").glob("*/references/update.md"))
+    assert targets, "expected shipped update.md runbooks"
+    for path in targets:
+        body = path.read_text(encoding="utf-8")
+        assert ".graphify_semantic.json" in body, (
+            f"{path.relative_to(REPO_ROOT)}: missing .graphify_semantic.json (#2844)"
+        )
+        assert "_stamped_manifest_files(incremental['files'], _semantic," in body, (
+            f"{path.relative_to(REPO_ROOT)}: must pass _semantic, not new_extraction (#2844)"
+        )
+        assert "_stamped_manifest_files(incremental['files'], new_extraction," not in body, (
+            f"{path.relative_to(REPO_ROOT)}: still stamps from new_extraction (#2844)"
+        )
+
+
 def test_devin_keeps_its_multi_field_frontmatter():
     """devin renders inline, so its 4+-field frontmatter is preserved verbatim."""
     platforms = gen.load_platforms()

--- a/tools/skillgen/expected/graphify__skills__agents__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__agents__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__amp__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__amp__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__claude__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claude__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__claw__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claw__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__codex__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__codex__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__copilot__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__copilot__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__droid__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__droid__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__kilo__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kilo__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__kiro__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kiro__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__opencode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__opencode__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__pi__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__pi__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__trae__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__trae__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__vscode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__vscode__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/expected/graphify__skills__windows__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__windows__references__update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')

--- a/tools/skillgen/fragments/references/shared/update.md
+++ b/tools/skillgen/fragments/references/shared/update.md
@@ -144,13 +144,14 @@ print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])
 # cached files instead of missing every one after a move (#1417).
 #
 # Only stamp semantic files (docs/papers/images) that ACTUALLY produced output
-# THIS run (new_extraction is this run's fresh extraction, read above before the
-# merge overwrote the file): a changed doc whose chunk failed must stay unstamped
-# so the next --update re-queues it, otherwise it is marked done and its content
-# is lost forever (#2015). Mirrors the library extract path
-# (cli._stamped_manifest_files + clear_semantic + scan_corpus).
+# THIS run (.graphify_semantic.json is the semantic-only result from Part B/C,
+# not the AST+semantic merge in new_extraction): a changed doc whose chunk failed
+# must stay unstamped so the next --update re-queues it, otherwise it is marked
+# done and its content is lost forever (#2015, #2844). Mirrors the library extract
+# path (cli._stamped_manifest_files + clear_semantic + scan_corpus).
 from graphify.cli import _stamped_manifest_files
-_manifest_files = _stamped_manifest_files(incremental['files'], new_extraction, Path('INPUT_PATH'))
+_semantic = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+_manifest_files = _stamped_manifest_files(incremental['files'], _semantic, Path('INPUT_PATH'))
 # Changed semantic files dispatched this run but NOT stamped had their chunk fail
 # or be omitted; clear any stale semantic_hash so they are re-queued (#1948).
 _sem_types = ('document', 'paper', 'image')


### PR DESCRIPTION
The skill `--update` runbook passes the AST+semantic merge to `_stamped_manifest_files`. A markdown file with only heading nodes looks semantically extracted, gets stamped in the manifest, and never re-queues on the next update. The CLI already reads `.graphify_semantic.json` for this. The runbook should too.

Fixes #2844

Tested locally: full pytest suite, all skillgen validators, `graphify install`.