### PR TITLE
fix(query): downweight rationale prefix seeds

### DIFF
--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -285,6 +285,11 @@ _EXACT_MATCH_BONUS = 1000.0
 _PREFIX_MATCH_BONUS = 100.0
 _SUBSTRING_MATCH_BONUS = 1.0
 _SOURCE_MATCH_BONUS = 0.5
+# Docstring/rationale labels start with natural-language action verbs (e.g.
+# "Computes ...", "Returns ...", "Creates ...") which would otherwise receive
+# the full 100x identifier-prefix bonus and out-seed production code symbols (#2962).
+_RATIONALE_PREFIX_FACTOR = 0.01
+
 
 
 def _compute_idf(G: nx.Graph, terms: list[str]) -> dict[str, float]:
@@ -529,6 +534,7 @@ def _score_query(
         # driver".
         label_tokens = " ".join(_search_tokens(data.get("label") or ""))
         source = (data.get("source_file") or "").lower()
+        prefix_factor = _RATIONALE_PREFIX_FACTOR if data.get("file_type") == "rationale" else 1.0
         # `nid_lower` is needed both by the full-query tier (`if joined`) and by
         # the per-token singleton tier (joined-singlet exact-match check). When
         # neither runs (`joined` empty AND not collecting seeds) skip the call;
@@ -549,7 +555,7 @@ def _score_query(
                 or bare_label.startswith(joined)
                 or label_tokens.startswith(joined)
             ):
-                score += _PREFIX_MATCH_BONUS * 10 * joined_w
+                score += _PREFIX_MATCH_BONUS * prefix_factor * 10 * joined_w
         # Term coverage (#1602): scale the per-term exact/prefix tiers by the
         # squared fraction of query terms the node's LABEL matches, so a lone
         # generic word that happens to equal a short label (query term "home"
@@ -579,7 +585,7 @@ def _score_query(
                 tier_value = _EXACT_MATCH_BONUS * w
                 matched += 1
             elif norm_label.startswith(t) or bare_label.startswith(t):
-                tier_value = _PREFIX_MATCH_BONUS * w
+                tier_value = _PREFIX_MATCH_BONUS * prefix_factor * w
                 matched += 1
             elif t in norm_label:
                 substr_value = _SUBSTRING_MATCH_BONUS * w
@@ -603,7 +609,7 @@ def _score_query(
                     or bare_label.startswith(t)
                     or label_tokens.startswith(t)
                 ):
-                    singleton = _PREFIX_MATCH_BONUS * 10 * w
+                    singleton = _PREFIX_MATCH_BONUS * prefix_factor * 10 * w
                 else:
                     singleton = 0.0
                 singleton += tier_value + substr_value + source_value

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1711,3 +1711,93 @@ def test_underscore_query_does_not_let_a_single_token_outrank_the_real_match():
     scored = _score_nodes(G, _query_terms("user_service_client"))
     assert scored, "the multi-token query must match the full-label node"
     assert scored[0][1] == "real", f"a single-token node out-ranked the real match: {scored}"
+
+
+# --- rationale prefix scaling tests (#2962) ---
+
+def test_rationale_generic_prefix_does_not_dominate_code():
+    """Docstring action verbs ('Computes ...') must not out-seed production code (#2962)."""
+    G = nx.Graph()
+    G.add_node("calc", label="calculate_roas", file_type="code", source_file="analytics/roas.py")
+    G.add_node("doc", label="Computes Return On Ad Spend (ROAS) from spend and revenue.", file_type="rationale", source_file="analytics/roas.py")
+    G.add_node("rep", label="roas_report", file_type="code", source_file="analytics/report.py")
+    G.add_edge("doc", "calc", relation="rationale_for")
+    G.add_edge("rep", "calc", relation="calls")
+
+    qs = _score_query(G, _query_terms("what computes ROAS"), collect_per_term_seeds=True)
+    seeds = _pick_seeds(qs.ranked, G=G, best_seed_by_term=qs.best_seed_by_term)
+
+    # Code symbol roas_report should beat the docstring for top seed position
+    assert qs.ranked[0][1] == "rep", f"code node must outrank rationale node; got top={qs.ranked[0][1]}"
+    assert seeds[0] == "rep", f"code node must be the primary seed; got seeds={seeds}"
+
+
+def test_rationale_multiword_joined_prefix_is_scaled():
+    """Multi-word query prefixing a rationale label must scale the joined prefix tier (#2962)."""
+    G = nx.Graph()
+    G.add_node("doc", label="Computes ROAS metrics for campaign performance and attribution.", file_type="rationale", source_file="analytics/roas.py")
+    G.add_node("cls", label="RoasCalculator", file_type="code", source_file="analytics/calculator.py")
+    G.add_node("fn", label="calculate_roas_metrics", file_type="code", source_file="analytics/roas.py")
+
+    qs = _score_query(G, _query_terms("computes roas"), collect_per_term_seeds=True)
+    seeds = _pick_seeds(qs.ranked, G=G, best_seed_by_term=qs.best_seed_by_term)
+
+    # RoasCalculator matching roas as code prefix must outrank the rationale joined-prefix
+    assert qs.ranked[0][1] == "cls", f"code node RoasCalculator must outrank doc; got {qs.ranked[0][1]}"
+    assert seeds[0] == "cls"
+
+
+def test_rationale_singleton_recovered_by_per_term_guarantee():
+    """When a rationale node is the only match for a query term, #1445 still seeds it (#2962)."""
+    G = nx.Graph()
+    G.add_node("noise", label="unrelated_service", file_type="code", source_file="src/noise.py")
+    G.add_node("doc", label="Widgets handler for UI components.", file_type="rationale", source_file="src/widget.py")
+
+    qs = _score_query(G, _query_terms("unrelated widget"), collect_per_term_seeds=True)
+    seeds = _pick_seeds(qs.ranked, G=G, best_seed_by_term=qs.best_seed_by_term)
+
+    assert "noise" in seeds
+    assert "doc" in seeds, f"rationale node must still be recovered by #1445; got seeds={seeds}"
+
+
+def test_code_prefix_scoring_unchanged():
+    """Code identifier prefix scoring remains at the full 100x bonus (#2962)."""
+    G = nx.Graph()
+    G.add_node("u", label="user", file_type="code", source_file="models/user.py")
+    G.add_node("us", label="user_service", file_type="code", source_file="services/user.py")
+    G.add_node("other", label="account", file_type="code", source_file="models/account.py")
+
+    scored = _score_nodes(G, ["user"])
+    by_id = {nid: s for s, nid in scored}
+    w = _compute_idf(G, ["user"])["user"]
+
+    # Exact match on 'user' (10000 + 1000) * w vs prefix on 'user_service' (1000 + 100) * w
+    assert scored[0][1] == "u"
+    assert scored[1][1] == "us"
+    assert by_id["us"] > 100.0 * w, "code prefix bonus must remain at full magnitude"
+
+
+def test_exact_rationale_search_remains_strong():
+    """Exact/full rationale query matches strongly via joined exact tier (#2962)."""
+    G = nx.Graph()
+    G.add_node("doc", label="Explains why authentication was redesigned to use JWT tokens.", file_type="rationale", source_file="auth/design.md")
+    G.add_node("code", label="auth_service", file_type="code", source_file="auth/service.py")
+
+    query = "Explains why authentication was redesigned to use JWT tokens."
+    qs = _score_query(G, _query_terms(query), collect_per_term_seeds=True)
+    assert qs.ranked[0][1] == "doc"
+    seeds = _pick_seeds(qs.ranked, G=G, best_seed_by_term=qs.best_seed_by_term)
+    assert seeds[0] == "doc"
+
+
+def test_rationale_substring_scoring_unchanged():
+    """Rationale substring match on content terms retains unscaled substring scoring (#2962)."""
+    G = nx.Graph()
+    G.add_node("doc", label="Explains why PostgreSQL is used for persistence.", file_type="rationale", source_file="db/postgres.md")
+    G.add_node("other", label="unrelated_service", file_type="code", source_file="other.py")
+
+    # 'postgres' matches 'doc' as an internal substring (not a prefix)
+    qs = _score_query(G, _query_terms("why use postgres"), collect_per_term_seeds=True)
+    assert qs.ranked[0][1] == "doc"
+    seeds = _pick_seeds(qs.ranked, G=G, best_seed_by_term=qs.best_seed_by_term)
+    assert "doc" in seeds


### PR DESCRIPTION
## Summary

closes #2962 

Natural-language docstrings/rationale nodes could dominate query seed selection when a query term matched the beginning of the docstring.

For example:

```text
graphify query "what computes ROAS"
````

could rank:

```text
"Computes Return On Ad Spend (ROAS)..."
```

above the production code responsible for ROAS because prefix matches receive a 100× bonus over substring matches.

This change makes that prefix signal type-aware without changing code-symbol scoring.

## Root Cause

`_score_query()` applies the same prefix-match bonus to all node types.

Rationale nodes are natural-language descriptions and commonly begin with verbs such as:

* `Computes ...`
* `Returns ...`
* `Creates ...`
* `Stored ...`

These sentence-initial words can therefore receive the same identifier-oriented prefix bonus as a code symbol.

The problem was amplified by the separate multi-word joined-prefix tier and the `best_by_term` singleton scoring used by the per-term seed guarantee.

`file_type` was already available on query-time nodes but was not used by the scorer.

## Solution

Introduce a rationale-specific prefix factor:

```python
_RATIONALE_PREFIX_FACTOR = 0.01
```

For `file_type == "rationale"` nodes, the factor is applied consistently to:

* multi-word joined-prefix scoring
* per-term prefix scoring
* singleton/per-term seed scoring

Code nodes retain the existing prefix scoring.

Exact matches, substring matches, source matches, coverage, seed-gap selection, and the per-term guarantee remain unchanged.

Other node types are also left unchanged.

## Why 0.01?

The existing prefix bonus is:

```text
100 × IDF
```

Reducing rationale prefixes by `0.01` makes their effective prefix contribution equivalent to the existing substring scale while preserving the prefix signal for code identifiers.

In the reproduced multi-word case, higher factors such as `0.05` and `0.10` still allowed the rationale node to dominate. `0.01` was sufficient to allow the relevant production code node to become the primary seed.

## Tests

Added focused regression coverage for:

* generic rationale prefixes no longer dominating production code
* multi-word joined rationale prefixes
* singleton/#1445 rationale recovery
* unchanged code prefix scoring
* exact rationale searches
* unchanged rationale substring scoring

### Validation

```text
uv run pytest tests/test_serve.py
151 passed
```

Full suite:

```text
4837 passed
41 skipped
20 pre-existing Windows platform limitations
```

Static checks:

```text
uv run ruff check .
All checks passed!
```

Pyright also reports no errors in the changed scoring code.

### Real Behavior Proof

Command:

```text
graphify query "what computes ROAS"
```

Before:

```text
Top seed: rationale/docstring node
Rationale score: 110.9009
roas_report: 17.3287
```

After:

```text
Top seed: roas_report
Rationale score: 2.1383
roas_report: 17.3287
calculate_roas: 1.0397
```

The production code node is now the primary seed while the rationale node remains available as a secondary seed.

## Scope

This change is intentionally limited to rationale-node prefix scoring. It does not alter the global prefix bonus or unrelated query-ranking behavior.

