### PR TITLE
fix(c): extract structs and their fields instead of dropping the whole type layer

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -872,8 +872,14 @@ _GROOVY_CONFIG = LanguageConfig(
 )
 
 _C_CONFIG = LanguageConfig(
+    # `struct_specifier` mirrors the C++ config: in C the struct is the primary
+    # data-modeling construct, so an empty class_types dropped every struct (and
+    # its fields) from the graph, erasing the entire type layer of a C codebase.
+    # tree-sitter-c and tree-sitter-cpp share the struct_specifier shape, so the
+    # generic extractor produces the same struct node + `defines`/field edges C++
+    # already gets.
     ts_module="tree_sitter_c",
-    class_types=frozenset(),
+    class_types=frozenset({"struct_specifier"}),
     function_types=frozenset({"function_definition"}),
     import_types=frozenset({"preproc_include"}),
     call_types=frozenset({"call_expression"}),

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -1031,6 +1031,15 @@ def _c_collect_type_refs(node, source: bytes, generic: bool, out: list[tuple[str
         if text:
             out.append((text, "generic_arg" if generic else "type"))
         return
+    if t in ("struct_specifier", "union_specifier", "enum_specifier"):
+        # `struct Point p` / `union U u` in field, parameter, or return position
+        # references the named aggregate by its tag. A body-carrying definition is
+        # handled as a nested type before we get here, so this only fires for a
+        # bare tag reference. Resolve to the tag's type_identifier name.
+        name_node = node.child_by_field_name("name")
+        if name_node is not None:
+            _c_collect_type_refs(name_node, source, generic, out)
+        return
     if t in ("pointer_declarator", "reference_declarator", "array_declarator",
              "type_qualifier", "type_descriptor", "abstract_pointer_declarator",
              "abstract_reference_declarator", "abstract_array_declarator"):
@@ -3971,9 +3980,16 @@ def _extract_generic(
                         add_edge(parent_class_nid, target_nid, "requires", line)
             return
 
-        if (config.ts_module == "tree_sitter_cpp"
+        if (config.ts_module in ("tree_sitter_c", "tree_sitter_cpp")
                 and t == "field_declaration"
                 and parent_class_nid):
+            # C and C++ share the struct/field grammar, so a C struct's members
+            # are emitted the same way as a C++ one's; the type-ref collector is
+            # the only language-specific piece.
+            field_type_collect = (
+                _cpp_collect_type_refs if config.ts_module == "tree_sitter_cpp"
+                else _c_collect_type_refs
+            )
             # Skip method prototypes (field_declaration with a function_declarator
             # is a member-function declaration, not a data member).
             decls = list(node.children_by_field_name("declarator"))
@@ -4008,7 +4024,7 @@ def _extract_generic(
                 if type_node is not None:
                     line = node.start_point[0] + 1
                     refs: list[tuple[str, str]] = []
-                    _cpp_collect_type_refs(type_node, source, False, refs)
+                    field_type_collect(type_node, source, False, refs)
                     for ref_name, role in refs:
                         ctx = "generic_arg" if role == "generic_arg" else "field"
                         target_nid = ensure_named_node(ref_name, line)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -175,6 +175,32 @@ def test_c_call_edges_have_call_context():
     assert all(e.get("context") == "call" for e in call_edges)
 
 
+def test_c_struct_and_fields_are_extracted(tmp_path):
+    """C structs are the primary data-modeling construct.
+
+    `class_types` was empty, so every struct (and its fields) was dropped,
+    erasing the C type layer -- while C++, using the same generic extractor,
+    captured them. Mirror the C++ struct handling.
+    """
+    src = tmp_path / "shapes.c"
+    src.write_text(
+        "struct Point { int x; int y; };\n"
+        "struct Rect { struct Point origin; int w; };\n"
+        "int area(struct Rect r) { return r.w; }\n"
+    )
+    r = extract_c(src)
+    assert "error" not in r
+    labels = _labels(r)
+    assert "Point" in labels
+    assert "Rect" in labels
+    # struct fields become `defines`/field edges, same as C++
+    assert ("Point", "x") in _edge_labels(r, "defines", "field")
+    assert ("Point", "y") in _edge_labels(r, "defines", "field")
+    assert ("Rect", "w") in _edge_labels(r, "defines", "field")
+    # a struct-typed field/parameter still references the struct type
+    assert ("Rect", "Point") in _edge_labels(r, "references", "field")
+
+
 # ── C++ ───────────────────────────────────────────────────────────────────────
 
 def test_cpp_no_error():


### PR DESCRIPTION
## What

The C extractor dropped **every** `struct` — and all their fields — from the graph.

`_C_CONFIG` set `class_types=frozenset()`, so structs were never emitted as nodes. In C the `struct` is the primary data-modeling construct, so this erased the entire type layer of a C codebase: no struct nodes, no field edges, and functions couldn't reference the structs they take or return. C++ — using the *same* `_extract_generic` engine — captured structs and fields correctly, so this was a C-only gap.

## Reproduce

```c
struct Point { int x; int y; };
struct Rect { struct Point origin; int w; };
int area(struct Rect r) { return r.w; }
```

Before: only `area()` is emitted. `Point`, `Rect`, and every field are absent.

## Fix

Three small, symmetric changes that reuse the existing C++ path:

1. Add `struct_specifier` to the C config's `class_types` (mirrors C++).
2. Let the shared `field_declaration` branch run for `tree_sitter_c` as well, selecting `_c_collect_type_refs` for field type references (it was hard-gated to `tree_sitter_cpp`).
3. Teach `_c_collect_type_refs` to resolve a bare aggregate tag (`struct Point p`, `union U u`) to its name — C keeps the `struct`/`union` keyword in type position far more often than C++, so those references were invisible.

After: `Point` and `Rect` are nodes; `Point defines x/y`, `Rect defines w`, and `Rect references Point` (field), plus `area references Rect` (parameter) all resolve — matching C++.

`enum_specifier` is intentionally left out (it isn't in C++'s `class_types` either), so enum handling stays consistent across the two languages and out of scope here.

## Tests

Adds `test_c_struct_and_fields_are_extracted` covering struct nodes, field `defines` edges, and a struct-typed field reference. Full suite green locally except the pre-existing order-dependent flake `test_label_communities_batches_when_over_batch_size` (#2877), which passes in isolation and is unrelated.
