### PR TITLE
fix(scala): extract trait definitions, their methods, and calls

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -964,7 +964,12 @@ _KOTLIN_CONFIG = LanguageConfig(
 
 _SCALA_CONFIG = LanguageConfig(
     ts_module="tree_sitter_scala",
-    class_types=frozenset({"class_definition", "object_definition"}),
+    # `trait_definition` is a first-class Scala type declaration (interface-like,
+    # but may carry concrete method bodies). It shares the identifier +
+    # template_body + extends_clause shape of class/object, so omitting it dropped
+    # every trait as a definition — its methods, their calls, and its `contains`
+    # edge — leaving traits visible only as sourceless inherit-stub targets.
+    class_types=frozenset({"class_definition", "object_definition", "trait_definition"}),
     function_types=frozenset({"function_definition"}),
     import_types=frozenset({"import_declaration"}),
     call_types=frozenset({"call_expression"}),

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1057,6 +1057,44 @@ def test_scala_call_edges_have_call_context():
     assert all(e.get("context") == "call" for e in call_edges)
 
 
+def test_scala_trait_is_a_definition_with_methods(tmp_path):
+    """A Scala `trait` must be extracted as a definition, with its methods.
+
+    `trait_definition` was missing from the Scala class_types, so every trait
+    was dropped as a definition — its methods and their calls were lost, and a
+    subclass's `extends Trait` resolved to a sourceless stub instead of the real
+    trait node.
+    """
+    f = tmp_path / "logging.scala"
+    f.write_text(
+        "trait Logger {\n"
+        "  def prefix: String = \"[log] \"\n"
+        "  def log(msg: String): Unit = println(prefix + msg)\n"
+        "}\n"
+        "\n"
+        "class Service extends Logger {\n"
+        "  def run(): Unit = log(\"started\")\n"
+        "}\n"
+    )
+    r = extract_scala(f)
+    assert "error" not in r
+
+    logger = next((n for n in r["nodes"] if n["label"] == "Logger"), None)
+    assert logger is not None, "trait definition dropped"
+    assert logger["source_file"] != "", "trait must be a real sourced definition, not a stub"
+
+    # the trait's own methods are captured
+    method_targets = {
+        n["label"] for n in r["nodes"]
+        for e in r["edges"]
+        if e["relation"] == "method" and e["source"] == logger["id"] and e["target"] == n["id"]
+    }
+    assert {".prefix()", ".log()"} <= method_targets, f"trait methods missing: {method_targets}"
+
+    # `extends Logger` resolves to the real trait node
+    assert ("Service", "Logger") in _edge_labels(r, "inherits")
+
+
 # ── PHP ───────────────────────────────────────────────────────────────────────
 
 def test_php_no_error():


### PR DESCRIPTION
## Problem

Scala's `class_types` listed `class_definition` and `object_definition` but **not `trait_definition`**. Traits are one of Scala's most fundamental constructs — interface-like, but frequently carrying concrete method bodies — and this dropped **every trait as a definition**:

- no trait node and no `contains` edge;
- all of the trait's methods were lost;
- every call made from a concrete trait method was lost;
- a subclass's `extends SomeTrait` resolved to a **sourceless stub** instead of the real trait node.

## Fix

`trait_definition` shares the `identifier` + `template_body` + `extends_clause` shape of `class`/`object`, so adding it to `class_types` extracts traits uniformly through the generic engine — no special-casing.

## Test

Adds a regression test with a trait carrying two concrete methods and a subclass extending it, asserting the trait is a real sourced definition, its `.prefix()`/`.log()` methods are captured, and the `extends` edge resolves to the trait node. Fails before the change, passes after; all 11 existing Scala tests still pass.