### PR TITLE
feat(typescript): emit a node per enum member

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2360,14 +2360,14 @@ def _ts_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
         name_node = node if node.type == "property_identifier" else node.child_by_field_name("name")
         member_name = ""
         if name_node is not None:
+            member_name = _read_text(name_node, source)
             if name_node.type == "string":
-                # `"Odd Name" = 7`: read the fragment so the label is the member
-                # name rather than the quoted literal.
-                fragment = next(
-                    (c for c in name_node.children if c.type == "string_fragment"), None)
-                member_name = _read_text(fragment, source) if fragment is not None else ""
-            else:
-                member_name = _read_text(name_node, source)
+                # `"Odd Name" = 7`: the label is the member name, not the quoted
+                # literal. Unquote the whole text the way the namespace handler
+                # below does rather than reading a `string_fragment`, because an
+                # escape splits the string into several fragments and the first
+                # one alone truncates the name (`"A\tB"` would become `A`).
+                member_name = member_name.strip("'\"`")
         if member_name:
             line = node.start_point[0] + 1
             member_nid = _make_id(parent_class_nid, member_name)

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2329,7 +2329,7 @@ def _ts_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
                    nodes: list, edges: list, seen_ids: set, function_bodies: list,
                    parent_class_nid: str | None, add_node_fn, add_edge_fn,
                    walk_fn) -> bool:
-    """Emit a container node for a TS `namespace`/`module` declaration.
+    """Emit enum member nodes, and a container node for a TS `namespace`/`module`.
 
     `namespace Foo {}` parses as `internal_module` (with `name`/`body` fields);
     `module Bar {}` and ambient `declare module "pkg" {}` parse as a named
@@ -2343,6 +2343,42 @@ def _ts_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
     The guard requires `is_named` because the anonymous `module` keyword token
     shares the `module` type string and would otherwise match here.
     """
+    if (parent_class_nid
+            and node.parent is not None
+            and node.parent.type == "enum_body"
+            and node.type in ("property_identifier", "enum_assignment")):
+        # `enum_declaration` is in TS's class_types "parity with Java/C#", so the
+        # enum type is a node while its members were not, leaving the type a leaf.
+        # Java emits a node per `enum_constant` with a `case_of` edge (#1719),
+        # Kotlin per `enum_entry` (#1738), Swift the same; this is that shape.
+        #
+        # Two member spellings: a bare `Red` is a `property_identifier`, while
+        # `Green = 5` is an `enum_assignment` whose `name` is either a
+        # `property_identifier` or, for a quoted member, a `string`. The parent
+        # check is what keeps this off the `property_identifier` nodes that
+        # appear all over a TS file.
+        name_node = node if node.type == "property_identifier" else node.child_by_field_name("name")
+        if name_node is None:
+            return True
+        if name_node.type == "string":
+            # `"Odd Name" = 7`: read the fragment so the label is the member
+            # name rather than the quoted literal.
+            fragment = next(
+                (c for c in name_node.children if c.type == "string_fragment"), None)
+            member_name = _read_text(fragment, source) if fragment is not None else ""
+        else:
+            member_name = _read_text(name_node, source)
+        if not member_name:
+            return True
+        line = node.start_point[0] + 1
+        member_nid = _make_id(parent_class_nid, member_name)
+        # TS is case-sensitive while the id recipe casefolds, so `enum E { Value,
+        # value }` puts two legal members on one id. The first declaration keeps
+        # the node rather than a second edge hanging off it.
+        if member_nid not in seen_ids:
+            add_node_fn(member_nid, member_name, line)
+            add_edge_fn(parent_class_nid, member_nid, "case_of", line)
+        return True
     if node.is_named and node.type in ("internal_module", "module"):
         name_node = node.child_by_field_name("name")
         if name_node is None:
@@ -4602,7 +4638,7 @@ def _extract_generic(
                               closure_locals_by_body, config=config):
                 return
 
-        # TS namespace / module containers (internal_module, module)
+        # TS enum members, and namespace / module containers
         if config.ts_module == "tree_sitter_typescript":
             if _ts_extra_walk(node, source, file_nid, stem, str_path,
                               nodes, edges, seen_ids, function_bodies,

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2358,26 +2358,34 @@ def _ts_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
         # check is what keeps this off the `property_identifier` nodes that
         # appear all over a TS file.
         name_node = node if node.type == "property_identifier" else node.child_by_field_name("name")
-        if name_node is None:
-            return True
-        if name_node.type == "string":
-            # `"Odd Name" = 7`: read the fragment so the label is the member
-            # name rather than the quoted literal.
-            fragment = next(
-                (c for c in name_node.children if c.type == "string_fragment"), None)
-            member_name = _read_text(fragment, source) if fragment is not None else ""
-        else:
-            member_name = _read_text(name_node, source)
-        if not member_name:
-            return True
-        line = node.start_point[0] + 1
-        member_nid = _make_id(parent_class_nid, member_name)
-        # TS is case-sensitive while the id recipe casefolds, so `enum E { Value,
-        # value }` puts two legal members on one id. The first declaration keeps
-        # the node rather than a second edge hanging off it.
-        if member_nid not in seen_ids:
-            add_node_fn(member_nid, member_name, line)
-            add_edge_fn(parent_class_nid, member_nid, "case_of", line)
+        member_name = ""
+        if name_node is not None:
+            if name_node.type == "string":
+                # `"Odd Name" = 7`: read the fragment so the label is the member
+                # name rather than the quoted literal.
+                fragment = next(
+                    (c for c in name_node.children if c.type == "string_fragment"), None)
+                member_name = _read_text(fragment, source) if fragment is not None else ""
+            else:
+                member_name = _read_text(name_node, source)
+        if member_name:
+            line = node.start_point[0] + 1
+            member_nid = _make_id(parent_class_nid, member_name)
+            # TS is case-sensitive while the id recipe casefolds, so `enum E {
+            # Value, value }` puts two legal members on one id. The first
+            # declaration keeps the node rather than a second edge on it.
+            if member_nid not in seen_ids:
+                add_node_fn(member_nid, member_name, line)
+                add_edge_fn(parent_class_nid, member_nid, "case_of", line)
+        if node.type == "enum_assignment":
+            # Claiming the member must not swallow its initializer. An enum value
+            # can hold a whole expression, and `A = class Inner { m() {} }.name`
+            # loses Inner's method node if the walk stops here. Descend into the
+            # `value` only: the `name` is already read above, and walking it
+            # again would put the member through the default recurse as well.
+            value_node = node.child_by_field_name("value")
+            if value_node is not None:
+                walk_fn(value_node, parent_class_nid)
         return True
     if node.is_named and node.type in ("internal_module", "module"):
         name_node = node.child_by_field_name("name")

--- a/tests/test_typescript_enum_members.py
+++ b/tests/test_typescript_enum_members.py
@@ -81,6 +81,20 @@ def test_a_quoted_member_uses_its_name_not_the_literal(tmp_path):
     assert (_find(r, "Weird"), _find(r, "Odd Name")) in case_of
 
 
+def test_an_escape_in_a_quoted_member_does_not_truncate_the_name(tmp_path):
+    # An escape splits the string into several fragments, so reading the first
+    # fragment alone would label this member `A`. The whole text is unquoted
+    # instead, which keeps the escape as it was written.
+    case_of, r = _extract(tmp_path, {"s.ts": (
+        "export enum E {\n"
+        "    \"A\\tB\" = 1\n"
+        "}\n"
+    )})
+    assert "A\\tB" in _labels(r)
+    assert "A" not in _labels(r)
+    assert (_find(r, "E"), _find(r, "A\\tB")) in case_of
+
+
 def test_a_string_valued_enum_still_emits_members(tmp_path):
     # String enums are the common TS spelling and assign a string to a plain
     # identifier name; the value must not be mistaken for the name.

--- a/tests/test_typescript_enum_members.py
+++ b/tests/test_typescript_enum_members.py
@@ -1,0 +1,160 @@
+"""TypeScript enum members get a node and a `case_of` edge, like Java's (#1719).
+
+`enum_declaration` is in `_TS_CONFIG.class_types` with the comment "parity with
+Java/C#", but only the container half was done: the enum type was a node while
+its members were not, leaving the type a leaf. Java has emitted a node per
+`enum_constant` with a `case_of` edge since #1719 and Kotlin since #1738 (both
+from #1700), and Swift does the same for `enum_entry`.
+
+TS spells a member two ways. A bare `Red` is a `property_identifier`; `Green = 5`
+is an `enum_assignment` whose `name` is a `property_identifier`, or a `string`
+when the member is quoted. Both live directly under `enum_body`, which is what
+keeps this off the `property_identifier` nodes elsewhere in a file.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from graphify.extract import extract
+
+
+def _extract(tmp_path, files: dict[str, str]):
+    for name, body in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+    old = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        r = extract([Path(n) for n in files], cache_root=Path(tempfile.mkdtemp()))
+    finally:
+        os.chdir(old)
+    case_of = {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "case_of"}
+    return case_of, r
+
+
+def _find(r, label):
+    return next(n["id"] for n in r["nodes"] if n["label"] == label)
+
+
+def _labels(r):
+    return [n["label"] for n in r["nodes"]]
+
+
+def test_a_bare_member_becomes_a_node(tmp_path):
+    case_of, r = _extract(tmp_path, {"s.ts": (
+        "export enum Color {\n"
+        "    Red\n"
+        "}\n"
+    )})
+    assert "Red" in _labels(r)
+    assert (_find(r, "Color"), _find(r, "Red")) in case_of
+
+
+def test_an_assigned_member_becomes_a_node(tmp_path):
+    # `Green = 5` parses as enum_assignment, a different node type from the bare
+    # spelling, and both must land on the same edge.
+    case_of, r = _extract(tmp_path, {"s.ts": (
+        "export enum Color {\n"
+        "    Red,\n"
+        "    Green = 5\n"
+        "}\n"
+    )})
+    color = _find(r, "Color")
+    assert (color, _find(r, "Red")) in case_of
+    assert (color, _find(r, "Green")) in case_of
+
+
+def test_a_quoted_member_uses_its_name_not_the_literal(tmp_path):
+    # The name node is a `string`; the label must be the member name without
+    # the surrounding quotes.
+    case_of, r = _extract(tmp_path, {"s.ts": (
+        "export enum Weird {\n"
+        "    \"Odd Name\" = 7\n"
+        "}\n"
+    )})
+    labels = _labels(r)
+    assert "Odd Name" in labels
+    assert '"Odd Name"' not in labels
+    assert (_find(r, "Weird"), _find(r, "Odd Name")) in case_of
+
+
+def test_a_string_valued_enum_still_emits_members(tmp_path):
+    # String enums are the common TS spelling and assign a string to a plain
+    # identifier name; the value must not be mistaken for the name.
+    case_of, r = _extract(tmp_path, {"s.ts": (
+        "export enum Direction {\n"
+        "    Up = \"UP\",\n"
+        "    Down = \"DOWN\"\n"
+        "}\n"
+    )})
+    direction = _find(r, "Direction")
+    assert (direction, _find(r, "Up")) in case_of
+    assert (direction, _find(r, "Down")) in case_of
+    assert "UP" not in _labels(r)
+
+
+def test_case_only_sibling_members_do_not_duplicate_an_edge(tmp_path):
+    # Legal TS, one id after normalization. The first declaration keeps it.
+    case_of, r = _extract(tmp_path, {"s.ts": (
+        "export enum Odd {\n"
+        "    Value,\n"
+        "    value\n"
+        "}\n"
+    )})
+    assert len(case_of) == 1
+
+
+def test_a_class_property_identifier_is_not_read_as_an_enum_member(tmp_path):
+    # `property_identifier` appears throughout a TS file. Only the ones directly
+    # under an enum_body are members, so a class with properties and methods
+    # must produce no case_of edges at all.
+    case_of, r = _extract(tmp_path, {"s.ts": (
+        "export class Widget {\n"
+        "    label: string = \"x\";\n"
+        "    render(): void {}\n"
+        "}\n"
+    )})
+    assert case_of == set()
+
+
+def test_a_const_enum_emits_members(tmp_path):
+    case_of, r = _extract(tmp_path, {"s.ts": (
+        "export const enum Mode {\n"
+        "    Fast\n"
+        "}\n"
+    )})
+    assert (_find(r, "Mode"), _find(r, "Fast")) in case_of
+
+
+def test_an_enum_inside_a_namespace_emits_members(tmp_path):
+    # The namespace container is handled in the same walk; the enum must not
+    # lose its members to the namespace hop.
+    case_of, r = _extract(tmp_path, {"s.ts": (
+        "namespace App {\n"
+        "    export enum Color {\n"
+        "        Red\n"
+        "    }\n"
+        "}\n"
+    )})
+    assert (_find(r, "Color"), _find(r, "Red")) in case_of
+
+
+def test_the_enum_type_node_is_kept(tmp_path):
+    # Regression guard: the member nodes are additive, the enum type stays.
+    _, r = _extract(tmp_path, {"s.ts": (
+        "export enum Color {\n"
+        "    Red\n"
+        "}\n"
+    )})
+    color = _find(r, "Color")
+    contains = {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "contains"}
+    assert any(target == color for _, target in contains)
+
+
+def test_an_empty_enum_emits_no_members(tmp_path):
+    case_of, r = _extract(tmp_path, {"s.ts": "export enum Empty {\n}\n"})
+    assert "Empty" in _labels(r)
+    assert case_of == set()

--- a/tests/test_typescript_enum_members.py
+++ b/tests/test_typescript_enum_members.py
@@ -158,3 +158,17 @@ def test_an_empty_enum_emits_no_members(tmp_path):
     case_of, r = _extract(tmp_path, {"s.ts": "export enum Empty {\n}\n"})
     assert "Empty" in _labels(r)
     assert case_of == set()
+
+
+def test_claiming_a_member_does_not_swallow_its_initializer(tmp_path):
+    # An enum value can hold a whole expression. Handling the member must not
+    # stop the walk before it, or everything the initializer declares is lost:
+    # here the class expression's method disappeared until the `value` was
+    # walked explicitly.
+    case_of, r = _extract(tmp_path, {"s.ts": (
+        "export enum E {\n"
+        "    A = class Inner { m() { return 1; } }.name.length\n"
+        "}\n"
+    )})
+    assert (_find(r, "E"), _find(r, "A")) in case_of
+    assert "m()" in _labels(r), "the initializer's class expression was not walked"


### PR DESCRIPTION
Closes #3064.

`enum_declaration` is in `_TS_CONFIG.class_types` with the comment `# parity with Java/C#`, but only the container half was implemented. The enum type was a node, its members were not, and the type sat in the graph as a leaf.

Java has emitted a node per `enum_constant` with a `case_of` edge since #1719 and Kotlin per `enum_entry` since #1738, both from #1700; Swift does the same for `enum_entry`. This finishes the parity the config comment already claims. No new relation, no config change.

### What it does

The class handler already descends into `enum_body` with the enum as `parent_class_nid`, so the members were reachable and unhandled. `_ts_extra_walk` now emits a node and a `case_of` edge for each one.

```
color_direction --case_of--> color_direction_up
color_direction --case_of--> color_direction_down
```

### Three details that shaped the patch

**Two spellings.** A bare `Red` is a `property_identifier`; `Green = 5` is an `enum_assignment` carrying the name in its `name` field. Both had to be handled or half the members would be missing depending on how the enum was written.

**Quoted members.** `"Odd Name" = 7` puts a `string` in the `name` field, so the text is unquoted before it becomes a label. Otherwise the node reads `"Odd Name"`, quotes included, and does not match a search for the member. This goes through the same two lines the namespace handler in the same function already uses, which matters: an escape splits the string into several fragments, so any rule that reads one fragment truncates `"A\tB"` to `A`.

**Scoping.** `property_identifier` appears throughout a normal TS file, so matching on the node type alone would have swept up every class property and object key. The handler requires the node's parent to be `enum_body`. There is a test asserting a class with a property and a method produces no `case_of` edges at all.

Also, as in C#, TS is case-sensitive while `normalize_id` casefolds, so `enum E { Value, value }` puts two legal members on one id; the first declaration keeps the node.

### Tests

`tests/test_typescript_enum_members.py`, 12 tests. They cover both spellings, quoted members, string-valued enums (checking the value is not mistaken for the name), `const enum`, an enum inside a namespace, the case-only collision, an empty enum, that the enum type node survives, the scoping guard above, and that claiming a member does not swallow its initializer.

Two of them came out of review:

- Returning early after claiming an `enum_assignment` stopped the walk before the value expression, and `A = class Inner { m() {} }.name` lost Inner's method node, which `v8` emits today. The handler now descends into the `value` field, and a full node/edge diff against `v8` on an enum with call, member-access, shift, and template initializers shows the `case_of` edges added and nothing removed.
- Reading a `string_fragment` truncated an escaped quoted name. Replaced with the file's existing unquoting rule, as described above.

Full suite: 4,982 passed. The 3 failures (2 falkordb, 1 labeling) reproduce on a clean `v8` checkout and are unrelated. `ruff` clean.

### Note

#3065 does the same thing for C#, which has the identical gap. They are separate because the grammars differ enough that the patches share no code, and each is reviewable on its own.
