### PR TITLE
fix(skill): stamp _origin on the semantic tier so update cannot delete it (#2843)

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -3898,6 +3898,14 @@ def dispatch_command(cmd: str) -> None:
         # first means semantic node attributes win on collision (richer labels
         # for symbols also referenced in docs). Hyperedges only come from the
         # semantic side.
+        # Everything in sem_result is semantic tier - fresh results and cache
+        # hits alike - so say so before the merge (#2843): an unstamped item
+        # is classified by the shape of its source_location, and a doc node
+        # located at 'L12' would read as AST and be deleted by the next
+        # incremental rebuild. Fresh results already carry the stamp
+        # (llm._stamp_semantic_origin); cache entries from before it do not.
+        from graphify.llm import _stamp_semantic_origin as _stamp_sem
+        _stamp_sem(sem_result)
         merged: dict = {
             "nodes": list(ast_result.get("nodes", [])) + list(sem_result.get("nodes", [])) + list(pg_result.get("nodes", [])) + list(cargo_result.get("nodes", [])),
             "edges": list(ast_result.get("edges", [])) + list(sem_result.get("edges", [])) + list(pg_result.get("edges", [])) + list(cargo_result.get("edges", [])),

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -2794,6 +2794,7 @@ def extract_corpus_parallel(
         if p.resolve() not in {c.resolve() for c in covered}
     )
     merged["uncovered_files"] = [str(p) for p in uncovered]
+    _stamp_semantic_origin(merged)
     if uncovered:
         shown = ", ".join(p.name for p in uncovered[:5])
         more = f" (+{len(uncovered) - 5} more)" if len(uncovered) > 5 else ""
@@ -2804,6 +2805,24 @@ def extract_corpus_parallel(
             file=sys.stderr,
         )
     return merged
+
+
+def _stamp_semantic_origin(result: dict) -> dict:
+    """Mark every node and edge of a semantic extraction ``_origin: "semantic"``.
+
+    build._is_ast_tier reads ``_origin`` when present and otherwise guesses
+    from the shape of ``source_location``: ``L<line>`` means AST. A backend
+    or subagent that reports line numbers for a document's sections made
+    those nodes read as AST, and the next incremental rebuild deleted them
+    with the re-extracted code file they seemed to belong to (#2843).
+    extract() stamps its items ``ast``; this is the semantic counterpart.
+    Existing stamps are kept (``setdefault``); returns ``result``.
+    """
+    for key in ("nodes", "edges"):
+        for item in result.get(key, []) or []:
+            if isinstance(item, dict):
+                item.setdefault("_origin", "semantic")
+    return result
 
 
 def _merge_into(merged: dict, result: dict) -> None:

--- a/graphify/skill-agents.md
+++ b/graphify/skill-agents.md
@@ -363,6 +363,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-aider.md
+++ b/graphify/skill-aider.md
@@ -361,6 +361,18 @@ from pathlib import Path
 ast = json.loads(Path('.graphify_ast.json').read_text())
 sem = json.loads(Path('.graphify_semantic.json').read_text())
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-amp.md
+++ b/graphify/skill-amp.md
@@ -363,6 +363,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-claw.md
+++ b/graphify/skill-claw.md
@@ -366,6 +366,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -363,6 +363,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-copilot.md
+++ b/graphify/skill-copilot.md
@@ -366,6 +366,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-devin.md
+++ b/graphify/skill-devin.md
@@ -425,6 +425,18 @@ from graphify.semantic_cleanup import sanitize_semantic_fragment
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text())
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text())
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-droid.md
+++ b/graphify/skill-droid.md
@@ -363,6 +363,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-kilo.md
+++ b/graphify/skill-kilo.md
@@ -366,6 +366,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-kiro.md
+++ b/graphify/skill-kiro.md
@@ -366,6 +366,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -358,6 +358,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-pi.md
+++ b/graphify/skill-pi.md
@@ -366,6 +366,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-trae.md
+++ b/graphify/skill-trae.md
@@ -364,6 +364,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-vscode.md
+++ b/graphify/skill-vscode.md
@@ -362,6 +362,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill-windows.md
+++ b/graphify/skill-windows.md
@@ -393,6 +393,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding="utf-8"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding="utf-8"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -366,6 +366,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tests/test_semantic_origin_stamp.py
+++ b/tests/test_semantic_origin_stamp.py
@@ -1,0 +1,142 @@
+"""Semantic-tier items must carry `_origin`, never be guessed by shape (#2843).
+
+`build._is_ast_tier` reads `_origin` when present and otherwise falls back to
+the shape of `source_location`: `L<line>` means AST. extract() stamps its own
+items `ast`; nothing stamped the semantic side. A subagent (or a backend)
+that reports `L12` for a document section therefore made that node read as
+AST, and the next `graphify update` — which replaces the AST tier of every
+re-extracted code file — deleted the document's whole semantic layer. On the
+reporter's 21-document corpus: 8 files, 133 nodes, 236 edges lost on a
+commit that touched one file.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from graphify.build import _is_ast_tier
+
+try:
+    from graphify.llm import _stamp_semantic_origin
+except ImportError:  # pre-fix tree
+    _stamp_semantic_origin = None
+
+FRAGMENTS = Path(__file__).resolve().parent.parent / "tools" / "skillgen" / "fragments" / "core"
+
+
+def _line_located_doc_node(**extra) -> dict:
+    """What a subagent writes for a section of a document without section
+    numbers: a line-number location, exactly the AST shape."""
+    return {"id": "docs_guide_deploy", "label": "Deploy", "file_type": "document",
+            "source_file": "docs/guide.md", "source_location": "L12", **extra}
+
+
+def test_the_shape_fallback_is_the_trap():
+    """Unstamped, a line-located document node reads as AST."""
+    assert _is_ast_tier(_line_located_doc_node()) is True
+    assert _is_ast_tier(_line_located_doc_node(_origin="semantic")) is False
+
+
+@pytest.mark.skipif(_stamp_semantic_origin is None, reason="pre-fix tree")
+def test_stamping_marks_nodes_and_edges_and_keeps_existing_marks():
+    result = {
+        "nodes": [_line_located_doc_node(), {"id": "x", "_origin": "ast"}],
+        "edges": [{"source": "a", "target": "b", "relation": "references", "source_location": "L3"}],
+        "hyperedges": [{"nodes": ["a", "b"]}],
+    }
+    out = _stamp_semantic_origin(result)
+    assert out is result
+    assert result["nodes"][0]["_origin"] == "semantic"
+    assert result["nodes"][1]["_origin"] == "ast"  # never overwritten
+    assert result["edges"][0]["_origin"] == "semantic"
+    assert not _is_ast_tier(result["nodes"][0])
+    assert not _is_ast_tier(result["edges"][0])
+    assert "_origin" not in result["hyperedges"][0]  # hyperedges are semantic by construction
+
+
+# ---------------------------------------------------------------------------
+# The runbook's Part C — the block the reporter's run went through
+# ---------------------------------------------------------------------------
+
+def _part_c_python(fragment: Path) -> str:
+    """The python passed to `-c` in the fragment's Part C block, unescaped the
+    way the shell would hand it to the interpreter."""
+    text = fragment.read_text(encoding="utf-8")
+    start = text.index("#### Part C - Merge AST + semantic into final extraction")
+    block = text[start:]
+    m = re.search(r'-c "\n(.*?)\n"\n```', block, re.S)
+    assert m, f"no Part C python block in {fragment.name}"
+    return m.group(1).replace('\\"', '"')
+
+
+@pytest.mark.parametrize("fragment", ["core.md", "aider.md", "devin.md"])
+def test_part_c_stamps_the_semantic_side(fragment, tmp_path):
+    code = _part_c_python(FRAGMENTS / fragment)
+    # The three runbooks read their intermediates from different places.
+    ast_path = re.search(r"Path\('([^']*\.graphify_ast\.json)'\)", code).group(1)
+    sem_path = re.search(r"Path\('([^']*\.graphify_semantic\.json)'\)", code).group(1)
+    out_path = re.search(r"Path\('([^']*\.graphify_extract\.json)'\)", code).group(1)
+    for rel in (ast_path, sem_path, out_path):
+        (tmp_path / rel).parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "graphify-out").mkdir(exist_ok=True)
+    ast = {"nodes": [{"id": "src_app_main", "label": "main", "file_type": "code",
+                      "source_file": "src/app.py", "source_location": "L1", "_origin": "ast"}],
+           "edges": []}
+    sem = {"nodes": [_line_located_doc_node()],
+           "edges": [{"source": "docs_guide_deploy", "target": "src_app_main",
+                      "relation": "references", "source_file": "docs/guide.md",
+                      "source_location": "L12", "confidence": "EXTRACTED"}],
+           "hyperedges": [], "input_tokens": 0, "output_tokens": 0}
+    (tmp_path / ast_path).write_text(json.dumps(ast), encoding="utf-8")
+    (tmp_path / sem_path).write_text(json.dumps(sem), encoding="utf-8")
+    r = subprocess.run([sys.executable, "-c", code], cwd=tmp_path, capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    merged = json.loads((tmp_path / out_path).read_text(encoding="utf-8"))
+    by_id = {n["id"]: n for n in merged["nodes"]}
+    assert by_id["src_app_main"]["_origin"] == "ast"
+    assert by_id["docs_guide_deploy"]["_origin"] == "semantic"
+    assert all(e["_origin"] == "semantic" for e in merged["edges"] if e["source_file"] == "docs/guide.md")
+    assert not _is_ast_tier(by_id["docs_guide_deploy"])
+
+
+# ---------------------------------------------------------------------------
+# The consequence: an incremental rebuild keeps the document's layer
+# ---------------------------------------------------------------------------
+
+def test_a_stamped_document_survives_the_code_files_re_extraction(tmp_path):
+    """The failure the reporter measured: re-extract one code file, and the
+    line-located document node — unstamped — is treated as that file's stale
+    AST and dropped. Stamped, it stays."""
+    from graphify.build import build_from_json, build_merge
+    from graphify.export import to_json
+
+    def graph_with(doc_node):
+        extraction = {
+            "nodes": [
+                {"id": "src_app_main", "label": "main", "file_type": "code",
+                 "source_file": "src/app.py", "source_location": "L1", "_origin": "ast"},
+                doc_node,
+            ],
+            "edges": [{"source": "docs_guide_deploy", "target": "src_app_main",
+                       "relation": "references", "source_file": "docs/guide.md",
+                       "confidence": "EXTRACTED", **({"_origin": "semantic"} if "_origin" in doc_node else {})}],
+            "hyperedges": [],
+        }
+        G = build_from_json(extraction)
+        p = tmp_path / f"graph_{'stamped' if '_origin' in doc_node else 'bare'}.json"
+        to_json(G, {0: list(G.nodes)}, str(p))
+        return p
+
+    re_extraction = {
+        "nodes": [{"id": "src_app_main", "label": "main", "file_type": "code",
+                   "source_file": "src/app.py", "source_location": "L2", "_origin": "ast"}],
+        "edges": [], "hyperedges": [],
+    }
+
+    stamped = build_merge([re_extraction], graph_with(_line_located_doc_node(_origin="semantic")))
+    assert "docs_guide_deploy" in stamped.nodes, "the stamped document node must survive"

--- a/tools/skillgen/expected/graphify__skill-agents.md
+++ b/tools/skillgen/expected/graphify__skill-agents.md
@@ -363,6 +363,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-aider.md
+++ b/tools/skillgen/expected/graphify__skill-aider.md
@@ -361,6 +361,18 @@ from pathlib import Path
 ast = json.loads(Path('.graphify_ast.json').read_text())
 sem = json.loads(Path('.graphify_semantic.json').read_text())
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-amp.md
+++ b/tools/skillgen/expected/graphify__skill-amp.md
@@ -363,6 +363,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-claw.md
+++ b/tools/skillgen/expected/graphify__skill-claw.md
@@ -366,6 +366,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-codex.md
+++ b/tools/skillgen/expected/graphify__skill-codex.md
@@ -363,6 +363,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-copilot.md
+++ b/tools/skillgen/expected/graphify__skill-copilot.md
@@ -366,6 +366,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-devin.md
+++ b/tools/skillgen/expected/graphify__skill-devin.md
@@ -425,6 +425,18 @@ from graphify.semantic_cleanup import sanitize_semantic_fragment
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text())
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text())
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-droid.md
+++ b/tools/skillgen/expected/graphify__skill-droid.md
@@ -363,6 +363,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-kilo.md
+++ b/tools/skillgen/expected/graphify__skill-kilo.md
@@ -366,6 +366,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-kiro.md
+++ b/tools/skillgen/expected/graphify__skill-kiro.md
@@ -366,6 +366,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-opencode.md
+++ b/tools/skillgen/expected/graphify__skill-opencode.md
@@ -358,6 +358,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-pi.md
+++ b/tools/skillgen/expected/graphify__skill-pi.md
@@ -366,6 +366,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-trae.md
+++ b/tools/skillgen/expected/graphify__skill-trae.md
@@ -364,6 +364,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-vscode.md
+++ b/tools/skillgen/expected/graphify__skill-vscode.md
@@ -362,6 +362,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill-windows.md
+++ b/tools/skillgen/expected/graphify__skill-windows.md
@@ -393,6 +393,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding="utf-8"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding="utf-8"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/expected/graphify__skill.md
+++ b/tools/skillgen/expected/graphify__skill.md
@@ -366,6 +366,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/fragments/core/aider.md
+++ b/tools/skillgen/fragments/core/aider.md
@@ -361,6 +361,18 @@ from pathlib import Path
 ast = json.loads(Path('.graphify_ast.json').read_text())
 sem = json.loads(Path('.graphify_semantic.json').read_text())
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/fragments/core/core.md
+++ b/tools/skillgen/fragments/core/core.md
@@ -301,6 +301,18 @@ from pathlib import Path
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/fragments/core/devin.md
+++ b/tools/skillgen/fragments/core/devin.md
@@ -425,6 +425,18 @@ from graphify.semantic_cleanup import sanitize_semantic_fragment
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text())
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text())
 
+# Stamp tier provenance on the semantic side. build._is_ast_tier reads
+# _origin when present and otherwise guesses from the SHAPE of
+# source_location ('L<line>' means AST). A subagent that writes 'L12' for a
+# doc section therefore made that node read as AST, and the next
+# `graphify update` deleted it along with the re-extracted code file it
+# seemed to belong to (#2843). extract() stamps its own items 'ast'; the
+# semantic side must say so explicitly.
+for n in sem['nodes']:
+    n.setdefault('_origin', 'semantic')
+for e in sem['edges']:
+    e.setdefault('_origin', 'semantic')
+
 # Merge: AST nodes first, semantic nodes deduplicated by id
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])

--- a/tools/skillgen/gen.py
+++ b/tools/skillgen/gen.py
@@ -1142,6 +1142,35 @@ def _is_community_label_export_fix_line(line: str) -> bool:
     )
 
 
+def _is_semantic_origin_stamp_fix_line(line: str) -> bool:
+    """Whether a line is part of the Part-C `_origin` stamping fix (#2843).
+
+    build._is_ast_tier reads ``_origin`` when present and otherwise guesses the
+    tier from the shape of ``source_location`` (``L<line>`` means AST). Part C
+    never stamped the semantic side, so a subagent writing ``L12`` for a doc
+    section made that node read as AST and the next ``graphify update`` deleted
+    it with the re-extracted code file it seemed to belong to. Part C now
+    ``setdefault``s ``_origin: 'semantic'`` on every semantic node and edge
+    before the merge. These are the comment block and the four code lines.
+    """
+    stripped = line.strip()
+    return (
+        stripped in (
+            "for n in sem['nodes']:",
+            "n.setdefault('_origin', 'semantic')",
+            "for e in sem['edges']:",
+            "e.setdefault('_origin', 'semantic')",
+        )
+        or "Stamp tier provenance on the semantic side" in line
+        or "_origin when present and otherwise guesses from the SHAPE of" in line
+        or "source_location ('L<line>' means AST). A subagent that writes 'L12' for a" in line
+        or "doc section therefore made that node read as AST, and the next" in line
+        or "`graphify update` deleted it along with the re-extracted code file it" in line
+        or "seemed to belong to (#2843). extract() stamps its own items 'ast'; the" in line
+        or "semantic side must say so explicitly." in line
+    )
+
+
 # Every line that may differ between a rendered monolith and its pristine v8
 # baseline. Each predicate documents one sanctioned change-class; a blank line is
 # allowed because the multi-line fix blocks insert spacing. Anything else failing
@@ -1163,6 +1192,7 @@ _SANCTIONED_MONOLITH_DIFFS = (
     _is_uv_from_interpreter_fix_line,
     _is_semantic_cache_scope_fix_line,
     _is_community_label_export_fix_line,
+    _is_semantic_origin_stamp_fix_line,
 )
 
 


### PR DESCRIPTION
Closes #2843.

## The problem

`build._is_ast_tier` reads `_origin` when present and otherwise guesses the tier from the **shape** of `source_location`: `L<line>` means AST. `extract()` stamps its own items `_origin: "ast"`; nothing stamped the semantic side — not the runbook's Part C merge, not `extract_corpus_parallel`, not the CLI's merge.

So a semantic node's tier was decided by what its location happened to look like. A subagent writing `"§4"` for a document with section numbers was fine; one writing `"L12"` for a document without them produced a node that read as AST. The next `graphify update` — which replaces the AST tier of every re-extracted code file — treated it as that file's stale AST and deleted it. On the reporter's 21-document run: **8 of 21 files lost, 133 nodes and 236 edges**, on a commit that touched one file.

## The change

Three sites now stamp `_origin: "semantic"` explicitly, with `setdefault` so an existing stamp is never overwritten:

1. **The runbook's Part C merge** (`core`, `aider` and `devin` fragments) — the block the reporter's run went through — stamps every semantic node and edge before merging with the AST side. The 134 generated skill artifacts are regenerated, the `expected/` snapshots blessed, and the new lines registered as a sanctioned monolith diff (`_is_semantic_origin_stamp_fix_line`) so the round-trip validator keeps guarding everything else. All five skillgen validators pass.
2. **`llm.extract_corpus_parallel`** stamps its result via a small `_stamp_semantic_origin(result)`, so library callers and the CLI's fresh results carry it.
3. **The CLI's AST+semantic merge** stamps `sem_result` as a whole, which also covers semantic-cache hits written before this change.

Hyperedges are untouched: they are semantic by construction and `_is_ast_tier` never looks at them.

## Tests

`tests/test_semantic_origin_stamp.py` — 6 tests: the shape fallback is shown to be the trap (an unstamped `L12` doc node reads as AST); the stamping helper marks nodes and edges and keeps existing marks; **each of the three runbooks' Part C python is extracted from its fragment, unescaped as the shell would, and executed** against an AST/semantic pair — the merged output must carry `ast` on the code node and `semantic` on the doc node and its edges; and a `build_merge` re-extraction of the code file keeps the stamped document node. With the fix reverted, 3 fail (the helper test skips). `test_skillgen`, the `test_llm*` suites, `test_extract_cli` and `test_build_merge*` are unchanged; the full suite matches the `v8` baseline.

Companion #2844 (Step 9 manifest stamping) is being handled in #2966 and is not touched here.
