### PR TITLE
fix(bash): emit calls edges for assignment command substitution

### DIFF
--- a/graphify/extractors/bash.py
+++ b/graphify/extractors/bash.py
@@ -194,6 +194,24 @@ def extract_bash(path: Path) -> dict:
             parent = parent.parent
         return False
 
+    def _bash_call_in_command_allowed(cmd_node) -> bool:
+        """Whether a command node should emit call edges.
+
+        Bare ``$(fn)`` at script level and process substitutions stay suppressed
+        (#2141). Value capture via ``x=$(fn)`` is a real invocation (#2978).
+        """
+        parent = cmd_node.parent
+        saw_command_substitution = False
+        while parent is not None:
+            if parent.type == "process_substitution":
+                return False
+            if parent.type == "command_substitution":
+                saw_command_substitution = True
+            if parent.type == "variable_assignment" and saw_command_substitution:
+                return True
+            parent = parent.parent
+        return not saw_command_substitution
+
     def literal(node) -> str | None:
         # Token-level filter: rejects names containing shell metacharacters.
         # Combined with `is_inside_expansion` for parent-context rejection.
@@ -223,7 +241,7 @@ def extract_bash(path: Path) -> dict:
                 # separately, so we don't attribute their calls to the
                 # enclosing scope.
                 continue
-            if child.type == "command" and not is_inside_expansion(child):
+            if child.type == "command" and _bash_call_in_command_allowed(child):
                 cmd_name_node = child.child_by_field_name("name")
                 if cmd_name_node is None and child.children:
                     cmd_name_node = child.children[0]

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2569,6 +2569,41 @@ def test_extract_bash_rejects_command_substitution_as_call(tmp_path):
     assert call_pairs == [], f"Command substitution erroneously emitted call edges: {call_pairs}"
 
 
+def test_extract_bash_command_substitution_in_assignment_emits_call(tmp_path):
+    """#2978: x=$(helper) inside a function must emit a calls edge to helper()."""
+    script = tmp_path / "a.sh"
+    script.write_text(
+        "#!/usr/bin/env bash\n"
+        "helper() { echo ok; }\n"
+        "bare()      { helper; }\n"
+        "subst()     { x=$(helper); echo \"$x\"; }\n"
+        "orlist()    { helper || return 1; }\n"
+        "andlist()   { true && helper; }\n"
+        "pipe()      { helper | cat; }\n"
+        "cond()      { if helper; then :; fi; }\n"
+        "loop()      { while helper; do break; done; }\n"
+        "redir()     { helper >/dev/null; }\n"
+        "neg()       { ! helper; }\n",
+        encoding="utf-8",
+    )
+    result = extract_bash(script)
+    labels = {n["id"]: n["label"] for n in result["nodes"]}
+    call_pairs = [
+        (labels.get(e["source"], e["source"]), labels.get(e["target"], e["target"]))
+        for e in result["edges"]
+        if e["relation"] == "calls"
+    ]
+    assert ("subst()", "helper()") in call_pairs
+    assert ("bare()", "helper()") in call_pairs
+    assert ("orlist()", "helper()") in call_pairs
+    assert ("andlist()", "helper()") in call_pairs
+    assert ("pipe()", "helper()") in call_pairs
+    assert ("cond()", "helper()") in call_pairs
+    assert ("loop()", "helper()") in call_pairs
+    assert ("redir()", "helper()") in call_pairs
+    assert ("neg()", "helper()") in call_pairs
+
+
 def test_extract_bash_process_substitution_not_recorded(tmp_path):
     """`<(helper)` (process substitution) must not be recorded as a call edge."""
     script = tmp_path / "process_substitution.sh"


### PR DESCRIPTION
## Problem

The bash extractor never emitted `calls` edges when a defined function was invoked inside command substitution, for example `x=$(helper)`. Value-returning helpers looked dead in the call graph. Other contexts (bare call, pipelines, conditionals) worked since #2141.

## Cause

`walk_calls` rejected every command inside `command_substitution` and `process_substitution` via `is_inside_expansion`, including assignment capture `x=$(helper)`.

## Fix

Replace the blanket expansion skip with context-aware rules:

- Process substitutions stay suppressed (`diff <(helper)` unchanged).
- Bare top-level `$(build)` stays suppressed (existing regression test).
- Commands inside `command_substitution` nested under `variable_assignment` now emit `calls` edges.

Argument-position substitution (`echo $(helper)`) is intentionally unchanged for this PR.

## Tests

- `tests/test_extract.py::test_extract_bash_command_substitution_in_assignment_emits_call`
- Existing rejection tests still pass:
  - `test_extract_bash_rejects_command_substitution_as_call`
  - `test_extract_bash_process_substitution_not_recorded`

```bash
pytest tests/test_extract.py -k bash -q
pytest tests/test_symbol_resolution.py -q
```

Fixes #2978
