### PR TITLE
fix(build): guard build_merge replace against under-producing re-extractions (#3004)

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -1502,6 +1502,31 @@ def _load_existing_graph(graph_path: Path) -> "tuple[list, list, list, bool] | N
     )
 
 
+def _sem_tier_counts(items: list) -> dict:
+    """Count semantic-tier items per RAW source_file (helper for #3004 gate).
+
+    AST-tier items are excluded: deterministic parsers legitimately shrink when
+    symbols are removed (#1116). Counts are taken pre-build, so dedup's fuzzy
+    id collapsing cannot distort them.
+    """
+    counts: dict = {}
+    for it in items:
+        if isinstance(it, dict) and not _is_ast_tier(it):
+            sf = it.get("source_file")
+            if sf:
+                counts[sf] = counts.get(sf, 0) + 1
+    return counts
+
+
+def _collapse_canon(counts: dict, root) -> dict:
+    """Fold raw source_file counts into canonical (normalised-relative) keys."""
+    out: dict = {}
+    for sf, c in counts.items():
+        k = _norm_source_file(sf, root) or sf
+        out[k] = out.get(k, 0) + c
+    return out
+
+
 def merge_raw_extraction(
     new: dict,
     graph_path: str | Path,
@@ -1522,6 +1547,9 @@ def merge_raw_extraction(
     - ``prune_sources`` (deleted / excluded / graph-stale files) are dropped,
       with the ``_abs_identity`` third-form fallback (#2012), and "replace" wins
       over a contradictory "delete" of a re-extracted source (#1796);
+    - sources whose NEW semantic extraction under-produces their on-disk
+      contribution are HELD BACK entirely (#3004 coverage gate, shared helpers
+      with build_merge) instead of being half-replaced;
     - everything else — nodes/edges/hyperedges owned by unchanged files — is
       carried forward unchanged.
 
@@ -1563,6 +1591,45 @@ def merge_raw_extraction(
         if norm:
             tier_sources.add(norm)
     new_sources: set[str] = new_ast_sources | new_sem_sources
+
+    # Coverage-gate parity with build_merge (#3004): hold back sources whose
+    # new semantic extraction under-produces vs the on-disk baseline, so the
+    # destructive replace below cannot destroy their prior contribution.
+    if new_sem_sources:
+        _disk_sem = _collapse_canon(_sem_tier_counts(existing_nodes), _eff_root)
+        _new_sem = _collapse_canon(
+            _sem_tier_counts(list(new.get("nodes", []))), _eff_root
+        )
+        held = [
+            (k, before, _new_sem[k])
+            for k, before in _disk_sem.items()
+            if k in _new_sem and _new_sem[k] < before
+        ]
+        if held:
+            held_keys = {k for k, _, _ in held}
+
+            def _held_item(item: dict) -> bool:
+                sf = item.get("source_file") if isinstance(item, dict) else None
+                return bool(sf) and (_norm_source_file(sf, _eff_root) or sf) in held_keys
+
+            for seq_key in ("nodes", "edges", "hyperedges"):
+                if new.get(seq_key):
+                    new[seq_key] = [i for i in new[seq_key] if not _held_item(i)]
+            for tier in (new_ast_sources, new_sem_sources):
+                tier.difference_update(
+                    sf for sf in tier
+                    if (_norm_source_file(sf, _eff_root) or sf) in held_keys
+                )
+            new_sources: set[str] = new_ast_sources | new_sem_sources
+            sample = ", ".join(f"{k}: {b}->{a}" for k, b, a in held[:5])
+            print(
+                f"[graphify] WARNING: {len(held)} re-extracted source(s) "
+                f"under-produced semantic nodes and were HELD BACK to protect "
+                f"the existing graph ({sample}); they keep their previous "
+                f"contribution and will be retried on the next extraction "
+                f"(#3004).",
+                file=sys.stderr,
+            )
 
     # "Replace" wins over a contradictory "delete" of the same source (#1796),
     # in both string and absolute-identity space (#2012) — as in build_merge.
@@ -1632,6 +1699,7 @@ def build_merge(
     dedup: bool = True,
     dedup_llm_backend: str | None = None,
     root: str | Path | None = None,
+    allow_shrink: list[str] | None = None,
 ) -> nx.Graph:
     """Load existing graph.json, merge new chunks into it, and save back.
 
@@ -1642,6 +1710,11 @@ def build_merge(
     while a one-tier re-extract keeps the other tier's layer intact. Files
     absent from new_chunks are preserved unchanged; deleted files are removed
     via prune_sources (tier-blind). Safe to call repeatedly.
+    allow_shrink (#3004): names sources exempt from the semantic coverage gate —
+    a re-extraction producing FEWER semantic nodes than the graph already holds
+    for that source is held back wholesale (its old contribution kept, retried
+    on the next run) unless the source is listed here. The AST tier is never
+    gated: deterministic parsers legitimately shrink when symbols are removed.
     root: if given, absolute source_file paths in new_chunks are made relative (#932).
     directed: if None (default), honor the on-disk graph's own ``directed`` flag
     when one exists, so an incremental merge can't silently flip a directed
@@ -1705,6 +1778,59 @@ def build_merge(
             if norm:
                 tier_sources.add(norm)
     new_sources: set[str] = new_ast_sources | new_sem_sources
+    # Per-source coverage gate (#3004): replace-on-re-extract used to delete ALL
+    # of a source's prior nodes as soon as the new extraction contained >= 1 node
+    # for it, then add back whatever the new pass produced — so a partial LLM
+    # extraction silently destroyed most of that file's contribution. Both guards
+    # meant to own the case were inert: the #479 block below skips itself under
+    # dedup=True (the default) and excused exactly this failure mode, pointing at
+    # an incomplete-build guard that does not exist in llm.py — so partial failure
+    # was punished harder than total failure (a file producing ZERO nodes never
+    # enters the replace sets at all). Hold such sources back instead: their chunk
+    # items are dropped for this run, their old contribution carries forward
+    # intact, and they are retried on the next extraction. SEMANTIC tier only;
+    # counts taken pre-build so dedup cannot distort them; allow_shrink names
+    # sources whose shrink is known-legitimate (rewritten documents).
+    if had_graph and new_sem_sources:
+        _disk_sem = _collapse_canon(_sem_tier_counts(existing_nodes), _replace_root)
+        _new_sem = _collapse_canon(
+            _sem_tier_counts([n for ch in new_chunks for n in ch.get("nodes", [])]),
+            _replace_root,
+        )
+        _allow = {
+            _norm_source_file(s, _replace_root) or s for s in (allow_shrink or ())
+        }
+        held = [
+            (k, before, _new_sem[k])
+            for k, before in _disk_sem.items()
+            if k in _new_sem and _new_sem[k] < before and k not in _allow
+        ]
+        if held:
+            held_keys = {k for k, _, _ in held}
+
+            def _held_item(item: dict) -> bool:
+                sf = item.get("source_file") if isinstance(item, dict) else None
+                return bool(sf) and (_norm_source_file(sf, _replace_root) or sf) in held_keys
+
+            for ch in new_chunks:
+                for seq_key in ("nodes", "edges", "hyperedges"):
+                    if ch.get(seq_key):
+                        ch[seq_key] = [i for i in ch[seq_key] if not _held_item(i)]
+            for tier in (new_ast_sources, new_sem_sources):
+                tier.difference_update(
+                    sf for sf in tier
+                    if (_norm_source_file(sf, _replace_root) or sf) in held_keys
+                )
+            new_sources: set[str] = new_ast_sources | new_sem_sources
+            sample = ", ".join(f"{k}: {b}->{a}" for k, b, a in held[:5])
+            print(
+                f"[graphify] WARNING: {len(held)} re-extracted source(s) "
+                f"under-produced semantic nodes and were HELD BACK to protect "
+                f"the existing graph ({sample}); they keep their previous "
+                f"contribution and will be retried on the next extraction; "
+                f"pass them in allow_shrink to accept the loss. (#3004)",
+                file=sys.stderr,
+            )
     # True on-disk baseline for the #479 shrink accounting at the end (#2497):
     # the rebind below removes the re-extracted sources' old nodes from
     # existing_nodes, so any later size comparison against the rebound list can
@@ -1930,11 +2056,11 @@ def build_merge(
     # this run's own re-extraction (same tier) or an explicit prune. Skipped
     # under dedup, where fuzzy merging collapses ids legitimately.
     #
-    # Residual tradeoff (accepted): a partial re-extraction that under-produces
-    # for ITS OWN file (>= 1 node still present in new_chunks) is excused here —
-    # that failure mode is owned by the extraction layer's incomplete-build
-    # guard (#1951), and refusing it here would reintroduce the #1116
-    # false-refuse for legitimate edits that remove symbols from a file.
+    # Own-file under-production is NOT excused here anymore: the per-source
+    # coverage gate above (#3004) owns it upstream of the replace, holding the
+    # source back instead of deleting its contribution — whatever reaches this
+    # point was replaced deliberately or pruned explicitly. (It used to be
+    # excused here in favour of an extraction-layer guard that does not exist.)
     if had_graph and not dedup:
         def _in_new_graph(n: dict) -> bool:
             nid = n.get("id")

--- a/tests/test_build_merge_shrink_guard.py
+++ b/tests/test_build_merge_shrink_guard.py
@@ -235,3 +235,112 @@ def test_merge_raw_extraction_absolute_prune_custom_layout(tmp_path):
     merged = merge_raw_extraction(new, gp, prune_sources=[str(root / "b.md")])
     sfs = {n.get("source_file") for n in merged["nodes"]}
     assert sfs == {"a.md"}, "raw path must prune the absolute entry too (#2446)"
+
+
+# ── #3004: per-source semantic coverage gate ──────────────────────────────────
+
+def _sem_node(i: int, sf: str) -> dict:
+    """Semantic-tier node dict (unstamped: no _origin, no L-loc), as the LLM
+    spec emits — _is_ast_tier's shape fallback classifies these as semantic."""
+    stem = sf.replace("/", "_").replace(".", "_")
+    return {
+        "id": f"{stem}_s{i}",
+        "label": f"{sf} entity {i}",
+        "file_type": "document",
+        "type": "entity",
+        "source_file": sf,
+    }
+
+
+def test_underproducing_semantic_source_held_back(tmp_path, capsys):
+    """The #3004 repro: 8 semantic nodes on disk, re-extraction yields 2.
+    Pre-fix, replace-on-re-extract deleted all 8 and merged back 2 (7 lost,
+    exit 0) — including under dedup=True, the default, where the #479 guard
+    skipped itself. The gate holds the source back instead: nothing lost."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(gp, [_sem_node(i, "areas/long-chronology.md") for i in range(8)])
+    poor = {
+        "nodes": [
+            _sem_node(0, "areas/long-chronology.md"),
+            _sem_node(99, "areas/long-chronology.md"),
+        ],
+        "edges": [],
+    }
+    G = build_merge([poor], gp)  # dedup=True default — guard used to be off here
+    ids = set(G.nodes)
+    assert all(f"areas_long-chronology_md_s{i}" in ids for i in range(8)), (
+        f"prior contribution destroyed despite the gate: {sorted(ids)}"
+    )
+    assert "areas_long-chronology_md_s99" not in ids, "held chunk leaked through"
+    err = capsys.readouterr().err
+    assert "HELD BACK" in err and "#3004" in err
+    assert "Replaced" not in err
+
+
+def test_equal_and_growing_semantic_replace_still_replaces(tmp_path, capsys):
+    """Healthy extractions must replace exactly as before — the gate only
+    fires on shrink."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(gp, [_sem_node(i, "chron.md") for i in range(8)])
+    equal = {"nodes": [_sem_node(i, "chron.md") for i in range(8)], "edges": []}
+    assert build_merge([equal], gp).number_of_nodes() == 8
+    grow = {"nodes": [_sem_node(i, "chron.md") for i in range(10)], "edges": []}
+    G = build_merge([grow], gp)
+    assert G.number_of_nodes() == 10
+    assert "#3004" not in capsys.readouterr().err
+
+
+def test_allow_shrink_override_accepts_the_loss(tmp_path, capsys):
+    """Escape hatch: sources listed in allow_shrink shrink deliberately
+    (rewritten documents) and are replaced like pre-gate behaviour."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(gp, [_sem_node(i, "rewritten.md") for i in range(8)])
+    poor = {"nodes": [_sem_node(i, "rewritten.md") for i in range(2)], "edges": []}
+    G = build_merge([poor], gp, allow_shrink=["rewritten.md"])
+    assert G.number_of_nodes() == 2
+    assert "HELD BACK" not in capsys.readouterr().err
+
+
+def test_gate_is_semantic_tier_only_ast_shrink_still_replaces(tmp_path):
+    """AST extraction legitimately shrinks when symbols are removed (#1116):
+    an AST 4->4 re-extract of a mixed file must replace normally while its
+    under-producing SEMANTIC layer is held back."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(
+        gp,
+        [_sem_node(i, "mix.md") for i in range(6)]
+        + [_node(i, "mix.md") for i in range(4)],
+    )
+    chunk = {
+        "nodes": [_sem_node(0, "mix.md")] + [_node(i, "mix.md") for i in range(4)],
+        "edges": [],
+    }
+    G = build_merge([chunk], gp)
+    ids = set(G.nodes)
+    assert all(f"mix_md_n{i}" in ids for i in range(4)), "AST tier was gated"
+    assert all(f"mix_md_s{i}" in ids for i in range(6)), "semantic tier was replaced"
+    assert len(ids) == 10
+
+
+def test_zero_node_production_never_trips_the_gate(tmp_path, capsys):
+    """A dispatched file producing ZERO nodes never enters the replace sets;
+    pin that long-standing asymmetry (total failure stays non-destructive)."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(gp, [_sem_node(i, "chron.md") for i in range(8)] + [_node(0, "b.md")])
+    other = {"nodes": [_node(0, "b.md")], "edges": []}
+    G = build_merge([other], gp)
+    assert sum(1 for n in G.nodes if str(n).endswith(("_s0", "_s7"))) >= 2
+    assert "HELD BACK" not in capsys.readouterr().err
+
+
+def test_merge_raw_extraction_holds_back_underproducing_source(tmp_path, capsys):
+    """Raw --no-cluster path shares the coverage gate (#3004 parity): the held
+    source keeps its on-disk contribution instead of being half-replaced."""
+    gp = tmp_path / "proj" / "graph.json"
+    _write_graph(gp, [_sem_node(i, "r.md") for i in range(6)])
+    new = {"nodes": [_sem_node(0, "r.md")], "edges": [], "hyperedges": []}
+    merged = merge_raw_extraction(new, gp)
+    ids = {n["id"] for n in merged["nodes"]}
+    assert all(f"r_md_s{i}" in ids for i in range(6)), sorted(ids)
+    assert "r_md_s99" not in ids
+    assert "HELD BACK" in capsys.readouterr().err


### PR DESCRIPTION
Closes #3004

Re-extracting a source could produce FEWER semantic nodes than the graph held, and build_merge replace-mode deleted the old nodes before validating the new set - silently shrinking the graph.

A pre-build coverage gate now counts semantic-tier nodes per source before dedup and drops under-producing chunks (with stderr warning naming counts), keeping the prior contribution intact unless allow_shrink is explicitly passed. Raw-path parity included; AST tier exempt to preserve #1116 semantics. Seven tests covering the reported repro, grow/equal replace, override, and zero-node asymmetry.
