### PR TITLE
docs(readme): add explicit git-workflow guidance for keeping the graph in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ graphify export callflow-html      # Mermaid architecture/call-flow HTML (auto-r
 /graphify add https://arxiv.org/abs/1706.03762   # fetch a paper and add it
 /graphify add <youtube-url>                       # transcribe and add a video
 
-graphify hook install              # auto-rebuild on git commit
+graphify hook install              # auto-rebuild on commit + branch checkout (run `graphify update .` after `git pull` — see "Recommended workflow" below)
 graphify merge-graphs a.json b.json              # combine two graphs
 
 graphify prs                       # PR dashboard: CI state, review status, worktree mapping
@@ -437,11 +437,27 @@ graphify-out/cost.json        # local only
 
 > `manifest.json` is now portable — keys are stored as relative paths and re-anchored on load, so committing it is safe and avoids a full rebuild on first checkout.
 
-**Workflow:**
-1. One person runs `/graphify .` and commits `graphify-out/`.
-2. Everyone pulls — their assistant reads the graph immediately.
-3. Run `graphify hook install` to auto-rebuild after each commit (AST only, no API cost). This also sets up a git merge driver so `graph.json` is never left with conflict markers — two devs committing in parallel get their graphs union-merged automatically.
-4. When docs or papers change, run `/graphify --update` to refresh those nodes.
+### Recommended workflow
+
+Set this up once per clone. From then on, three of your normal git commands keep the graph current by themselves, and one keeps it in sync with your team:
+
+| you do | graphify does |
+|---|---|
+| `graphify hook install` (once, right after cloning) | installs the hooks below, plus a merge driver so `graph.json` never shows conflict markers |
+| `git commit` | rebuilds automatically — AST only, no API cost |
+| `git checkout` / `git switch` | rebuilds automatically |
+| `git pull` / `git merge` | run `graphify update .` right after |
+| `git push` | nothing to do |
+
+**Step by step:**
+1. Clone the repo and run `graphify hook install` once.
+2. Commit and switch branches as normal — the graph stays current on its own.
+3. After every `git pull` (or merge), run `graphify update .` to bring the graph in sync with what you just pulled. On a large or active repo, put it on autopilot with a pull alias:
+   ```bash
+   git config --global alias.gpull '!git pull && graphify update .'
+   ```
+4. When docs or papers change, run `/graphify --update` to refresh those nodes too (code and docs update independently).
+5. If a query ever seems to be missing something you just added, run `graphify update .` first, then ask again.
 
 ---
 
@@ -613,6 +629,13 @@ graphify query "..."
 
 **`graph.json` has conflict markers after two devs commit at once**
 Run `graphify hook install` — it sets up a git merge driver that union-merges `graph.json` automatically so conflicts never happen.
+
+**Graph doesn't reflect a teammate's recent changes**
+Run `graphify update .` right after `git pull` or any merge — see [Recommended workflow](#recommended-workflow). Commits and branch switches update the graph automatically via the installed hooks; syncing with a pull is the one step you run yourself. Fold it into a pull alias so it's one command either way:
+```bash
+git config --global alias.gpull '!git pull && graphify update .'
+```
+Confirm the hooks are active with `graphify hook status`; re-run `graphify hook install` after an interpreter upgrade/reinstall to refresh them.
 
 **Extraction returns empty nodes/edges for docs or PDFs**
 Docs, PDFs, and images require an LLM call — code-only corpora need no key. Check that your API key is set and the backend is correct:


### PR DESCRIPTION
## Summary

Adds a clear, step-by-step workflow to the README's "Team setup" section covering how the graph stays in sync with normal git usage:

- A table mapping each git operation to what graphify does: `git commit` and `git checkout`/`git switch` rebuild automatically via the installed hooks; `git pull`/`git merge` requires running `graphify update .` yourself.
- Step-by-step setup instructions, including a one-line pull alias (`git config --global alias.gpull '!git pull && graphify update .'`) so keeping the graph current after a pull is a single command.
- A matching Troubleshooting entry ("Graph doesn't reflect a teammate's recent changes") for anyone who hits this before reading the workflow section.
- Minor wording fixes to two existing lines that implied broader automatic-rebuild coverage than the hooks actually provide.

## Motivation

Several users have reported the graph feeling "stale" after using it for a few days, particularly on large/active repos. In practice this is because commits and branch switches rebuild automatically, but pulling in a teammate's changes does not — so a normal day of `git pull`-ing quickly drifts out of sync unless `graphify update .` is run afterward. This makes that step explicit and easy to build into a habit or alias, rather than something users discover only after hitting it.

## Test plan

- [x] Read through the rendered markdown (table + steps + troubleshooting entry) for accuracy against actual hook behavior (`graphify/hooks.py`: `post-commit` + `post-checkout` only, no `post-merge`)
- [x] Verified `graphify update .` is the correct incremental command (matches existing usage elsewhere in the README, e.g. `graphify update ./src`)
- [x] Docs-only change, no code touched