### PR TITLE
fix(julia): extract abstract types declared with a supertype

### DIFF
--- a/graphify/extractors/julia.py
+++ b/graphify/extractors/julia.py
@@ -84,6 +84,26 @@ def extract_julia(path: Path) -> dict:
             })
         return nid
 
+    def _type_head_names(type_head) -> tuple[str | None, str | None]:
+        """Return (type_name, supertype_name) from a Julia `type_head`.
+
+        A bare declaration (`Foo`) exposes an `identifier`; a subtyping
+        declaration (`Foo <: Bar`) wraps both names in a `binary_expression`.
+        Both the struct and abstract-type paths need this, so parse it once.
+        """
+        bin_expr = next(
+            (c for c in type_head.children if c.type == "binary_expression"), None
+        )
+        if bin_expr:
+            identifiers = [c for c in bin_expr.children if c.type == "identifier"]
+            if identifiers:
+                name = _read_text(identifiers[0], source)
+                super_name = _read_text(identifiers[-1], source) if len(identifiers) >= 2 else None
+                return name, super_name
+            return None, None
+        name_node = next((c for c in type_head.children if c.type == "identifier"), None)
+        return (_read_text(name_node, source) if name_node else None), None
+
     def _func_name_from_signature(sig_node) -> str | None:
         """Extract function name from a Julia signature node (call_expression > identifier)."""
         for child in sig_node.children:
@@ -139,19 +159,7 @@ def extract_julia(path: Path) -> dict:
             type_head = next((c for c in node.children if c.type == "type_head"), None)
             if not type_head:
                 return
-            struct_name: str | None = None
-            super_name: str | None = None
-            bin_expr = next((c for c in type_head.children if c.type == "binary_expression"), None)
-            if bin_expr:
-                identifiers = [c for c in bin_expr.children if c.type == "identifier"]
-                if identifiers:
-                    struct_name = _read_text(identifiers[0], source)
-                    if len(identifiers) >= 2:
-                        super_name = _read_text(identifiers[-1], source)
-            else:
-                name_node = next((c for c in type_head.children if c.type == "identifier"), None)
-                if name_node:
-                    struct_name = _read_text(name_node, source)
+            struct_name, super_name = _type_head_names(type_head)
             if not struct_name:
                 return
             struct_nid = _make_id(stem, struct_name)
@@ -175,16 +183,22 @@ def extract_julia(path: Path) -> dict:
 
         # Abstract type
         if t == "abstract_definition":
-            # type_head > identifier
+            # type_head is a bare `identifier` (`abstract type Foo end`) or a
+            # `binary_expression` for the subtyping form (`abstract type Foo <: Bar end`).
+            # The latter was dropped entirely — abstract types are the backbone of
+            # Julia's dispatch hierarchies, so an intermediate `Foo <: Bar` vanishing
+            # broke the inheritance chain and lost the type node itself.
             type_head = next((c for c in node.children if c.type == "type_head"), None)
             if type_head:
-                name_node = next((c for c in type_head.children if c.type == "identifier"), None)
-                if name_node:
-                    abs_name = _read_text(name_node, source)
+                abs_name, super_name = _type_head_names(type_head)
+                if abs_name:
                     abs_nid = _make_id(stem, abs_name)
                     line = node.start_point[0] + 1
                     add_node(abs_nid, abs_name, line)
                     add_edge(scope_nid, abs_nid, "defines", line)
+                    if super_name:
+                        add_edge(abs_nid, ensure_named_node(super_name, line),
+                                 "inherits", line, confidence="EXTRACTED")
             return
 
         # Function: function foo(...) ... end

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1886,6 +1886,24 @@ def test_julia_abstract_concrete_hierarchy_inherits():
     assert ("Circle", "Shape") in _edge_labels(r, "inherits")
 
 
+def test_julia_abstract_type_with_supertype_is_extracted(tmp_path):
+    """`abstract type Dog <: Animal end` must yield a node and an inherits edge.
+
+    The abstract-type path only matched a bare `identifier` type_head, so the
+    subtyping form (a `binary_expression`) dropped the type entirely — losing an
+    intermediate node in the dispatch hierarchy and the inheritance edge with it.
+    """
+    f = tmp_path / "types.jl"
+    f.write_text(
+        "abstract type Animal end\n"
+        "abstract type Dog <: Animal end\n"
+    )
+    r = extract_julia(f)
+    assert "error" not in r
+    assert "Dog" in [n["label"] for n in r["nodes"]], "abstract subtype node dropped"
+    assert ("Dog", "Animal") in _edge_labels(r, "inherits"), "abstract inherits edge dropped"
+
+
 def test_julia_struct_field_type_context():
     r = extract_julia(FIXTURES / "sample.jl")
     assert ("Point", "Float64") in _edge_labels(r, "references", "field")


### PR DESCRIPTION
## Problem

`abstract type Foo <: Bar end` was dropped completely — no node, no `defines` edge, and no `inherits` edge. The abstract-type path only matched a bare `identifier` in the `type_head`, but the subtyping form wraps both names in a `binary_expression` (the exact shape the struct path already handles).

Abstract types anchor Julia's multiple-dispatch hierarchies, so an intermediate `Foo <: Bar` vanishing severed the inheritance chain and lost the type node itself. A concrete `struct Cat <: Animal` resolved its supertype fine; the abstract equivalent did not.

## Fix

Factor the shared `type_head` parsing (bare name vs. `<:` form) into one helper used by both the struct and abstract-type paths, and emit the `inherits` edge for abstract subtypes.

## Test

Adds a regression test for `abstract type Dog <: Animal end` asserting both the node and the `inherits` edge. The five pre-existing Julia hierarchy tests still pass, confirming the struct path is unchanged by the refactor. Fails before the change, passes after.