### PR TITLE
fix(csharp): resolve a type reference to the type, not a same-named property (#3034)

### DIFF
--- a/graphify/extractors/csharp.py
+++ b/graphify/extractors/csharp.py
@@ -11,6 +11,7 @@ the core migration happens.
 from __future__ import annotations
 
 import html
+import re
 from pathlib import Path
 
 from graphify.extractors.base import _make_id
@@ -40,22 +41,45 @@ def _build_csharp_type_def_index(all_nodes: list[dict]) -> dict[tuple[str, str],
             continue
         if label.endswith(")") or label.startswith(".") or "." in label:
             continue
+        # A member is not a type. `public DbSet<Widget> Widget { get; set; }` declares a
+        # PROPERTY named Widget alongside the CLASS Widget, and both land in the same
+        # (namespace, name) bucket -- so the index either resolved every `Widget` type
+        # reference to the property, or (when the property sorted second) saw two
+        # candidates and refused. Either way the class kept only its own file's
+        # `contains` edge. `_callable_class` is stamped on every C# type declaration --
+        # class, interface, enum, record, struct, static and abstract classes -- and on
+        # no property or method, so it is the discriminator that belongs in a
+        # TYPE-definition index.
+        if not node.get("_callable_class"):
+            continue
         namespace = metadata.get("namespace", "")
         if not isinstance(namespace, str):
             namespace = ""
         candidates.setdefault((namespace, label), []).append(node)
 
     return {
-        key: sorted(
-            nodes,
-            key=lambda node: (
-                str(node.get("source_file") or ""),
-                str(node.get("source_location") or ""),
-                str(node.get("id") or ""),
-            ),
-        )[0]["id"]
+        key: sorted(nodes, key=_type_def_sort_key)[0]["id"]
         for key, nodes in candidates.items()
     }
+
+
+def _type_def_sort_key(node: dict) -> tuple:
+    """Deterministic "first declaration wins" ordering for same-(namespace, name) types.
+
+    source_location is an `L<line>` string, and sorting it lexically ranks L12 above L5
+    -- so the tie-break did not mean "declared first" for any file where the contenders
+    straddle line 10. Sort on the parsed line number, keeping the raw string and id as
+    stable secondary keys for locations that do not parse.
+    """
+    location = str(node.get("source_location") or "")
+    match = re.match(r"^L(\d+)$", location)
+    line = int(match.group(1)) if match else -1
+    return (
+        str(node.get("source_file") or ""),
+        line,
+        location,
+        str(node.get("id") or ""),
+    )
 
 
 def _strip_trailing_csharp_generic_args(target_fqn: str) -> str:

--- a/tests/test_csharp_type_vs_member_resolution.py
+++ b/tests/test_csharp_type_vs_member_resolution.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify.extract import extract
+from graphify.extractors.csharp import _build_csharp_type_def_index, _type_def_sort_key
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _node_by_id(result: dict, nid: str) -> dict | None:
+    return next((n for n in result["nodes"] if n.get("id") == nid), None)
+
+
+def _edge_targets(result: dict, context: str, label: str) -> list[dict]:
+    """Nodes targeted by `references` edges of the given context, for a label."""
+    out = []
+    for edge in result["edges"]:
+        if edge.get("relation") != "references" or edge.get("context") != context:
+            continue
+        node = _node_by_id(result, edge.get("target"))
+        if node is not None and node.get("label") == label:
+            out.append(node)
+    return out
+
+
+def _type_def(result: dict, label: str) -> dict:
+    defs = [
+        n for n in result["nodes"]
+        if n.get("label") == label and n.get("source_file") and n.get("_callable_class")
+    ]
+    assert len(defs) == 1, f"expected one {label} type definition, got {defs}"
+    return defs[0]
+
+
+CONTEXT = "App.Data"
+
+# The context sorts BEFORE the entity by filename on purpose. The index tie-breaks on
+# (source_file, line), so with the property still in the running it wins on filename
+# alone -- which is the realistic layout, an entity class and its DbContext in separate
+# files. Putting both in one file lets the line-number ordering mask the bug.
+DBCONTEXT = """namespace App.Data;
+
+public class AppContext
+{
+    public DbSet<Widget> Widget { get; set; }
+}
+"""
+
+ENTITY = """namespace App.Data;
+
+public class Widget
+{
+    public int Id { get; set; }
+}
+"""
+
+CONSUMER = """using System.Collections.Generic;
+using App.Data;
+
+namespace App.Services;
+
+public static class WidgetAdapter
+{
+    public static string Describe(Widget widget) => widget.Id.ToString();
+
+    public static int CountAll(List<Widget> widgets) => widgets.Count;
+}
+"""
+
+
+def _corpus(tmp_path: Path) -> list[Path]:
+    return [
+        _write(tmp_path / "AppContext.cs", DBCONTEXT),
+        _write(tmp_path / "Widget.cs", ENTITY),
+        _write(tmp_path / "Service.cs", CONSUMER),
+    ]
+
+
+def test_type_reference_binds_to_the_type_not_a_same_named_property(tmp_path: Path):
+    """A DbSet<T> property named after its own element type must not absorb type refs.
+
+    `public DbSet<Widget> Widget` puts a PROPERTY named Widget in the same
+    (namespace, name) bucket as the CLASS Widget, and the property used to win the
+    type-definition index -- so every cross-file `Widget` type reference pointed at the
+    property and the class kept only its own file's `contains` edge.
+    """
+    result = extract(_corpus(tmp_path), cache_root=tmp_path)
+
+    widget_class = _type_def(result, "Widget")
+    assert widget_class.get("source_file", "").endswith("Widget.cs")
+
+    for context in ("parameter_type", "generic_arg"):
+        targets = _edge_targets(result, context, "Widget")
+        assert targets, f"no {context} reference to Widget was emitted"
+        for node in targets:
+            assert node["id"] == widget_class["id"], (
+                f"{context} reference bound to {node['id']} "
+                f"({node.get('source_location')}) instead of the class"
+            )
+
+
+def test_the_same_named_property_keeps_its_own_member_edge(tmp_path: Path):
+    """Excluding members from the TYPE index must not delete or orphan the member."""
+    result = extract(_corpus(tmp_path), cache_root=tmp_path)
+
+    prop = [
+        n for n in result["nodes"]
+        if n.get("label") == "Widget"
+        and str(n.get("source_file", "")).endswith("AppContext.cs")
+    ]
+    assert len(prop) == 1, "the DbSet property node should still exist"
+    assert not prop[0].get("_callable_class"), "a property is not a type declaration"
+
+    owner = next(n for n in result["nodes"] if n.get("label") == "AppContext")
+    assert any(
+        e.get("source") == owner["id"] and e.get("target") == prop[0]["id"]
+        for e in result["edges"]
+    ), "AppContext should still own its Widget property"
+
+
+def test_every_csharp_type_kind_still_resolves(tmp_path: Path):
+    """Guard the discriminator: `_callable_class` must cover all type declarations.
+
+    Filtering the index on `_callable_class` would silently break resolution for any
+    type kind that does not carry it, so pin the whole set rather than just classes.
+    """
+    kinds = _write(
+        tmp_path / "Kinds.cs",
+        "namespace App.Kinds;\n\n"
+        "public class AClass {}\n"
+        "public interface AnInterface {}\n"
+        "public enum AnEnum { One }\n"
+        "public record ARecord(int X);\n"
+        "public struct AStruct { public int Y; }\n"
+        "public abstract class AnAbstract {}\n"
+        "public static class AStatic {}\n",
+    )
+    user = _write(
+        tmp_path / "User.cs",
+        "using App.Kinds;\n\n"
+        "namespace App.Use;\n\n"
+        "public class Consumer\n"
+        "{\n"
+        "    public void A(AClass a) {}\n"
+        "    public void B(AnInterface b) {}\n"
+        "    public void C(AnEnum c) {}\n"
+        "    public void D(ARecord d) {}\n"
+        "    public void E(AStruct e) {}\n"
+        "    public void F(AnAbstract f) {}\n"
+        "    public void G(AStatic g) {}\n"
+        "}\n",
+    )
+    result = extract([kinds, user], cache_root=tmp_path)
+
+    for label in ("AClass", "AnInterface", "AnEnum", "ARecord", "AStruct", "AnAbstract", "AStatic"):
+        definition = _type_def(result, label)
+        targets = _edge_targets(result, "parameter_type", label)
+        assert targets, f"{label} lost its parameter_type reference"
+        assert all(n["id"] == definition["id"] for n in targets), (
+            f"{label} reference did not bind to its declaration"
+        )
+
+
+def test_type_def_index_skips_members(tmp_path: Path):
+    nodes = [
+        {
+            "id": "cls", "label": "Widget", "file_type": "code",
+            "source_file": "Ctx.cs", "source_location": "L5",
+            "_callable_class": True, "metadata": {"namespace": CONTEXT},
+        },
+        {
+            "id": "prop", "label": "Widget", "file_type": "code",
+            "source_file": "Ctx.cs", "source_location": "L12",
+            "metadata": {"namespace": CONTEXT},
+        },
+    ]
+    assert _build_csharp_type_def_index(nodes) == {(CONTEXT, "Widget"): "cls"}
+
+
+def test_type_def_tie_break_orders_by_line_number_not_lexically():
+    """`L12` sorts before `L5` as a string, so the tie-break has to parse the line."""
+    early = {"id": "a", "source_file": "F.cs", "source_location": "L5"}
+    late = {"id": "b", "source_file": "F.cs", "source_location": "L12"}
+    assert sorted([late, early], key=_type_def_sort_key)[0]["id"] == "a"
+
+    unparseable = {"id": "c", "source_file": "F.cs", "source_location": ""}
+    assert sorted([early, unparseable], key=_type_def_sort_key)[0]["id"] == "c"


### PR DESCRIPTION
Fixes #3034.

### The bug

`_build_csharp_type_def_index` describes itself as an index of "C# **type** definitions", but its filter accepts any code node whose label is a bare identifier — it rules out namespaces, nested types, method labels (`endswith(")")`), dotted and `.`-prefixed labels, and nothing else. A property clears every one of those checks.

So `public DbSet<Widget> Widget { get; set; }` puts a **property** named `Widget` into the same `(namespace, name)` bucket as the **class** `Widget`, and whichever sorts first becomes the resolution target for every cross-file `Widget` type reference.

With the DbContext in its own file — the normal EF layout — the property sorts first on filename and wins:

```
.Describe()  --references/parameter_type-->  Widget @ AppContext.cs:L5   (the property)
```

The class node is left holding only its own file's `contains` edge, so `graphify affected <the class>` reports nothing.

There is a second-order effect worth noting: when the two happen to sort the other way the index sees two candidates and the reference is left dangling on a sourceless stub instead. Same user-visible outcome — the class has no inbound references — reached by a different path, which is why the symptom looked inconsistent depending on whether the scan path was relative or absolute.

### The fix

Filter the index on `_callable_class`. It is stamped on every C# type declaration and on no member — I pinned the whole set rather than assuming:

| | `_callable_class` |
|---|---|
| class, interface, enum, record, struct, static class, abstract class | `True` |
| property, method, namespace, file | absent |

The property node and its `defines/field` edge are untouched; only its claim to be a *type definition* goes away.

**Second, smaller correction in the same function.** The tie-break sorted `source_location` as a string, so `"L12"` ranked above `"L5"` and "first declaration wins" was false for any pair straddling line 10. It now parses the line number, keeping the raw string and id as stable secondary keys. This is independent of the fix above and easy to drop if you would rather take it separately — though note it is also what made the single-file version of the repro *appear* to work, by accidentally ordering the class ahead of the property.

### Tests

Five, in `tests/test_csharp_type_vs_member_resolution.py`:

- the DbSet repro, with the context in its own file so the property wins on filename — this is the one that fails without the fix
- the property keeps its own node and its owner's `defines` edge
- **every type kind still resolves** — class, interface, enum, record, struct, abstract, static. This is the guard that matters: filtering on `_callable_class` would silently break any type kind that lacks it
- a direct unit test of the index, and one of the sort key

I checked they actually fail without the change:

```
FAILED test_type_reference_binds_to_the_type_not_a_same_named_property
-  widget_app_data_widget
+  appcontext_app_data_appcontext_widget
```

A first version of the primary test put both declarations in one file and passed even with the fix reverted — the numeric-sort change alone rescued it. Splitting the files is what makes it a real guard.

### Verification

Full suite, before and after: the **same set of 25 pre-existing failures** (terraform, skillgen, ollama — all unrelated, and identical by test name), 4673 → 4678 passed, the difference being the five new tests. `ruff check` clean under the committed lint selection.

Measured on a private ~90k-node C# graph, querying the type declaration node directly, production files only, against `git grep -w`. Four EF entity types, each sharing its name with a DbSet property, plus two interfaces as controls:

| | Before | After |
|---|---|---|
| entity A | **0%** | **36%** |
| entity B | 11% | 23% |
| entity C | 11% | 33% |
| entity D | 8% | 9% |
| interface A | 97% | 97% |
| interface B | 100% | 100% |

Interfaces were already resolving correctly and are unchanged — the gain is entirely on types sharing a name with a DbSet property, which in an EF codebase is every entity. The corpus also sheds ~5,250 phantom stub nodes, since references now land on the real declaration instead of minting a placeholder.

(The graph is of a private codebase, so the type names are elided; the shapes are all the `DbSet<T> T` collision the tests reproduce.)

### Deliberately not fixed here

`new Widget { ... }` still leaves its `calls` edge on a sourceless stub. That edge carries no metadata distinguishing construction from a method call, so repointing it safely means stamping the emit site rather than changing this resolver — a bigger change touching the shared config-driven call path, which seemed worth separating from a resolution fix. Happy to follow up if you'd like it in the same place.

The numbers above stop well short of grep parity for the same reason, plus `db.Widget` member access emitting no edge at all (noted in #3034). This PR fixes attribution, not coverage.

