### PR TITLE
fix(csharp): emit generic_arg references for field types

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -3687,18 +3687,12 @@ def _extract_generic(
                         type_node = child.child_by_field_name("type")
                         if type_node is not None:
                             break
-            type_info = _read_csharp_type_name(type_node, source)
-            if type_info:
-                type_name, qualified, qualifier = type_info
+            if type_node is not None:
                 csharp_type_params = _csharp_type_parameters_in_scope(
-                    type_node if type_node is not None else node, source
+                    type_node, source
                 )
-                if not type_name or type_name in csharp_type_params:
-                    return
-                # Record the field's declared type for the method-scoped
-                # receiver tables (#2299) — the C# twin of java_field_types.
-                # Pascal-case only: primitives never own a resolvable method.
-                if type_name[:1].isupper():
+                receiver_type = _csharp_receiver_type_name(type_node, source)
+                if receiver_type and receiver_type[:1].isupper() and receiver_type not in csharp_type_params:
                     fields = csharp_field_types.setdefault(parent_class_nid, {})
                     for child in node.children:
                         if child.type != "variable_declaration":
@@ -3712,15 +3706,23 @@ def _extract_generic(
                                 None,
                             )
                             if name_node is not None:
-                                fields[_read_text(name_node, source)] = type_name
+                                fields[_read_text(name_node, source)] = receiver_type
                 line = node.start_point[0] + 1
-                metadata = {"ref_token": type_name}
-                if qualified:
-                    metadata["qualified"] = True
-                if qualifier:
-                    metadata["ref_qualifier"] = qualifier
-                add_edge(parent_class_nid, ensure_named_node(type_name, line),
-                         "references", line, context="field", metadata=metadata)
+                refs: list[tuple[str, str, bool, str]] = []
+                _csharp_collect_type_refs(
+                    type_node, source, False, refs, csharp_type_params
+                )
+                for ref_name, role, qualified, qualifier in refs:
+                    ctx = "generic_arg" if role == "generic_arg" else "field"
+                    target_nid = ensure_named_node(ref_name, line)
+                    if target_nid != parent_class_nid:
+                        metadata = {"ref_token": ref_name}
+                        if qualified:
+                            metadata["qualified"] = True
+                        if qualifier:
+                            metadata["ref_qualifier"] = qualifier
+                        add_edge(parent_class_nid, target_nid, "references",
+                                 line, context=ctx, metadata=metadata)
             return
 
         if (config.ts_module == "tree_sitter_c_sharp"

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -442,6 +442,36 @@ def test_csharp_parameter_return_and_generic_contexts():
     assert ("Build", "DataProcessor") in _edge_labels(result, "references", "generic_arg")
 
 
+def test_csharp_field_generic_type_arguments_emit_references(tmp_path):
+    """#2911: Box<IAlpha> on a field must emit references[generic_arg] like properties."""
+    source = tmp_path / "FieldGeneric.cs"
+    source.write_text(
+        "public interface IAlpha { }\n"
+        "public class Box<T> { }\n"
+        "public class Probe\n"
+        "{\n"
+        "    private Box<IAlpha> _field = null!;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    result = extract_csharp(source)
+    assert ("Probe", "Box") in _edge_labels(result, "references", "field")
+    assert ("Probe", "IAlpha") in _edge_labels(result, "references", "generic_arg")
+
+
+def test_csharp_field_type_parameter_emits_no_reference(tmp_path):
+    source = tmp_path / "TypeParamField.cs"
+    source.write_text(
+        "public class Box<T>\n"
+        "{\n"
+        "    private T _value;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    result = extract_csharp(source)
+    assert ("Box", "T") not in _edge_labels(result, "references")
+
+
 def test_java_normalizes_inherits_and_implements():
     result = extract_java(FIXTURES / "sample.java")
     assert ("DataProcessor", "BaseProcessor") in _edge_labels(result, "inherits")


### PR DESCRIPTION
## Problem

C# generic type arguments on fields were dropped. `private Box<IAlpha> _field` emitted a `references[field]` edge to `Box` but not `references[generic_arg]` to `IAlpha`. The same type on a property already emitted both edges.

Call-site generic arguments (`r.Do<IEpsilon>()`) and DI registration (`AddScoped<IZeta, Box<IZeta>>()`) are unchanged in this PR and left for a follow up.

## Cause

The `field_declaration` handler used `_read_csharp_type_name`, which reads only the outermost type name. The `property_declaration` handler beside it already uses `_csharp_collect_type_refs` to recurse into generic arguments.

## Fix

Rewrite the C# `field_declaration` branch to mirror `property_declaration`:

- Walk types with `_csharp_collect_type_refs` and emit `field` / `generic_arg` edges.
- Keep `csharp_field_types` receiver registration via `_csharp_receiver_type_name` (#2299).
- Skip type parameters via the existing `skip` set so `T value` does not fabricate references.

## Tests

- `tests/test_languages.py::test_csharp_field_generic_type_arguments_emit_references`
- `tests/test_languages.py::test_csharp_field_type_parameter_emits_no_reference`

```bash
pytest tests/test_languages.py -k csharp -q
```

Fixes #2911 (field position only)
