### PR TITLE
fix(extract): keep the definition site when a C++/ObjC decl/def pair is merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## Unreleased
+
+- Fix: a C/C++/ObjC symbol declared in a header and defined in the sibling impl file is merged into one node keyed to the header (#1547, #1556), and the dropped impl node took the definition's file and line with it — the graph reported the declaration as the symbol's only location, so "where is this implemented?" answered with a header line and the reader had to scan the `.cpp` by hand. The survivor now carries `definition_file`/`definition_location` and `get_node` names it ("Defined in:"); ids, labels, `source_file`, node count and edges are all unchanged, so existing graphs are not re-keyed and the single-definition guarantee the resolvers rely on is untouched. Several impls folding onto one header (ObjC categories) pick deterministically by lowest `(source_file, source_location)` (#2990).
+
 ## 0.9.48 (2026-08-20)
 
 - Fix: a control character in a node label or id no longer aborts the whole export; the GraphML and Obsidian exporters scrub only the characters those formats forbid (tab, newline, and non-ASCII letters are preserved), and `graph.json` and its byte-identity round-trip are untouched (#2897, thanks @abhay-codes07).

--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -2129,7 +2129,10 @@ def _merge_decl_def_classes(
     and leaves it alone, and the downstream resolvers see ONE definition. Because
     the colliding nodes already share an id, no edge re-pointing is needed: every
     edge that referenced the impl symbol already points at the surviving id. We
-    only drop the redundant duplicate node and prefer the header's label.
+    only drop the redundant duplicate node and prefer the header's label — but
+    the dropped impl node's provenance is preserved on the survivor as
+    ``definition_file`` / ``definition_location``, so the definition site is
+    still reachable from the merged node.
 
     GOD-NODE GUARDS (false merges are the main risk):
 
@@ -2200,6 +2203,30 @@ def _merge_decl_def_classes(
             if len(base_headers) > 1:
                 continue
             keeper = base_headers[0] if base_headers else min(headers, key=_source_stem)
+        # The keeper is the DECLARATION, so without this the graph reports the
+        # header as the symbol's only location and the definition site — the file
+        # and line a reader actually wants — is discarded with the dropped node.
+        # Recorded as separate attributes: the survivor's id, label and
+        # source_file are untouched, so no existing graph is re-keyed, no edge
+        # moves, and the single-definition guarantee downstream resolvers rely on
+        # is unchanged. Chosen deterministically (lowest source_file, then
+        # location) so an ObjC class whose members are split across several
+        # category impls does not depend on node arrival order.
+        impls = sorted(
+            (n for n in group
+             if n is not keeper
+             and Path(str(n.get("source_file", ""))).suffix.lower()
+             in _DECLDEF_IMPL_SUFFIXES),
+            key=lambda n: (str(n.get("source_file", "")),
+                           str(n.get("source_location", ""))),
+        )
+        if impls:
+            definition = impls[0]
+            if definition.get("source_file"):
+                keeper["definition_file"] = definition["source_file"]
+            if definition.get("source_location"):
+                keeper["definition_location"] = definition["source_location"]
+
         for node in group:
             if node is not keeper:
                 drop_objs.add(id(node))
@@ -2208,7 +2235,8 @@ def _merge_decl_def_classes(
         return
 
     # Drop the redundant duplicate nodes. The surviving (header) node keeps its
-    # own label/source_file; edges are unchanged because the id is identical. Then
+    # own label/source_file (and now carries the impl's definition_file/
+    # definition_location); edges are unchanged because the id is identical. Then
     # de-dup any now-identical edges (e.g. the impl file's `contains`/`method`
     # edge that duplicates the header's after the collapse).
     all_nodes[:] = [n for n in all_nodes if id(n) not in drop_objs]

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -1769,6 +1769,12 @@ def _build_server(graph_path: str):
             f"Node: {sanitize_label(d.get('label', nid))}",
             f"  ID: {sanitize_label(nid)}",
             f"  Source: {sanitize_label(str(d.get('source_file', '')))} {sanitize_label(str(d.get('source_location', '')))}",
+            # A C/C++/ObjC symbol declared in a header and defined in the sibling
+            # impl file is ONE node keyed to the header, so Source alone points at
+            # the declaration. Name where it is implemented too, when known.
+            *([f"  Defined in: {sanitize_label(str(d.get('definition_file', '')))} "
+               f"{sanitize_label(str(d.get('definition_location', '')))}"]
+              if d.get("definition_file") else []),
             f"  Type: {sanitize_label(str(d.get('file_type', '')))}",
             f"  Community: {sanitize_label(str(d.get('community_name') or d.get('community', '')))}",
             f"  Degree: {G.degree(nid)}",

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -3308,6 +3308,28 @@ def test_cpp_paired_method_decl_and_def_are_one_node():
     assert bar_nodes, "the merged bar node should be a member of Foo"
 
 
+def test_cpp_paired_merged_node_records_definition_site():
+    """The decl/def merge keeps the header node, so `source_file` names the
+    DECLARATION. The survivor must still carry where the symbol is implemented,
+    or the definition site is lost with the dropped impl node."""
+    r = _corpus("cpp_paired/Foo.h", "cpp_paired/Foo.cpp", "cpp_paired/Main.cpp")
+    bars = [n for n in r["nodes"] if n["label"] in ("bar", "Foo::bar()")]
+    assert len(bars) == 1, f"bar decl/def should be one node, got {bars}"
+    bar = bars[0]
+    assert str(bar["source_file"]).endswith("Foo.h"), bar
+    assert str(bar.get("definition_file", "")).endswith("Foo.cpp"), bar
+    assert bar.get("definition_location"), bar
+
+
+def test_cpp_unpaired_symbol_has_no_definition_site():
+    """A symbol that was never merged must not grow the new attributes — they mark
+    a collapsed decl/def pair, not every node."""
+    r = _corpus("cpp_paired/Foo.h", "cpp_paired/Foo.cpp", "cpp_paired/Main.cpp")
+    for n in r["nodes"]:
+        if str(n.get("source_file", "")).endswith("Main.cpp"):
+            assert "definition_file" not in n, n
+
+
 def test_cpp_paired_includes_resolve_to_real_header():
     """Foo.cpp and Main.cpp `#include "Foo.h"` must resolve to the real Foo.h file
     node (no dangling import)."""


### PR DESCRIPTION
Fixes #2990.

## What

A C/C++/ObjC symbol declared in a header and defined in the sibling impl file is collapsed into one node keyed to the header by `_merge_decl_def_classes` (#1547, #1556). That merge is right and this PR leaves it alone — the downstream resolvers need exactly one definition node. But the dropped impl node took the definition's file and line with it, so the graph reported the declaration as the symbol's only location and `get_node` answered "where is this implemented?" with a header line number.

This records the dropped impl's provenance on the survivor before discarding it:

- `definition_file` / `definition_location` on the merged node
- `get_node` prints a `Defined in:` line when present

## Why this shape

Additive only — id, `label`, `source_file`, node count and edges are all unchanged, so **no existing graph is re-keyed** and the single-definition guarantee the resolvers depend on is untouched. When several impls fold onto one header (ObjC categories) the pick is deterministic, lowest `(source_file, source_location)`, so it does not depend on node arrival order.

Two alternatives are written up in #2990 (flip the merge so the definition wins; keep both nodes and disambiguate the impl id, the shape used for Go in #2779). Both change more than the reported harm needs — the first flips surviving labels from `Alpha` to `Foo::Alpha()` and breaks bare-name lookups, the second grows node counts on header-heavy C++ and needs an edge-resolution policy. Happy to switch if you would rather have one of those.

## Tests

`tests/test_languages.py`, on the existing `cpp_paired` fixture:

- `test_cpp_paired_merged_node_records_definition_site` — the single merged `bar` node keeps `source_file` = `Foo.h` and now carries `definition_file` = `Foo.cpp` with a location. Verified red before the fix (`definition_file` was `''`).
- `test_cpp_unpaired_symbol_has_no_definition_site` — a node that was never merged does not grow the attributes.

Full suite, same machine, with and without the patch:

```
without:  24 failed, 4568 passed, 211 skipped
with:     24 failed, 4570 passed, 211 skipped
```

Identical failure set (pre-existing, all environment-dependent: `test_ollama_retry_cap`, `test_terraform`, `test_skillgen`, `test_install_references`, `test_markdown_nested_frontmatter_survives` — none touch this path), +2 from the new tests.

## Real-world check

On a 1,767-file C++ codebase where 541 of 700 implementation files over 3 KB previously contributed nothing but their file node: one 188 KB `.cpp` recovers the definition sites of all 198 of its method definitions, e.g. a method declared at `…/Foo.h` L85 now carries `definition_location` L1002 in the sibling `.cpp`. Sanity check: no `definition_file` resolves to anything but an impl extension.

Environment: Python 3.12.3, tree-sitter 0.25.2, Linux, AST-only build with no LLM backend.
