### PR TITLE
fix(detect): keep manifest mtime/seen stable for unchanged inputs (#2988)

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1975,6 +1975,11 @@ def save_manifest(
                       Stamps semantic_hash; preserves existing ast_hash.
     kind="both"     — full pipeline: stamps both hashes (default).
 
+    Volatile fields are stamped only on real change (#2988): a row whose
+    freshly computed hashes equal its stored ones inherits the previous
+    ``mtime`` / ``seen`` VERBATIM, so repeated saves over an untouched corpus
+    leave manifest.json byte-identical — safe to commit behind a rebuild hook.
+
     When ``root`` is provided, keys are relativized against it before write
     (forward-slash, posix-style) so the on-disk manifest is portable across
     machines and checkout locations (#777). Out-of-root entries are written
@@ -2136,20 +2141,35 @@ def save_manifest(
             # Preserve semantic_hash only when content is unchanged
             sem_h = prev.get("semantic_hash", "") if h == prev.get("ast_hash", "") else ""
 
-        # Preserve previous seen timestamp if the entry's mtime and target hash(es)
-        # are genuinely unchanged and no clear was requested for this file.
-        prev_seen = prev.get("seen")
-        is_unchanged = (
-            isinstance(prev_seen, (int, float))
-            and mtime == prev.get("mtime")
-            and (ast_h == prev.get("ast_hash", "") if kind in ("ast", "both") else True)
-            and (sem_h == prev.get("semantic_hash", "") if kind in ("semantic", "both") else True)
+        # Idempotent volatile fields (#2988): mtime/seen are cache-invalidation
+        # state, not graph content — but manifest.json is an artifact teams are
+        # told to COMMIT, so restamping them on every run keeps the working
+        # tree dirty forever (a committed graphify-out/ can never present a
+        # clean status, and committing the restamp fires the hook again).
+        # When the freshly computed hashes equal the stored ones, the content
+        # is unchanged: inherit the previous mtime/seen VERBATIM so a rebuild
+        # over an untouched corpus leaves manifest.json byte-identical and the
+        # #2838 skip below can fire. Only a real hash change (or a requested
+        # clear) earns fresh stamps. Keying on hashes instead of mtime equality
+        # also survives benign mtime motion (checkout / copy / touch) that used
+        # to churn dozens of unchanged rows per run; detection stays correct
+        # either way, because detect_incremental's hash comparison remains
+        # authoritative whenever the stored mtime drifts from disk.
+        inherits_volatile = (
+            bool(prev)
+            and ast_h == prev.get("ast_hash", "")
+            and sem_h == prev.get("semantic_hash", "")
             and not _in_clear_ast(f)
             and not _in_clear(f)
         )
+        prev_seen = prev.get("seen")
         entry: dict = {
-            "mtime": mtime,
-            "seen": prev_seen if is_unchanged else time.time(),
+            "mtime": prev.get("mtime", mtime) if inherits_volatile else mtime,
+            "seen": (
+                prev_seen
+                if inherits_volatile and isinstance(prev_seen, (int, float))
+                else time.time()
+            ),
             "ast_hash": ast_h,
             "semantic_hash": sem_h,
         }

--- a/tests/test_manifest_idempotency.py
+++ b/tests/test_manifest_idempotency.py
@@ -1,0 +1,137 @@
+"""manifest.json rebuild idempotency (#2988).
+
+save_manifest restamped volatile ``mtime``/``seen`` values on every run
+whenever the stored row no longer matched a fresh stat (checkout / copy /
+touch move mtimes without touching content), and one restamped field broke
+the other's preservation condition too — so with the README-recommended flow
+of committing graphify-out/ behind a post-commit rebuild hook, the working
+tree went dirty again after every single commit. The volatile fields are now
+inherited verbatim from the previous row whenever the freshly computed hashes
+match the stored ones, so an unchanged corpus yields a byte-identical
+manifest.json and #2838's skip-write fires.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from graphify.detect import save_manifest
+
+
+def _corpus(tmp_path: Path, n: int = 3) -> list[str]:
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    paths = []
+    for i in range(n):
+        p = docs / f"note{i}.md"
+        p.write_text(f"# Note {i}\n\nStable content {i}.\n", encoding="utf-8")
+        paths.append(str(p))
+    return paths
+
+
+def _save(paths: list[str], mp: Path, **kw) -> None:
+    save_manifest({"document": paths}, str(mp), **kw)
+
+
+def _bump_mtime(path: str, delta: float) -> None:
+    st = os.stat(path)
+    os.utime(path, (st.st_atime + delta, st.st_mtime + delta))
+
+
+def test_repeated_save_over_untouched_corpus_is_byte_identical(tmp_path):
+    """The #2988 headline: rebuilds over a settled corpus must not rewrite
+    manifest.json at all."""
+    files = _corpus(tmp_path)
+    mp = tmp_path / "graphify-out" / "manifest.json"
+    _save(files, mp)
+    first = mp.read_text(encoding="utf-8")
+
+    _save(files, mp)
+    assert mp.read_text(encoding="utf-8") == first
+
+
+def test_mtime_motion_without_content_change_does_not_restamp(tmp_path):
+    """A checkout/copy/touch moves mtimes without changing content; hashes stay
+    authoritative, so every row keeps its previous mtime/seen verbatim."""
+    files = _corpus(tmp_path)
+    mp = tmp_path / "graphify-out" / "manifest.json"
+    _save(files, mp)
+    before = json.loads(mp.read_text(encoding="utf-8"))
+
+    for f in files:
+        _bump_mtime(f, 3600.0)
+
+    _save(files, mp)
+    after = json.loads(mp.read_text(encoding="utf-8"))
+    assert set(after) == set(before)
+    for f in files:
+        assert after[f]["mtime"] == before[f]["mtime"], f
+        assert after[f]["seen"] == before[f]["seen"], f
+        assert after[f]["ast_hash"] == before[f]["ast_hash"], f
+
+
+def test_real_content_change_still_freshens_stamps(tmp_path):
+    """Only genuine hash changes earn fresh stamps: the edited row restamps,
+    untouched rows stay frozen."""
+    files = _corpus(tmp_path)
+    mp = tmp_path / "graphify-out" / "manifest.json"
+    _save(files, mp)
+    before = json.loads(mp.read_text(encoding="utf-8"))
+
+    target = files[0]
+    Path(target).write_text("# Note 0\n\nChanged.\n", encoding="utf-8")
+    _bump_mtime(target, 7200.0)
+
+    _save(files, mp)
+    after = json.loads(mp.read_text(encoding="utf-8"))
+    assert after[target]["ast_hash"] != before[target]["ast_hash"]
+    assert after[target]["mtime"] != before[target]["mtime"]
+    assert after[target]["seen"] >= before[target]["seen"]
+    for f in files[1:]:
+        assert after[f] == before[f], f
+
+
+def test_kind_alternation_between_update_and_extract_settles(tmp_path):
+    """Hook flows alternate kind='ast' (`update`) and kind='semantic'
+    (`extract`) saves. Each hash-state transition may stamp once, but once
+    both hashes are recorded the alternation is byte-stable."""
+    files = _corpus(tmp_path)
+    mp = tmp_path / "graphify-out" / "manifest.json"
+    _save(files, mp, kind="ast")
+    _save(files, mp, kind="semantic")  # semantic_hash "" -> h: one legit stamp
+    settled = mp.read_text(encoding="utf-8")
+
+    _save(files, mp, kind="ast")
+    assert mp.read_text(encoding="utf-8") == settled
+    _save(files, mp, kind="semantic")
+    assert mp.read_text(encoding="utf-8") == settled
+
+
+def test_subset_save_preserves_untouched_rows_verbatim(tmp_path):
+    """A caller saving a SUBSET of files (#917) must not churn the seeded rows
+    — and the stamped subset row inherits its volatile fields too."""
+    files = _corpus(tmp_path)
+    mp = tmp_path / "graphify-out" / "manifest.json"
+    _save(files, mp)
+    first = mp.read_text(encoding="utf-8")
+
+    _save(files[:1], mp)
+    assert mp.read_text(encoding="utf-8") == first
+
+
+def test_legacy_float_row_promotes_once_then_stable(tmp_path):
+    """Legacy bare-float rows promote to the dict schema exactly once; the
+    promoted row is then frozen like any other unchanged row."""
+    files = _corpus(tmp_path, n=1)
+    f = files[0]
+    mp = tmp_path / "graphify-out" / "manifest.json"
+    mp.parent.mkdir(parents=True, exist_ok=True)
+    mp.write_text(json.dumps({f: os.stat(f).st_mtime}), encoding="utf-8")
+
+    _save(files, mp)
+    promoted = json.loads(mp.read_text(encoding="utf-8"))
+    assert isinstance(promoted[f], dict) and promoted[f]["ast_hash"]
+
+    _save(files, mp)
+    assert json.loads(mp.read_text(encoding="utf-8")) == promoted


### PR DESCRIPTION
Closes #2988

manifest.json restamped mtime/seen on every run even when file content was unchanged, so committed graphify-out directories always showed a dirty working tree.

save_manifest now inherits previous mtime/seen verbatim when freshly computed hashes equal stored ones; stamps refresh only on real content change or explicit clear. Rebuilds over unchanged inputs are byte-identical (existing skip-write now actually fires); detection remains authoritative on ast_hash/semantic_hash. Six-case idempotency test suite added.
