### PR TITLE
fix(hooks): emit the hook-guard nudge once per session per kind (#2984)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ for example `graphify claude install --project` or `graphify codex install --pro
 
 > **Strict mode (Claude Code):** `graphify install --project --strict` makes the assistant actually use the graph. The default install *nudges* it to run `graphify query` before reading files; strict mode *blocks* the first raw source read of a session and redirects it to the graph, then reverts to the nudge (so it fires at most once per session and never gets stuck). Toggle at runtime with `GRAPHIFY_HOOK_STRICT=1`/`0`; the default install is unchanged (soft nudge).
 
+> **Nudge frequency:** the soft nudge fires at most once per session for reads and once for searches — the assistant only needs telling that a graph exists, and repeating it on every later call just spends its context window. Set `GRAPHIFY_HOOK_NUDGE_ONCE=0` to get the old behaviour (nudge on every matching call).
+
 <details>
 <summary><b>Pick your platform</b> (20+ assistants, click to expand)</summary>
 

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -707,35 +707,71 @@ def _query_stamp_fresh() -> bool:
         return False
 
 
-def _mark_session_denied(session_id: str) -> bool:
-    """Atomically claim a one-time strict block for this session. Returns True only
-    on the FIRST call for a given session id (O_EXCL create wins once); every later
-    call — or any error — returns False, so a session is blocked at most once and an
-    agent can never be stranded. Best-effort GC of markers older than 24h."""
+def _claim_session_marker(session_id: str, suffix: str, on_error: bool) -> bool:
+    """Atomically claim a once-per-session marker file under the graph's cache dir.
+
+    Returns True only on the FIRST claim of a given (session id, suffix) pair —
+    the O_EXCL create wins exactly once — and False once it is already claimed.
+    When the claim cannot be made at all (no usable session id, or a filesystem
+    error) there is no state to key off, so *on_error* is returned and each caller
+    picks the fail direction that keeps its own behaviour safe. Best-effort GC of
+    markers older than 24h."""
     from graphify.paths import out_path
     sid = re.sub(r"[^A-Za-z0-9_-]", "_", str(session_id))[:64]
     if not sid:
-        return False
+        return on_error
+    # Preparing the directory is kept out of the claim's try block on purpose: an
+    # unusable cache path can itself raise FileExistsError, which must not be read
+    # as "already claimed".
     try:
         d = out_path("cache", "hook_sessions")
         d.mkdir(parents=True, exist_ok=True)
-        fd = os.open(str(d / f"{sid}.denied"), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
-        os.close(fd)
-        try:
-            cutoff = time.time() - 86400
-            for entry in os.scandir(d):
-                try:
-                    if entry.stat().st_mtime < cutoff:
-                        os.unlink(entry.path)
-                except OSError:
-                    pass
-        except OSError:
-            pass
-        return True
+        marker = str(d / f"{sid}.{suffix}")
+    except Exception:
+        return on_error
+    try:
+        os.close(os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644))
     except FileExistsError:
         return False
     except Exception:
-        return False
+        return on_error
+    try:
+        cutoff = time.time() - 86400
+        for entry in os.scandir(d):
+            try:
+                if entry.stat().st_mtime < cutoff:
+                    os.unlink(entry.path)
+            except OSError:
+                pass
+    except OSError:
+        pass
+    return True
+
+
+def _mark_session_denied(session_id: str) -> bool:
+    """Atomically claim a one-time strict block for this session. Returns True only
+    on the FIRST call for a given session id; every later call — or any error —
+    returns False, so a session is blocked at most once and an agent can never be
+    stranded."""
+    return _claim_session_marker(session_id, "denied", on_error=False)
+
+
+def _nudge_once(session_id: str, kind: str) -> bool:
+    """Whether the *kind* nudge should still be emitted for this session (#2984).
+
+    The nudge is orientation, not information: once an agent has been told the
+    graph exists it has either used it or decided not to, and repeating the same
+    line on every later matching call only spends its context window. So emit on
+    the first in-scope call per session per kind and stay quiet afterwards.
+
+    An untrackable session (a host that sends no session id, or an unwritable
+    cache) keeps the historic always-emit behaviour rather than going silent —
+    never nudging is the worse failure. ``GRAPHIFY_HOOK_NUDGE_ONCE=0`` restores
+    the unthrottled behaviour outright."""
+    v = os.environ.get("GRAPHIFY_HOOK_NUDGE_ONCE", "").strip().lower()
+    if v in ("0", "false", "no", "off"):
+        return True
+    return _claim_session_marker(session_id, f"{kind}.nudged", on_error=True)
 
 
 _SEARCH_COMMANDS = frozenset({
@@ -828,7 +864,10 @@ def _run_hook_guard(kind: str, strict: bool = False) -> None:
     nudge-only: a compound shell command has no single parseable target and blocking
     file listing would strand navigation. #1840: reads of out-of-project files are
     ignored, and a graph that is stale for the target file softens to a non-mandatory
-    nudge instead of blocking or demanding.
+    nudge instead of blocking or demanding. #2984: an in-scope nudge is emitted at
+    most once per session per kind (`GRAPHIFY_HOOK_NUDGE_ONCE=0` to disable), since
+    repeating it on every later call spends the agent's context without telling it
+    anything it was not already told.
     """
     from graphify.paths import out_path, GRAPHIFY_OUT_NAME
     # Gemini's BeforeTool hook takes no stdin and must ALWAYS return a decision so
@@ -866,7 +905,8 @@ def _run_hook_guard(kind: str, strict: bool = False) -> None:
             # grep. Nudge-only, even in strict mode — see the docstring.
             is_grep_tool = not cmd_str and bool(t.get("pattern"))
             is_bash_search = bool(cmd_str) and _bash_invokes_search(cmd_str)
-            if (is_grep_tool or is_bash_search) and out_path("graph.json").is_file():
+            if (is_grep_tool or is_bash_search) and out_path("graph.json").is_file() \
+                    and _nudge_once(str(d.get("session_id") or ""), "search"):
                 sys.stdout.write(_SEARCH_NUDGE)
         elif kind == "read":
             vals = [str(t.get("file_path") or ""), str(t.get("pattern") or ""), str(t.get("path") or "")]
@@ -926,10 +966,13 @@ def _run_hook_guard(kind: str, strict: bool = False) -> None:
             except Exception:
                 pass
             if stale:
-                sys.stdout.write(_READ_NUDGE_STALE)
+                if _nudge_once(str(d.get("session_id") or ""), "read"):
+                    sys.stdout.write(_READ_NUDGE_STALE)
                 return
             # Strict block: Read tool only, first time per session, not recently
-            # oriented, and the file is demonstrably indexed.
+            # oriented, and the file is demonstrably indexed. The deny carries its
+            # own once-per-session claim and is not part of the nudge budget, so a
+            # denied read still leaves the session its one soft nudge.
             tool_name = d.get("tool_name")
             if _hook_strict_enabled(strict) and tool_name in (None, "Read") \
                     and not _query_stamp_fresh() \
@@ -937,7 +980,8 @@ def _run_hook_guard(kind: str, strict: bool = False) -> None:
                     and _mark_session_denied(str(d.get("session_id") or "")):
                 sys.stdout.write(_READ_DENY)
                 return
-            sys.stdout.write(_READ_NUDGE)
+            if _nudge_once(str(d.get("session_id") or ""), "read"):
+                sys.stdout.write(_READ_NUDGE)
     except Exception:
         pass
 

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -849,6 +849,22 @@ def _bash_invokes_search(cmd_str: str) -> bool:
     return False
 
 
+def _strict_denies(d: dict, fp: str, root: "Path", strict: bool) -> bool:
+    """Whether this read earns the strict one-per-session block.
+
+    Every term is a precondition of the next and the last one *claims* the
+    session marker, so the short-circuit order is load-bearing: a read that is
+    not strict-eligible must never reach the claim and burn the session's single
+    block. Kept as one predicate so that ordering lives in one place."""
+    return bool(
+        _hook_strict_enabled(strict)
+        and d.get("tool_name") in (None, "Read")
+        and not _query_stamp_fresh()
+        and _target_is_indexed(fp, root)
+        and _mark_session_denied(str(d.get("session_id") or ""))
+    )
+
+
 def _run_hook_guard(kind: str, strict: bool = False) -> None:
     """Shell-agnostic PreToolUse guard (#522).
 
@@ -972,14 +988,11 @@ def _run_hook_guard(kind: str, strict: bool = False) -> None:
                     sys.stdout.write(_READ_NUDGE_STALE)
                 return
             # Strict block: Read tool only, first time per session, not recently
-            # oriented, and the file is demonstrably indexed. The deny carries its
-            # own once-per-session claim and is not part of the nudge budget, so a
-            # denied read still leaves the session its one soft nudge.
-            tool_name = d.get("tool_name")
-            if _hook_strict_enabled(strict) and tool_name in (None, "Read") \
-                    and not _query_stamp_fresh() \
-                    and _target_is_indexed(fp, root) \
-                    and _mark_session_denied(str(d.get("session_id") or "")):
+            # oriented, and the file is demonstrably indexed (see _strict_denies).
+            # The deny carries its own once-per-session claim and is not part of
+            # the nudge budget, so a denied read still leaves the session its one
+            # soft nudge.
+            if _strict_denies(d, fp, root, strict):
                 sys.stdout.write(_READ_DENY)
                 return
             if _nudge_once(str(d.get("session_id") or ""), "read"):

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -767,7 +767,9 @@ def _nudge_once(session_id: str, kind: str) -> bool:
     An untrackable session (a host that sends no session id, or an unwritable
     cache) keeps the historic always-emit behaviour rather than going silent —
     never nudging is the worse failure. ``GRAPHIFY_HOOK_NUDGE_ONCE=0`` restores
-    the unthrottled behaviour outright."""
+    the unthrottled behaviour outright. Markers are GC'd after 24h, so a session
+    still alive past that gets one more nudge — which is the right side to err on.
+    """
     v = os.environ.get("GRAPHIFY_HOOK_NUDGE_ONCE", "").strip().lower()
     if v in ("0", "false", "no", "off"):
         return True

--- a/tests/test_hook_nudge_throttle.py
+++ b/tests/test_hook_nudge_throttle.py
@@ -13,7 +13,17 @@ import json
 import sys
 import time
 
+import pytest
+
 import graphify.cli as cli
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_throttle_env(monkeypatch):
+    """A GRAPHIFY_HOOK_NUDGE_ONCE inherited from the developer's or CI's
+    environment would silently turn the default-behaviour cases into kill-switch
+    cases. Tests that want the switch set it themselves."""
+    monkeypatch.delenv("GRAPHIFY_HOOK_NUDGE_ONCE", raising=False)
 
 
 def _project(tmp_path):
@@ -121,6 +131,31 @@ def test_stale_nudge_spends_the_same_read_budget(tmp_path, monkeypatch):
     first = _invoke("read", _read(f), tmp_path, monkeypatch)
     assert "STALE" in first and "MANDATORY" not in first
     assert _invoke("read", _read(f), tmp_path, monkeypatch) == ""
+
+
+def test_an_ineligible_read_does_not_burn_the_strict_claim(tmp_path, monkeypatch):
+    """_strict_denies claims the session marker in its last term, so the
+    short-circuit order is load-bearing: a read that is not strict-eligible (here,
+    a file the graph does not index) must not spend the session's single block."""
+    f = _project(tmp_path)
+    unindexed = f.parent / "other.py"
+    unindexed.write_text("y = 2\n", encoding="utf-8")
+    time.sleep(0.02)  # keep the graph newer than both files, so neither is stale
+    (tmp_path / "graphify-out" / "graph.json").write_text('{"nodes":[],"links":[]}', encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    def _run(path):
+        class _Stdin:
+            buffer = io.BytesIO(json.dumps(_read(path)).encode())
+        monkeypatch.setattr(sys, "stdin", _Stdin())
+        buf = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", buf)
+        cli._run_hook_guard("read", strict=True)
+        return buf.getvalue()
+
+    assert "MANDATORY" in _run(unindexed)  # nudge, not a deny
+    assert not (tmp_path / "graphify-out" / "cache" / "hook_sessions" / "s1.denied").exists()
+    assert json.loads(_run(f))["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
 def test_the_strict_deny_keeps_its_own_budget(tmp_path, monkeypatch):

--- a/tests/test_hook_nudge_throttle.py
+++ b/tests/test_hook_nudge_throttle.py
@@ -1,0 +1,144 @@
+"""Session-scoped throttle on the hook-guard soft nudge (#2984).
+
+The PreToolUse nudge is orientation, not information: once an agent has been told
+an in-project graph exists it has either used it or decided not to, so repeating
+the identical line on every later matching call only spends its context window.
+The guard now emits at most one nudge per session per kind (search / read). Both
+escape hatches stay wide open: a session the host does not identify, or a cache
+that cannot hold markers, keeps the historical nudge-every-call behaviour, and
+GRAPHIFY_HOOK_NUDGE_ONCE=0 turns the throttle off outright.
+"""
+import io
+import json
+import sys
+import time
+
+import graphify.cli as cli
+
+
+def _project(tmp_path):
+    """A project with one indexed source file and a graph that is fresh for it."""
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "mod.py"
+    f.write_text("def x():\n    return 1\n", encoding="utf-8")
+    out = tmp_path / "graphify-out"
+    out.mkdir()
+    (out / "manifest.json").write_text(json.dumps({"src/mod.py": {"mtime": 1}}), encoding="utf-8")
+    time.sleep(0.02)
+    (out / "graph.json").write_text('{"nodes":[],"links":[]}', encoding="utf-8")
+    return f
+
+
+def _invoke(kind, payload, tmp_path, monkeypatch, *, env=None):
+    monkeypatch.chdir(tmp_path)
+    for k, v in (env or {}).items():
+        monkeypatch.setenv(k, v)
+
+    class _Stdin:
+        buffer = io.BytesIO(json.dumps(payload).encode())
+    monkeypatch.setattr(sys, "stdin", _Stdin())
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    cli._run_hook_guard(kind)
+    return buf.getvalue()
+
+
+def _read(fpath, sid="s1"):
+    return {"session_id": sid, "tool_name": "Read", "tool_input": {"file_path": str(fpath)}}
+
+
+def _search(sid="s1"):
+    return {"session_id": sid, "tool_name": "Bash", "tool_input": {"command": "grep -rn foo ."}}
+
+
+def test_read_nudges_once_per_session(tmp_path, monkeypatch):
+    f = _project(tmp_path)
+    assert "MANDATORY" in _invoke("read", _read(f), tmp_path, monkeypatch)
+    assert _invoke("read", _read(f), tmp_path, monkeypatch) == ""
+    assert _invoke("read", _read(f), tmp_path, monkeypatch) == ""
+
+
+def test_search_nudges_once_per_session(tmp_path, monkeypatch):
+    _project(tmp_path)
+    assert "MANDATORY" in _invoke("search", _search(), tmp_path, monkeypatch)
+    assert _invoke("search", _search(), tmp_path, monkeypatch) == ""
+
+
+def test_search_and_read_budgets_are_independent(tmp_path, monkeypatch):
+    f = _project(tmp_path)
+    assert "MANDATORY" in _invoke("search", _search(), tmp_path, monkeypatch)
+    assert "MANDATORY" in _invoke("read", _read(f), tmp_path, monkeypatch)
+
+
+def test_each_session_gets_its_own_nudge(tmp_path, monkeypatch):
+    f = _project(tmp_path)
+    assert "MANDATORY" in _invoke("read", _read(f, "s1"), tmp_path, monkeypatch)
+    assert _invoke("read", _read(f, "s1"), tmp_path, monkeypatch) == ""
+    assert "MANDATORY" in _invoke("read", _read(f, "s2"), tmp_path, monkeypatch)
+
+
+def test_untrackable_session_keeps_nudging(tmp_path, monkeypatch):
+    """No session id means no key to throttle on — never go silent instead."""
+    f = _project(tmp_path)
+    payload = _read(f)
+    payload.pop("session_id")
+    assert "MANDATORY" in _invoke("read", payload, tmp_path, monkeypatch)
+    assert "MANDATORY" in _invoke("read", payload, tmp_path, monkeypatch)
+
+
+def test_unusable_marker_dir_keeps_nudging(tmp_path, monkeypatch):
+    """A cache path that cannot hold markers must not silence the nudge either —
+    and must not be mistaken for an already-claimed marker."""
+    f = _project(tmp_path)
+    (tmp_path / "graphify-out" / "cache").write_text("not a directory", encoding="utf-8")
+    assert "MANDATORY" in _invoke("read", _read(f), tmp_path, monkeypatch)
+    assert "MANDATORY" in _invoke("read", _read(f), tmp_path, monkeypatch)
+
+
+def test_kill_switch_restores_the_nudge_on_every_call(tmp_path, monkeypatch):
+    f = _project(tmp_path)
+    env = {"GRAPHIFY_HOOK_NUDGE_ONCE": "0"}
+    assert "MANDATORY" in _invoke("read", _read(f), tmp_path, monkeypatch, env=env)
+    assert "MANDATORY" in _invoke("read", _read(f), tmp_path, monkeypatch, env=env)
+
+
+def test_an_out_of_scope_read_does_not_spend_the_nudge(tmp_path, monkeypatch):
+    """#1840's scoping stays orthogonal to the throttle: a call the guard declines
+    to nudge for must not consume the session's one nudge."""
+    f = _project(tmp_path)
+    outside = tmp_path.parent / "outside_the_project.py"
+    outside.write_text("x = 1\n", encoding="utf-8")
+    assert _invoke("read", _read(outside), tmp_path, monkeypatch) == ""
+    assert "MANDATORY" in _invoke("read", _read(f), tmp_path, monkeypatch)
+
+
+def test_stale_nudge_spends_the_same_read_budget(tmp_path, monkeypatch):
+    """The stale variant is the same reminder in softer words — one per session."""
+    f = _project(tmp_path)
+    time.sleep(0.02)
+    f.write_text("def x():\n    return 2\n", encoding="utf-8")  # source newer -> stale
+    first = _invoke("read", _read(f), tmp_path, monkeypatch)
+    assert "STALE" in first and "MANDATORY" not in first
+    assert _invoke("read", _read(f), tmp_path, monkeypatch) == ""
+
+
+def test_the_strict_deny_keeps_its_own_budget(tmp_path, monkeypatch):
+    """The strict block already fires once per session off its own marker; it must
+    not also eat the soft nudge that follows it."""
+    f = _project(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    def _run(strict):
+        class _Stdin:
+            buffer = io.BytesIO(json.dumps(_read(f)).encode())
+        monkeypatch.setattr(sys, "stdin", _Stdin())
+        buf = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", buf)
+        cli._run_hook_guard("read", strict=strict)
+        return buf.getvalue()
+
+    denied = _run(True)
+    assert json.loads(denied)["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "MANDATORY" in _run(True)
+    assert _run(True) == ""

--- a/tests/test_hook_nudge_throttle.py
+++ b/tests/test_hook_nudge_throttle.py
@@ -40,7 +40,9 @@ def _project(tmp_path):
     return f
 
 
-def _invoke(kind, payload, tmp_path, monkeypatch, *, env=None):
+def _invoke(kind, payload, tmp_path, monkeypatch, *, env=None, strict=False):
+    """The single seam these tests drive the guard through — every case goes via
+    here rather than growing its own copy of the stdin/stdout plumbing."""
     monkeypatch.chdir(tmp_path)
     for k, v in (env or {}).items():
         monkeypatch.setenv(k, v)
@@ -50,8 +52,12 @@ def _invoke(kind, payload, tmp_path, monkeypatch, *, env=None):
     monkeypatch.setattr(sys, "stdin", _Stdin())
     buf = io.StringIO()
     monkeypatch.setattr(sys, "stdout", buf)
-    cli._run_hook_guard(kind)
+    cli._run_hook_guard(kind, strict=strict)
     return buf.getvalue()
+
+
+def _decision(out):
+    return json.loads(out)["hookSpecificOutput"].get("permissionDecision")
 
 
 def _read(fpath, sid="s1"):
@@ -142,38 +148,22 @@ def test_an_ineligible_read_does_not_burn_the_strict_claim(tmp_path, monkeypatch
     unindexed.write_text("y = 2\n", encoding="utf-8")
     time.sleep(0.02)  # keep the graph newer than both files, so neither is stale
     (tmp_path / "graphify-out" / "graph.json").write_text('{"nodes":[],"links":[]}', encoding="utf-8")
-    monkeypatch.chdir(tmp_path)
 
-    def _run(path):
-        class _Stdin:
-            buffer = io.BytesIO(json.dumps(_read(path)).encode())
-        monkeypatch.setattr(sys, "stdin", _Stdin())
-        buf = io.StringIO()
-        monkeypatch.setattr(sys, "stdout", buf)
-        cli._run_hook_guard("read", strict=True)
-        return buf.getvalue()
-
-    assert "MANDATORY" in _run(unindexed)  # nudge, not a deny
+    out = _invoke("read", _read(unindexed), tmp_path, monkeypatch, strict=True)
+    assert "MANDATORY" in out  # the soft nudge, not a deny
     assert not (tmp_path / "graphify-out" / "cache" / "hook_sessions" / "s1.denied").exists()
-    assert json.loads(_run(f))["hookSpecificOutput"]["permissionDecision"] == "deny"
+    # the claim was not spent, so the next eligible read still denies
+    assert _decision(_invoke("read", _read(f), tmp_path, monkeypatch, strict=True)) == "deny"
 
 
 def test_the_strict_deny_keeps_its_own_budget(tmp_path, monkeypatch):
     """The strict block already fires once per session off its own marker; it must
     not also eat the soft nudge that follows it."""
     f = _project(tmp_path)
-    monkeypatch.chdir(tmp_path)
 
-    def _run(strict):
-        class _Stdin:
-            buffer = io.BytesIO(json.dumps(_read(f)).encode())
-        monkeypatch.setattr(sys, "stdin", _Stdin())
-        buf = io.StringIO()
-        monkeypatch.setattr(sys, "stdout", buf)
-        cli._run_hook_guard("read", strict=strict)
-        return buf.getvalue()
+    def _run():
+        return _invoke("read", _read(f), tmp_path, monkeypatch, strict=True)
 
-    denied = _run(True)
-    assert json.loads(denied)["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "MANDATORY" in _run(True)
-    assert _run(True) == ""
+    assert _decision(_run()) == "deny"
+    assert "MANDATORY" in _run()  # the deny did not eat the session's nudge
+    assert _run() == ""


### PR DESCRIPTION
Closes #2984.

## The problem

`hook-guard search` / `hook-guard read` emit their nudge on **every** matching tool call. Nothing tracks that the agent has already been told, so re-reading one file re-prints the identical `MANDATORY: graphify-out/graph.json exists...` line each time.

Measured on 0.9.48 over 10,506 Claude Code session transcripts from a single repo:

| Metric | Value |
|---|---|
| `hook-guard search` / `read` firings | 1,739 |
| Sessions those landed in | 42 |
| Resulting `graphify query` / `explain` calls | 21 |
| Conversion | ~1.2% |
| Est. cost | ~55 tokens/firing → ~95K tokens |

`#1840` scoped the nudge to the graph's own project root, which is a different half of the problem — the numbers above are from **after** it shipped. It changed *whether a call is in scope*, not *how often an in-scope reminder repeats*.

### Repro

In a project with a built graph, wire the default hooks (`graphify install`) and read the same source file three times in one session. The nudge fires three times, identically.

## The fix

The nudge is orientation, not information: once the agent has been told the graph exists it has either used it or decided not to, and repeating that only spends the context window the hook is trying to protect.

`_mark_session_denied` already did exactly this once-per-session claim for the strict block — an `O_CREAT | O_EXCL` marker under `graphify-out/cache/hook_sessions/`. So rather than inventing a second mechanism, that helper is generalized to `_claim_session_marker(session_id, suffix, on_error)`, and `_nudge_once()` takes a marker per kind (`search` / `read`). The strict marker filename (`{sid}.denied`) is unchanged.

Two details worth flagging in review:

- **The two callers need opposite fail directions**, hence the explicit `on_error` argument. If a claim can't be tracked at all, the strict deny must not fire (never block a read on a bug) while the nudge must still print (never go silent). Guessing one direction for both would be wrong in one of them.
- **Directory setup moved out of the claim's `try` block.** An unusable cache path can itself raise `FileExistsError` from `mkdir`, which the old single-block shape would have read as "already claimed" — i.e. silently fail closed. Separating them keeps the `FileExistsError` catch attached only to the `os.open` that actually means it.

The strict deny keeps its own marker, so a denied read still leaves the session its one soft nudge. Stale reads share the read budget (same reminder, softer words). Scoping stays orthogonal: a call `#1840` declines to nudge for does not spend the budget.

`GRAPHIFY_HOOK_NUDGE_ONCE=0` restores the previous nudge-every-call behaviour, matching the `GRAPHIFY_HOOK_STRICT` toggle convention. README updated next to the strict-mode note.

## Scope

Once-per-session-per-kind only. The issue also floated N-per-session and once-per-file; happy to add a count if you'd prefer it configurable, but a fixed 1 seemed like the honest default and the smaller change. `hook-guard gemini` is untouched — it reads no stdin and so has no session id.

## Tests

`tests/test_hook_nudge_throttle.py` — 10 cases. The fail-open paths get equal weight to the happy path: untrackable session keeps nudging, unusable cache dir keeps nudging, out-of-project call doesn't spend the budget, strict deny doesn't eat the following nudge, kill switch restores every-call.

`pytest tests/` is green apart from 15 failures that are identical on `v8` at `b2cd362` (Windows-only: fifo/unix-socket/symlink, install paths). Full suite run on Windows/py3.12; `ruff --config pyproject.toml` and `tools.skillgen --check` clean.

No CHANGELOG entry — the history suggests those land in your own batched `docs(changelog)` commits. Say the word and I'll add one.
