### PR TITLE
fix(php): extract interface, trait, and enum definitions

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -980,7 +980,16 @@ _SCALA_CONFIG = LanguageConfig(
 _PHP_CONFIG = LanguageConfig(
     ts_module="tree_sitter_php",
     ts_language_fn="language_php",
-    class_types=frozenset({"class_declaration"}),
+    # interface/trait/enum are first-class PHP type declarations that share
+    # class_declaration's name + declaration_list body contract. Omitting them
+    # dropped every interface, trait and enum as a definition — and, worse,
+    # re-attributed their methods to the FILE as free functions instead of the
+    # type — erasing a load-bearing slice of the graph in interface/trait-heavy
+    # codebases (Laravel, Symfony, PSR). Mirrors Java's interface/enum handling.
+    class_types=frozenset({
+        "class_declaration", "interface_declaration",
+        "trait_declaration", "enum_declaration",
+    }),
     function_types=frozenset({"function_definition", "method_declaration"}),
     import_types=frozenset({"namespace_use_clause"}),
     call_types=frozenset({"function_call_expression", "member_call_expression", "scoped_call_expression", "class_constant_access_expression"}),

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1077,6 +1077,48 @@ def test_php_finds_function():
     r = extract_php(FIXTURES / "sample.php")
     assert any("parseResponse" in l for l in _labels(r))
 
+def test_php_interface_trait_enum_are_definitions_with_methods(tmp_path):
+    """PHP interface/trait/enum must be real definitions, with methods attributed
+    to them (not the file), and implements/uses edges resolving to them.
+
+    Only `class_declaration` was in the PHP class_types, so interfaces, traits and
+    enums were dropped as definitions and their methods were re-attributed to the
+    FILE as free functions — and a class's `implements`/`use` resolved to a
+    sourceless stub instead of the real type.
+    """
+    f = tmp_path / "svc.php"
+    f.write_text(
+        "<?php\n"
+        "interface Logger { public function log(string $m): void; }\n"
+        "trait Timestamps { public function touch(): void { $this->t = time(); } }\n"
+        "enum Status { case Active; case Inactive; }\n"
+        "class Service implements Logger {\n"
+        "    use Timestamps;\n"
+        "    public function log(string $m): void { $this->touch(); }\n"
+        "}\n"
+    )
+    r = extract_php(f)
+    assert "error" not in r
+    by_label = {n["label"]: n for n in r["nodes"]}
+
+    for name in ("Logger", "Timestamps", "Status"):
+        assert name in by_label, f"{name} dropped as a definition"
+        assert by_label[name]["source_file"], f"{name} must be a real sourced definition"
+
+    def method_targets(owner_label):
+        owner = by_label[owner_label]["id"]
+        return {n["label"] for n in r["nodes"] for e in r["edges"]
+                if e["relation"] == "method" and e["source"] == owner and e["target"] == n["id"]}
+
+    # methods attributed to their type, not the file
+    assert ".log()" in method_targets("Logger"), "interface method not attributed to interface"
+    assert ".touch()" in method_targets("Timestamps"), "trait method not attributed to trait"
+
+    # class relationships resolve to the real interface/trait nodes
+    assert ("Service", "Logger") in _edge_labels(r, "implements")
+    assert ("Service", "Timestamps") in _edge_labels(r, "mixes_in")
+
+
 def test_php_finds_imports():
     r = extract_php(FIXTURES / "sample.php")
     assert "imports" in _relations(r)


### PR DESCRIPTION
## Problem

The PHP `class_types` listed only `class_declaration`, so `interface_declaration`, `trait_declaration`, and `enum_declaration` were all dropped as definitions. Worse — because the type wasn't recognized as a container, its `method_declaration` children were **re-attributed to the FILE as free-standing functions** instead of methods of the interface/trait, and a class's `implements`/`use` resolved to a **sourceless stub** rather than the real type.

Interfaces and traits are load-bearing across the PHP ecosystem (Laravel, Symfony, every PSR), so this erased a large slice of the graph.

### Before (this input)
```php
interface Logger { public function log(string $m): void; }
trait Timestamps { public function touch(): void { /* … */ } }
enum Status { case Active; case Inactive; }
class Service implements Logger { use Timestamps; /* … */ }
```
- `Logger`, `Timestamps`, `Status` → no definition nodes
- `log()`, `touch()` → attached to the **file** as free functions
- `Service implements Logger` / `use Timestamps` → point at sourceless stubs

## Fix

All three share `class_declaration`'s name + `declaration_list` body contract, so add them to `class_types` — mirroring Java's interface/enum handling. Methods now attribute to their type, and `implements`/`use`/`calls` resolve to the real nodes.

## Test

Adds a regression test asserting each type is a real sourced definition, that interface/trait methods attribute to the type (not the file), and that `implements`/`mixes_in` resolve to the real nodes. Fails before, passes after; all 18 existing PHP language tests and the PHP type-resolution suite still pass.