### PR TITLE
fix(sql): resolve a default-schema-qualified FOREIGN KEY to an unqualified table

### DIFF
--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -7,6 +7,12 @@ from pathlib import Path
 from graphify.extractors.base import _file_stem, _make_id
 
 
+# An unqualified CREATE TABLE lands in the first schema of search_path, which is
+# `public` unless the corpus overrides it. Only this schema is bridged to bare
+# definitions, so a reference to `other.users` still refuses to bind to `users`.
+_DEFAULT_SCHEMA = "public"
+
+
 def _norm_ident(name: str) -> str:
     """Normalize a SQL identifier for name-based reference resolution.
 
@@ -393,6 +399,21 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
     for bare, alias_nid in bare_candidates.items():
         if alias_nid is not None and bare not in table_nids:
             table_nids[bare] = alias_nid
+
+    # The mirror case: a reference written WITH the default schema
+    # (`REFERENCES "public"."users"`) must resolve to an unqualified definition
+    # (`CREATE TABLE "users"`). drizzle-kit emits exactly this pair -- unqualified
+    # CREATE, default-schema-qualified FOREIGN KEY -- so without the alias every
+    # generated foreign key dangles on a sourceless stub, and `_ref_stub` cannot
+    # recover it either: corpus rewire matches on label, and `"public"."users"`
+    # and `"users"` never share one. Same guards as above: never shadow an
+    # explicit `public.x` definition, and bridge only the default schema.
+    for key in list(table_nids):
+        if "." in key:
+            continue
+        qualified = f"{_DEFAULT_SCHEMA}.{key}"
+        if qualified not in table_nids:
+            table_nids[qualified] = table_nids[key]
 
     for stmt in root.children:
         if stmt.type == "statement":

--- a/tests/fixtures/sample_schema_explicit.sql
+++ b/tests/fixtures/sample_schema_explicit.sql
@@ -1,0 +1,12 @@
+-- An explicit public.x definition must win over the bare alias.
+CREATE TABLE "public"."accounts" (
+  "id" uuid PRIMARY KEY
+);
+
+CREATE TABLE "accounts_mirror" (
+  "id" uuid PRIMARY KEY,
+  "account_id" uuid
+);
+
+ALTER TABLE "accounts_mirror" ADD CONSTRAINT "accounts_mirror_account_id_fk"
+  FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id");

--- a/tests/fixtures/sample_schema_qualified_fk.sql
+++ b/tests/fixtures/sample_schema_qualified_fk.sql
@@ -1,0 +1,21 @@
+-- drizzle-kit's generated shape: unqualified CREATE TABLE, default-schema-qualified FK.
+CREATE TABLE "companies" (
+  "id" uuid PRIMARY KEY
+);
+
+CREATE TABLE "children" (
+  "id" uuid PRIMARY KEY,
+  "company_id" uuid
+);
+
+ALTER TABLE "children" ADD CONSTRAINT "children_company_id_fk"
+  FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id");
+
+-- A non-default schema must NOT bind to the bare definition.
+CREATE TABLE "audit_log" (
+  "id" uuid PRIMARY KEY,
+  "company_id" uuid
+);
+
+ALTER TABLE "audit_log" ADD CONSTRAINT "audit_log_company_id_fk"
+  FOREIGN KEY ("company_id") REFERENCES "archive"."companies"("id");

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -480,6 +480,44 @@ def test_sql_create_table_inside_transaction_block():
         for s, t in refs
     )
 
+def test_sql_qualified_fk_resolves_to_unqualified_table():
+    """drizzle emits unqualified CREATE + public-qualified FK; they must connect."""
+    r = _extract_sql_or_skip("sample_schema_qualified_fk.sql")
+    by_id = {n["id"]: n for n in r["nodes"]}
+    refs = [
+        (by_id[e["source"]]["label"], by_id[e["target"]])
+        for e in r["edges"]
+        if e["relation"] == "references"
+    ]
+
+    hit = [t for src, t in refs if "children" in src and "companies" in t["label"]]
+    assert hit, "the public-qualified FK must reach the companies table"
+    assert hit[0].get("source_file"), (
+        "it must land on the real definition, not a sourceless stub"
+    )
+
+    # A non-default schema keeps its own stub: archive.companies is a different table.
+    other = [t for src, t in refs if "audit_log" in src and "companies" in t["label"]]
+    assert other, "the archive-qualified FK must still emit an edge"
+    assert not other[0].get("source_file"), (
+        "archive.companies must NOT bind to the bare companies definition"
+    )
+
+
+def test_sql_explicit_qualified_definition_is_not_shadowed():
+    """An explicit public.x definition must be preferred over the bare alias."""
+    r = _extract_sql_or_skip("sample_schema_explicit.sql")
+    by_id = {n["id"]: n for n in r["nodes"]}
+    hit = [
+        by_id[e["target"]]
+        for e in r["edges"]
+        if e["relation"] == "references" and "accounts_mirror" in by_id[e["source"]]["label"]
+    ]
+    assert hit
+    assert hit[0]["label"] == '"public"."accounts"'
+    assert hit[0].get("source_file")
+
+
 def test_sql_finds_view():
     r = _extract_sql_or_skip()
     labels = [n["label"] for n in r["nodes"]]


### PR DESCRIPTION
## Problem

`REFERENCES "public"."users"` did not resolve to `CREATE TABLE "users"`. The foreign key landed
on a sourceless stub, so the two tables were never connected — silently, exit 0.

That pair is what drizzle-kit generates: unqualified `CREATE TABLE`, default-schema-qualified
`FOREIGN KEY`. Every foreign key in such a migration dangled.

## Cause

`_norm_ident` keeps schema qualification, so `public.companies` and `companies` are distinct
keys and the `table_nids` lookup misses.

The file already bridges the opposite direction — the "Secondary bare-name aliases" block lets an
unqualified reference find a qualified definition — but not the mirror, which is the half drizzle
emits.

`_ref_stub` says the corpus rewire will collapse the stub onto the real definition, but for a
dotted label it cannot: `_node_label_key` strips non-alphanumerics, giving `publiccompanies`
against `companies`, so neither the exact nor the folded pass ever matches.

## Fix

Alias each unqualified definition under the default schema, mirroring the existing block and
reusing its guards:

- an explicit `public.x` definition is never shadowed by the alias;
- only the default schema is bridged, so `archive.users` still refuses to bind to a bare `users`.

`_DEFAULT_SCHEMA` is a named constant rather than an inline `"public"`, so a dialect with a
different default (T-SQL's `dbo`) has one place to grow. I did not add `dbo` speculatively.

## Scope

This repairs the **in-file** case, where a generated baseline migration concentrates its foreign
keys. On the corpus that prompted this:

| | unresolved `"public"."x"` stubs | `references` edges ending on a stub |
|---|---|---|
| before | 90 | 193 / 404 |
| after | 62 | 84 / 404 |

The remainder is **cross-file**: a later migration referencing a table defined in an earlier one.
Fixing that needs `_node_label_key` to fold SQL schema qualification, and that key is shared by
every language and carries the #1581 `Path`/`PATH` guard — so it felt like your call rather than
something to change from outside a single extractor. Happy to follow up if you want it there.

## Tests

- `tests/fixtures/sample_schema_qualified_fk.sql` — the drizzle shape, plus an `archive.`-qualified
  FK that must stay unbound.
- `tests/fixtures/sample_schema_explicit.sql` — an explicit `"public"."accounts"` definition.
- `tests/test_multilang.py::test_sql_qualified_fk_resolves_to_unqualified_table` — the FK reaches
  the real definition (asserts `source_file` is set, not just that an edge exists), and the
  non-default schema keeps its own stub.
- `tests/test_multilang.py::test_sql_explicit_qualified_definition_is_not_shadowed` — pins the
  no-shadow guard.

```bash
pytest tests/test_multilang.py -k sql -q
```

22 passed. Full suite: 4,964 passed, with 8 pre-existing environment-dependent failures that also
fail on an unmodified 282976b (hidden-file collection, `.graphifyignore` without VCS, git-repo
detection, ollama SDK retries, the convex-hull geometry check).

Fixes #3019
