### PR TITLE
fix(js): keep import edges to declared npm packages

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1366,7 +1366,7 @@ def _rescue_js_dynamic_imports(path: Path, result: dict) -> None:
             resolution = _resolve_rescued_specifier(path, raw, aliases, base_url)
             if resolution is None:
                 continue
-            node_id, _stub_sf, resolved_file = resolution
+            node_id, _stub_sf, resolved_file, _is_external = resolution
             # AST-captured already: same resolved target id, same resolved
             # on-disk file, or the engine's ref-namespaced external id.
             if node_id in deferred_ids or _make_id("ref", raw) in deferred_ids:
@@ -1508,10 +1508,10 @@ def _resolve_rescued_specifier(
     raw: str,
     aliases,
     base_url,
-) -> "tuple[str, str, Path | None] | None":
+) -> "tuple[str, str, Path | None, bool] | None":
     """Resolve a regex-rescued import specifier the way ``_import_js`` does.
 
-    Returns ``(node_id, stub_source_file, resolved_file)`` — ``resolved_file``
+    Returns ``(node_id, stub_source_file, resolved_file, is_external)`` — ``resolved_file``
     is the target as a real on-disk file, or None when the specifier is
     external or dangling. Returns None when no target can be minted at all
     (empty bare-import segment). Split out of :func:`_emit_rescued_import` so
@@ -1524,7 +1524,7 @@ def _resolve_rescued_specifier(
             Path(os.path.normpath(path.parent / raw))
         )
         resolved_file = resolved if resolved is not None and resolved.is_file() else None
-        return _make_id(str(resolved)), str(resolved), resolved_file
+        return _make_id(str(resolved)), str(resolved), resolved_file, False
     # Check tsconfig.json path aliases (e.g. "$lib/" -> "src/lib/",
     # "@/" -> "src/") before treating as external. Mirrors _import_js
     # logic so alias imports resolve to the same file node IDs the
@@ -1534,13 +1534,13 @@ def _resolve_rescued_specifier(
         resolved_alias = _resolve_js_module_path(resolved_alias)
         resolved_file = (resolved_alias if resolved_alias is not None
                          and resolved_alias.is_file() else None)
-        return _make_id(str(resolved_alias)), str(resolved_alias), resolved_file
+        return _make_id(str(resolved_alias)), str(resolved_alias), resolved_file, False
     # Bare/scoped import (node_modules) - use last segment;
     # build_from_json drops as external if no matching node exists.
     module_name = raw.split("/")[-1]
     if not module_name:
         return None
-    return _make_id(module_name), raw, None
+    return _make_id(module_name), raw, None, True
 
 
 def _emit_rescued_import(
@@ -1573,7 +1573,7 @@ def _emit_rescued_import(
     resolution = _resolve_rescued_specifier(path, raw, aliases, base_url)
     if resolution is None:
         return
-    node_id, stub_source_file, resolved_file = resolution
+    node_id, stub_source_file, resolved_file, is_external = resolution
     edge = {
         "source": file_node_id, "target": node_id,
         "relation": relation, "confidence": "EXTRACTED",
@@ -1589,11 +1589,23 @@ def _emit_rescued_import(
         # Edge target already a real node - just add the edge, don't add a node.
         result.setdefault("edges", []).append(edge)
         return
-    result.setdefault("nodes", []).append({
+    stub: dict = {
         "id": node_id, "label": raw,
         "file_type": "code", "source_file": stub_source_file,
         "confidence": "EXTRACTED",
-    })
+    }
+    if is_external:
+        # A bare/scoped specifier names a MODULE, not a path: the same package
+        # imported from N files is one node, and it is the same package a
+        # manifest in the corpus declares under that name. Mark it the way Swift
+        # module anchors are marked (#1327) — `file_type=code` keeps build.py
+        # validation happy, `type=module` exempts it from id-disambiguation — so
+        # it collapses with that declaration instead of being salted apart from
+        # it. Without this the salt renames the node and every importing edge is
+        # left on the dead id, so a declared dependency silently loses all of its
+        # inbound edges while an undeclared one keeps them (#3084).
+        stub["type"] = "module"
+    result.setdefault("nodes", []).append(stub)
     result.setdefault("edges", []).append(edge)
     existing_ids.add(node_id)
 

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1535,12 +1535,14 @@ def _resolve_rescued_specifier(
         resolved_file = (resolved_alias if resolved_alias is not None
                          and resolved_alias.is_file() else None)
         return _make_id(str(resolved_alias)), str(resolved_alias), resolved_file, False
-    # Bare/scoped import (node_modules) - use last segment;
-    # build_from_json drops as external if no matching node exists.
-    module_name = raw.split("/")[-1]
+    # Bare/scoped import (node_modules) - anchor to the PACKAGE, not the path
+    # leaf: `lodash/fp/map` is a dependency on `lodash`, and `@a/utils` and
+    # `@b/utils` are different packages that share a leaf.
+    parts = raw.split("/")
+    module_name = "/".join(parts[:2]) if raw.startswith("@") and len(parts) >= 2 else parts[0]
     if not module_name:
         return None
-    return _make_id(module_name), raw, None, True
+    return _make_id(module_name), module_name, None, True
 
 
 def _emit_rescued_import(
@@ -1605,6 +1607,11 @@ def _emit_rescued_import(
         # left on the dead id, so a declared dependency silently loses all of its
         # inbound edges while an undeclared one keeps them (#3084).
         stub["type"] = "module"
+        # For an external, `stub_source_file` is the package name (see
+        # _resolve_rescued_specifier) — and the node IS that package, so name it
+        # that way. `lodash/fp/map` and `lodash/debounce` are one `lodash` node,
+        # and neither subpath should end up titling it.
+        stub["label"] = stub_source_file
     result.setdefault("nodes", []).append(stub)
     result.setdefault("edges", []).append(edge)
     existing_ids.add(node_id)

--- a/tests/test_js_dynamic_imports.py
+++ b/tests/test_js_dynamic_imports.py
@@ -275,3 +275,79 @@ def test_dynamic_import_is_traversed_by_affected():
     g.add_edge("importer", "dep", relation="dynamic_import")
     hits = affected_nodes(g, "dep", depth=1)
     assert any(h.node_id == "importer" for h in hits)
+
+
+def test_declared_npm_dependency_keeps_its_import_edge(tmp_path, monkeypatch):
+    """A package declared in package.json must not lose its inbound import edges.
+
+    The bare specifier mints an external stub whose id is the package name; the
+    manifest in the same corpus produces a node under that same name. Two nodes,
+    one id, different source_files -> _disambiguate_colliding_node_ids salted both
+    apart, and the importing edge — which carries neither salt's source key —
+    was left on the now-dead id and dropped at build. The perverse result was
+    that an UNDECLARED package kept its edge (nothing to collide with) while a
+    properly declared dependency became invisible (#3084).
+
+    The stub is a module anchor, like the Swift ones (#1327), so it collapses onto
+    the declaration instead of being salted away from it.
+    """
+    _write(tmp_path / "package.json",
+           '{"name": "mre", "version": "1.0.0", "dependencies": {"postgres": "^3.4.0"}}\n')
+    _write(tmp_path / "app.mts",
+           "const postgres = (await import('postgres')).default;\n"
+           "export async function connect(url: string): Promise<void> {\n"
+           "  postgres(url, { max: 1 });\n"
+           "}\n")
+
+    monkeypatch.chdir(tmp_path)
+    result = extract([Path("app.mts"), Path("package.json")], cache_root=tmp_path / ".cache")
+
+    node_ids = {n["id"] for n in result["nodes"]}
+    pg_edges = [e for e in result["edges"]
+                if e["relation"] in ("dynamic_import", "imports_from")
+                and "postgres" in e["target"]]
+    assert pg_edges, "the dynamic import of a declared dependency must emit an edge"
+    for edge in pg_edges:
+        assert edge["target"] in node_ids, (
+            f"edge target {edge['target']!r} has no node — it would be dropped at build"
+        )
+
+
+def test_undeclared_npm_dependency_still_keeps_its_edge(tmp_path, monkeypatch):
+    """The no-manifest case must keep working: nothing to collapse onto, but the
+    stub still anchors the edge."""
+    _write(tmp_path / "app.mts",
+           "const postgres = (await import('postgres')).default;\n"
+           "export async function connect(url: string): Promise<void> {\n"
+           "  postgres(url, { max: 1 });\n"
+           "}\n")
+
+    monkeypatch.chdir(tmp_path)
+    result = extract([Path("app.mts")], cache_root=tmp_path / ".cache")
+
+    node_ids = {n["id"] for n in result["nodes"]}
+    pg_edges = [e for e in result["edges"]
+                if e["relation"] in ("dynamic_import", "imports_from")
+                and "postgres" in e["target"]]
+    assert pg_edges
+    for edge in pg_edges:
+        assert edge["target"] in node_ids
+
+
+def test_unresolved_relative_import_is_not_marked_a_module(tmp_path, monkeypatch):
+    """Only bare/scoped specifiers are module anchors.
+
+    An unresolved RELATIVE specifier names a path, not a module, so it must stay
+    subject to id-disambiguation — two `./helper` stubs in different directories
+    are different files and must not collapse onto one node.
+    """
+    _write(tmp_path / "app.mts", "const h = (await import('./missing-helper')).default;\n")
+
+    monkeypatch.chdir(tmp_path)
+    result = extract([Path("app.mts")], cache_root=tmp_path / ".cache")
+
+    for node in result["nodes"]:
+        if "missing" in str(node.get("label", "")) or "missing" in node["id"]:
+            assert node.get("type") != "module", (
+                "an unresolved relative import must not be exempted from disambiguation"
+            )

--- a/tests/test_js_dynamic_imports.py
+++ b/tests/test_js_dynamic_imports.py
@@ -351,3 +351,51 @@ def test_unresolved_relative_import_is_not_marked_a_module(tmp_path, monkeypatch
             assert node.get("type") != "module", (
                 "an unresolved relative import must not be exempted from disambiguation"
             )
+
+
+def test_scoped_packages_sharing_a_leaf_stay_distinct(tmp_path, monkeypatch):
+    """`@a/utils` and `@b/utils` are different packages that share a path leaf.
+
+    The external stub is anchored to the package name, not the last segment.
+    Anchoring to the leaf gave both the id `utils`, and because a module anchor
+    is exempt from id-disambiguation they then merged into one node — so an
+    import of `@scope-a/utils` resolved to a node labelled `@scope-b/utils`.
+    """
+    _write(tmp_path / "a.mts", "const x = (await import('@scope-a/utils')).default;\nexport const A = 1;\n")
+    _write(tmp_path / "b.mts", "const y = (await import('@scope-b/utils')).default;\nexport const B = 2;\n")
+
+    monkeypatch.chdir(tmp_path)
+    result = extract([Path("a.mts"), Path("b.mts")], cache_root=tmp_path / ".cache")
+
+    stubs = {n["id"]: n for n in result["nodes"] if n.get("type") == "module"}
+    assert len(stubs) == 2, f"the two packages must not share a node: {sorted(stubs)}"
+    assert {n["label"] for n in stubs.values()} == {"@scope-a/utils", "@scope-b/utils"}
+
+    node_ids = {n["id"] for n in result["nodes"]}
+    targets = {e["target"] for e in result["edges"] if e["relation"] == "dynamic_import"}
+    assert len(targets) == 2, f"each import must reach its own package: {targets}"
+    for t in targets:
+        assert t in node_ids
+
+
+def test_subpath_imports_collapse_onto_their_package(tmp_path, monkeypatch):
+    """`lodash/fp/map` is a dependency on `lodash`, not on `map`.
+
+    Every subpath of one package is one package node, and it is named for the
+    package — not for whichever specifier happened to be extracted first.
+    """
+    _write(tmp_path / "a.mts", "const x = (await import('lodash/fp/map')).default;\nexport const A = 1;\n")
+    _write(tmp_path / "b.mts", "const y = (await import('lodash/debounce')).default;\nexport const B = 2;\n")
+
+    monkeypatch.chdir(tmp_path)
+    result = extract([Path("a.mts"), Path("b.mts")], cache_root=tmp_path / ".cache")
+
+    # One stub dict is emitted per importing file; they carry the same id and so
+    # collapse to a single node at build. What matters is that the id and the
+    # name are the package's, whichever subpath minted them.
+    stubs = [n for n in result["nodes"] if n.get("type") == "module"]
+    assert {n["id"] for n in stubs} == {"lodash"}, "both subpaths are the same package"
+    assert {n["label"] for n in stubs} == {"lodash"}, "the node is the package, not one of its subpaths"
+
+    targets = {e["target"] for e in result["edges"] if e["relation"] == "dynamic_import"}
+    assert targets == {"lodash"}


### PR DESCRIPTION
Fixes #3084 (the dynamic-import half — see the closing note on the static half).

## Summary

A bare specifier mints an external stub whose id is the package name. When a manifest in the same corpus declares that package, it produces a node under that same name. Two nodes, one id, different `source_file` — so `_disambiguate_colliding_node_ids` salts both apart (`postgres` becomes `postgres_postgres` and `package_json_postgres`).

The importing edge carries neither salt's source key: its own `source_file` is the importer (`app.mts`), and `unambiguous_remaps` deliberately excludes ids that were ambiguous. So the edge is left on the now-dead `postgres` id and dropped at build. The pass already documents this exact shape for C headers — *"a cross-file import edge from a THIRD file carries neither salt's source_key, so the edge dangles on the now dead `foo` id"* (#1475) — this is the same failure for npm packages.

The result is backwards, as the report says: an **undeclared** package keeps its edge (nothing to collide with), while a properly **declared** dependency becomes invisible, and "which files use this package?" answers nothing with no warning anywhere.

## Reproduction

The issue's repro, on `v8` (0.9.50):

| case | before | after |
|---|---|---|
| dynamic import, package **not** in a manifest | edge kept | edge kept |
| dynamic import, package **declared** in `package.json` | **target dangling → dropped at build** | **edge kept** |

## Fix

Mark the external stub the way Swift module anchors are marked (#1327). That comment already describes this case:

> Module-level import handlers name a module, not a file path, so there is no pre-existing node to anchor the edge to. […] otherwise build_from_json prunes every such import edge as a dangling/external reference. The same module imported from N files shares one id (`file_type=code` keeps build.py validation happy; `type=module` exempts it from id-disambiguation) so it collapses to one shared node.

An npm package is a module rather than a path; the same package imported from N files is one node; and it is the same package the manifest declares. So the stub now collapses onto that declaration instead of being salted away from it.

Scoped to bare/scoped specifiers only, via an explicit `is_external` flag threaded out of `_resolve_rescued_specifier`. An unresolved **relative** specifier names a path, not a module, and must stay subject to disambiguation — two `./helper` stubs in different directories are different files and must not collapse. There is a test pinning that.

No id construction is touched, so #1638's ref-namespacing and #2457's portable target ids both stand unchanged.

## Tests

Three added to `tests/test_js_dynamic_imports.py`:

- `test_declared_npm_dependency_keeps_its_import_edge` — the repro; confirmed to **fail without this change**
- `test_undeclared_npm_dependency_still_keeps_its_edge` — guard: the no-manifest path must keep working
- `test_unresolved_relative_import_is_not_marked_a_module` — guard: a relative specifier must NOT become a module anchor, or two same-named stubs in different directories would collapse onto one node

`uv run --no-sync pytest tests/test_js_import_resolution.py tests/test_ts_import_require.py tests/test_phantom_external_import.py -q` — 72 passed.

`uv run --no-sync pytest tests/test_js_dynamic_imports.py tests/test_js_dynamic_import_affected.py tests/test_astro_extraction.py tests/test_astro_import_ids.py tests/test_vue_extraction.py -q` — 44 passed.

`uv run --no-sync ruff check graphify/extract.py` — passed.

Full suite: 12 failed, 5035 passed, 43 skipped — the same 12 as a clean `v8` checkout on this Windows machine (fifo / unix-socket / hermes / gemini install paths / watch), none related to this change.

## The static-import half, deliberately not changed

The report's second case (`import x from 'pkg'` targeting `ref_pkg`) is left alone. That target is ref-namespaced on purpose, and `_resolve_js_import_target` states the intent:

> The ref-namespaced target has no node, so build drops it as an external reference — the correct outcome for a third-party import.

The namespacing is also what guards #1638 (a bare `tailwindcss/colors` → `colors` id colliding with an unrelated local `colors.ts` and producing a confident phantom edge). Materializing a node there, or dropping the prefix, would contradict that decision and add a node for every external static import in every JS repo — a design call rather than a bug fix, so it is yours to make. Worth noting the two paths do disagree today: the rescue path materializes an external stub while the AST path does not. Happy to follow up in whichever direction you prefer.