### PR TITLE
fix(prs): fall back to smaller PR pages on a GitHub timeout, and report gh's real error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## 0.9.50 (unreleased)
+
+- Fix: `graphify prs` no longer reports every `gh` failure as an authentication problem, and no longer fails outright on a busy repo. A 50-PR page with `statusCheckRollup` exceeds GitHub's GraphQL timeout once a repo has a few hundred open PRs, so the fetch now steps down through smaller pages (20, 10, 5) on a server timeout and says on stderr which page it settled for; every other failure — missing `gh`, bad credentials, unknown repo, a secondary rate limit — is reported at once with what `gh` actually printed. New `graphify prs --limit <n>` sets the page size, and an undetected default branch is flagged instead of being silently assumed to be `main` — including under `--repo`, where the local clone's branch was being used for a repo it knows nothing about (#2850, thanks @andraghetti).
+
 ## 0.9.49 (2026-08-24)
 
 - Feature: `graphify merge-graphs` now links a type declaration that two repos share — same fully-qualified namespace and name, from different repos — with a `same_type_as` edge, so a shared contract type is navigable across the repo boundary; two unrelated types that merely share a short name are not linked (#3007, thanks @durmazoguzhan).

--- a/README.md
+++ b/README.md
@@ -770,6 +770,7 @@ graphify prs --worktrees                  # worktree → branch → PR mapping
 graphify prs --conflicts                  # PRs sharing graph communities (merge-order risk)
 graphify prs --base main                  # filter to PRs targeting a specific base branch
 graphify prs --repo owner/repo            # run against a different GitHub repo
+graphify prs --limit 20                   # PRs per page (default 50; lower it if GitHub times out on a busy repo)
 GRAPHIFY_TRIAGE_BACKEND=kimi graphify prs --triage   # use a specific backend for triage
 
 graphify clone https://github.com/karpathy/nanoGPT

--- a/graphify/prs.py
+++ b/graphify/prs.py
@@ -11,6 +11,8 @@ Usage:
   graphify prs --worktrees       # show worktree → branch → PR mapping
   graphify prs --conflicts       # PRs sharing graph communities (merge-order risk)
   graphify prs --base <branch>   # filter to PRs targeting this base (default: v8)
+  graphify prs --limit <n>       # PRs to request per page (default: 50; lower it
+                                 # if GitHub times out on a very busy repo)
 """
 
 from __future__ import annotations
@@ -138,19 +140,42 @@ def _ci_icon(status: str) -> str:
 
 # ── GitHub data fetching ──────────────────────────────────────────────────────
 
+_GH_TIMEOUT = 30
+
+# Why _gh's last call returned None. A non-zero exit, a timeout, unparseable
+# output and a missing binary all collapse to the same None, which is how an
+# HTTP 504 came to be reported as "run gh auth login" (#2850).
+_LAST_GH_ERROR = ""
+
+
+def last_gh_error() -> str:
+    """The error behind the last _gh() call that returned None ("" if it succeeded)."""
+    return _LAST_GH_ERROR
+
+
 def _gh(*args: str) -> list | dict | None:
+    global _LAST_GH_ERROR
     try:
         result = subprocess.run(
             ["gh", *args],
             # Decode gh's output as UTF-8, not the Windows cp1252 locale codec: gh
             # emits UTF-8 JSON with non-Latin1 titles/logins (emoji, فارسی), and the
             # default text=True decode crashes on those (#1505 fixed the same in llm).
-            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=_GH_TIMEOUT
         )
         if result.returncode != 0:
+            _LAST_GH_ERROR = (result.stderr or "").strip() or f"gh exited {result.returncode}"
             return None
+        _LAST_GH_ERROR = ""
         return json.loads(result.stdout)
-    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+    except subprocess.TimeoutExpired:
+        _LAST_GH_ERROR = f"gh timed out after {_GH_TIMEOUT}s: gh {' '.join(args)}"
+        return None
+    except json.JSONDecodeError as exc:
+        _LAST_GH_ERROR = f"gh returned output that is not JSON: {exc}"
+        return None
+    except FileNotFoundError:
+        _LAST_GH_ERROR = "gh CLI not found on PATH. Install it, then run: gh auth login"
         return None
 
 
@@ -163,18 +188,24 @@ def _detect_default_branch(repo: str | None = None) -> str:
     data = _gh(*args)
     if data and data.get("defaultBranchRef", {}).get("name"):
         return data["defaultBranchRef"]["name"]
-    # Fall back to git symbolic-ref for the current repo
-    try:
-        result = subprocess.run(
-            ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
-            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5
-        )
-        if result.returncode == 0:
-            # refs/remotes/origin/main → main
-            ref = result.stdout.strip()
-            return ref.split("/")[-1] if ref else "main"
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
+    # Fall back to git symbolic-ref, but only for the current repo: --repo names
+    # a different one, whose default branch the local clone does not know.
+    if not repo:
+        try:
+            result = subprocess.run(
+                ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5
+            )
+            ref = result.stdout.strip() if result.returncode == 0 else ""
+            if ref:
+                return ref.split("/")[-1]  # refs/remotes/origin/main → main
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+    # Nothing answered, so "main" is a guess — and a wrong guess silently labels
+    # every PR WRONG-BASE. Say so rather than presenting it as detected.
+    target = f" for {repo}" if repo else ""
+    print(dim(f"  Could not detect the default branch{target}; assuming 'main'. "
+              "Pass --base to be sure."), file=sys.stderr)
     return "main"
 
 
@@ -195,19 +226,64 @@ def _parse_ci(rollup: list) -> str:
     return "NONE"
 
 
-def fetch_prs(repo: str | None = None, base: str | None = None, limit: int = 50) -> list[PRInfo]:
-    resolved_base = base or _detect_default_branch(repo)
-    args = [
-        "pr", "list", "--state", "open", "--limit", str(limit),
-        "--json", "number,title,headRefName,baseRefName,author,isDraft,"
-                  "reviewDecision,statusCheckRollup,updatedAt",
-    ]
-    if repo:
-        args += ["--repo", repo]
+# statusCheckRollup is resolved per PR server side, so on a repo with a few
+# hundred open PRs a 50-PR page exceeds GitHub's GraphQL timeout while a page of
+# 20 comes back in about a second — hence the step-down (#2850).
+_DEFAULT_PR_LIMIT = 50
+_PR_PAGE_FALLBACKS = (20, 10, 5)
 
-    raw = _gh(*args)
+# Failures a smaller page can plausibly fix: GitHub gave up on this query.
+# Everything else fails on the first call — including a secondary rate limit,
+# which a smaller page cannot fix and an immediate retry only aggravates.
+_GH_RETRYABLE_MARKERS = ("502", "503", "504", "gateway",
+                         "timed out", "timeout", "temporarily unavailable")
+
+
+def _is_retryable_gh_error(err: str) -> bool:
+    low = err.lower()
+    return any(marker in low for marker in _GH_RETRYABLE_MARKERS)
+
+
+def _gh_error_summary(err: str, width: int = 120) -> str:
+    """First line of a gh error, short enough to sit inside a one-line notice."""
+    first = err.splitlines()[0].strip() if err else ""
+    if not first:
+        return "no detail"
+    return first if len(first) <= width else first[: width - 1] + "…"
+
+
+def fetch_prs(repo: str | None = None, base: str | None = None, limit: int = _DEFAULT_PR_LIMIT) -> list[PRInfo]:
+    resolved_base = base or _detect_default_branch(repo)
+
+    def _list(page_size: int) -> list | dict | None:
+        args = [
+            "pr", "list", "--state", "open", "--limit", str(page_size),
+            "--json", "number,title,headRefName,baseRefName,author,isDraft,"
+                      "reviewDecision,statusCheckRollup,updatedAt",
+        ]
+        if repo:
+            args += ["--repo", repo]
+        return _gh(*args)
+
+    page_sizes = [limit] + [n for n in _PR_PAGE_FALLBACKS if n < limit]
+    raw, err, tried = None, "", []
+    for page_size in page_sizes:
+        tried.append(page_size)
+        raw = _list(page_size)
+        if raw is not None:
+            if page_size != limit:
+                print(dim(f"  gh could not return {limit} PRs ({_gh_error_summary(err)}); "
+                          f"showing {page_size} of them instead. Use --limit to pick a page size."),
+                      file=sys.stderr)
+            break
+        err = last_gh_error()
+        if not _is_retryable_gh_error(err):
+            break
+
     if raw is None:
-        raise RuntimeError("gh CLI not found or not authenticated. Run: gh auth login")
+        detail = err or "gh produced no output"
+        sizes = ", ".join(str(n) for n in tried)
+        raise RuntimeError(f"gh pr list failed (page sizes tried: {sizes}): {detail}")
 
     prs = []
     for item in raw:
@@ -678,6 +754,19 @@ def triage_with_opus(prs: list[PRInfo], base: str) -> None:
 
 # ── Entry point ───────────────────────────────────────────────────────────────
 
+def _parse_limit(value: str) -> int:
+    """Parse --limit; reject values gh itself would refuse rather than passing them on."""
+    try:
+        limit = int(value)
+    except ValueError:
+        print(red(f"  Error: --limit expects a number, got {value!r}"), file=sys.stderr)
+        sys.exit(1)
+    if limit < 1:
+        print(red(f"  Error: --limit must be at least 1, got {limit}"), file=sys.stderr)
+        sys.exit(1)
+    return limit
+
+
 def cmd_prs(argv: list[str]) -> None:
     base: str | None = None  # auto-detected from repo if not given
     repo: str | None = None
@@ -686,6 +775,7 @@ def cmd_prs(argv: list[str]) -> None:
     do_conflicts = False
     show_wrong_base = False
     pr_number: int | None = None
+    limit = _DEFAULT_PR_LIMIT
     graph_path = Path(_default_graph_json())
 
     i = 0
@@ -705,6 +795,10 @@ def cmd_prs(argv: list[str]) -> None:
             base = arg.split("=", 1)[1]
         elif arg in ("--repo", "-R") and i + 1 < len(argv):
             repo = argv[i + 1]; i += 1
+        elif arg in ("--limit", "-n") and i + 1 < len(argv):
+            limit = _parse_limit(argv[i + 1]); i += 1
+        elif arg.startswith("--limit="):
+            limit = _parse_limit(arg.split("=", 1)[1])
         elif arg.startswith("--graph="):
             graph_path = Path(arg.split("=", 1)[1])
         elif arg == "--graph" and i + 1 < len(argv):
@@ -720,7 +814,7 @@ def cmd_prs(argv: list[str]) -> None:
         base = _detect_default_branch(repo)
 
     try:
-        prs = fetch_prs(repo=repo, base=base)
+        prs = fetch_prs(repo=repo, base=base, limit=limit)
     except RuntimeError as e:
         print(red(f"  Error: {e}"), file=sys.stderr)
         sys.exit(1)

--- a/tests/test_prs.py
+++ b/tests/test_prs.py
@@ -16,11 +16,14 @@ from graphify.prs import (
     _parse_ci,
     _path_match,
     build_community_labels,
+    cmd_prs,
     compute_pr_impact,
     fetch_pr_files,
+    fetch_prs,
     fetch_worktrees,
     format_prs_text,
     _detect_default_branch,
+    last_gh_error,
 )
 
 
@@ -376,6 +379,22 @@ class TestDetectDefaultBranch:
         ):
             assert _detect_default_branch() == "main"
 
+    def test_another_repo_is_not_answered_from_the_local_clone(self):
+        """--repo names a repo the local clone knows nothing about (#2850)."""
+        with patch("graphify.prs._gh", return_value=None), patch(
+            "graphify.prs.subprocess.run"
+        ) as mock_run:
+            assert _detect_default_branch("cilium/cilium") == "main"
+        mock_run.assert_not_called()
+
+    def test_undetected_default_branch_is_flagged(self, capsys):
+        mock_result = MagicMock(returncode=0, stdout="")
+        with patch("graphify.prs._gh", return_value=None), patch(
+            "graphify.prs.subprocess.run", return_value=mock_result
+        ):
+            assert _detect_default_branch() == "main"
+        assert "assuming 'main'" in capsys.readouterr().err
+
 
 # ── build_community_labels ─────────────────────────────────────────────────────
 
@@ -462,3 +481,198 @@ class TestSubprocessOutputEncoding:
             _detect_default_branch()
         _args, kwargs = mock_run.call_args
         assert kwargs.get("encoding") == "utf-8"
+
+
+# ── gh failure reporting + page-size fallback (#2850) ─────────────────────────
+
+_GH_504 = (
+    "HTTP 504: We couldn't respond to your request in time. "
+    "(https://api.github.com/graphql)"
+)
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _pr_payload(count: int) -> str:
+    return json.dumps([
+        {
+            "number": 100 + i,
+            "title": f"PR {i}",
+            "headRefName": f"feature-{i}",
+            "baseRefName": "v8",
+            "author": {"login": "alice"},
+            "isDraft": False,
+            "reviewDecision": "APPROVED",
+            "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+            "updatedAt": "2026-01-02T03:04:05Z",
+        }
+        for i in range(count)
+    ])
+
+
+def _gh_pr_list_runner(fails_at: set[int], stderr: str = _GH_504):
+    """Fake subprocess.run for `gh pr list`: fail for the given --limit values."""
+    calls: list[int] = []
+
+    def run(cmd, **kwargs):
+        page_size = int(cmd[cmd.index("--limit") + 1])
+        calls.append(page_size)
+        if page_size in fails_at:
+            return _completed(1, "", stderr)
+        return _completed(0, _pr_payload(page_size), "")
+
+    return run, calls
+
+
+class TestGhErrorReporting:
+    """_gh collapses every failure to None; last_gh_error() must say which one."""
+
+    def test_nonzero_exit_records_stderr(self):
+        with patch("subprocess.run", return_value=_completed(1, "", _GH_504)):
+            assert _gh("pr", "list") is None
+        assert "504" in last_gh_error()
+
+    def test_nonzero_exit_without_stderr_records_exit_code(self):
+        with patch("subprocess.run", return_value=_completed(2, "", "")):
+            assert _gh("pr", "list") is None
+        assert "2" in last_gh_error()
+
+    def test_timeout_is_reported_as_a_timeout(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("gh", 30)):
+            assert _gh("pr", "list") is None
+        assert "timed out" in last_gh_error()
+
+    def test_missing_binary_is_reported_as_missing(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            assert _gh("pr", "list") is None
+        assert "not found" in last_gh_error()
+
+    def test_unparseable_output_is_reported_as_bad_json(self):
+        with patch("subprocess.run", return_value=_completed(0, "not json", "")):
+            assert _gh("pr", "list") is None
+        assert "JSON" in last_gh_error()
+
+    def test_success_clears_the_previous_error(self):
+        with patch("subprocess.run", return_value=_completed(1, "", _GH_504)):
+            _gh("pr", "list")
+        with patch("subprocess.run", return_value=_completed(0, "[]", "")):
+            assert _gh("pr", "list") == []
+        assert last_gh_error() == ""
+
+
+class TestFetchPrsPaging:
+    def test_full_page_succeeds_in_one_call(self):
+        run, calls = _gh_pr_list_runner(fails_at=set())
+        with patch("subprocess.run", side_effect=run):
+            prs = fetch_prs(base="v8", limit=50)
+        assert calls == [50]
+        assert len(prs) == 50
+
+    def test_504_on_the_full_page_falls_back_to_a_smaller_one(self):
+        """A 50-PR page 504s on a busy repo; 20 comes back — show those, not an error."""
+        run, calls = _gh_pr_list_runner(fails_at={50})
+        with patch("subprocess.run", side_effect=run):
+            prs = fetch_prs(base="v8", limit=50)
+        assert calls == [50, 20]
+        assert len(prs) == 20
+        assert prs[0].expected_base == "v8"
+
+    def test_fallback_walks_all_the_way_down(self):
+        run, calls = _gh_pr_list_runner(fails_at={50, 20, 10})
+        with patch("subprocess.run", side_effect=run):
+            prs = fetch_prs(base="v8", limit=50)
+        assert calls == [50, 20, 10, 5]
+        assert len(prs) == 5
+
+    def test_fallback_pages_never_exceed_the_requested_limit(self):
+        """--limit is a ceiling: a smaller request must not retry with a bigger page."""
+        run, calls = _gh_pr_list_runner(fails_at={12, 10})
+        with patch("subprocess.run", side_effect=run):
+            prs = fetch_prs(base="v8", limit=12)
+        assert calls == [12, 10, 5]  # never 20 or 50
+        assert len(prs) == 5
+
+    def test_non_retryable_error_is_not_retried(self):
+        """A bad repo name is not fixed by a smaller page — fail on the first call."""
+        run, calls = _gh_pr_list_runner(
+            fails_at={50, 20, 10, 5},
+            stderr="GraphQL: Could not resolve to a Repository with the name 'x/y'.",
+        )
+        with patch("subprocess.run", side_effect=run):
+            with pytest.raises(RuntimeError) as exc:
+                fetch_prs(base="v8", limit=50)
+        assert calls == [50]
+        assert "Could not resolve to a Repository" in str(exc.value)
+
+    def test_secondary_rate_limit_is_not_retried(self):
+        """A smaller page does not clear a rate limit, and retrying aggravates it."""
+        run, calls = _gh_pr_list_runner(
+            fails_at={50, 20, 10, 5},
+            stderr="You have exceeded a secondary rate limit. "
+                   "Please wait a few minutes before you try again.",
+        )
+        with patch("subprocess.run", side_effect=run):
+            with pytest.raises(RuntimeError) as exc:
+                fetch_prs(base="v8", limit=50)
+        assert calls == [50]
+        assert "secondary rate limit" in str(exc.value)
+
+    def test_failure_message_reports_gh_stderr_not_an_auth_guess(self):
+        run, _calls = _gh_pr_list_runner(fails_at={50, 20, 10, 5})
+        with patch("subprocess.run", side_effect=run):
+            with pytest.raises(RuntimeError) as exc:
+                fetch_prs(base="v8", limit=50)
+        message = str(exc.value)
+        assert "504" in message
+        assert "50, 20, 10, 5" in message
+        assert "gh auth login" not in message
+
+    def test_missing_gh_is_still_reported_plainly(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            with pytest.raises(RuntimeError) as exc:
+                fetch_prs(base="v8", limit=50)
+        assert "gh CLI not found" in str(exc.value)
+
+    def test_degraded_page_prints_a_notice(self, capsys):
+        run, _calls = _gh_pr_list_runner(fails_at={50})
+        with patch("subprocess.run", side_effect=run):
+            fetch_prs(base="v8", limit=50)
+        err = capsys.readouterr().err
+        assert "504" in err
+        assert "20" in err
+
+
+class TestCmdPrsLimitFlag:
+    def _run_cmd(self, argv: list[str]):
+        with patch("graphify.prs.fetch_prs", return_value=[]) as fetch, \
+             patch("graphify.prs.fetch_worktrees", return_value={}), \
+             patch("graphify.prs.render_dashboard"), \
+             patch("graphify.prs._detect_default_branch", return_value="v8"):
+            cmd_prs(argv)
+        return fetch
+
+    def test_default_limit_is_50(self):
+        fetch = self._run_cmd([])
+        assert fetch.call_args.kwargs["limit"] == 50
+
+    def test_space_separated_limit(self):
+        fetch = self._run_cmd(["--limit", "20"])
+        assert fetch.call_args.kwargs["limit"] == 20
+
+    def test_equals_form_limit(self):
+        fetch = self._run_cmd(["--limit=10"])
+        assert fetch.call_args.kwargs["limit"] == 10
+
+    def test_short_flag_limit(self):
+        fetch = self._run_cmd(["-n", "5"])
+        assert fetch.call_args.kwargs["limit"] == 5
+
+    def test_non_numeric_limit_exits(self):
+        with pytest.raises(SystemExit):
+            self._run_cmd(["--limit", "many"])
+
+    def test_zero_limit_exits(self):
+        with pytest.raises(SystemExit):
+            self._run_cmd(["--limit", "0"])


### PR DESCRIPTION
Fixes #2850.

## What was wrong

`graphify prs` against a repo with a few hundred open PRs fails with `Error: gh CLI not found or not authenticated. Run: gh auth login`, while `gh` is authenticated and fine. Two defects, exactly as the issue describes:

1. `statusCheckRollup` is resolved per PR server side, so a 50-PR page exceeds GitHub's GraphQL timeout on a busy repo. `fetch_prs` accepted a `limit`, but `cmd_prs` never passed one and parsed no flag, so 50 was the only reachable page size — no user-side workaround.
2. `_gh` discarded `result.stderr` and returned `None` for a non-zero exit, a timeout, a JSON decode error and a missing binary alike, and `fetch_prs` turned that `None` into the auth message. `gh auth login` cannot fix a 504.

## What this changes

- **`_gh` records why it failed.** `last_gh_error()` returns gh's stderr, or a description of the exception that replaced it (timeout / non-JSON output / binary missing). Success clears it. The `None` return and the call signature are unchanged, so existing callers and the `#1505` UTF-8 decode guarantee are untouched.
- **`fetch_prs` steps down the page size.** On a server timeout (502/503/504, gateway, timed out) it retries with 20, 10, then 5 — never above the requested limit — and prints a one-line stderr notice saying what gh said and which page it settled for. Anything a smaller page cannot fix — missing `gh`, bad credentials, unknown repo, and a secondary rate limit, where an immediate retry only makes things worse — fails on the first call rather than burning three more 30 s attempts.
- **The failure message quotes gh.** `gh pr list failed (page sizes tried: 50, 20, 10, 5): HTTP 504: ...` instead of an auth guess.
- **`graphify prs --limit <n>` / `-n <n>`** sets the page size (default 50, validated).
- **`_detect_default_branch` stops guessing silently, and stops guessing from the wrong repo.** When nothing detects the default branch it now says it is assuming `main` and to pass `--base`; that guess otherwise mislabels every PR `WRONG-BASE` on a repo whose default is not `main`. It also no longer falls back to the local clone's `git symbolic-ref` when `--repo` names a different repo — the local default branch says nothing about `cilium/cilium`. That path is reachable exactly when this issue bites, since the `gh repo view` probe times out on the same busy repos.

## Verification

Against the repo from the issue, before → after:

```
$ graphify prs --repo cilium/cilium
  Error: gh CLI not found or not authenticated. Run: gh auth login

$ graphify prs --repo cilium/cilium --base main
  gh could not return 50 PRs (HTTP 504: We couldn't respond to your request in time. Sorry about that. …); showing 20 of them instead. Use --limit to pick a page size.

  graphify prs  ·  base: main  ·  12 PRs
  ...
  4 ready · 7 CI failing · 1 draft · 8 wrong base
```

17 s end to end, of which the 504 is the bulk. An unknown repo now reports the real reason, on one call:

```
$ graphify prs --repo Graphify-Labs/no-such-repo-xyz
  Could not detect the default branch for Graphify-Labs/no-such-repo-xyz; assuming 'main'. Pass --base to be sure.
  Error: gh pr list failed (page sizes tried: 50): GraphQL: Could not resolve to a Repository with the name 'Graphify-Labs/no-such-repo-xyz'. (repository)
```

23 new tests in `tests/test_prs.py` cover the error recording (exit code, timeout, missing binary, non-JSON, cleared on success), the fallback walk, the "never above `--limit`" ceiling, the no-retry path for an unknown repo and for a secondary rate limit, the message contents, the degrade notice, `--limit` parsing, and the two `_detect_default_branch` cases. `tests/test_prs.py`: 69 passed.
