### PR TITLE
Go: package-level constants and variables become nodes

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2487,6 +2487,56 @@ def _augment_js_reexport_edges(
 # Header / implementation file-extension pairing for the decl/def class merge.
 
 
+
+def _bind_cross_file_value_refs(
+    per_file: list[dict],
+    all_nodes: list[dict],
+    all_edges: list[dict],
+) -> None:
+    """Bind value references that cross a file boundary.
+
+    An extractor sees one file. It can bind a constant only where that
+    constant is also declared, and reports the rest as ``raw_value_refs``
+    rather than guessing - the same split ``raw_calls`` already uses for
+    calls. Here every file is available.
+
+    Measured on a 59-file Go project: of fifteen constants each used in
+    exactly one function, three were used from a sibling file, and those
+    three stayed unreachable until this pass existed.
+
+    Only for an unambiguous name, the same god-node guard the call
+    resolver applies: two same-named constants in two packages would
+    otherwise wire a caller to the wrong one.
+    """
+    by_name: dict[str, list[str]] = {}
+    for n in all_nodes:
+        if n.get("value_kind"):
+            by_name.setdefault(str(n.get("label", "")), []).append(n["id"])
+    if not by_name:
+        return
+
+    have = {(e.get("source"), e.get("target")) for e in all_edges}
+    for result in per_file:
+        for rv in result.get("raw_value_refs") or []:
+            ids = by_name.get(rv.get("name", ""), [])
+            if len(ids) != 1:
+                continue
+            src, tgt = rv.get("caller_nid"), ids[0]
+            if not src or src == tgt or (src, tgt) in have:
+                continue
+            have.add((src, tgt))
+            all_edges.append({
+                "source": src,
+                "target": tgt,
+                "relation": "references",
+                "context": "value_use",
+                "confidence": "EXTRACTED",
+                "source_file": rv.get("source_file", ""),
+                "source_location": rv.get("source_location", ""),
+                "weight": 1.0,
+            })
+
+
 def _merge_swift_extensions(
     per_file: list[dict],
     all_nodes: list[dict],
@@ -6198,6 +6248,13 @@ def extract(
             cn = rc.get("caller_nid")
             if cn in id_remap:
                 rc["caller_nid"] = id_remap[cn]
+        # raw_value_refs carry the same kind of id and are consumed by
+        # _bind_cross_file_value_refs, so they need the same rewrite.
+        for result in per_file:
+            for rv in result.get("raw_value_refs") or []:
+                vn = rv.get("caller_nid")
+                if vn in id_remap:
+                    rv["caller_nid"] = id_remap[vn]
         # swift_extensions[].nid is the same kind of id carrier as caller_nid
         # above (cache.py remaps both), consumed by _merge_swift_extensions far
         # below. Left stale it matches no node, so whether the extension merge
@@ -6270,6 +6327,11 @@ def extract(
                 cn = rc.get("caller_nid")
                 if cn in sym_remap:
                     rc["caller_nid"] = sym_remap[cn]
+            for result in per_file:
+                for rv in result.get("raw_value_refs") or []:
+                    vn = rv.get("caller_nid")
+                    if vn in sym_remap:
+                        rv["caller_nid"] = sym_remap[vn]
             # Same for swift_extensions[].nid (see the id_remap pass above).
             for result in per_file:
                 for ext in result.get("swift_extensions", []) or []:
@@ -6400,6 +6462,7 @@ def extract(
     # (src/) package root before the resolver/import-evidence passes run, so the
     # graph is identical regardless of scan root (#2072).
     _repoint_python_package_imports(paths, all_nodes, all_edges, root)
+    _bind_cross_file_value_refs(per_file, all_nodes, all_edges)
     _merge_swift_extensions(per_file, all_nodes, all_edges)
     _merge_csharp_partial_class_nodes(per_file, all_nodes, all_edges, paths, root)
     _disambiguate_colliding_node_ids(all_nodes, all_edges, all_raw_calls, root)

--- a/graphify/extractors/go.py
+++ b/graphify/extractors/go.py
@@ -83,7 +83,7 @@ def _go_collect_type_refs(node, source: bytes, generic: bool, out: list[tuple[st
                 _go_collect_type_refs(c, source, generic, out)
 
 def extract_go(path: Path) -> dict:
-    """Extract functions, methods, type declarations, and imports from a .go file."""
+    """Extract functions, methods, types, values, and imports from a .go file."""
     try:
         import tree_sitter_go as tsgo
         from tree_sitter import Language, Parser
@@ -269,8 +269,50 @@ def extract_go(path: Path) -> dict:
         salt = hashlib.sha1(name.encode("utf-8"), usedforsecurity=False).hexdigest()[:6]
         return _make_id(plain_nid, salt)
 
+    # Package-level value names declared in this file. Kept separate from
+    # label_to_nid so the reference pass below binds only these and not
+    # every identifier it walks past.
+    value_nids: dict[str, str] = {}
+
+    def add_value_decl(node, kind: str) -> None:
+        """Emit a node per name in a const_declaration or var_declaration.
+
+        The dispatch below handled function_declaration,
+        method_declaration, type_declaration and import_declaration. Go's
+        grammar also has const_declaration and var_declaration, so a
+        package-level constant never became a node and nothing could
+        point at it.
+
+        Measured on a 59-file Go project: of fifteen constants each used
+        in exactly one function, none was a node, while all fifteen of
+        those functions were. Asked "which function uses X", the graph
+        had the answer but no way in.
+        """
+        for spec in node.children:
+            if spec.type not in ("const_spec", "var_spec"):
+                continue
+            line = spec.start_point[0] + 1
+            for child in spec.children:
+                if child.type != "identifier":
+                    continue
+                name = _read_text(child, source)
+                if not name or name == "_":
+                    continue
+                nid = _make_id(pkg_scope, name)
+                add_node(nid, name, line)
+                for n in nodes:
+                    if n["id"] == nid:
+                        n["value_kind"] = kind
+                        break
+                add_edge(file_nid, nid, "contains", line, context=kind)
+                value_nids[name] = nid
+
     def walk(node) -> None:
         t = node.type
+
+        if t in ("const_declaration", "var_declaration"):
+            add_value_decl(node, "const" if t == "const_declaration" else "var")
+            return
 
         if t == "function_declaration":
             name_node = node.child_by_field_name("name")
@@ -430,6 +472,8 @@ def extract_go(path: Path) -> dict:
         label_to_nid[normalised] = n["id"]
 
     seen_call_pairs: set[tuple[str, str]] = set()
+    seen_value_refs: set[tuple[str, str]] = set()
+    raw_value_refs: list[dict] = []
     raw_calls: list[dict] = []
 
     def walk_calls(node, caller_nid: str) -> None:
@@ -493,6 +537,40 @@ def extract_go(path: Path) -> dict:
                         "source_file": str_path,
                         "source_location": f"L{node.start_point[0] + 1}",
                     })
+        # Reading a value is a relation this extractor did not record.
+        # "Where is this constant used" asks for exactly that, and
+        # without the edge the node stays unreachable even once it
+        # exists. Restricted to names declared as package-level values,
+        # so a local identifier does not produce an edge.
+        if node.type == "identifier":
+            name = _read_text(node, source)
+            tgt = value_nids.get(name)
+            if tgt is None and name and name not in _LANGUAGE_BUILTIN_GLOBALS:
+                # Not declared in this file. It may be a constant from a
+                # sibling file or a local variable; only a pass that sees
+                # every file can tell, which is how cross-file calls are
+                # already resolved. See _bind_cross_file_value_refs.
+                raw_value_refs.append({
+                    "caller_nid": caller_nid,
+                    "name": name,
+                    "source_file": str_path,
+                    "source_location": f"L{node.start_point[0] + 1}",
+                })
+            elif tgt and tgt != caller_nid:
+                pair = (caller_nid, tgt)
+                if pair not in seen_value_refs:
+                    seen_value_refs.add(pair)
+                    edges.append({
+                        "source": caller_nid,
+                        "target": tgt,
+                        "relation": "references",
+                        "context": "value_use",
+                        "confidence": "EXTRACTED",
+                        "source_file": str_path,
+                        "source_location": f"L{node.start_point[0] + 1}",
+                        "weight": 1.0,
+                    })
+
         for child in node.children:
             walk_calls(child, caller_nid)
 
@@ -510,5 +588,6 @@ def extract_go(path: Path) -> dict:
         "nodes": nodes,
         "edges": clean_edges,
         "raw_calls": raw_calls,
+        "raw_value_refs": raw_value_refs,
         "go_imports": dict(go_imported_pkgs),
     }

--- a/tests/test_go_value_nodes.py
+++ b/tests/test_go_value_nodes.py
@@ -1,0 +1,121 @@
+"""Go package-level constants and variables must be nodes with inbound edges.
+
+The Go extractor dispatched on four node types: function_declaration,
+method_declaration, type_declaration and import_declaration. Go's grammar
+also has const_declaration and var_declaration, so a package-level
+constant never became a node, and reading one was not recorded as a
+relation.
+
+Observed on a 59-file Go codebase, using fifteen constants each read in
+exactly one function: none of the fifteen constants was a node, while all
+fifteen of the reading functions were. Asked "which function uses X", the
+graph held the answer and offered no way in - every query returned "No
+matching nodes found".
+
+Three of those fifteen were read from a sibling file, which a per-file
+extractor cannot bind. Those go through raw_value_refs and
+_bind_cross_file_value_refs, the same split raw_calls already uses.
+"""
+import pytest
+
+from graphify.extract import extract
+
+
+def _extract_go(tmp_path):
+    return extract(sorted(tmp_path.glob("*.go")), cache_root=tmp_path, parallel=False)
+
+
+def _node_by_label(result, label):
+    for n in result["nodes"]:
+        if (n.get("label") or "").strip(".()") == label:
+            return n
+    return None
+
+
+def _has_edge(result, src_label, tgt_label, relation):
+    src = _node_by_label(result, src_label)
+    tgt = _node_by_label(result, tgt_label)
+    if src is None or tgt is None:
+        return False
+    return any(
+        e.get("source") == src["id"]
+        and e.get("target") == tgt["id"]
+        and e.get("relation") == relation
+        for e in result["edges"]
+    )
+
+
+@pytest.fixture
+def same_file(tmp_path):
+    (tmp_path / "sandbox.go").write_text(
+        "package runtime\n"
+        "\n"
+        "const (\n"
+        "\tsandboxProviderFD = 3\n"
+        "\tmaxOutput         = 4096\n"
+        ")\n"
+        "\n"
+        "var defaultTimeout = 30\n"
+        "\n"
+        "func bubblewrapArguments() []string {\n"
+        "\t_ = sandboxProviderFD\n"
+        "\treturn nil\n"
+        "}\n"
+    )
+    return _extract_go(tmp_path)
+
+
+def test_constants_become_nodes(same_file):
+    for name in ("sandboxProviderFD", "maxOutput"):
+        node = _node_by_label(same_file, name)
+        assert node is not None, f"{name} is not a node"
+        assert node.get("value_kind") == "const"
+
+
+def test_package_variables_become_nodes(same_file):
+    node = _node_by_label(same_file, "defaultTimeout")
+    assert node is not None
+    assert node.get("value_kind") == "var"
+
+
+def test_reading_a_constant_is_an_edge(same_file):
+    assert _has_edge(same_file, "bubblewrapArguments", "sandboxProviderFD", "references")
+
+
+def test_unused_constant_has_no_reader(same_file):
+    # maxOutput is declared and never read. A node, but nothing points at
+    # it: the pass must not invent an edge for every name it walks past.
+    assert not _has_edge(same_file, "bubblewrapArguments", "maxOutput", "references")
+
+
+def test_constant_read_from_a_sibling_file(tmp_path):
+    (tmp_path / "sandbox.go").write_text(
+        "package runtime\n"
+        "\n"
+        "const sandboxProviderFD = 3\n"
+    )
+    (tmp_path / "plan.go").write_text(
+        "package runtime\n"
+        "\n"
+        "func bubblewrapArguments() int {\n"
+        "\treturn sandboxProviderFD\n"
+        "}\n"
+    )
+    result = _extract_go(tmp_path)
+    assert _has_edge(result, "bubblewrapArguments", "sandboxProviderFD", "references")
+
+
+def test_local_variable_does_not_bind_to_a_constant(tmp_path):
+    # A local shadowing a package constant of another file must not wire
+    # the reader to it. The cross-file pass binds by name, so the guard
+    # is that only declared package-level values are candidates.
+    (tmp_path / "a.go").write_text(
+        "package runtime\n"
+        "\n"
+        "func caller() int {\n"
+        "\tnotAConstant := 7\n"
+        "\treturn notAConstant\n"
+        "}\n"
+    )
+    result = _extract_go(tmp_path)
+    assert _node_by_label(result, "notAConstant") is None


### PR DESCRIPTION
## Problem

The Go extractor dispatches on four node types:

```python
if t == "function_declaration": ...
if t == "method_declaration":   ...
if t == "type_declaration":     ...
if t == "import_declaration":   ...
```

Go's grammar also has `const_declaration` and `var_declaration`. A
package-level constant therefore never becomes a node, and reading one
is not recorded as a relation.

I hit this while comparing retrieval tools on a 59-file Go project,
using fifteen constants that are each read in exactly one function.
Every query returned the same thing:

```
$ graphify query "sandboxProviderFD"
No matching nodes found.
```

Checking the graph rather than guessing: **none** of the fifteen
constants was a node, while **all fifteen** of the reading functions
were. The graph held the answer and offered no way in.

## Change

Three parts, roughly 130 lines.

1. `const_declaration` and `var_declaration` become nodes, marked with
   `value_kind`, with a `contains` edge from their file.

2. Reading such a name inside a function body emits a `references` edge
   with context `value_use`. Without it the node exists but stays
   unreachable. Restricted to names declared as package-level values, so
   a local identifier produces nothing.

3. Names not declared in the file being extracted go to a new
   `raw_value_refs` bucket, bound afterwards by
   `_bind_cross_file_value_refs`. This mirrors `raw_calls`: an extractor
   sees one file and reports what it cannot resolve rather than
   guessing. Three of the fifteen constants were read from a sibling
   file and stayed unreachable until this pass existed. Bound only for
   an unambiguous name, the same god-node guard the call resolver uses.
   `raw_value_refs[].caller_nid` is rewritten by both `id_remap` and
   `sym_remap`, as `raw_calls[].caller_nid` already is.

## Result

Same project, same fifteen questions, `graphify query --budget 2000`:

| | answered | graph | build time |
|---|---|---|---|
| before | 0/15 | 327 nodes, 797 edges | 0.76 s |
| after | **15/15** | 395 nodes, 976 edges | 0.76 s |

The jump-style questions this tool is built for are unaffected: 7/7
before and after on a separate 7-question set.

## Tests

`tests/test_go_value_nodes.py`, six cases covering both directions: a
declared constant becomes a node, an unused one gets no reader, a
cross-file read is bound, and a local variable neither becomes a node
nor binds to one. Four of the six fail without this change.

Full suite: 25 failures before, 25 after (all pre-existing, in
`test_terraform.py` and `test_skillgen.py`), 4728 passing. `ruff check`
clean on the touched files.

## Note on scope

This is Go only. Of the 30 extractors, three mention a constant node
type at all, so the same gap likely exists elsewhere - Rust has
`const_item` and `static_item` and neither is handled. I did not touch
those: the cross-file pass is language-agnostic, so another extractor
only needs to emit `value_kind` nodes and `raw_value_refs` to use it.
