### PR TITLE
fix(watch): ignore read-only inotify events so the watcher stops re-triggering on its own reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## Unreleased
+
+- Fix: `graphify watch` no longer counts read-only inotify events (`opened`, emitted by watchdog >= 2.3, and `closed_no_write`, emitted by watchdog >= 4) as file changes on Linux, so the watcher's own AST rebuild — which reads every watched file — no longer re-triggers the watcher in a permanent loop ("N file(s) changed" with nothing modified; measured at ~26 CPU-minutes per hour and 15 memory-kills in 3 days on a ~1.7k-file tree, with the `needs_update` flag re-written every 1-3 minutes). Creation, modification, move, deletion and close-after-write still count; macOS (PollingObserver) never emits these events, so nothing changes there.
+
 ## 0.9.49 (2026-08-24)
 
 - Feature: `graphify merge-graphs` now links a type declaration that two repos share — same fully-qualified namespace and name, from different repos — with a `same_type_as` edge, so a shared contract type is navigable across the repo boundary; two unrelated types that merely share a short name are not linked (#3007, thanks @durmazoguzhan).

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1930,6 +1930,24 @@ def _batch_triggers_rebuild(batch: list[Path]) -> bool:
     return has_code or has_deletion
 
 
+_READ_ONLY_EVENT_TYPES = frozenset({"opened", "closed_no_write"})
+
+
+def _is_read_only_event(event) -> bool:
+    """True for watchdog events that mean a file was merely READ, not changed.
+
+    On Linux, inotify (watchdog >= 2.3) reports ``opened`` and, since watchdog 4,
+    ``closed_no_write`` for every file open/close — including the watcher's own
+    AST rebuild reading the tree, hook guards stat-ing sources, and editors or
+    agents reading files. Counting those as changes makes the watcher re-trigger
+    itself forever ("N file(s) changed" while nothing was modified), burn CPU and
+    keep re-writing the ``needs_update`` flag. Only creation, modification, move,
+    deletion and close-after-write are changes; macOS (PollingObserver) never
+    emits these, so the filter is a no-op there.
+    """
+    return getattr(event, "event_type", None) in _READ_ONLY_EVENT_TYPES
+
+
 def _batch_needs_llm_flag(batch: list[Path]) -> bool:
     """True when the batch contains a non-code file that still exists on disk.
 
@@ -1977,7 +1995,7 @@ def watch(watch_path: Path, debounce: float = 3.0) -> None:
     class Handler(FileSystemEventHandler):
         def on_any_event(self, event):
             nonlocal last_trigger, pending
-            if event.is_directory:
+            if event.is_directory or _is_read_only_event(event):
                 return
             path = Path(os.fsdecode(event.src_path))
             # Check .graphifyignore BEFORE the extension/dotfile/out filters so

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -3769,3 +3769,32 @@ def test_subfolder_marker_incremental_matches_cold_build(tmp_path, monkeypatch):
         f"incremental vs cold id drift: only-incremental={sorted(incremental_ids - cold_ids)[:5]}, "
         f"only-cold={sorted(cold_ids - incremental_ids)[:5]}"
     )
+
+
+# --- read-only inotify events must not count as changes (#watch-self-trigger) ---
+
+def test_read_only_events_are_ignored():
+    """``opened`` / ``closed_no_write`` mean a file was read, not changed."""
+    from graphify.watch import _is_read_only_event
+
+    class E:
+        def __init__(self, t):
+            self.event_type = t
+
+    assert _is_read_only_event(E("opened"))
+    assert _is_read_only_event(E("closed_no_write"))
+    for t in ("created", "modified", "deleted", "moved", "closed"):
+        assert not _is_read_only_event(E(t)), t
+
+
+def test_read_only_events_with_real_watchdog_classes():
+    pytest.importorskip("watchdog.events")
+    from watchdog import events as we
+    from graphify.watch import _is_read_only_event
+
+    assert _is_read_only_event(we.FileOpenedEvent("/tmp/x.py"))
+    if hasattr(we, "FileClosedNoWriteEvent"):
+        assert _is_read_only_event(we.FileClosedNoWriteEvent("/tmp/x.py"))
+    assert not _is_read_only_event(we.FileModifiedEvent("/tmp/x.py"))
+    assert not _is_read_only_event(we.FileCreatedEvent("/tmp/x.py"))
+    assert not _is_read_only_event(we.FileClosedEvent("/tmp/x.py"))


### PR DESCRIPTION
Replaces #2969, which is the same fix but was opened from a branch that also carried unrelated work from our fork — 13 files and 25 commits, when the change itself is one function. That was my mistake in how I cut the branch, not a change in what I am proposing. This branch is cut from `v8` and carries only the fix. #2969 is being closed with a pointer here.

### The defect

On Linux, watchdog >= 2.3 emits `opened` and watchdog >= 4 emits `closed_no_write` for every file open and close. `Handler.on_any_event` counted both as file changes.

The watcher's own AST rebuild reads every watched file. So: rebuild reads the tree → inotify reports `opened`/`closed_no_write` for each file → the watcher counts them as changes → it rebuilds → it reads the tree again. A permanent loop that prints `N file(s) changed` while nothing was modified.

Hook guards that stat sources, editors, and agents reading files feed the same loop.

### Measured

On a ~1,700-file tree, over 3 days:

| | |
|---|---|
| CPU burned | ~26 minutes per hour |
| memory-kills | 15 in 3 days |
| `needs_update` flag rewritten | every 1-3 minutes |

After the fix the watcher is idle between real edits.

### The change

`_is_read_only_event(event)` returns True for exactly `opened` and `closed_no_write`; `on_any_event` returns early on those, next to its existing `is_directory` early return.

Creation, modification, move, deletion and **close-after-write** (`closed`) all still count, so no real change is missed. macOS uses `PollingObserver`, which never emits these event types, so the filter is a no-op there.

### Diff

3 files: `graphify/watch.py` (+20/-1), `tests/test_watch.py` (+29), `CHANGELOG.md` (+4). `tests/test_watch.py` passes 130/130.
