### PR TITLE
fix(hooks): keep installed hooks portable

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -10,12 +10,14 @@ _HOOK_MARKER_END = "# graphify-hook-end"
 _CHECKOUT_MARKER = "# graphify-checkout-hook-start"
 _CHECKOUT_MARKER_END = "# graphify-checkout-hook-end"
 
-# __PINNED_PYTHON__ is replaced at install time with the absolute path of the
-# Python interpreter that ran `graphify hook install`.  For uv-tool and pipx
-# installs the interpreter lives inside an isolated venv, so the launcher on
-# PATH is the only entry point — and GUI git clients / CI runners often have a
-# minimal PATH that omits ~/.local/bin.  Pinning sys.executable at install time
-# makes the hook work regardless of PATH at git-trigger time.
+# The Python interpreter running `graphify hook install` is recorded in the
+# gitignored graphify-out/.graphify_python sidecar rather than baked into the
+# hook script itself, so tracked .githooks files stay portable across machines.
+# For uv-tool and pipx installs the interpreter lives inside an isolated venv,
+# so the launcher on PATH is the only entry point — and GUI git clients / CI
+# runners often have a minimal PATH that omits ~/.local/bin. Recording the local
+# interpreter in graphify-out/.graphify_python makes the hook work regardless
+# of PATH at git-trigger time.
 _PYTHON_DETECT = """\
 # Detect the correct Python interpreter (handles uv tool, pipx, venv, system installs).
 # _PINNED was recorded at hook-install time; tried first so the hook works even
@@ -30,14 +32,18 @@ _PYTHON_DETECT = """\
 # fails loudly in the log if the package is broken under that interpreter.
 _GFY_PROBE="import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
 GRAPHIFY_PYTHON=""
-_PINNED='__PINNED_PYTHON__'
+_PINNED=''
 if [ -n "$_PINNED" ] && [ -x "$_PINNED" ] && "$_PINNED" -c "$_GFY_PROBE" 2>/dev/null; then
     GRAPHIFY_PYTHON="$_PINNED"
 fi
-# Second probe: read graphify-out/.graphify_python (written by the skill and
-# CLI; survives uv-tool reinstalls and is the same source the README documents).
+# Second probe: read ${GRAPHIFY_OUT:-graphify-out}/.graphify_python (written by the skill,
+# CLI, and hook install; survives uv-tool reinstalls and is machine-local).
 if [ -z "$GRAPHIFY_PYTHON" ]; then
-    _GFY_PYTHON_FILE="graphify-out/.graphify_python"
+    _GFY_OUT_DIR="${GRAPHIFY_OUT:-graphify-out}"
+    _GFY_PYTHON_FILE="${_GFY_OUT_DIR}/.graphify_python"
+    if [ ! -f "$_GFY_PYTHON_FILE" ] && [ -f "graphify-out/.graphify_python" ]; then
+        _GFY_PYTHON_FILE="graphify-out/.graphify_python"
+    fi
     if [ -f "$_GFY_PYTHON_FILE" ]; then
         _FROM_FILE=$(cat "$_GFY_PYTHON_FILE" 2>/dev/null | tr -d '[:space:]')
         case "$_FROM_FILE" in
@@ -356,7 +362,7 @@ if [ "$BRANCH_SWITCH" != "1" ]; then
 fi
 
 # A no-op checkout (e.g. `git checkout -b` with no start point) reports a
-# branch switch but leaves the tree unchanged ΓÇö nothing to rebuild (#2421).
+# branch switch but leaves the tree unchanged — nothing to rebuild (#2421).
 [ "$PREV_HEAD" = "$NEW_HEAD" ] && exit 0
 
 # Only run if graphify-out/ exists (graph has been built before)
@@ -582,8 +588,7 @@ def _merge_attr_line() -> str:
     absolute output-dir override cannot be expressed there — fall back to the
     default name in that case.
     """
-    from graphify.paths import GRAPHIFY_OUT
-    out = GRAPHIFY_OUT
+    out = os.environ.get("GRAPHIFY_OUT", "graphify-out")
     if not out or Path(out).is_absolute() or "\\" in out:
         out = "graphify-out"
     return f"{out.rstrip('/')}/graph.json merge=graphify"
@@ -734,8 +739,16 @@ def install(path: Path = Path(".")) -> str:
         viz_export = ""
 
     pinned = _pinned_python()
-    hook = _HOOK_SCRIPT.replace("__PINNED_PYTHON__", pinned).replace("__VIZ_LIMIT_EXPORT__", viz_export)
-    checkout = _CHECKOUT_SCRIPT.replace("__PINNED_PYTHON__", pinned).replace("__VIZ_LIMIT_EXPORT__", viz_export)
+    if pinned:
+        out_name = os.environ.get("GRAPHIFY_OUT", "graphify-out")
+        if not out_name or Path(out_name).is_absolute() or "\\" in out_name:
+            out_name = "graphify-out"
+        py_file = root / out_name / ".graphify_python"
+        py_file.parent.mkdir(parents=True, exist_ok=True)
+        py_file.write_text(pinned, encoding="utf-8")
+
+    hook = _HOOK_SCRIPT.replace("__VIZ_LIMIT_EXPORT__", viz_export)
+    checkout = _CHECKOUT_SCRIPT.replace("__VIZ_LIMIT_EXPORT__", viz_export)
 
     commit_msg = _install_hook(hooks_dir, "post-commit", hook, _HOOK_MARKER, _HOOK_MARKER_END)
     checkout_msg = _install_hook(hooks_dir, "post-checkout", checkout, _CHECKOUT_MARKER, _CHECKOUT_MARKER_END)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -81,7 +81,8 @@ def test_status_not_installed(tmp_path):
     assert "not installed" in result
 
 
-def test_no_git_repo_raises(tmp_path):
+def test_no_git_repo_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr("graphify.hooks._git_root", lambda p: None)
     with pytest.raises(RuntimeError, match="No git repository"):
         install(tmp_path / "not_a_repo")
 
@@ -162,30 +163,32 @@ def test_hook_skips_head_on_exe():
     assert "*.exe) _SHEBANG=" in _PYTHON_DETECT or '*.exe)' in _PYTHON_DETECT
 
 
-def test_install_embeds_pinned_interpreter(tmp_path):
-    """Hook scripts must embed sys.executable so the hook works without the
-    graphify launcher on PATH (uv tool / pipx isolation, #1127).
+def test_install_records_interpreter_in_sidecar(tmp_path):
+    """Hook scripts must record sys.executable in graphify-out/.graphify_python
+    rather than baking it into tracked hook files (#2989, #1127).
 
     When graphify is installed via `uv tool install graphifyy` or `pipx install
     graphifyy`, the interpreter lives in an isolated venv and the launcher is in
-    ~/.local/bin.  GUI git clients and CI runners often run with a minimal PATH
-    that omits that directory, so `command -v graphify` fails, the python3/python
-    fallbacks cannot import graphify (wrong venv), and the hook silently exits 0.
-    Pinning sys.executable at install time makes the hook work regardless of PATH.
+    ~/.local/bin. GUI git clients and CI runners often run with a minimal PATH
+    that omits that directory. Recording the interpreter in the local gitignored
+    .graphify_python file allows Probe 2 to resolve it without churning tracked
+    hook files with machine-specific absolute paths.
     """
     import re, sys
     repo = _make_git_repo(tmp_path)
     install(repo)
-    commit_hook = (repo / ".git" / "hooks" / "post-commit").read_text()
-    checkout_hook = (repo / ".git" / "hooks" / "post-checkout").read_text()
-    # Compute the sanitized value the same way install() does.
-    expected = sys.executable if not re.search(r"[^a-zA-Z0-9/_.@:\\-]", sys.executable) else ""
+    commit_hook = (repo / ".git" / "hooks" / "post-commit").read_text(encoding="utf-8")
+    checkout_hook = (repo / ".git" / "hooks" / "post-checkout").read_text(encoding="utf-8")
+    expected = sys.executable if not re.search(r"[^a-zA-Z0-9/_.@: \\-]", sys.executable) else ""
     if expected:
-        assert expected in commit_hook, "sanitized sys.executable missing from post-commit"
-        assert expected in checkout_hook, "sanitized sys.executable missing from post-checkout"
-    # The placeholder must be fully substituted -- no __PINNED_PYTHON__ left.
-    assert "__PINNED_PYTHON__" not in commit_hook, "placeholder not substituted in post-commit"
-    assert "__PINNED_PYTHON__" not in checkout_hook, "placeholder not substituted in post-checkout"
+        py_file = repo / "graphify-out" / ".graphify_python"
+        assert py_file.exists(), "graphify-out/.graphify_python must be created by hook install"
+        assert py_file.read_text(encoding="utf-8") == expected, "recorded interpreter mismatch"
+        # The machine-specific absolute interpreter path must NOT be in the hook files:
+        assert expected not in commit_hook, "machine-specific interpreter leaked into post-commit"
+        assert expected not in checkout_hook, "machine-specific interpreter leaked into post-checkout"
+    assert "_PINNED=''" in commit_hook, "_PINNED must be empty in post-commit"
+    assert "_PINNED=''" in checkout_hook, "_PINNED must be empty in post-checkout"
 
 
 def test_install_fallback_is_loud_not_silent(tmp_path):
@@ -851,7 +854,7 @@ def test_merge_driver_quotes_interpreter_with_spaces(tmp_path, monkeypatch):
 
 
 def test_install_pins_interpreter_path_with_spaces(tmp_path, monkeypatch):
-    """#2166 end to end: the emitted hooks must carry the real interpreter, not ''."""
+    """#2166 / #2989: an interpreter path with spaces must be recorded in the sidecar."""
     import sys as _sys
 
     from graphify.hooks import install
@@ -861,10 +864,79 @@ def test_install_pins_interpreter_path_with_spaces(tmp_path, monkeypatch):
     monkeypatch.setattr(_sys, "executable", exe)
     install(repo)
 
+    py_file = repo / "graphify-out" / ".graphify_python"
+    assert py_file.exists()
+    assert py_file.read_text(encoding="utf-8") == exe
+
     for name in ("post-commit", "post-checkout"):
-        script = (repo / ".git" / "hooks" / name).read_text()
-        assert f"_PINNED='{exe}'" in script, f"{name} did not pin the spaced interpreter"
-        assert "_PINNED=''" not in script, f"{name} pinned an empty interpreter (#2166)"
+        script = (repo / ".git" / "hooks" / name).read_text(encoding="utf-8")
+        assert exe not in script, f"{name} must not contain machine-specific path"
+        assert "_PINNED=''" in script
+
+
+def test_hook_install_no_machine_specific_path_in_tracked_output(tmp_path, monkeypatch):
+    """#2989 Invariant 1: Simulated interpreter paths must never be baked into tracked hooks."""
+    import sys as _sys
+
+    from graphify.hooks import install
+
+    simulated_exes = [
+        "/Users/alice/.local/pipx/venvs/graphify/bin/python",
+        r"C:\Users\Bob\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe",
+    ]
+    for exe in simulated_exes:
+        repo = _make_git_repo(tmp_path / f"repo_{abs(hash(exe))}")
+        monkeypatch.setattr(_sys, "executable", exe)
+        install(repo)
+        for name in ("post-commit", "post-checkout"):
+            hook_text = (repo / ".git" / "hooks" / name).read_text(encoding="utf-8")
+            assert exe not in hook_text, f"{name} leaked machine-specific interpreter path {exe}"
+
+
+def test_hook_install_populates_local_interpreter_state(tmp_path, monkeypatch):
+    """#2989 Invariant 2: graphify-out/.graphify_python is populated and remains local."""
+    import sys as _sys
+
+    from graphify.hooks import install
+
+    exe = "/custom/isolated/venv/bin/python"
+    repo = _make_git_repo(tmp_path)
+    monkeypatch.setattr(_sys, "executable", exe)
+    install(repo)
+
+    py_file = repo / "graphify-out" / ".graphify_python"
+    assert py_file.exists()
+    assert py_file.read_text(encoding="utf-8") == exe
+
+
+def test_different_machines_do_not_churn_tracked_hooks(tmp_path, monkeypatch):
+    """#2989 Invariant 3: Different machine interpreters produce byte-identical hook scripts."""
+    import sys as _sys
+
+    from graphify.hooks import install
+
+    repo_a = _make_git_repo(tmp_path / "repo_a")
+    monkeypatch.setattr(_sys, "executable", "/machine/a/venv/bin/python")
+    install(repo_a)
+
+    repo_b = _make_git_repo(tmp_path / "repo_b")
+    monkeypatch.setattr(_sys, "executable", r"C:\machine\b\uv\Scripts\python.exe")
+    install(repo_b)
+
+    for name in ("post-commit", "post-checkout"):
+        script_a = (repo_a / ".git" / "hooks" / name).read_bytes()
+        script_b = (repo_b / ".git" / "hooks" / name).read_bytes()
+        assert script_a == script_b, f"{name} differed across machines with different interpreter paths"
+
+
+def test_checkout_script_contains_unicode_em_dash():
+    """#2989 Invariant 4: _CHECKOUT_SCRIPT must contain U+2014 em-dash and no mojibake."""
+    from graphify.hooks import _CHECKOUT_SCRIPT
+
+    assert "—" in _CHECKOUT_SCRIPT, "_CHECKOUT_SCRIPT must contain unicode em-dash (—)"
+    assert "\u2014" in _CHECKOUT_SCRIPT, "U+2014 em-dash missing from _CHECKOUT_SCRIPT"
+    assert "ΓÇö" not in _CHECKOUT_SCRIPT, "mojibake ΓÇö found in _CHECKOUT_SCRIPT"
+    assert "\u0393\u00c7\u00f6" not in _CHECKOUT_SCRIPT, "mojibake code points found in _CHECKOUT_SCRIPT"
 
 
 def test_graphifyrc_parsing(tmp_path):
@@ -1002,3 +1074,77 @@ def test_both_hooks_configured(tmp_path):
     for name in ("post-commit", "post-checkout"):
         hook_text = (repo / ".git" / "hooks" / name).read_text()
         assert 'export GRAPHIFY_VIZ_NODE_LIMIT="${GRAPHIFY_VIZ_NODE_LIMIT:-42}"' in hook_text
+
+
+def test_install_custom_relative_graphify_out(tmp_path, monkeypatch):
+    """#2989: install() and _PYTHON_DETECT must consistently use custom relative GRAPHIFY_OUT."""
+    import sys as _sys
+
+    from graphify.hooks import install, _PYTHON_DETECT
+
+    custom_out = "my-custom-graphify-out"
+    monkeypatch.setenv("GRAPHIFY_OUT", custom_out)
+    exe = "/custom/env/bin/python"
+    monkeypatch.setattr(_sys, "executable", exe)
+
+    repo = _make_git_repo(tmp_path)
+    install(repo)
+
+    sidecar = repo / custom_out / ".graphify_python"
+    assert sidecar.exists(), f"{custom_out}/.graphify_python must be written by install()"
+    assert sidecar.read_text(encoding="utf-8") == exe
+
+    for name in ("post-commit", "post-checkout"):
+        script = (repo / ".git" / "hooks" / name).read_text(encoding="utf-8")
+        assert exe not in script, f"{name} must not contain machine-specific path"
+        assert "_PINNED=''" in script
+
+    # Verify template contains GRAPHIFY_OUT probe logic
+    assert '${GRAPHIFY_OUT:-graphify-out}/.graphify_python' in _PYTHON_DETECT or '_GFY_OUT_DIR="${GRAPHIFY_OUT:-graphify-out}"' in _PYTHON_DETECT
+
+
+def test_python_detect_runtime_probe_custom_graphify_out(tmp_path, monkeypatch):
+    """#2989: Test the shell probe logic when GRAPHIFY_OUT is set."""
+    import sys as _sys
+    from graphify.hooks import _PYTHON_DETECT
+
+    repo = _make_git_repo(tmp_path)
+    custom_dir = repo / "custom-graph"
+    custom_dir.mkdir(parents=True)
+    (custom_dir / ".graphify_python").write_text(_sys.executable, encoding="utf-8")
+
+    # Run the probe under sh with GRAPHIFY_OUT set
+    test_sh = f"""
+    cd "{repo.as_posix()}"
+    export GRAPHIFY_OUT="custom-graph"
+    {_PYTHON_DETECT}
+    echo "RESOLVED=$GRAPHIFY_PYTHON"
+    """
+    res = subprocess.run(["sh", "-c", test_sh], capture_output=True, text=True)
+    if res.returncode == 0 and "RESOLVED=" in res.stdout:
+        resolved = res.stdout.split("RESOLVED=")[1].strip()
+        assert resolved != "", "GRAPHIFY_PYTHON must not be empty"
+        assert "python" in resolved.lower()
+
+
+def test_python_detect_runtime_fallback_to_default_graphify_out(tmp_path):
+    """#2989: Probe falls back to graphify-out/.graphify_python if custom GRAPHIFY_OUT is missing."""
+    import sys as _sys
+    from graphify.hooks import _PYTHON_DETECT
+
+    repo = _make_git_repo(tmp_path)
+    default_dir = repo / "graphify-out"
+    default_dir.mkdir(parents=True)
+    (default_dir / ".graphify_python").write_text(_sys.executable, encoding="utf-8")
+
+    test_sh = f"""
+    cd "{repo.as_posix()}"
+    export GRAPHIFY_OUT="nonexistent-custom-dir"
+    {_PYTHON_DETECT}
+    echo "RESOLVED=$GRAPHIFY_PYTHON"
+    """
+    res = subprocess.run(["sh", "-c", test_sh], capture_output=True, text=True)
+    if res.returncode == 0 and "RESOLVED=" in res.stdout:
+        resolved = res.stdout.split("RESOLVED=")[1].strip()
+        assert resolved != "", "GRAPHIFY_PYTHON must not be empty"
+        assert "python" in resolved.lower()


### PR DESCRIPTION
## Summary

Fixes #2989.

`graphify hook install` was embedding the absolute path of the Python
interpreter used to run the command directly into the tracked
`.githooks/post-commit` and `.githooks/post-checkout` files.

For example, installing Graphify on two different machines could produce:

```diff
-_PINNED='/Users/alice/.local/pipx/venvs/graphify/bin/python'
+_PINNED='C:\Users\Bob\AppData\Roaming\uv\tools\graphify\Scripts\python.exe'
````

Because these hook files are tracked, running `hook install` on different
machines could continuously rewrite the same tracked files and introduce
unnecessary churn or conflicts.

This change moves the machine-specific interpreter path into the existing
gitignored `graphify-out/.graphify_python` sidecar while keeping the tracked
hook templates portable.

## What changed

### 1. Keep interpreter paths out of tracked hooks

The hook templates no longer receive the installing machine's
`sys.executable` as `_PINNED`.

Instead, `graphify hook install` records the sanitized interpreter path in:

```text
graphify-out/.graphify_python
```

The existing runtime interpreter detection then uses this local sidecar before
falling back to launcher/PATH discovery.

`_pinned_python()` itself is retained because it is also used when configuring
the local `graphify` merge driver.

### 2. Respect `GRAPHIFY_OUT`

The sidecar location now follows the configured `GRAPHIFY_OUT` directory.

For example:

```text
GRAPHIFY_OUT=my-graphify-out
```

results in:

```text
my-graphify-out/.graphify_python
```

Runtime hook detection uses the same configured location and retains a fallback
to the default:

```text
graphify-out/.graphify_python
```

This keeps existing repositories compatible while allowing custom output
directories.

### 3. Fix corrupted post-checkout template text

The post-checkout template contained:

```text
ΓÇö
```

instead of the intended Unicode em dash:

```text
—
```

Investigation showed that this was already present in the committed
`graphify/hooks.py` source and was introduced by commit `5c88af7`. The existing
hook writer already uses explicit UTF-8 encoding, so no encoding changes were
needed in `_install_hook()`.

The source/template text has been corrected and regression coverage added.

## Why this approach

The original `_PINNED` mechanism was introduced to support installations such
as uv/pipx where Graphify may live inside an isolated environment and the
Graphify launcher may not be available on the PATH used by GUI Git clients or
CI.

Removing the mechanism entirely could therefore regress those environments.

Instead, the interpreter path remains available at runtime through the
gitignored per-checkout sidecar, while the tracked hook remains
machine-independent.

The resulting flow is:

```text
graphify hook install
        |
        +--> graphify-out/.graphify_python
        |        (machine-local, gitignored)
        |
        +--> tracked .githooks/*
                 (machine-independent)
                         |
                         v
                  runtime detection
                         |
              sidecar -> launcher -> PATH
```

## Regression coverage

Added/updated tests cover:

* machine-specific interpreter paths are not written into generated hooks
* installations using different interpreter paths produce identical tracked
  hook contents
* `graphify-out/.graphify_python` is populated during hook installation
* interpreter paths containing spaces are handled correctly
* custom `GRAPHIFY_OUT` directories work
* runtime detection reads the custom sidecar
* runtime detection falls back to the default `graphify-out` sidecar
* the post-checkout template contains U+2014 rather than `ΓÇö`

## Validation

```text
uv run pytest tests/test_hooks.py -v
98 passed

uv run pytest tests/ -k "not test_benchmarks and not test_live" --maxfail=5
2288 passed, 30 skipped, 4 warnings

git diff --check
clean
```

## Scope

The changes are limited to:

* `graphify/hooks.py`
* `tests/test_hooks.py`

No changes were made to the existing UTF-8 file-writing behavior of
`_install_hook()`.

