### PR TITLE
fix(postgres): carry tree-sitter-sql in the postgres extra and surface grammar errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## Unreleased
+
+- Fix: the `postgres` extra now carries `tree-sitter-sql`, and `pg_introspect` reports the missing grammar instead of returning an empty graph. Installing exactly as the README documents (`pip install "graphifyy[postgres]"`) and pointing graphify at a live database returned "0 nodes, 0 edges" and exited 0: the extra pulled the `psycopg` driver but not the SQL grammar the synthesized DDL is parsed with, so every table, view and function silently produced nothing. Reproduced on `postgres:17-alpine` with 0.9.48 against a database with 3 tables, foreign keys, a view and a function. A silent empty result is worse than a failure, so a missing grammar now raises with the install hint rather than being swallowed.
+
 ## 0.9.49 (2026-08-24)
 
 - Feature: `graphify merge-graphs` now links a type declaration that two repos share — same fully-qualified namespace and name, from different repos — with a `same_type_as` edge, so a shared contract type is navigable across the repo boundary; two unrelated types that merely share a short name are not linked (#3007, thanks @durmazoguzhan).

--- a/graphify/pg_introspect.py
+++ b/graphify/pg_introspect.py
@@ -154,4 +154,12 @@ def introspect_postgres(dsn: str | None = None) -> dict:
 
     # Pass virtual path and in-memory DDL content to extract_sql
     result = extract_sql(virtual_path, content=ddl_string)
+    # extract_sql() reports a missing grammar as an 'error' key with empty
+    # nodes/edges; surface it instead of letting the CLI print
+    # "PostgreSQL: 0 nodes" as if the database were empty.
+    if result.get("error"):
+        raise ImportError(
+            f"{result['error']} (required by --postgres; "
+            "install with: pip install 'graphifyy[postgres]')"
+        )
     return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,10 @@ svg = ["matplotlib", "numpy>=2.0; python_version >= '3.13'"]
 leiden = ["graspologic; python_version < '3.13'"]
 office = ["python-docx", "openpyxl"]
 google = ["openpyxl"]
-postgres = ["psycopg[binary]"]
+# --postgres reconstructs DDL and feeds it to extract_sql(), which needs the
+# tree-sitter-sql grammar; without it introspection silently returns 0 nodes,
+# so the postgres extra must carry the grammar too.
+postgres = ["psycopg[binary]", "tree-sitter-sql"]
 video = ["faster-whisper; python_version >= '3.11'", "yt-dlp>=2026.6.9"]
 kimi = ["openai", "tiktoken"]
 ollama = ["openai"]

--- a/tests/test_pg_introspect.py
+++ b/tests/test_pg_introspect.py
@@ -367,6 +367,26 @@ def test_pg_introspect_import_error():
     assert "graphifyy[postgres]" in str(exc_info.value)
 
 
+def test_pg_introspect_grammar_error_surfaces():
+    """If extract_sql reports an error (e.g. tree-sitter-sql missing), the
+    introspection must raise instead of returning an empty graph — otherwise
+    the CLI prints "PostgreSQL: 0 nodes" as if the database were empty."""
+    mock_psycopg = _make_mock_psycopg(
+        [("public", "users", "BASE TABLE")], [], [], []
+    )
+    with patch.dict("sys.modules", {"psycopg": mock_psycopg}):
+        with patch(
+            "graphify.pg_introspect.extract_sql",
+            return_value={
+                "nodes": [],
+                "edges": [],
+                "error": "tree_sitter_sql not installed. Run: pip install tree-sitter-sql",
+            },
+        ):
+            with pytest.raises(ImportError, match="tree_sitter_sql not installed"):
+                introspect_postgres("postgresql://myhost/mydb")
+
+
 def test_pg_introspect_uri_forward_slashes():
     """Assert that the virtual path in postgresql introspection output uses forward slashes on all platforms."""
     mock_psycopg = _make_mock_psycopg([], [], [], [], host="some-host", dbname="some-db")


### PR DESCRIPTION
Replaces #3048. Same fix, but that PR was opened from a branch carrying our whole fork — 62 files and 41 commits for a change that is two lines plus a test. Nobody should have to review that, and I am sorry for sending it in that shape. This branch is cut from `v8` and carries only the fix. #3048 is being closed with a pointer here.

Fixes #3047.

### The defect

`pip install "graphifyy[postgres]"` — the command the README gives — installs `psycopg` but not `tree-sitter-sql`.

`introspect_postgres()` reconstructs the catalog as DDL text and hands it to `extract_sql()`. Without the grammar, `extract_sql()` returns `{"error": ..., "nodes": [], "edges": []}`. `introspect_postgres()` returned that dict through unchanged, so the CLI printed:

```
PostgreSQL: 0 nodes, 0 edges
```

and exited **0** — indistinguishable from pointing at an empty database.

### Reproduced

`postgres:17-alpine`, graphifyy 0.9.48, installed exactly as documented. Database with 3 tables, foreign keys between them, one view and one function. Result: `0 nodes, 0 edges`, exit 0.

### The change

1. `pyproject.toml`: the `postgres` extra now lists `tree-sitter-sql` alongside `psycopg[binary]`, so the documented install works.
2. `graphify/pg_introspect.py`: a grammar error coming back from `extract_sql` raises `ImportError` with the install hint, instead of being reported as an empty database.

The `sql` and `all` extras already carried the grammar — only `postgres` was short, which is probably why this went unnoticed. The second half is there because even with the extra fixed, an environment that has the driver and not the grammar should say so rather than report zero.

### Diff

4 files: `pyproject.toml` (+5/-1), `graphify/pg_introspect.py` (+8), `tests/test_pg_introspect.py` (+20), `CHANGELOG.md` (+4). 9 tests pass.
