### PR TITLE
feat(csharp): emit a node per property

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -3687,30 +3687,6 @@ def _extract_generic(
                         type_node = child.child_by_field_name("type")
                         if type_node is not None:
                             break
-            # Emit a node per declared member, the way the C++ field branch does.
-            # Runs before the type checks below so a member keeps its node even
-            # when its type is a generic parameter or a primitive: the node is
-            # the class's state, independent of what that state is typed as.
-            for child in node.children:
-                if child.type != "variable_declaration":
-                    continue
-                for declarator in child.children:
-                    if declarator.type != "variable_declarator":
-                        continue
-                    member_name_node = declarator.child_by_field_name("name") or next(
-                        (g for g in declarator.children if g.type == "identifier"),
-                        None,
-                    )
-                    if member_name_node is None:
-                        continue
-                    member_name = _read_text(member_name_node, source)
-                    if not member_name:
-                        continue
-                    member_line = declarator.start_point[0] + 1
-                    member_nid = _make_id(parent_class_nid, member_name)
-                    add_node(member_nid, member_name, member_line)
-                    add_edge(parent_class_nid, member_nid, "defines",
-                             member_line, context="field")
             type_info = _read_csharp_type_name(type_node, source)
             if type_info:
                 type_name, qualified, qualifier = type_info
@@ -3758,15 +3734,22 @@ def _extract_generic(
             # field. Use _csharp_collect_type_refs (like the Java/PHP/Kotlin
             # siblings) so `List<Widget>` yields both the List field ref and the
             # Widget generic_arg ref.
+            # A property becomes a node, the way a C++ data member does. Fields
+            # stay out: the id recipe casefolds and strips leading underscores, so
+            # `_count` and `Count` normalize to the same id, and emitting both
+            # would hand the node to whichever the parser reached first — in
+            # practice the private backing field, hiding the public member behind
+            # it. See #3006 for the follow-up.
             prop_node_name = node.child_by_field_name("name")
             if prop_node_name is not None:
                 property_name = _read_text(prop_node_name, source)
                 if property_name:
                     property_line = node.start_point[0] + 1
                     property_nid = _make_id(parent_class_nid, property_name)
-                    add_node(property_nid, property_name, property_line)
-                    add_edge(parent_class_nid, property_nid, "defines",
-                             property_line, context="field")
+                    if property_nid not in seen_ids:
+                        add_node(property_nid, property_name, property_line)
+                        add_edge(parent_class_nid, property_nid, "defines",
+                                 property_line, context="field")
             type_node = node.child_by_field_name("type")
             if type_node is not None:
                 # Record the property's declared type for the method-scoped

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -3687,6 +3687,30 @@ def _extract_generic(
                         type_node = child.child_by_field_name("type")
                         if type_node is not None:
                             break
+            # Emit a node per declared member, the way the C++ field branch does.
+            # Runs before the type checks below so a member keeps its node even
+            # when its type is a generic parameter or a primitive: the node is
+            # the class's state, independent of what that state is typed as.
+            for child in node.children:
+                if child.type != "variable_declaration":
+                    continue
+                for declarator in child.children:
+                    if declarator.type != "variable_declarator":
+                        continue
+                    member_name_node = declarator.child_by_field_name("name") or next(
+                        (g for g in declarator.children if g.type == "identifier"),
+                        None,
+                    )
+                    if member_name_node is None:
+                        continue
+                    member_name = _read_text(member_name_node, source)
+                    if not member_name:
+                        continue
+                    member_line = declarator.start_point[0] + 1
+                    member_nid = _make_id(parent_class_nid, member_name)
+                    add_node(member_nid, member_name, member_line)
+                    add_edge(parent_class_nid, member_nid, "defines",
+                             member_line, context="field")
             type_info = _read_csharp_type_name(type_node, source)
             if type_info:
                 type_name, qualified, qualifier = type_info
@@ -3734,6 +3758,15 @@ def _extract_generic(
             # field. Use _csharp_collect_type_refs (like the Java/PHP/Kotlin
             # siblings) so `List<Widget>` yields both the List field ref and the
             # Widget generic_arg ref.
+            prop_node_name = node.child_by_field_name("name")
+            if prop_node_name is not None:
+                property_name = _read_text(prop_node_name, source)
+                if property_name:
+                    property_line = node.start_point[0] + 1
+                    property_nid = _make_id(parent_class_nid, property_name)
+                    add_node(property_nid, property_name, property_line)
+                    add_edge(parent_class_nid, property_nid, "defines",
+                             property_line, context="field")
             type_node = node.child_by_field_name("type")
             if type_node is not None:
                 # Record the property's declared type for the method-scoped

--- a/tests/test_csharp_member_nodes.py
+++ b/tests/test_csharp_member_nodes.py
@@ -1,14 +1,16 @@
-"""C# fields and properties get a node, like C++ data members (#3006).
+"""C# properties get a node, like C++ data members (#3006).
 
 `_CSHARP_CONFIG` emitted a `references` edge to a member's *type* and no node for
 the member, so C# was the only language with a class-shaped type layer whose
-state was absent from the graph. C++ has emitted a node per data member with a
-`defines` edge for a while, #2971 is adding the same for C structs, and Swift
-computed properties became nodes in #2220. This brings C# to that line.
+state was absent from the graph. C++ emits a node per data member with `defines`,
+#2971 is adding the same for C structs, and #2220 gave Swift computed properties
+nodes. This brings C# to that line.
 
-The node is the class's state, so it does not depend on what that state is typed
-as: a primitive and a generic parameter both leave a member behind, even though
-neither produces a type reference.
+Properties only, not fields. `ids.normalize_id` casefolds and strips leading
+underscores, so `_count` and `Count` are the same id: emitting both would hand
+the node to whichever the parser reached first, which is the private backing
+field, hiding the public member behind it. In C# the property is the state's
+public identity, so it is the half worth having first.
 """
 from __future__ import annotations
 
@@ -51,64 +53,71 @@ def test_auto_property_becomes_a_member_node(tmp_path):
     assert (_find(r, "Variant"), _find(r, "IsShowCategory")) in defines
 
 
-def test_field_becomes_a_member_node(tmp_path):
+def test_every_property_on_a_class_gets_its_own_node(tmp_path):
     defines, r = _extract(tmp_path, {"S.cs": (
         "public class Variant {\n"
-        "    private Widget _widget;\n"
-        "}\n"
-        "public class Widget { }\n"
-    )})
-    assert (_find(r, "Variant"), _find(r, "_widget")) in defines
-
-
-def test_one_declaration_with_several_names_leaves_one_node_each(tmp_path):
-    defines, r = _extract(tmp_path, {"S.cs": (
-        "public class Point {\n"
-        "    private int x, y;\n"
+        "    public bool IsShowCategory { get; set; }\n"
+        "    public bool ShowOnWeb { get; set; }\n"
         "}\n"
     )})
-    point = _find(r, "Point")
-    assert (point, _find(r, "x")) in defines
-    assert (point, _find(r, "y")) in defines
+    variant = _find(r, "Variant")
+    assert (variant, _find(r, "IsShowCategory")) in defines
+    assert (variant, _find(r, "ShowOnWeb")) in defines
 
 
-def test_a_primitive_member_still_gets_a_node(tmp_path):
-    # `int` produces no member-worthy type reference, and the member is still
+def test_a_primitive_property_still_gets_a_node(tmp_path):
+    # `int` produces no member-worthy type reference, and the property is still
     # part of the class's state.
     defines, r = _extract(tmp_path, {"S.cs": (
         "public class Counter {\n"
-        "    private int _count;\n"
-        "    public string Name { get; set; }\n"
+        "    public int Count { get; set; }\n"
         "}\n"
     )})
-    counter = _find(r, "Counter")
-    assert (counter, _find(r, "_count")) in defines
-    assert (counter, _find(r, "Name")) in defines
+    assert (_find(r, "Counter"), _find(r, "Count")) in defines
 
 
-def test_a_generic_parameter_typed_member_still_gets_a_node(tmp_path):
+def test_a_generic_parameter_typed_property_still_gets_a_node(tmp_path):
     # The type-reference path returns early for a type parameter, which is right
     # for a reference and wrong for the member itself.
     defines, r = _extract(tmp_path, {"S.cs": (
         "public class Box<T> {\n"
-        "    private T _value;\n"
+        "    public T Value { get; set; }\n"
         "}\n"
     )})
-    assert (_find(r, "Box"), _find(r, "_value")) in defines
+    assert (_find(r, "Box"), _find(r, "Value")) in defines
 
 
-def test_a_const_member_gets_a_node(tmp_path):
+def test_a_backing_field_does_not_take_the_property_node(tmp_path):
+    # `_count` and `Count` normalize to one id. The public member is the one to
+    # keep, and there is exactly one edge rather than two onto a shared node.
     defines, r = _extract(tmp_path, {"S.cs": (
-        "public class Limits {\n"
-        "    public const int Max = 100;\n"
+        "public class Counter {\n"
+        "    private int _count;\n"
+        "    public int Count { get; set; }\n"
         "}\n"
     )})
-    assert (_find(r, "Limits"), _find(r, "Max")) in defines
+    assert (_find(r, "Counter"), _find(r, "Count")) in defines
+    assert len(defines) == 1
+    assert "_count" not in _labels(r)
 
 
-def test_member_type_references_are_kept(tmp_path):
+def test_a_field_alone_makes_no_member_node_but_keeps_its_type_reference(tmp_path):
+    # Fields are out for now, and the reference to a field's type is untouched.
+    defines, r = _extract(tmp_path, {"S.cs": (
+        "public class Runner {\n"
+        "    private readonly Worker _worker;\n"
+        "}\n"
+        "public class Worker { }\n"
+    )})
+    assert defines == set()
+    references = {(e["source"], e["target"], e.get("context")) for e in r["edges"]
+                  if e["relation"] == "references"}
+    assert (_find(r, "Runner"), _find(r, "Worker"), "field") in references
+
+
+def test_property_type_references_are_kept(tmp_path):
     # Regression guard for #1591: the member node is additive, the reference to
-    # the member's type stays.
+    # the property's type stays.
     _, r = _extract(tmp_path, {"S.cs": (
         "public class Holder {\n"
         "    public Widget Main { get; set; }\n"
@@ -134,3 +143,15 @@ def test_methods_are_still_methods(tmp_path):
     assert (variant, _find(r, "Flag")) in defines
     assert (variant, _find(r, ".Touch()")) in methods
     assert (variant, _find(r, ".Touch()")) not in defines
+
+
+def test_case_only_sibling_properties_do_not_duplicate_an_edge(tmp_path):
+    # Legal C#, and one id after normalization. One node, one edge, rather than a
+    # second edge hung on the first property's node.
+    defines, r = _extract(tmp_path, {"S.cs": (
+        "public class Odd {\n"
+        "    public int Count { get; set; }\n"
+        "    public int count { get; set; }\n"
+        "}\n"
+    )})
+    assert len(defines) == 1

--- a/tests/test_csharp_member_nodes.py
+++ b/tests/test_csharp_member_nodes.py
@@ -1,0 +1,136 @@
+"""C# fields and properties get a node, like C++ data members (#3006).
+
+`_CSHARP_CONFIG` emitted a `references` edge to a member's *type* and no node for
+the member, so C# was the only language with a class-shaped type layer whose
+state was absent from the graph. C++ has emitted a node per data member with a
+`defines` edge for a while, #2971 is adding the same for C structs, and Swift
+computed properties became nodes in #2220. This brings C# to that line.
+
+The node is the class's state, so it does not depend on what that state is typed
+as: a primitive and a generic parameter both leave a member behind, even though
+neither produces a type reference.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from graphify.extract import extract
+
+
+def _extract(tmp_path, files: dict[str, str]):
+    for name, body in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+    old = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        r = extract([Path(n) for n in files], cache_root=Path(tempfile.mkdtemp()))
+    finally:
+        os.chdir(old)
+    defines = {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "defines"}
+    return defines, r
+
+
+def _find(r, label):
+    return next(n["id"] for n in r["nodes"] if n["label"] == label)
+
+
+def _labels(r):
+    return [n["label"] for n in r["nodes"]]
+
+
+def test_auto_property_becomes_a_member_node(tmp_path):
+    defines, r = _extract(tmp_path, {"S.cs": (
+        "public class Variant {\n"
+        "    public bool IsShowCategory { get; set; }\n"
+        "}\n"
+    )})
+    assert (_find(r, "Variant"), _find(r, "IsShowCategory")) in defines
+
+
+def test_field_becomes_a_member_node(tmp_path):
+    defines, r = _extract(tmp_path, {"S.cs": (
+        "public class Variant {\n"
+        "    private Widget _widget;\n"
+        "}\n"
+        "public class Widget { }\n"
+    )})
+    assert (_find(r, "Variant"), _find(r, "_widget")) in defines
+
+
+def test_one_declaration_with_several_names_leaves_one_node_each(tmp_path):
+    defines, r = _extract(tmp_path, {"S.cs": (
+        "public class Point {\n"
+        "    private int x, y;\n"
+        "}\n"
+    )})
+    point = _find(r, "Point")
+    assert (point, _find(r, "x")) in defines
+    assert (point, _find(r, "y")) in defines
+
+
+def test_a_primitive_member_still_gets_a_node(tmp_path):
+    # `int` produces no member-worthy type reference, and the member is still
+    # part of the class's state.
+    defines, r = _extract(tmp_path, {"S.cs": (
+        "public class Counter {\n"
+        "    private int _count;\n"
+        "    public string Name { get; set; }\n"
+        "}\n"
+    )})
+    counter = _find(r, "Counter")
+    assert (counter, _find(r, "_count")) in defines
+    assert (counter, _find(r, "Name")) in defines
+
+
+def test_a_generic_parameter_typed_member_still_gets_a_node(tmp_path):
+    # The type-reference path returns early for a type parameter, which is right
+    # for a reference and wrong for the member itself.
+    defines, r = _extract(tmp_path, {"S.cs": (
+        "public class Box<T> {\n"
+        "    private T _value;\n"
+        "}\n"
+    )})
+    assert (_find(r, "Box"), _find(r, "_value")) in defines
+
+
+def test_a_const_member_gets_a_node(tmp_path):
+    defines, r = _extract(tmp_path, {"S.cs": (
+        "public class Limits {\n"
+        "    public const int Max = 100;\n"
+        "}\n"
+    )})
+    assert (_find(r, "Limits"), _find(r, "Max")) in defines
+
+
+def test_member_type_references_are_kept(tmp_path):
+    # Regression guard for #1591: the member node is additive, the reference to
+    # the member's type stays.
+    _, r = _extract(tmp_path, {"S.cs": (
+        "public class Holder {\n"
+        "    public Widget Main { get; set; }\n"
+        "}\n"
+        "public class Widget { }\n"
+    )})
+    references = {(e["source"], e["target"], e.get("context")) for e in r["edges"]
+                  if e["relation"] == "references"}
+    assert (_find(r, "Holder"), _find(r, "Widget"), "field") in references
+    assert "Main" in _labels(r)
+
+
+def test_methods_are_still_methods(tmp_path):
+    # A property is not a method: it lands on `defines`, the method on `method`.
+    defines, r = _extract(tmp_path, {"S.cs": (
+        "public class Variant {\n"
+        "    public bool Flag { get; set; }\n"
+        "    public void Touch() { }\n"
+        "}\n"
+    )})
+    variant = _find(r, "Variant")
+    methods = {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "method"}
+    assert (variant, _find(r, "Flag")) in defines
+    assert (variant, _find(r, ".Touch()")) in methods
+    assert (variant, _find(r, ".Touch()")) not in defines


### PR DESCRIPTION
Closes #3006.

C# is the only language with a class-shaped type layer whose state is missing from the graph. A property produces a `references` edge to its *type* and no node of its own:

```csharp
public class Variant {
    public bool IsShowCategory { get; set; }
    public void Touch() { }
}
```

Nodes: `Variant`, `.Touch()`. `IsShowCategory` is absent, so nothing in the graph can point at it.

This emits a node per property with a `defines` edge, the same relation and `context="field"` the C++ data-member branch uses:

```
Variant defines IsShowCategory
```

### Following what the tree already does

Checked by running each language rather than reading the configs:

| language | member | relation |
| --- | --- | --- |
| C++ | data member | `defines` |
| C | struct field | `defines` (in flight, #2971) |
| Swift | computed / observed property | function-like member node (#2220) |
| Swift | enum case | `case_of` |
| Java | enum constant | `case_of` |
| JS/TS | class field | `method` when callable |
| C# | field, property | nothing |

#2971's argument for C is the one that applies here: the struct is C's primary data-modeling construct, so dropping it erased the type layer. Properties are C#'s.

The member node is emitted before the type checks, so it does not depend on what the property is typed as. A primitive and a generic parameter both leave a member behind even though neither produces a type reference. A property stays on `defines` rather than `method`: it is state, not a call target.

### Properties only, not fields

`ids.normalize_id` casefolds and strips leading underscores, so `_count` and `Count` are the same id — an ordinary backing field and its property. Emitting both handed the node to whichever the parser reached first, which is the private field, and the public member vanished behind it; two case-only siblings produced one node with two identical edges. That was the review finding on the first revision.

Fields are out rather than disambiguated here. The id recipe is the single source of truth three producers have to agree on (#811, #550, #1033, #2614), and a local suffix scheme would diverge from whatever #2779 and #2810 settle on. A field's type reference is untouched, and the property path keeps a `seen_ids` check since two properties differing only by case are legal and land on one id.

### Cost, since it is not small

On a 1457-file .NET service:

```
before:  9925 nodes, 29547 edges
after:  14683 nodes, 34182 edges     (+4758 nodes / +48%, +4635 edges / +16%)
```

A DTO-heavy corpus, which is where the ratio comes from. The added nodes are leaves and the hub structure does not move: the top god nodes are unchanged.

### What this does not do

A member node on its own does not answer "which code fills this property", because no language in the tree emits a member-level usage edge. That is #3012, filed with the evidence and the open questions, including whether the node set should instead be narrowed to members something touches — which would reverse the order and make this PR the follow-up. Happy to go that way if you prefer.

### Tests

`tests/test_csharp_member_nodes.py`, 9 tests: an auto-property, several properties on one class, a primitive-typed property, a generic-parameter-typed property, a backing field not taking the property's node, a field alone producing no member node while keeping its type reference, property type references surviving (#1591 guard), a property landing on `defines` while a method stays on `method`, and case-only sibling properties not duplicating an edge.

```
$ uv run pytest tests/test_csharp_member_nodes.py -q
9 passed

$ uv run pytest tests/ -q --ignore=tests/test_skillgen.py --ignore=tests/test_falkordb_integration.py
4825 passed, 1 failed
```

The failure is `test_labeling.py::test_label_communities_batches_when_over_batch_size`, order dependent and failing identically on a clean `v8` checkout here. `test_skillgen.py` and the two FalkorDB cases also fail on clean `v8` in this environment, which is why they are excluded from that run. `ruff check` clean.
