### PR TITLE
fix(sql): recover CREATE POLICY so RLS is not silently dropped

### DIFF
--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -455,4 +455,46 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
             fn_line = src_text[: m.start()].count("\n") + 1
             _add_node(_make_id(stem, fn_name), f"{fn_name}()", fn_line)
 
+    # Global regex fallback for RLS policies. tree-sitter-sql has no grammar rule
+    # for CREATE POLICY, so the statement never parses: it lands in an ERROR node
+    # (often one blob swallowing the whole file). A policy-heavy Postgres file
+    # therefore contributes only its file node -- every policy is silently
+    # absent, no warning, exit 0. Same failure shape as the routines above, so
+    # the same recovery applies.
+    #
+    # A policy becomes a node linked to the table it is ON with a `secures` edge,
+    # mirroring how create_trigger links a trigger to its table. The id carries
+    # the table name because policy names are unique only per table: two tables
+    # may each define `tenant_isolation`, and a name-only id would collapse them
+    # into one node.
+    #
+    # The USING / WITH CHECK body is deliberately not scanned for references, for
+    # the reason the ERROR branch gives: expression locals would produce junk.
+    #
+    # Gated on a failed parse like the routine fallback, so a cleanly-parsing
+    # file cannot have policies fabricated out of comments or EXECUTE '...'
+    # bodies.
+    if root.has_error:
+        # Blank out comments first, preserving offsets and newlines so reported
+        # line numbers stay correct. The routine fallback above cannot do this
+        # (it predates the need), but a commented-out policy is a realistic
+        # thing to find in a migration that also fails to parse, and a
+        # fabricated node here would be indistinguishable from a real one.
+        def _blank(match: re.Match) -> str:
+            return re.sub(r"[^\n]", " ", match.group(0))
+
+        scan_text = re.sub(r"--[^\n]*|/\*.*?\*/", _blank, src_text, flags=re.DOTALL)
+        for m in re.finditer(
+            r"CREATE\s+POLICY\s+"
+            r"(\"[^\"\n]+\"|[\w$]+)\s+ON\s+"
+            r"((?:\"[^\"\n]+\"|[\w$]+)(?:\s*\.\s*(?:\"[^\"\n]+\"|[\w$]+))*)",
+            scan_text, re.IGNORECASE,
+        ):
+            pol_name, tbl_name = m.group(1), m.group(2)
+            pol_line = scan_text[: m.start()].count("\n") + 1
+            pol_nid = _make_id(stem, tbl_name, pol_name)
+            _add_node(pol_nid, pol_name, pol_line)
+            tbl_nid = table_nids.get(_norm_ident(tbl_name)) or _ref_stub(tbl_name)
+            _add_edge(pol_nid, tbl_nid, "secures", pol_line)
+
     return {"nodes": nodes, "edges": edges}

--- a/tests/fixtures/sample_rls.sql
+++ b/tests/fixtures/sample_rls.sql
@@ -1,0 +1,21 @@
+-- Row-level security: two tables that share a policy name, plus a quoted,
+-- schema-qualified table. tree-sitter-sql has no CREATE POLICY rule, so the
+-- whole file parses into ERROR nodes.
+CREATE TABLE tenants (id integer PRIMARY KEY);
+CREATE TABLE invoices (id integer PRIMARY KEY, tenant_id integer REFERENCES tenants);
+
+ALTER TABLE tenants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE invoices ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON tenants
+  FOR SELECT USING (id = current_tenant());
+
+CREATE POLICY tenant_isolation ON invoices
+  FOR ALL USING (tenant_id = current_tenant())
+  WITH CHECK (tenant_id = current_tenant());
+
+CREATE POLICY invoices_admin_write ON "public"."invoices"
+  FOR UPDATE USING (true);
+
+-- Commented-out DDL must not become a node.
+-- CREATE POLICY commented_out ON tenants FOR SELECT USING (true);

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -480,6 +480,35 @@ def test_sql_create_table_inside_transaction_block():
         for s, t in refs
     )
 
+def test_sql_extracts_rls_policies():
+    """CREATE POLICY has no tree-sitter-sql rule; it must still be recovered."""
+    r = _extract_sql_or_skip("sample_rls.sql")
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    labels = list(node_by_id.values())
+    assert labels.count("tenant_isolation") == 2, (
+        "a policy name is unique only per table; both must survive"
+    )
+    assert "invoices_admin_write" in labels
+    assert "commented_out" not in labels
+
+    secures = [
+        (node_by_id[e["source"]], node_by_id.get(e["target"], ""))
+        for e in r["edges"]
+        if e["relation"] == "secures"
+    ]
+    assert ("tenant_isolation", "tenants") in secures
+    assert ("tenant_isolation", "invoices") in secures
+    assert any(
+        src == "invoices_admin_write" and "invoices" in tgt for src, tgt in secures
+    ), "a quoted, schema-qualified table must resolve to the same table node"
+
+
+def test_sql_policies_are_not_fabricated_in_a_clean_file():
+    """sample.sql parses cleanly, so the policy fallback must stay silent."""
+    r = _extract_sql_or_skip()
+    assert not [e for e in r["edges"] if e["relation"] == "secures"]
+
+
 def test_sql_finds_view():
     r = _extract_sql_or_skip()
     labels = [n["label"] for n in r["nodes"]]


### PR DESCRIPTION
## Problem

`CREATE POLICY` produced no nodes. A Postgres file that defines row-level security appeared in
the graph as a bare file node — no policies, no link to the tables they protect, no warning.

Minimal reproduction:

```sql
CREATE POLICY tenant_isolation ON tenants
  FOR SELECT USING (id = current_tenant());
```

`CREATE TABLE` beside it extracted fine; the policy did not.

## Cause

tree-sitter-sql has no grammar rule for `CREATE POLICY`, so the statement never parses — it lands
in an `ERROR` node, and on a policy-heavy file one `ERROR` blob swallows nearly the whole file.
`extract_sql` recovers PL/pgSQL routines from this same shape (`walk()`'s `ERROR` branch and the
global `root.has_error` fallback from #2180), but has no equivalent for policies, so they fall
through and the file contributes nothing.

## Fix

A global regex fallback next to the routine one, gated on `root.has_error` for the same reason: a
cleanly-parsing file must not have policies fabricated out of DDL inside `EXECUTE '...'` bodies.

Each policy becomes a node linked to the table it is `ON` with a `secures` edge, mirroring how
`create_trigger` links a trigger to its table with `triggers`.

Two details worth flagging for review:

- **The id carries the table name.** Policy names are unique only per table — two tables may each
  define `tenant_isolation` — so a name-only id would collapse distinct policies into one node.
  The label stays the policy name so it remains queryable.
- **Comments are blanked before scanning**, preserving offsets so line numbers stay correct. The
  routine fallback does not do this; a commented-out policy is a realistic thing to find in a
  migration that also fails to parse, and a fabricated node would be indistinguishable from a
  real one. Happy to drop this if you would rather keep the two fallbacks identical.

The `USING` / `WITH CHECK` body is deliberately not scanned for references, for the reason the
`ERROR` branch already gives about PL/pgSQL bodies: expression locals would produce junk targets.
Linking a policy to the functions it calls would be a good follow-up, but it needs scoping rules
this recovery path does not have.

`ALTER TABLE … ENABLE ROW LEVEL SECURITY` is left alone. It is a property of a table rather than
an object of its own, so it is not obvious it should become a node; happy to add it if you want
RLS-enabled tables marked.

## Result

On the 1,251-line RLS file that prompted this (108 `CREATE POLICY`, 90 `ENABLE ROW LEVEL SECURITY`):

| | nodes | edges |
|---|---|---|
| before | 6 | 0 |
| after | 198 | 216 |

108 policy nodes and 108 `secures` edges, one per statement in the source.

## Tests

- `tests/fixtures/sample_rls.sql`: two tables sharing a policy name, a quoted schema-qualified
  table reference, and a commented-out policy.
- `tests/test_multilang.py::test_sql_extracts_rls_policies` — both same-named policies survive as
  distinct nodes, each `secures` its own table, the quoted reference resolves to the same table
  node, and the commented-out policy is not emitted.
- `tests/test_multilang.py::test_sql_policies_are_not_fabricated_in_a_clean_file` — pins the
  `has_error` gate.

```bash
pytest tests/test_multilang.py -k sql -q
```

22 passed. Full suite: 4,964 passed, with 7 pre-existing environment-dependent failures that also
fail on an unmodified 282976b (hidden-file collection, git-repo detection, ollama SDK retries, the
convex-hull geometry check).

Fixes #3017
