### PR TITLE
fix(elixir): capture calls made from single-line `def …, do:` bodies

### DIFF
--- a/graphify/extractors/elixir.py
+++ b/graphify/extractors/elixir.py
@@ -87,6 +87,32 @@ def extract_elixir(path: Path) -> dict:
                 return [_text(child)]
         return []
 
+    def _keyword_do_body(arguments_node):
+        """Return the body expression of a single-line ``def f(...), do: expr``.
+
+        The keyword form stores the body as a ``do:`` pair inside the call's
+        ``arguments`` (``keywords`` -> ``pair`` -> ``keyword`` "do:" + value),
+        not as a ``do_block``. Without this the call graph loses every function
+        written in the (idiomatic, very common) one-line form.
+        """
+        for child in arguments_node.children:
+            if child.type != "keywords":
+                continue
+            for pair in child.children:
+                if pair.type != "pair":
+                    continue
+                kw = None
+                value = None
+                for sub in pair.children:
+                    if sub.type == "keyword":
+                        kw = source[sub.start_byte:sub.end_byte].decode(
+                            "utf-8", errors="replace").strip()
+                    elif sub.is_named:
+                        value = sub
+                if kw in ("do:", "do") and value is not None:
+                    return value
+        return None
+
     def walk(node, parent_module_nid: str | None = None) -> None:
         if node.type != "call":
             for child in node.children:
@@ -147,6 +173,12 @@ def extract_elixir(path: Path) -> dict:
                 add_edge(file_nid, func_nid, "contains", line)
             if do_block_node:
                 function_bodies.append((func_nid, do_block_node))
+            elif arguments_node is not None:
+                # Single-line keyword form: ``def f(x), do: g(x)``. The body is a
+                # ``do:`` pair inside the arguments rather than a do_block.
+                kw_body = _keyword_do_body(arguments_node)
+                if kw_body is not None:
+                    function_bodies.append((func_nid, kw_body))
             return
 
         if keyword in _IMPORT_KEYWORDS and arguments_node:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1415,6 +1415,36 @@ def test_elixir_method_edges():
     assert len(methods) >= 3
 
 
+def test_elixir_single_line_do_body_emits_calls(tmp_path):
+    """`def f(x), do: g(x)` must still emit a call edge to g.
+
+    The keyword one-liner stores its body as a `do:` pair inside the call's
+    arguments, not a `do_block`; the body walker only visited do_block nodes, so
+    every call made from the (idiomatic, extremely common) one-line form was
+    dropped from the graph.
+    """
+    src = tmp_path / "calc.ex"
+    src.write_text(
+        "defmodule Calc do\n"
+        "  def add(a, b), do: a + b\n"
+        "  def line_caller(x), do: add(x, 1)\n"
+        "  def block_caller(x) do\n"
+        "    add(x, 2)\n"
+        "  end\n"
+        "end\n"
+    )
+    r = extract_elixir(src)
+    assert "error" not in r
+    labels = {n["id"]: n["label"] for n in r["nodes"]}
+    call_pairs = {
+        (labels.get(e["source"], ""), labels.get(e["target"], ""))
+        for e in r["edges"] if e["relation"] == "calls"
+    }
+    assert ("line_caller()", "add()") in call_pairs
+    # the do..end form kept working
+    assert ("block_caller()", "add()") in call_pairs
+
+
 # ── Objective-C ──────────────────────────────────────────────────────────────
 from graphify.extract import extract_objc
 


### PR DESCRIPTION
## What

Calls made from Elixir's single-line keyword function form are silently dropped from the graph.

`def f(x), do: g(x)` — the idiomatic one-liner — stores its body as a `do:` pair inside the call's `arguments` (`keywords → pair → keyword "do:" + value`), **not** as a `do_block`. The extractor only registered a body for the call pass when it found a `do_block` child, so every call issued from a one-line function was never walked.

This form is pervasive in real Elixir (short delegating functions, `defp` helpers, guards), so a large slice of the intra-module call graph goes missing.

## Reproduce

```elixir
defmodule Calc do
  def add(a, b), do: a + b
  def line_caller(x), do: add(x, 1)   # calls edge to add/2 was dropped
  def block_caller(x) do
    add(x, 2)                          # this one was captured
  end
end
```

Before this change only `block_caller → add` was emitted; `line_caller → add` was missing.

## Fix

When a `def`/`defp` has no `do_block`, look for the `do:` keyword pair in its `arguments` and register that value node for the existing call-walking pass. The multi-line `do..end` path is untouched.

## Tests

Adds `test_elixir_single_line_do_body_emits_calls`, asserting the one-line caller now emits its `calls` edge while the `do..end` form keeps working. Full suite green locally (4822 passed, 0 failed).
