### PR TITLE
perf(cluster): call graspologic_native.leiden() directly, skip graspologic's import chain

### DIFF
--- a/graphify/cluster.py
+++ b/graphify/cluster.py
@@ -19,11 +19,86 @@ def _suppress_output():
     return contextlib.redirect_stdout(io.StringIO())
 
 
+def _native_leiden(stable: nx.Graph, resolution: float) -> dict[str, int] | None:
+    """Call graspologic_native.leiden() directly, bypassing graspologic's own
+    package import.
+
+    graspologic.partition.leiden() is a thin wrapper around exactly this
+    native (Rust) call. Importing the *package* — as opposed to the native
+    extension module it depends on — pulls in graspologic.layouts, which
+    imports umap, which imports pynndescent, which numba-JIT-compiles at
+    import time for a layout algorithm this function never calls: measured
+    at 7-19s of one-time import cost against a ~1s native call and a ~1.4s
+    full round trip (conversion + call + map-back) — see the "third update"
+    in GRAPHIFY_BUILD_PERF.md for the measurements this is based on.
+
+    Returns None (the caller falls through to the graspologic.partition.leiden
+    path, then to the networkx Louvain fallback) if graspologic_native isn't
+    installed, or if `stable` isn't the plain undirected, non-multigraph
+    input leiden actually supports — the same shape check
+    graspologic.partition.leiden itself makes before calling the same native
+    function.
+    """
+    try:
+        import graspologic_native as gn
+    except ImportError:
+        return None
+
+    if stable.is_directed() or stable.is_multigraph():
+        return None
+
+    # graspologic_native identifies nodes by their string form; two DISTINCT
+    # node objects that happen to stringify the same way would silently merge
+    # under it (this is exactly what graspologic.partition.leiden's own
+    # _IdentityMapper guards against). Graphify's own node IDs are already
+    # unique strings by construction — extractors/resolution.py's
+    # _disambiguate_colliding_node_ids salts any two distinct nodes that would
+    # otherwise share a string id before the graph is ever built — so this is
+    # a defensive check on an assumption that should never actually trip, not
+    # an expected path. One pass over the nodes, cheaper than an
+    # _IdentityMapper-style dict-store-per-edge-endpoint.
+    id_to_node: dict[str, object] = {}
+    for node in stable.nodes():
+        key = str(node)
+        existing = id_to_node.get(key)
+        if existing is not None and existing != node:
+            return None  # let graspologic.partition.leiden's own check handle/raise on this
+        id_to_node[key] = node
+
+    edges = [
+        (str(u), str(v), float(attrs.get("weight", 1.0)))
+        for u, v, attrs in stable.edges(data=True)
+    ]
+
+    try:
+        old_stderr = sys.stderr
+        try:
+            sys.stderr = io.StringIO()
+            with _suppress_output():
+                _quality, native_partitions = gn.leiden(
+                    edges=edges,
+                    starting_communities=None,
+                    resolution=resolution,
+                    randomness=0.001,
+                    iterations=1,
+                    use_modularity=True,
+                    seed=42,
+                    trials=1,
+                )
+        finally:
+            sys.stderr = old_stderr
+    except Exception:
+        return None
+
+    return {id_to_node[node_id]: community for node_id, community in native_partitions.items()}
+
+
 def _partition(G: nx.Graph, resolution: float = 1.0) -> dict[str, int]:
     """Run community detection. Returns {node_id: community_id}.
 
-    Tries Leiden (graspologic) first — best quality.
-    Falls back to Louvain (built into networkx) if graspologic is not installed.
+    Tries Leiden (graspologic_native directly, then graspologic) first — best
+    quality. Falls back to Louvain (built into networkx) if neither is
+    installed.
 
     resolution > 1.0 → more, smaller communities.
     resolution < 1.0 → fewer, larger communities.
@@ -43,6 +118,10 @@ def _partition(G: nx.Graph, resolution: float = 1.0) -> dict[str, int]:
     )
     for src, tgt, attrs in edge_rows:
         stable.add_edge(src, tgt, **attrs)
+
+    native_result = _native_leiden(stable, resolution)
+    if native_result is not None:
+        return native_result
 
     try:
         from graspologic.partition import leiden


### PR DESCRIPTION
## Summary

- `_partition()` currently reaches `graspologic.partition.leiden()` through the full `graspologic` package import, which eagerly pulls in `graspologic.layouts` → `umap` → `pynndescent` → numba JIT compilation — 7-19s per process, for a layout module the clustering path never calls.
- `graspologic_native` (the PyO3/Rust binding `graspologic.partition.leiden()` itself wraps) imports in ~0.5ms. This adds a `_native_leiden()` adapter that calls it directly, falling back to the existing `graspologic.partition.leiden` path (then NetworkX Louvain) if `graspologic_native` isn't installed or the graph shape isn't supported.
- Graphify's node IDs are guaranteed-unique strings by construction (`extractors/resolution.py`'s `_disambiguate_colliding_node_ids` runs before the graph is built), so the string-collision case `graspologic`'s `_IdentityMapper` guards against can't occur here; the adapter keeps a defensive check anyway.

## Measured (Bun corpus, 161k nodes / 336k edges, golden-cache-restored before each run)

| | before | after |
|---|---:|---:|
| `cluster` stage | 27.3-28.6s | 17.9s (~36-37% faster) |
| total build | 155.4-159.8s | 146.7s (~6-8% faster) |

## Correctness verified, not assumed

- Feeding the identical graph to both code paths in the same process produces a byte-identical partition (exact canonical-form match, Adjusted Rand Index = 1.0).
- Community counts, modularity, and singleton counts track within <0.3% across runs.
- Full test suite: 4,735 passed, 233 skipped, 12 pre-existing unrelated failures (same set as before this change). `tests/test_cluster.py`: 11/11.
- Adversarially tested degenerate inputs (empty graph, single node, resolution ≤ 0, self-loops, negative/zero/NaN edge weights, disconnected components) against both code paths side by side — all diverging behavior traced back to `graspologic_native` itself being called identically by both, not something this change introduces. Confirmed separately that Graphify's own extraction pipeline never produces a negative/zero/NaN edge weight (every extractor hardcodes `weight: 1.0`), so that pre-existing panic risk isn't reachable through normal use.

## Note on run-to-run variance

Separate full-pipeline invocations show community-label drift between runs (Adjusted Rand Index ≈ 0.73-0.75), but this is pre-existing and identical on both code paths — traced to the already-filed #2817 / #1667 (hash-seed-sensitive iteration in `cluster()`'s post-processing splitting pass, downstream of `_partition()`), not introduced or worsened by this change.

## Test plan

- [x] `pytest tests/test_cluster.py` — 11/11 passed
- [x] Full suite — no new failures vs. baseline
- [x] Same-input, same-process partition equivalence check (adapter vs. wrapper)
- [x] End-to-end timing on Bun corpus, golden-cache-restored, matched load
- [x] Adversarial edge-case testing (degenerate graphs, invalid resolution, bad weights)