### PR TITLE
fix: capture HOF-wrapped CommonJS exports

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2149,33 +2149,59 @@ def _js_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
                        if c.type == "assignment_expression"), None)
         if assign is not None:
             value = assign.child_by_field_name("right")
-            if value is not None and value.type in _JS_FUNCTION_VALUE_TYPES:
+            if value is not None:
                 target = _js_member_assignment_target(
                     assign.child_by_field_name("left"), source)
                 if target is not None:
                     kind, owner_name, member_name = target
                     line = node.start_point[0] + 1
-                    handled = False
-                    if kind == "exports":
-                        nid = _make_id(stem, member_name)
-                        add_node_fn(nid, f"{member_name}()", line)
-                        add_edge_fn(file_nid, nid, "contains", line)
-                        handled = True
-                    elif kind == "prototype":
-                        owner_nid = _make_id(stem, owner_name)
-                        nid = _make_id(owner_nid, member_name)
-                        add_node_fn(nid, f".{member_name}()", line)
-                        add_edge_fn(owner_nid, nid, "method", line)
-                        handled = True
-                    if handled:
-                        if callable_def_nids is not None:
-                            callable_def_nids.add(nid)  # CJS/prototype fn is callable
-                        if local_bound_names is not None:
-                            local_bound_names[nid] = _js_local_bound_names(value, source)
-                        body = value.child_by_field_name("body")
-                        if body:
-                            function_bodies.append((nid, body))
-                        return True
+                    if value.type in _JS_FUNCTION_VALUE_TYPES:
+                        handled = False
+                        if kind == "exports":
+                            nid = _make_id(stem, member_name)
+                            add_node_fn(nid, f"{member_name}()", line)
+                            add_edge_fn(file_nid, nid, "contains", line)
+                            handled = True
+                        elif kind == "prototype":
+                            owner_nid = _make_id(stem, owner_name)
+                            nid = _make_id(owner_nid, member_name)
+                            add_node_fn(nid, f".{member_name}()", line)
+                            add_edge_fn(owner_nid, nid, "method", line)
+                            handled = True
+                        if handled:
+                            if callable_def_nids is not None:
+                                callable_def_nids.add(nid)  # CJS/prototype fn is callable
+                            if local_bound_names is not None:
+                                local_bound_names[nid] = _js_local_bound_names(value, source)
+                            body = value.child_by_field_name("body")
+                            if body:
+                                function_bodies.append((nid, body))
+                            return True
+                    elif kind == "exports":
+                        # #3035: `exports.handler = wrapper(async (req) => …)` or `module.exports.handler = wrapper(…)`
+                        inner = value
+                        while inner is not None and inner.type in (
+                                "as_expression", "satisfies_expression"):
+                            inner = (inner.named_children[0]
+                                     if inner.named_children else None)
+                        if inner is not None and inner.type in (
+                                "call_expression", "new_expression"):
+                            closures: list = []
+                            _js_topmost_closures(inner, closures)
+                            if closures:
+                                nid = _make_id(stem, member_name)
+                                add_node_fn(nid, f"{member_name}()", line)
+                                add_edge_fn(file_nid, nid, "contains", line)
+                                if callable_def_nids is not None:
+                                    callable_def_nids.add(nid)  # exported HOF is callable
+                                for closure in closures:
+                                    body = closure.child_by_field_name("body")
+                                    if body:
+                                        if closure_locals_by_body is not None:
+                                            closure_locals_by_body[id(body)] = (
+                                                _js_local_bound_names(closure, source))
+                                        function_bodies.append((nid, body))
+                                return True
 
     # Class fields whose value is a function:
     #   class C { handler = () => {} }   → method handler() owned by C

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -988,6 +988,63 @@ def test_extract_js_commonjs_exports_assignment(tmp_path):
     assert "beta()" in labels
 
 
+def test_extract_js_commonjs_exports_hof_assignment(tmp_path):
+    """#3035: `exports.X = wrap(...)` and `module.exports.X = wrap(...)` must produce function nodes."""
+    from graphify.extract import extract_js
+    f = tmp_path / "mod.js"
+    f.write_text(
+        "function wrap(fn) { return fn; }\n"
+        "exports.assignedCall = wrap(async (x) => x);\n"
+        "module.exports.moduleAssignedCall = wrap(function(y) { return y; });\n"
+    )
+    res = extract_js(f)
+    by_label = {n["label"]: n for n in res["nodes"]}
+    assert "assignedCall()" in by_label
+    assert "moduleAssignedCall()" in by_label
+    assert by_label["assignedCall()"].get("_callable") is True
+    assert by_label["moduleAssignedCall()"].get("_callable") is True
+    file_nid = next(n["id"] for n in res["nodes"] if n["label"] == "mod.js")
+    edges = {(e["source"], e["relation"], e["target"]) for e in res["edges"]}
+    assert (file_nid, "contains", by_label["assignedCall()"]["id"]) in edges
+    assert (file_nid, "contains", by_label["moduleAssignedCall()"]["id"]) in edges
+
+
+def test_extract_js_commonjs_exports_hof_options_and_calls(tmp_path):
+    """#3035: Calls inside HOF-wrapped export callbacks (with options) are attributed to the exported node."""
+    from graphify.extract import extract_js
+    f = tmp_path / "handler.js"
+    f.write_text(
+        "function onCall(opts, fn) { return fn; }\n"
+        "function helperA() {}\n"
+        "function helperB() {}\n"
+        "exports.apiHandler = onCall({ cors: true }, async (req) => {\n"
+        "    helperA();\n"
+        "});\n"
+        "module.exports.otherHandler = onCall({ timeout: 5000 }, (req) => helperB());\n"
+    )
+    res = extract_js(f)
+    by_label = {n["label"]: n for n in res["nodes"]}
+    assert {"apiHandler()", "otherHandler()", "helperA()", "helperB()"} <= set(by_label)
+    edges = {(e["source"], e["relation"], e["target"]) for e in res["edges"]}
+    assert (by_label["apiHandler()"]["id"], "calls", by_label["helperA()"]["id"]) in edges
+    assert (by_label["otherHandler()"]["id"], "calls", by_label["helperB()"]["id"]) in edges
+
+
+def test_extract_js_arbitrary_member_hof_assignment_not_captured(tmp_path):
+    """#3035 / #1077: Arbitrary `obj.x = wrap(...)` must NOT produce a node."""
+    from graphify.extract import extract_js
+    f = tmp_path / "noise.js"
+    f.write_text(
+        "function wrap(fn) { return fn; }\n"
+        "const obj = {};\n"
+        "obj.assignedCall = wrap(async () => {});\n"
+    )
+    labels = [n["label"] for n in extract_js(f)["nodes"]]
+    assert "assignedCall()" not in labels
+    assert ".assignedCall()" not in labels
+    assert "assignedCall" not in labels
+
+
 def test_extract_js_prototype_method_assignment(tmp_path):
     """`Foo.prototype.bar = fn` must be captured as a method owned by Foo."""
     from graphify.extract import extract_js


### PR DESCRIPTION
## Summary

Fixes #3035.

The JavaScript extractor currently captures CommonJS exports when the right-hand side is directly a function or arrow function, but misses higher-order-function (HOF) exports such as:

```js
exports.myCallable = onCall({ secrets: [KEY] }, async (request) => {
    // ...
});
```

As a result, the exported entry point is absent from the graph even though its wrapped callback is the externally reachable handler.

This change extends CommonJS export extraction to recognize HOF-wrapped call expressions and associate their top-level closures with the exported callable node.

## Changes

* Reuse the existing `_js_topmost_closures()` mechanism for HOF-wrapped exports.
* Preserve existing `exports.foo` and `module.exports.foo` callable-node semantics.
* Associate discovered closure bodies with the exported node so calls inside wrapped handlers are attributed correctly.
* Preserve closure-local scoping behavior.
* Keep arbitrary member assignments such as `obj.foo = wrapper(...)` excluded.

## Tests

Added regression coverage for:

* `exports.foo = wrapper(async () => {})`
* `module.exports.foo = wrapper(function () {})`
* HOF wrappers with options before the callback.
* Calls inside HOF-wrapped export callbacks.
* Rejection of arbitrary member HOF assignments.

Validation:

* `tests/test_extract.py`: 41 JS/TS tests passed
* `tests/test_js_callback_calls.py`: 8 passed
* `tests/test_js_import_resolution.py`: 63 passed
* Full validation: 272 passed, 4 skipped

There is one unrelated Windows C `#include` long-path test failure.

## Scope

`module.exports = { foo: () => {} }` is intentionally not addressed here because it follows a separate object-literal export extraction path.
