### PR TITLE
feat(merge): link a type declaration two repos share

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -2445,6 +2445,13 @@ def dispatch_command(cmd: str) -> None:
             if isinstance(hes, list):
                 collected_hyperedges.extend(h for h in hes if isinstance(h, dict))
             merged = _nx.compose(merged, prefixed)
+        # A contract type both repos declare arrives as two unconnected nodes,
+        # since every id is repo-prefixed. Link them so a traversal can cross
+        # the repo boundary (#3007).
+        from graphify.cross_repo_types import link_shared_type_declarations as _link_shared
+        shared_links = _link_shared(merged)
+        if shared_links:
+            print(f"  linked {shared_links} type declaration(s) shared across repos")
         # Drop whatever compose left behind (the last input's list, possibly
         # with internal duplicates) so attach_hyperedges dedups the full
         # collection by id from a clean slate.

--- a/graphify/cross_repo_types.py
+++ b/graphify/cross_repo_types.py
@@ -1,0 +1,75 @@
+"""Join the same declared type across repositories in a merged graph (#3007).
+
+`merge-graphs` prefixes every node id with its repo tag, so a contract type that
+two services both declare arrives as two unconnected nodes. In a message-bus
+codebase that is exactly where the interesting hop lives: the producer references
+`SyncProductUpsertToSearchEvent` in one repo, the consumer implements
+`IConsumer<SyncProductUpsertToSearchEvent>` in the other, and the merged graph has
+no way to get from one to the other even though both sides name the same type.
+
+This pass adds a `same_type_as` edge between type declarations that share both a
+namespace and a name and come from different repos. Requiring the namespace keeps
+it to types that were declared identically rather than two classes that merely
+picked the same short name: on a pair of .NET services with 1440 and 262 declared
+types, the namespace-plus-name match produced 7 pairs, all of them the shared
+`EventManager.Models.*Event` contracts, and nothing else.
+
+Edges only, no node merging. Two repos can hold copies of a contract that have
+drifted, and collapsing them would hide that; a link lets a traversal cross while
+each side keeps its own members, file and provenance.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import networkx as nx
+
+SHARED_TYPE_RELATION = "same_type_as"
+
+
+def link_shared_type_declarations(merged: "nx.Graph") -> int:
+    """Link identically declared types across repos. Returns the edge count added.
+
+    A candidate node is a sourced type declaration carrying a namespace and a
+    repo tag. A group qualifies when its members span at least two repos, and
+    every pair inside a qualifying group gets one edge. Groups are the handful of
+    types two repos genuinely share, so the pairwise walk stays small.
+    """
+    by_declaration: dict[tuple[str, str], list[str]] = defaultdict(list)
+    for node, data in merged.nodes(data=True):
+        if not data.get("_callable_class") or not data.get("source_file"):
+            continue
+        namespace = str((data.get("metadata") or {}).get("namespace") or "")
+        label = str(data.get("label") or "")
+        if not namespace or not label or not data.get("repo"):
+            continue
+        by_declaration[(namespace, label)].append(node)
+
+    added = 0
+    for (namespace, label), nodes in by_declaration.items():
+        if len(nodes) < 2:
+            continue
+        if len({merged.nodes[n].get("repo") for n in nodes}) < 2:
+            continue
+        for index, left in enumerate(nodes):
+            for right in nodes[index + 1:]:
+                if merged.nodes[left].get("repo") == merged.nodes[right].get("repo"):
+                    continue
+                if merged.has_edge(left, right):
+                    continue
+                merged.add_edge(
+                    left,
+                    right,
+                    relation=SHARED_TYPE_RELATION,
+                    context="cross_repo",
+                    confidence="INFERRED",
+                    confidence_score=0.9,
+                    source_file=str(merged.nodes[left].get("source_file") or ""),
+                    weight=1.0,
+                    _src=left,
+                    _tgt=right,
+                )
+                added += 1
+    return added

--- a/tests/test_cross_repo_shared_types.py
+++ b/tests/test_cross_repo_shared_types.py
@@ -1,0 +1,123 @@
+"""`merge-graphs` links a type declaration two repos share (#3007).
+
+Node ids are repo-prefixed, so a contract type both services declare arrives as
+two unconnected nodes and a traversal cannot cross the repo boundary even though
+both sides name the same type. The merge now adds a `same_type_as` edge between
+declarations that agree on namespace and name and come from different repos.
+
+Namespace agreement is what keeps this from linking two classes that merely
+picked the same short name, so the cases below pin both halves of that rule.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+PYTHON = sys.executable
+
+
+def _run(args, cwd):
+    return subprocess.run([PYTHON, "-m", "graphify"] + args, cwd=cwd,
+                          capture_output=True, text=True)
+
+
+def _type_node(node_id: str, label: str, namespace: str | None, source_file: str = "a.cs"):
+    node: dict = {
+        "id": node_id,
+        "label": label,
+        "source_file": source_file,
+        "_callable_class": True,
+        "_callable": True,
+    }
+    if namespace is not None:
+        node["metadata"] = {"namespace": namespace}
+    return node
+
+
+def _write(p: Path, nodes: list[dict]):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({
+        "directed": True, "multigraph": False, "graph": {},
+        "nodes": nodes, "links": [],
+    }))
+
+
+def _merge(tmp_path, left: list[dict], right: list[dict]):
+    a = tmp_path / "svc_a" / "graphify-out" / "graph.json"
+    b = tmp_path / "svc_b" / "graphify-out" / "graph.json"
+    _write(a, left)
+    _write(b, right)
+    out = tmp_path / "merged.json"
+    r = _run(["merge-graphs", str(a), str(b), "--out", str(out)], tmp_path)
+    assert r.returncode == 0, f"merge failed: {r.stderr}"
+    data = json.loads(out.read_text())
+    links = [e for e in data["links"] if e.get("relation") == "same_type_as"]
+    return links, data
+
+
+def test_same_namespace_and_name_across_repos_are_linked(tmp_path):
+    links, _ = _merge(
+        tmp_path,
+        [_type_node("evt", "OrderPlaced", "Contracts.Events")],
+        [_type_node("evt", "OrderPlaced", "Contracts.Events")],
+    )
+    assert len(links) == 1
+    endpoints = {links[0]["source"], links[0]["target"]}
+    assert endpoints == {"svc_a::evt", "svc_b::evt"}
+    assert links[0]["confidence"] == "INFERRED"
+
+
+def test_same_name_in_different_namespaces_is_not_linked(tmp_path):
+    # Two services with their own unrelated `Settings` class.
+    links, _ = _merge(
+        tmp_path,
+        [_type_node("s", "Settings", "Catalog.Configuration")],
+        [_type_node("s", "Settings", "Search.Configuration")],
+    )
+    assert links == []
+
+
+def test_two_declarations_inside_one_repo_are_not_linked(tmp_path):
+    # A partial class or a same-named type in two files of one repo is not a
+    # cross-repo join, and merging them is #296's question, not this one.
+    links, _ = _merge(
+        tmp_path,
+        [
+            _type_node("one", "OrderPlaced", "Contracts.Events", "one.cs"),
+            _type_node("two", "OrderPlaced", "Contracts.Events", "two.cs"),
+        ],
+        [_type_node("other", "Unrelated", "Contracts.Events")],
+    )
+    assert links == []
+
+
+def test_a_type_with_no_namespace_is_not_linked(tmp_path):
+    # Without a namespace the name alone is too weak to claim they are the same.
+    links, _ = _merge(
+        tmp_path,
+        [_type_node("evt", "OrderPlaced", None)],
+        [_type_node("evt", "OrderPlaced", None)],
+    )
+    assert links == []
+
+
+def test_non_type_nodes_are_not_linked(tmp_path):
+    method_a = {"id": "m", "label": ".Handle()", "source_file": "a.cs",
+                "metadata": {"namespace": "Contracts.Events"}}
+    method_b = dict(method_a)
+    links, _ = _merge(tmp_path, [method_a], [method_b])
+    assert links == []
+
+
+def test_sourceless_stub_is_not_linked(tmp_path):
+    # A stub minted for a dangling reference has no declaration behind it.
+    stub = {"id": "evt", "label": "OrderPlaced", "_callable_class": True,
+            "metadata": {"namespace": "Contracts.Events"}}
+    links, _ = _merge(
+        tmp_path,
+        [stub],
+        [_type_node("evt", "OrderPlaced", "Contracts.Events")],
+    )
+    assert links == []


### PR DESCRIPTION
Closes #3007.

`merge-graphs` prefixes every node id with its repo tag, so a contract type both repos declare arrives as two unconnected nodes:

```
p_CatalogService::...syncproductupserttosearchevent         <- the producing method references it
p_ElasticsearchService::...syncproductupserttosearchevent    <- ProductUpsertConsumer references it
```

Same namespace, same name, nothing between them, so a walk from the producer to the consumer finds no route and one flow reads as two unrelated halves.

The merge now adds an edge between sourced type declarations that agree on namespace and name and come from different repos:

```
p_CatalogService::...event  --same_type_as-->  p_ElasticsearchService::...event
```

Edges, not node merging. Two repos can hold copies of a contract that have drifted, and collapsing them would hide that, while a link lets the traversal cross with each side keeping its own members, file and provenance. That also keeps it clear of #296 and #207, which are about merging duplicates rather than relating them.

### Why namespace plus name

I expected to need something structural and measured first. Between two .NET services with 1440 and 262 sourced type declarations:

- 7 pairs agree on namespace and name
- all 7 are the shared contracts: `EventManager.Models.ClearCacheEvent`, `IndexCompletedEvent`, `PrepareElasticDataEvent`, `SyncPriceToSearchEvent`, `SyncProductDeleteToSearchEvent`, `SyncProductUpsertToSearchEvent`, `UpdateVariantElasticPublishedEvent`
- nothing else matches, so there is no false pair to weigh against them

Keying on the bare name is what makes this unsafe, and it fails at once: both services carry their own `Settings` and `Configuration`. The namespace is doing the work, and the test suite pins that.

### What it buys

On that pair the pass adds 7 edges and the producer to consumer walk becomes three hops:

```
.UpdateProductOnSearchAppAsync()  (CatalogService)
  -> SyncProductUpsertToSearchEvent  (CatalogService)
  -> SyncProductUpsertToSearchEvent  (ElasticsearchService)   [same_type_as]
  -> ProductUpsertConsumer           (ElasticsearchService)
```

The last hop is a reverse traversal, since the consumer references the event rather than the other way round, so this shows up on an undirected walk. That direction comes from `references` and is not something this pass changes.

The producer's first edge comes from #2997. Without that fix the CatalogService half of this walk does not exist, so the two are worth taking together, though neither depends on the other to build.

### Tests

`tests/test_cross_repo_shared_types.py`, 6 tests through the CLI the way `test_merge_graphs_cli.py` does: the cross-repo link itself, the same name in different namespaces staying unlinked, two declarations inside one repo staying unlinked, a type with no namespace staying unlinked, non-type nodes staying unlinked, and a sourceless stub staying unlinked.

```
$ uv run pytest tests/test_cross_repo_shared_types.py -q
6 passed

$ uv run pytest tests/test_merge_graphs_cli.py tests/test_global_graph.py tests/test_serve.py -q
170 passed
```

Full suite excluding `tests/test_skillgen.py`: 4822 passed, 1 failed. The failure is `test_labeling.py::test_label_communities_batches_when_over_batch_size`, which fails the same way on a clean `v8` checkout here (4816 passed, 1 failed) and passes on its own in both, so it is order dependent rather than mine. `test_skillgen.py` fails here on clean `v8` too, which is why it is out of that run. `ruff check` clean on the three files.

### Two things I would change on request

The pass runs unconditionally in `merge-graphs`. A `--no-shared-types` opt-out is easy to add if you would rather this be opt-in, the way `--no-dedup` works.

If the cluster graphs in #2134 land, the same pass belongs in `cluster build`. The two do not compete: cluster links model connections that need declaring, such as an API call with no shared symbol, and this derives the ones both repos already name.
