### PR TITLE
fix(label): allow explicit graph overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,6 +790,7 @@ graphify cluster-only ./my-project --backend=gemini            # backend for com
 graphify cluster-only ./my-project --backend=gemini --model gemini-2.5-pro  # specific model
 graphify label ./my-project                                    # (re)name communities with the configured backend
 graphify label ./my-project --backend=openai --model gpt-4o   # force a specific backend and model
+graphify label ./my-project --force                            # overwrite a graph that grew during labeling
 ```
 
 > **Community names:** inside an agent (Claude Code, Gemini CLI) the agent names communities itself. When you run the bare CLI, `cluster-only` auto-names them with the configured backend (built-in or custom OpenAI-compatible provider) — pass `--no-label` to keep `Community N`, or run `graphify label` to (re)generate names on demand.

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -547,6 +547,7 @@ def _run_cli() -> None:
         print("    --max-concurrency=N     parallel community-labeling LLM calls (default 4; forced to 1 for ollama/claude-cli)")
         print("    --batch-size=N          communities per labeling LLM call (default 100)")
         print("  label <path>            (re)name communities with the configured LLM backend, regenerate report")
+        print("    --force                overwrite graph.json even if another writer grew it during labeling")
         print("    --missing-only         keep existing labels and only name missing/placeholder communities")
         print("    --backend=<name>        backend to use (default: auto-detect from API keys)")
         print("    --model=<name>          model to use for community naming")

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -1751,6 +1751,7 @@ def dispatch_command(cmd: str) -> None:
         no_viz = "--no-viz" in sys.argv
         no_label = "--no-label" in sys.argv
         missing_only = "--missing-only" in sys.argv
+        force_graph_write = False
         co_timing = "--timing" in sys.argv
         _backend_arg = next((a for a in sys.argv if a.startswith("--backend=")), None)
         label_backend = _backend_arg.split("=", 1)[1] if _backend_arg else None
@@ -1800,6 +1801,9 @@ def dispatch_command(cmd: str) -> None:
                 label_batch_size = int(args[i_arg + 1]); label_batch_size_explicit = True; i_arg += 2
             elif a.startswith("--batch-size="):
                 label_batch_size = int(a.split("=", 1)[1]); label_batch_size_explicit = True; i_arg += 1
+            elif a == "--force":
+                force_graph_write = cmd == "label"
+                i_arg += 1
             elif a in ("--no-viz", "--missing-only") or a.startswith("--min-community-size="):
                 i_arg += 1
             elif a.startswith("--"):
@@ -1817,6 +1821,25 @@ def dispatch_command(cmd: str) -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
+        # Resolve the output boundary before any expensive labeling work. An
+        # arbitrary --graph path is a restore source, not necessarily the file
+        # this command will replace (#934); --force must never let a label run
+        # overwrite a different graph that it did not load.
+        _out_name = Path(_GRAPHIFY_OUT).name
+        if graph_override is not None and graph_json.parent.name == _out_name:
+            out = graph_json.parent
+        else:
+            out = watch_path / _GRAPHIFY_OUT
+        if (
+            force_graph_write
+            and graph_json.resolve() != (out / "graph.json").resolve()
+        ):
+            print(
+                "error: label --force requires the loaded --graph to be the "
+                "graph.json that will be overwritten",
+                file=sys.stderr,
+            )
+            sys.exit(2)
         from networkx.readwrite import json_graph as _jg
         from graphify.build import build_from_json
         from graphify.cluster import cluster, score_all, remap_communities_to_previous
@@ -1878,11 +1901,6 @@ def dispatch_command(cmd: str) -> None:
         # before re-clustering (#934) — fall back to the CWD's graphify-out/,
         # which is the restore-into-place workflow that test pins. The default
         # (no --graph) case already has graph_json under watch_path/graphify-out.
-        _out_name = Path(_GRAPHIFY_OUT).name
-        if graph_override is not None and graph_json.parent.name == _out_name:
-            out = graph_json.parent
-        else:
-            out = watch_path / _GRAPHIFY_OUT
         out.mkdir(parents=True, exist_ok=True)
         labels_path = out / ".graphify_labels.json"
         existing_labels: dict[int, str] = {}
@@ -2055,9 +2073,12 @@ def dispatch_command(cmd: str) -> None:
         html_stale_marker.touch()
         # The #479 guard can refuse this write, so it goes before the sidecars —
         # a report and labels describing a clustering graph.json does not contain
-        # are worse than no run at all (#2436).
+        # are worse than no run at all (#2436). A long `label` run may observe a
+        # newer graph here; only its explicit --force recovery path may replace it
+        # after the user has verified that losing the newer topology is acceptable.
         if not to_json(G, communities, str(out / "graph.json"),
-                       community_labels=labels, built_at_commit=_commit):
+                       force=force_graph_write, community_labels=labels,
+                       built_at_commit=_commit):
             if not stale_marker_preexisted:
                 _clear_html_stale_marker()
             print(

--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -503,6 +503,119 @@ def _two_community_graph(out):
     (out / "graph.json").write_text(json.dumps(graph), encoding="utf-8")
 
 
+@pytest.mark.parametrize(
+    ("extra_args", "force"),
+    [
+        ([], False),
+        (["--force"], True),
+        (["--backend", "--force"], False),
+    ],
+)
+def test_label_force_controls_graph_growth_after_load(
+    tmp_path, monkeypatch, extra_args, force,
+):
+    """#2976: a long label run may observe graph.json grow after loading it."""
+    import graphify.__main__ as cli
+
+    out = tmp_path / "graphify-out"
+    out.mkdir()
+    _two_community_graph(out)
+    graph_path = out / "graph.json"
+    report_path = out / "GRAPH_REPORT.md"
+    labels_path = out / ".graphify_labels.json"
+    analysis_path = out / ".graphify_analysis.json"
+    report_path.write_text("previous report", encoding="utf-8")
+    labels_path.write_text(json.dumps({"0": "Old orders"}), encoding="utf-8")
+    analysis_path.write_text(json.dumps({"previous": True}), encoding="utf-8")
+
+    def grow_graph_during_labeling(G, communities, **kwargs):
+        persisted = json.loads(graph_path.read_text(encoding="utf-8"))
+        persisted["nodes"].append(
+            {"id": "concurrent", "label": "ConcurrentNode", "community": 2},
+        )
+        graph_path.write_text(json.dumps(persisted), encoding="utf-8")
+        return {cid: f"Fresh community {cid}" for cid in communities}, "test"
+
+    monkeypatch.setattr(cli, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        "graphify.llm.generate_community_labels",
+        grow_graph_during_labeling,
+    )
+    argv = ["graphify", "label", str(tmp_path), "--no-viz", *extra_args]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    if force:
+        cli.main()
+    else:
+        with pytest.raises(SystemExit) as stopped:
+            cli.main()
+        assert stopped.value.code == 1
+
+    persisted = json.loads(graph_path.read_text(encoding="utf-8"))
+    persisted_ids = {node["id"] for node in persisted["nodes"]}
+    if force:
+        assert persisted_ids == {"orders", "order_db", "payments", "pay_db"}
+        assert all(
+            node["community_name"].startswith("Fresh community ")
+            for node in persisted["nodes"]
+        )
+        assert json.loads(labels_path.read_text(encoding="utf-8")) == {
+            "0": "Fresh community 0",
+            "1": "Fresh community 1",
+        }
+    else:
+        assert "concurrent" in persisted_ids
+        assert report_path.read_text(encoding="utf-8") == "previous report"
+        assert json.loads(labels_path.read_text(encoding="utf-8")) == {
+            "0": "Old orders",
+        }
+        assert json.loads(analysis_path.read_text(encoding="utf-8")) == {
+            "previous": True,
+        }
+
+
+def test_label_force_rejects_a_detached_graph_source(tmp_path, monkeypatch):
+    """A forced label run must not load one graph and overwrite another."""
+    import graphify.__main__ as cli
+
+    out = tmp_path / "graphify-out"
+    out.mkdir()
+    _two_community_graph(out)
+    current_path = out / "graph.json"
+    current_before = current_path.read_bytes()
+
+    backup = tmp_path / "backup"
+    backup.mkdir()
+    _two_community_graph(backup)
+    backup_path = backup / "graph.json"
+    backup_before = backup_path.read_bytes()
+
+    monkeypatch.setattr(cli, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        "graphify.llm.generate_community_labels",
+        lambda *args, **kwargs: pytest.fail("labeling must not start"),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "graphify",
+            "label",
+            str(tmp_path),
+            "--graph",
+            str(backup_path),
+            "--force",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as stopped:
+        cli.main()
+
+    assert stopped.value.code == 2
+    assert current_path.read_bytes() == current_before
+    assert backup_path.read_bytes() == backup_before
+
+
 @pytest.mark.parametrize("command", ["cluster-only", "label"])
 def test_cluster_commands_render_aggregated_html_above_viz_limit(
     tmp_path, monkeypatch, capsys, command,


### PR DESCRIPTION
## Summary

- add an explicit, label-only `--force` recovery path when `graph.json` grows during a long labeling run
- keep the default shrink guard fail-closed, and reject forced runs that load a detached `--graph` but would overwrite a different canonical graph
- document the option and cover the guarded, forced, consumed-value, and detached-source paths

Fixes #2976

## Result

| Invocation | Result |
| --- | --- |
| `graphify label PROJECT` | exits 1 and preserves the newer graph and existing sidecars |
| `graphify label PROJECT --force` | exits 0 and publishes the labeled graph |
| `graphify label PROJECT --graph BACKUP --force` | exits 2 before labeling when the write target differs |

`cluster-only` and ambient `GRAPHIFY_FORCE` behavior are unchanged.

## Testing

- `uv run --frozen pytest tests/test_labeling.py tests/test_cli_export.py -q` (86 passed)
- `uv run --frozen pytest tests/ -q --tb=short` (4885 passed, 11 skipped)
- `uv run --frozen ruff check graphify/cli.py graphify/__main__.py tests/test_labeling.py` (passed)
- `uv run --frozen python -m tools.skillgen --check` (passed)
