### PR TITLE
fix(sql): extract CREATE TABLE inside BEGIN/COMMIT blocks

### DIFF
--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -398,6 +398,10 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
         if stmt.type == "statement":
             for child in stmt.children:
                 walk(child)
+        elif stmt.type == "transaction":
+            # BEGIN; ... COMMIT; wraps DDL in a transaction node whose children
+            # are statement nodes, not direct create_table nodes (#2953).
+            walk(stmt)
         elif stmt.type in ("fb_proc_or_trigger", "set_term", "declare_external_function", "ERROR"):
             walk(stmt)
 

--- a/tests/fixtures/sample_transaction.sql
+++ b/tests/fixtures/sample_transaction.sql
@@ -1,0 +1,11 @@
+CREATE TABLE alfa (id integer PRIMARY KEY);
+
+BEGIN;
+
+CREATE TABLE gamma (id integer PRIMARY KEY);
+CREATE TABLE delta (
+  id integer PRIMARY KEY,
+  alfa_id integer REFERENCES alfa(id)
+);
+
+COMMIT;

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -461,6 +461,25 @@ def test_sql_finds_tables():
     assert any("users" in l for l in labels)
     assert any("organizations" in l for l in labels)
 
+
+def test_sql_create_table_inside_transaction_block():
+    """#2953: DDL wrapped in BEGIN; ... COMMIT; must emit table nodes."""
+    r = _extract_sql_or_skip("sample_transaction.sql")
+    labels = [n["label"] for n in r["nodes"]]
+    assert any("alfa" in l for l in labels)
+    assert any("gamma" in l for l in labels)
+    assert any("delta" in l for l in labels)
+    refs = [
+        (e["source"], e["target"])
+        for e in r["edges"]
+        if e["relation"] == "references"
+    ]
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    assert any(
+        "delta" in node_by_id.get(s, "") and "alfa" in node_by_id.get(t, "")
+        for s, t in refs
+    )
+
 def test_sql_finds_view():
     r = _extract_sql_or_skip()
     labels = [n["label"] for n in r["nodes"]]


### PR DESCRIPTION
## Problem

`CREATE TABLE` statements inside `BEGIN; ... COMMIT;` transaction blocks produced no table nodes. The file appeared in the graph, but every table in a wrapped migration was silently absent.

Minimal reproduction:

```sql
BEGIN;
CREATE TABLE gamma (id integer PRIMARY KEY);
COMMIT;
```

Plain `CREATE TABLE` outside a transaction worked; the same statement inside `BEGIN/COMMIT` did not.

## Cause

`extract_sql` pre-registers defined table names by recursing the full parse tree, but the emitting walk only descended direct children of top-level `statement` nodes. tree-sitter-sql wraps transaction DDL under a `transaction` node containing nested `statement` nodes, so `walk()` never reached those `create_table` nodes.

## Fix

Call `walk(stmt)` on `transaction` nodes at the top level. `walk()` already recurses into children, so nested `statement` / `create_table` nodes are processed like unwrapped DDL.

## Tests

- `tests/fixtures/sample_transaction.sql`: tables inside and outside a transaction block, plus a cross-boundary foreign key.
- `tests/test_multilang.py::test_sql_create_table_inside_transaction_block`

```bash
pytest tests/test_multilang.py -k sql -q
```

Fixes #2953
