### PR TITLE
fix(kotlin): extract secondary constructors and the calls in their bodies

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -944,7 +944,12 @@ _CSHARP_CONFIG = LanguageConfig(
 _KOTLIN_CONFIG = LanguageConfig(
     ts_module="tree_sitter_kotlin",
     class_types=frozenset({"class_declaration", "object_declaration"}),
-    function_types=frozenset({"function_declaration"}),
+    # `secondary_constructor` is a callable member (`constructor(...) { … }`) with
+    # a body, but it was omitted — so every secondary constructor was dropped
+    # along with all the calls made from it (field init, validation, delegation).
+    # It has no name field; the engine labels it `.constructor()` (see the
+    # deinit/subscript name-less-callable handling).
+    function_types=frozenset({"function_declaration", "secondary_constructor"}),
     # Grammar 1.1.0 (PyPI tree_sitter_kotlin) names the import node `import`;
     # older forks use `import_header`. Accept both (#2526).
     import_types=frozenset({"import_header", "import"}),
@@ -957,8 +962,12 @@ _KOTLIN_CONFIG = LanguageConfig(
     # older forks use `simple_identifier`. Accept both so the extractor
     # works across grammar generations.
     name_fallback_child_types=("simple_identifier", "identifier"),
-    body_fallback_child_types=("function_body", "class_body", "enum_class_body"),
-    function_boundary_types=frozenset({"function_declaration"}),
+    # `block` is the secondary_constructor body (it exposes no `body` field); the
+    # other entries cover function/class bodies. Order is irrelevant here because
+    # function_declaration/class_declaration expose their body via a field, so the
+    # fallback only fires for the name-/field-less secondary_constructor.
+    body_fallback_child_types=("function_body", "class_body", "enum_class_body", "block"),
+    function_boundary_types=frozenset({"function_declaration", "secondary_constructor"}),
     import_handler=_import_kotlin,
 )
 

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -4063,11 +4063,14 @@ def _extract_generic(
 
         # Function types
         if t in config.function_types:
-            # Swift deinit/subscript have no name field — resolve before generic fallback
+            # Swift deinit/subscript and Kotlin secondary constructors have no name
+            # field — resolve before generic fallback.
             if t == "deinit_declaration":
                 func_name: str | None = "deinit"
             elif t == "subscript_declaration":
                 func_name = "subscript"
+            elif t == "secondary_constructor":
+                func_name = "constructor"
             elif config.resolve_function_name_fn is not None:
                 # C/C++ style: use declarator
                 declarator = node.child_by_field_name("declarator")

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -954,6 +954,37 @@ def test_kotlin_emits_in_file_calls():
     assert ("createClient()", "HttpClient") in calls
 
 
+def test_kotlin_secondary_constructor_is_extracted_with_body_calls(tmp_path):
+    """A Kotlin secondary constructor must be a method node, and its body calls resolve.
+
+    secondary_constructor was missing from function_types, so every secondary
+    constructor was dropped along with all calls made from its body (field init,
+    validation, delegation).
+    """
+    f = tmp_path / "svc.kt"
+    f.write_text(
+        "class Service {\n"
+        "    var name: String = \"\"\n"
+        "    constructor(n: String) {\n"
+        "        name = n\n"
+        "        validate()\n"
+        "    }\n"
+        "    fun validate() { }\n"
+        "}\n"
+    )
+    r = extract_kotlin(f)
+    assert "error" not in r
+    by_label = {n["label"]: n for n in r["nodes"]}
+    service = by_label["Service"]
+    ctor = by_label.get(".constructor()")
+    assert ctor is not None, "secondary constructor node dropped"
+    assert any(e["relation"] == "method" and e["source"] == service["id"]
+               and e["target"] == ctor["id"] for e in r["edges"]), "constructor not linked to class"
+    validate = by_label[".validate()"]
+    assert any(e["relation"] == "calls" and e["source"] == ctor["id"]
+               and e["target"] == validate["id"] for e in r["edges"]), "call from constructor body dropped"
+
+
 def test_kotlin_splits_inherits_and_implements():
     r = extract_kotlin(FIXTURES / "sample.kt")
     assert ("DataProcessor", "BaseProcessor") in _edge_labels(r, "inherits")


### PR DESCRIPTION
## Problem

A Kotlin `secondary_constructor` (`constructor(...) { … }`) is a callable class member with a body, but it was missing from the Kotlin `function_types`. So every secondary constructor was dropped — and with it **all the calls made from its body**: field initialization, validation, `this()`/`super()` delegation. That silently erased a real slice of the construction-time call graph.

### Before (this input)
```kotlin
class Service {
    var name: String = ""
    constructor(n: String) { name = n; validate() }
    fun validate() { }
}
```
Only `.validate()` was emitted — the constructor node and the `constructor → validate` call were both gone.

## Fix

- A `secondary_constructor` has no `name` field, so — exactly like Swift's `deinit`/`subscript` — the engine labels it `.constructor()`.
- Its body is a bare `block` (no `body` field), so `block` is added to Kotlin's `body_fallback_child_types`. This only fires for the secondary constructor, since function/class declarations expose their body via a field.
- It's added to `function_boundary_types` so the body is a proper call scope.

## Test

Adds a regression test asserting the `.constructor()` node exists, hangs off its class via a `method` edge, and that a call made in the constructor body resolves. Fails before, passes after.

All 12 existing Kotlin language tests pass, and a broad engine-touching sweep (648 tests across `test_languages`, `test_cross_language_call_resolution`, `test_language_resolvers`, `test_extract`, `test_analyze`) is green — the shared `engine.py` change (one name-less-callable case) is safe across languages.