### PR TITLE
fix(csharp): extract constructors and the calls made from their bodies

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -928,7 +928,12 @@ _CSHARP_CONFIG = LanguageConfig(
         "struct_declaration",
         "record_declaration",
     }),
-    function_types=frozenset({"method_declaration"}),
+    # constructor_declaration shares method_declaration's name/parameters/body
+    # contract (its name is the class name), so — like Java (#1373) — it must be
+    # a first-class function node. Omitting it dropped every C# constructor along
+    # with all calls made from its body (DI wiring, field initialization, etc.),
+    # a large and load-bearing slice of the call graph.
+    function_types=frozenset({"method_declaration", "constructor_declaration"}),
     import_types=frozenset({"using_directive"}),
     # `object_creation_expression` joins the invocation node so `new Foo(...)`
     # links the constructing method to Foo, the way Java has since #1373.
@@ -937,7 +942,7 @@ _CSHARP_CONFIG = LanguageConfig(
     call_accessor_node_types=frozenset({"member_access_expression"}),
     call_accessor_field="name",
     body_fallback_child_types=("declaration_list",),
-    function_boundary_types=frozenset({"method_declaration"}),
+    function_boundary_types=frozenset({"method_declaration", "constructor_declaration"}),
     import_handler=_import_csharp,
 )
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -409,6 +409,39 @@ def test_csharp_finds_methods():
     labels = _labels(r)
     assert any("Process" in l for l in labels)
 
+def test_csharp_constructor_is_extracted_with_body_calls(tmp_path):
+    """A C# constructor must be a method node, and calls in its body must resolve.
+
+    constructor_declaration was missing from the C# function_types, so every
+    constructor was dropped — along with all calls made from its body (DI wiring,
+    field initialization, etc.), a large slice of the call graph.
+    """
+    f = tmp_path / "svc.cs"
+    f.write_text(
+        "namespace Demo {\n"
+        "    public class Service {\n"
+        "        public Service(Repo repo) { Initialize(); }\n"
+        "        public void Initialize() { }\n"
+        "    }\n"
+        "}\n"
+    )
+    r = extract_csharp(f)
+    assert "error" not in r
+
+    service = next((n for n in r["nodes"] if n["label"] == "Service"), None)
+    assert service is not None
+    ctor = next((n for n in r["nodes"] if n["label"] == ".Service()"), None)
+    assert ctor is not None, "constructor node dropped"
+    # it hangs off the class as a method
+    assert any(e["relation"] == "method" and e["source"] == service["id"]
+               and e["target"] == ctor["id"] for e in r["edges"]), "constructor not linked to class"
+    # a call made in the constructor body resolves
+    init = next((n for n in r["nodes"] if n["label"] == ".Initialize()"), None)
+    assert init is not None
+    assert any(e["relation"] == "calls" and e["source"] == ctor["id"]
+               and e["target"] == init["id"] for e in r["edges"]), "call from constructor body dropped"
+
+
 def test_csharp_finds_usings():
     r = extract_csharp(FIXTURES / "sample.cs")
     assert "imports" in _relations(r)


### PR DESCRIPTION
## Problem

The C# `function_types` listed only `method_declaration`, so every `constructor_declaration` was dropped:

- no constructor node;
- because the constructor body was never treated as a function scope, **all calls it makes** — dependency-injection wiring, field initialization, validation — were lost from the call graph.

Constructors are load-bearing in C#, and their bodies are exactly where a lot of the interesting wiring happens, so this erased a large slice of the graph.

## Fix

`constructor_declaration` shares `method_declaration`'s name/parameters/body contract (its name is the class name), so this mirrors what Java has done since #1373: add it to both `function_types` and `function_boundary_types`. Constructors now surface as `.Ctor()` method nodes and their body calls resolve.

## Test

Adds a regression test asserting the constructor node exists, hangs off its class via a `method` edge, and that a call made in the constructor body resolves. Fails before the change, passes after.

All 14 existing C# language tests and the full C#/cross-language resolver suites (152 tests across `test_csharp_*`, `test_cross_language_call_resolution`, `test_language_resolvers`, `test_phantom_cross_package_call`) still pass.