### PR TITLE
feat(llm): send an explicit reasoning_effort for Kimi models that support it (GRAPHIFY_KIMI_EFFORT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## Unreleased
+
+- Feature: the `kimi` backend now sends an explicit `reasoning_effort` (default `max`, overridable via `GRAPHIFY_KIMI_EFFORT`) for Kimi models that support it — K3 advertises `valid_efforts ["low","high","max"]` on `/models`, and sending nothing let the server default (`"high"` for K3) apply silently while the gemini backend already carried an effort setting. Forwarded by the existing request plumbing; no behaviour change for models that ignore the field.
+
 ## 0.9.49 (2026-08-24)
 
 - Feature: `graphify merge-graphs` now links a type declaration that two repos share — same fully-qualified namespace and name, from different repos — with a `same_type_as` edge, so a shared contract type is navigable across the repo boundary; two unrelated types that merely share a short name are not linked (#3007, thanks @durmazoguzhan).

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -123,6 +123,12 @@ BACKENDS: dict[str, dict] = {
         "pricing": {"input": 0.74, "output": 4.66},  # USD per 1M tokens
         "temperature": None,  # kimi-k2.6 enforces its own fixed temperature; sending any value raises 400
         "max_tokens": 16384,
+        # Reasoning effort for Kimi models that support it (K3 advertises
+        # valid_efforts ["low","high","max"] on /models). Sending nothing lets the
+        # server default ("high" for K3) apply silently, while the gemini block
+        # above carries an effort setting. Forwarded as `reasoning_effort` by the
+        # existing request plumbing; models that ignore the field are unaffected.
+        "reasoning_effort": os.environ.get("GRAPHIFY_KIMI_EFFORT", "max"),
     },
     "ollama": {
         "base_url": _resolve_ollama_base_url("http://localhost:11434/v1"),

--- a/tests/test_kimi_reasoning_effort.py
+++ b/tests/test_kimi_reasoning_effort.py
@@ -1,0 +1,31 @@
+"""Tests for the kimi backend's reasoning_effort config (GRAPHIFY_KIMI_EFFORT).
+
+Kimi K3 advertises valid_efforts ["low","high","max"] on /models; sending
+nothing let the server default ("high") apply silently. The backend config now
+carries an explicit effort, defaulting to "max", overridable via env — the
+same import-time pattern as ANTHROPIC_BASE_URL on the claude backend.
+"""
+
+import importlib
+
+from graphify import llm
+
+
+def test_kimi_reasoning_effort_defaults_to_max(monkeypatch):
+    monkeypatch.delenv("GRAPHIFY_KIMI_EFFORT", raising=False)
+    reloaded = importlib.reload(llm)
+    try:
+        assert reloaded.BACKENDS["kimi"]["reasoning_effort"] == "max"
+    finally:
+        monkeypatch.undo()
+        importlib.reload(llm)
+
+
+def test_kimi_reasoning_effort_env_override(monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_KIMI_EFFORT", "low")
+    reloaded = importlib.reload(llm)
+    try:
+        assert reloaded.BACKENDS["kimi"]["reasoning_effort"] == "low"
+    finally:
+        monkeypatch.undo()
+        importlib.reload(llm)


### PR DESCRIPTION
Replaces #2982, which is the same six-line change but was opened from a branch that also carried unrelated work from our fork — 12 files and 21 commits. That was my mistake in how I cut the branch. This branch is cut from `v8` and carries only the change. #2982 is being closed with a pointer here.

### The gap

The `kimi` backend entry in `BACKENDS` has no `reasoning_effort`, so graphify sends none and the server's own default applies silently — `"high"` for K3. The `gemini` block directly above already carries an effort setting, so this reads as an omission rather than a deliberate choice.

Kimi K3 advertises `valid_efforts ["low","high","max"]` on `/models`, so the field is supported and settable.

### The change

The `kimi` entry gains `"reasoning_effort": os.environ.get("GRAPHIFY_KIMI_EFFORT", "max")`. It is forwarded by the existing request plumbing — no new call path — so models that ignore the field are unaffected.

`max` as the default is a judgement call: extraction quality is the point of the pass and the effort field does not change per-token pricing. If you would rather default to `high` (today's effective behaviour) and leave `max` opt-in, that is a one-word change and I am happy to make it.

### Diff

3 files: `graphify/llm.py` (+6), `tests/test_kimi_reasoning_effort.py` (+31), `CHANGELOG.md` (+4). Tests pass.
