### PR TITLE
fix(watch): report graph delta on --force overwrite (#2833)

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -920,7 +920,23 @@ def _check_shrink(
     Files in ``failed_sources`` never account for lost nodes: extraction did not
     complete, so their disappearance is the silent shrink this guard protects.
     """
-    if force or not existing_data:
+    if force:
+        if existing_data:
+            existing_nodes = existing_data.get("nodes", [])
+            existing_edges = (
+                existing_data.get("links") or existing_data.get("edges") or []
+            )
+            new_nodes = new_data.get("nodes", [])
+            new_edges = new_data.get("links") or new_data.get("edges") or []
+            old_n, old_e = len(existing_nodes), len(existing_edges)
+            new_n, new_e = len(new_nodes), len(new_edges)
+            print(
+                f"[graphify] --force: replacing {old_n} nodes / {old_e} edges "
+                f"with {new_n} / {new_e} ({new_n - old_n:+d} nodes, {new_e - old_e:+d} edges)",
+                file=sys.stderr,
+            )
+        return True
+    if not existing_data:
         return True
     if had_explicit_deletions and rebuilt_sources is None:
         # Legacy callers declare deletions but pass no rebuilt_sources, so the

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1194,7 +1194,7 @@ def test_check_shrink_blocks_silent_shrink(capsys):
     assert "80 nodes" in captured.err and "100" in captured.err
 
 
-def test_check_shrink_allows_force_override():
+def test_check_shrink_allows_force_override(capsys):
     """force=True bypasses the guard regardless of node delta."""
     ok = _check_shrink(
         force=True,
@@ -1202,6 +1202,21 @@ def test_check_shrink_allows_force_override():
         new_data=_shrink_payload(1),
     )
     assert ok is True
+    assert "--force: replacing" in capsys.readouterr().err
+
+
+def test_check_shrink_force_reports_delta(capsys):
+    """#2833: force=True prints before/after node and edge counts."""
+    existing = _shrink_payload(100)
+    existing["links"] = [{"source": "a", "target": "b"}] * 50
+    new = _shrink_payload(98)
+    new["links"] = [{"source": "a", "target": "b"}] * 48
+    ok = _check_shrink(force=True, existing_data=existing, new_data=new)
+    assert ok is True
+    err = capsys.readouterr().err
+    assert "--force: replacing" in err
+    assert "100" in err and "98" in err
+    assert "50" in err and "48" in err
 
 
 def test_check_shrink_allows_explicit_deletions(capsys):


### PR DESCRIPTION
`graphify update --force` skips the shrink guard with no record of what it replaced. A 2-node drop and a 2000-node drop look identical in the logs. Print the before/after node and edge counts when force overwrites an existing graph.

Fixes #2833

Tested locally: `tests/test_watch.py -k check_shrink`, full pytest suite, skillgen validators.