### PR TITLE
fix(build): keep definition_file repo-relative like source_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## Unreleased
+
+- Fix: the `definition_file` recorded on a merged C/C++/Objective-C decl/def node is now stored repo-relative like its sibling `source_file`, instead of keeping the build machine's absolute path — every path-normalizing pass keyed on `source_file` alone, so a graph shipped the builder's filesystem layout and `get_node`'s `Defined in:` line named a path that does not exist on any other checkout (#3223).
+
 ## 0.9.53 (2026-08-30)
 
 - Fix: a batch of cross-language inheritance-edge corrections (thanks @Synvoya): JavaScript `class X extends Y` now emits an `inherits` edge (#1790); PHP interfaces, enums, and traits are captured as class-like nodes with their heritage (#1791); Scala `trait` declarations become class-like nodes (#1792) and qualified `extends`/`with` bases resolve to the tail type (#1794); a qualified Kotlin supertype resolves to its tail type instead of the package head (#1793); a C# interface extending an interface is classified as `inherits`, not `implements` (#1817); and a Go interface type-set constraint no longer emits a spurious `embeds` edge (#1818).

--- a/graphify/build.py
+++ b/graphify/build.py
@@ -973,6 +973,11 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
                 continue
             if "source_file" in node:
                 node["source_file"] = _norm_source_file(node["source_file"], _root)
+            # A merged C/C++/ObjC decl/def node also carries the definition's
+            # file; it is a source path like any other and must be relativized
+            # too, or the graph ships the build machine's absolute path.
+            if "definition_file" in node:
+                node["definition_file"] = _norm_source_file(node["definition_file"], _root)
         G.add_node(node["id"], **{k: v for k, v in node.items() if k != "id"})
     node_set = set(G.nodes())
 

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -318,22 +318,30 @@ def _changed_path_candidates(raw: Path, *, change_root: Path, watch_root: Path) 
     return candidates
 
 
+# Every stored path that names a file in the scanned tree. ``definition_file``
+# is the implementation site recorded when a C/C++/ObjC declaration and its
+# definition merge into one node; it must stay repo-relative like its sibling
+# ``source_file`` so a graph built on one machine reads on another.
+_PORTABLE_PATH_KEYS = ("source_file", "definition_file")
+
+
 def _relativize_source_files(payload: dict, root: Path, *, scope: Path | None = None) -> None:
     for bucket in ("nodes", "edges", "hyperedges"):
         for item in payload.get(bucket, []):
-            source = item.get("source_file")
-            if not source:
-                continue
-            source_path = Path(source)
-            if not source_path.is_absolute():
-                continue
-            try:
-                resolved = source_path.resolve()
-                if scope is not None and not _is_relative_to(resolved, scope):
+            for key in _PORTABLE_PATH_KEYS:
+                source = item.get(key)
+                if not source:
                     continue
-                item["source_file"] = resolved.relative_to(root).as_posix()
-            except ValueError:
-                continue
+                source_path = Path(source)
+                if not source_path.is_absolute():
+                    continue
+                try:
+                    resolved = source_path.resolve()
+                    if scope is not None and not _is_relative_to(resolved, scope):
+                        continue
+                    item[key] = resolved.relative_to(root).as_posix()
+                except ValueError:
+                    continue
 
 
 def _rebase_relative_source_files(payload: dict, source_root: Path, target_root: Path) -> None:
@@ -342,13 +350,14 @@ def _rebase_relative_source_files(payload: dict, source_root: Path, target_root:
         return
     for bucket in ("nodes", "edges", "hyperedges"):
         for item in payload.get(bucket, []):
-            source = item.get("source_file")
-            if not source or Path(source).is_absolute():
-                continue
-            try:
-                item["source_file"] = (source_root / source).relative_to(target_root).as_posix()
-            except ValueError:
-                continue
+            for key in _PORTABLE_PATH_KEYS:
+                source = item.get(key)
+                if not source or Path(source).is_absolute():
+                    continue
+                try:
+                    item[key] = (source_root / source).relative_to(target_root).as_posix()
+                except ValueError:
+                    continue
 
 
 class _StoredSourcePaths:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1614,6 +1614,36 @@ def test_norm_source_file_relativizes_a_posix_absolute_path():
     ) == "docs/api/README.md"
 
 
+def test_build_from_json_relativizes_definition_file():
+    """A merged C/C++/ObjC decl/def node records where the symbol is implemented
+    in `definition_file`. That is a path into the scanned tree just like
+    `source_file`, so the graph must store it repo-relative — otherwise the
+    build machine's absolute path ships in graph.json and a reader on another
+    checkout (or the MCP `get_node` answer) points at a file that is not there."""
+    from graphify.build import build_from_json
+
+    root = "/home/ci/build/repo"
+    extraction = {
+        "nodes": [{
+            "id": "foo_bar",
+            "label": "bar",
+            "type": "function",
+            "file_type": "code",
+            "_origin": "ast",
+            "source_file": f"{root}/src/Foo.h",
+            "source_location": "L10",
+            "definition_file": f"{root}/src/Foo.cpp",
+            "definition_location": "L42",
+        }],
+        "edges": [],
+    }
+    G = build_from_json(extraction, root=root)
+    assert G.nodes["foo_bar"]["source_file"] == "src/Foo.h"
+    assert G.nodes["foo_bar"]["definition_file"] == "src/Foo.cpp"
+    # the line number is a plain string and must survive untouched
+    assert G.nodes["foo_bar"]["definition_location"] == "L42"
+
+
 def test_derive_prune_root_recovers_root_from_posix_absolute_prune_sources():
     """The prune-root recovery skips any prune source it thinks is relative.
 

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -4203,3 +4203,62 @@ def test_markdown_reconcile_does_not_suffix_match_top_level_target(tmp_path):
     assert _rebuild_code(corpus, no_cluster=True, acquire_lock=False) is True
     links = json.loads(graph_path.read_text(encoding="utf-8"))["links"]
     assert not any(edge.get("relation") == "references" for edge in links)
+
+
+# --- portable paths: definition_file travels with source_file --------------
+
+def test_relativize_source_files_relativizes_definition_file(tmp_path):
+    """`definition_file` (the implementation site recorded when a C/C++/ObjC
+    decl/def pair merges) names a file in the scanned tree exactly like
+    `source_file`, so it must be relativized too. Left absolute, the graph
+    carries the build machine's paths and cannot be read on another checkout."""
+    from graphify.watch import _relativize_source_files
+
+    root = tmp_path.resolve()
+    payload = {"nodes": [{
+        "id": "foo_bar",
+        "source_file": str(root / "src" / "Foo.h"),
+        "definition_file": str(root / "src" / "Foo.cpp"),
+    }]}
+    _relativize_source_files(payload, root)
+    node = payload["nodes"][0]
+    assert node["source_file"] == "src/Foo.h"
+    assert node["definition_file"] == "src/Foo.cpp"
+
+
+def test_relativize_source_files_leaves_an_outside_definition_file_alone(tmp_path):
+    """The scope guard applies to the new key as well: a path outside the
+    watched tree is left as-is rather than being forced under the root."""
+    from graphify.watch import _relativize_source_files
+
+    root = (tmp_path / "repo").resolve()
+    (root).mkdir()
+    outside = (tmp_path / "elsewhere" / "Foo.cpp").resolve()
+    payload = {"nodes": [{
+        "id": "foo_bar",
+        "source_file": str(root / "Foo.h"),
+        "definition_file": str(outside),
+    }]}
+    _relativize_source_files(payload, root, scope=root)
+    node = payload["nodes"][0]
+    assert node["source_file"] == "Foo.h"
+    assert node["definition_file"] == str(outside)
+
+
+def test_rebase_relative_source_files_rebases_definition_file(tmp_path):
+    """Cache-root-relative rebasing moves both keys, so a decl/def node built
+    under a cache root keeps a definition site that resolves from the project
+    root instead of pointing one directory level off."""
+    from graphify.watch import _rebase_relative_source_files
+
+    source_root = tmp_path / "cache" / "pkg"
+    target_root = tmp_path / "cache"
+    payload = {"nodes": [{
+        "id": "foo_bar",
+        "source_file": "src/Foo.h",
+        "definition_file": "src/Foo.cpp",
+    }]}
+    _rebase_relative_source_files(payload, source_root, target_root)
+    node = payload["nodes"][0]
+    assert node["source_file"] == "pkg/src/Foo.h"
+    assert node["definition_file"] == "pkg/src/Foo.cpp"


### PR DESCRIPTION
Follow-up to #2990 / #2991, shipped in 0.9.49. My own regression — sorry.

## What

`_merge_decl_def_classes` records the dropped impl node's provenance on the survivor by copying its `source_file` verbatim:

```python
keeper["definition_file"] = definition["source_file"]
```

At that point the value is still absolute. Every pass that makes a stored path portable keys on the literal string `"source_file"`, so the new attribute never gets relativized while its sibling does. The result, on a real C++ corpus built at `/data/graphify/repos/ston-edge-server`:

```
Source:     Application/Cache/Process/CacheHttp2Config.h L96
Defined in: /data/graphify/repos/ston-edge-server/Application/Cache/Process/CacheHttp2Config.cpp L47
```

Two consequences, both from the same line:

- **The graph is no longer portable.** `source_file` is repo-relative precisely so a graph built on CI can be read from any checkout; `Defined in:` now names a path that exists on no other machine. A reader who follows it gets "no such file" and reasonably concludes the graph is stale.
- **It leaks the build machine's layout.** For anyone who commits `graphify-out/` or publishes a graph as a release asset, home-directory and directory-structure detail lands in `graph.json`. Nothing in `get_node`'s output hints that this one field is machine-local.

Scope is `.c/.cc/.cpp/.cxx/.m/.mm` paired with a header — C/C++/Objective-C corpora only; nothing else grows the attribute.

## Fix

Relativize `definition_file` wherever `source_file` is relativized:

- `build_from_json`'s per-node normalization (`_norm_source_file`, which also handles the Windows backslash case)
- `watch._relativize_source_files` and `watch._rebase_relative_source_files`

In `watch.py` the two keys now share one `_PORTABLE_PATH_KEYS` tuple, so a future portable path cannot be added to one pass and missed by the other — which is exactly how this slipped through. The scope guard is unchanged: a `definition_file` outside the watched tree is still left alone rather than forced under the root.

Only the recorded string changes. Node ids, labels, `source_file`, node/edge counts and communities are all untouched.

## Tests

Four, all red before the fix except the scope-guard regression test:

- `test_build_from_json_relativizes_definition_file` — an absolute `definition_file` under `root` comes out as `src/Foo.cpp`; `definition_location` passes through untouched.
- `test_relativize_source_files_relativizes_definition_file`
- `test_rebase_relative_source_files_rebases_definition_file`
- `test_relativize_source_files_leaves_an_outside_definition_file_alone` — pins the scope guard for the new key (passes either way; there to stop a future widening).

Note that the tests I shipped with #2991 asserted `str(node["definition_file"]).endswith("Foo.cpp")`, which passes for an absolute path too. That is why this got through, so the new assertions compare full relative strings.

Full suite, same machine, clean `v8` vs this branch:

```
v8:           13 failed, 4756 passed, 232 skipped
this branch:  13 failed, 4760 passed, 232 skipped
```

Identical failure set by name (terraform, ollama-retry-cap, install-references, markdown-nested-frontmatter — all missing-optional-dependency failures in my environment, none on this path); +4 is the new tests.

## Real-world check

Rebuilt three C++ corpora (1.7k, 1.2k and 550 files) on 0.9.49 plus this patch: 13,682 nodes carry a `definition_file`, and every one is now repo-relative — 0 absolute, 0 pointing at a non-impl extension, and all 13,682 survivors are headers, as expected. Node counts before and after the patch are identical (39,041 / 46,551 / 15,613), confirming only the string changed. Verified over the served path too: `get_node` now answers `Defined in: Application/Granite/Delivery/CacheService/CacheFile.cpp L1684`.

Environment: Python 3.12.3, tree-sitter 0.25.2, Linux, AST-only build with no LLM backend.

---

Unrelated nit, mentioning it only because it is one line in the same feature: the 0.9.49 release note for #2990 reads "the node now points at the definition site (the implementation body) instead of the header prototype". The shipped behaviour keeps `source_file` on the declaration and adds the definition site as separate attributes — that additivity (no re-keying of existing graphs) is the part worth stating. Happy to send a note-only PR if that is useful.
