### PR TITLE
fix: expose node descriptions in live queries

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -12,6 +12,7 @@ import re
 import sys
 import time
 from graphify.paths import GRAPHIFY_OUT as _GRAPHIFY_OUT
+import graphify.security as _security
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 
@@ -1612,6 +1613,8 @@ def dispatch_command(cmd: str) -> None:
         )
         print(f"  Type:      {d.get('file_type', '')}")
         print(f"  Community: {d.get('community_name') or d.get('community', '')}")
+        if d.get("description"):
+            print(f"  Description: {_security.sanitize_label(str(d['description']))}")
         # Work-memory overlay: a derived experiential hint from `graphify reflect`,
         # merged in display-only from the .graphify_learning.json sidecar next to
         # graph.json. No line when the node has no overlay entry.

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -1034,11 +1034,15 @@ def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_bu
             status = sanitize_label(str(entry.get("status", "")))
             if status:
                 learning_suffix = f" learning={status}{':stale' if entry.get('stale') else ''}"
+        description_suffix = ""
+        if d.get("description"):
+            description_suffix = f" description={sanitize_label(str(d['description']))}"
         line = (
             f"NODE {sanitize_label(d.get('label', nid))} "
             f"[src={sanitize_label(str(d.get('source_file', '')))} "
             f"loc={sanitize_label(str(d.get('source_location', '')))} "
             f"community={sanitize_label(str(d.get('community_name') or d.get('community', '')))}"
+            f"{description_suffix}"
             f"{learning_suffix}]"
         )
         lines.append(line)

--- a/tests/test_explain_cli.py
+++ b/tests/test_explain_cli.py
@@ -82,6 +82,31 @@ def test_explain_source_file_path_prefers_file_level_node(monkeypatch, tmp_path,
     assert "Node: GET()" not in out
 
 
+def test_explain_shows_node_description_and_community_name(monkeypatch, tmp_path, capsys):
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {
+                "id": "billing_service",
+                "label": "BillingService",
+                "source_file": "services/billing.py",
+                "source_location": "L12",
+                "community": 4,
+                "community_name": "Payments",
+                "description": "Coordinates invoice creation and payment capture.",
+            },
+        ],
+        "links": [],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+
+    out = _run(monkeypatch, p, "BillingService", capsys)
+
+    assert "Community: Payments" in out
+    assert "Description: Coordinates invoice creation and payment capture." in out
+
+
 # --- work-memory overlay Lesson line ------------------------------------------
 
 def _write_sidecar(tmp_path, nodes):

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1192,6 +1192,25 @@ def test_query_text_chinese_finds_routing_nodes():
     assert "路由" in text
 
 
+def test_query_text_includes_node_description_and_community_name():
+    """Live query output exposes the metadata already stored on graph nodes."""
+    G = nx.Graph()
+    G.add_node(
+        "billing_service",
+        label="BillingService",
+        source_file="services/billing.py",
+        source_location="L12",
+        community=4,
+        community_name="Payments",
+        description="Coordinates invoice creation and payment capture.",
+    )
+
+    text = _query_graph_text(G, "BillingService", mode="bfs", depth=1)
+
+    assert "community=Payments" in text
+    assert "description=Coordinates invoice creation and payment capture." in text
+
+
 # --- get_community header (#1448): show the community name, no placeholder doubling ---
 
 def test_community_header_shows_real_name():


### PR DESCRIPTION
## Summary
- render persisted node descriptions in `graphify query` and MCP `query_graph` output
- render persisted node descriptions in `graphify explain` output
- add regression tests for both live query surfaces

## Validation
- `uv run pytest tests/ -q` (4940 passed, 72 skipped)
- `uv run ruff check graphify/cli.py graphify/serve.py tests/test_explain_cli.py tests/test_serve.py`

Closes #3026