### PR TITLE
feat(salesforce): read metadata XML, not just Apex

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -508,6 +508,13 @@ def classify_file(path: Path) -> FileType | None:
     from graphify.manifest_ingest import is_package_manifest_path
     if is_package_manifest_path(path):
         return FileType.CODE
+    # Salesforce metadata (`Account.object-meta.xml`) is parsed deterministically,
+    # so it takes the AST path like the manifests above. Its component kind sits in
+    # a compound suffix, and plain `.xml` is deliberately NOT in CODE_EXTENSIONS —
+    # claiming it would sweep every pom.xml/web.xml into the graph.
+    from graphify.extractors.salesforce_meta_xml import is_salesforce_meta_xml_path
+    if is_salesforce_meta_xml_path(path):
+        return FileType.CODE
     # Compound extensions must be checked before simple suffix lookup
     if path.name.lower().endswith(".blade.php"):
         return FileType.CODE

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -53,6 +53,7 @@ from graphify.extractors.pascal_forms import extract_delphi_form, extract_lazaru
 from graphify.extractors.powershell import extract_powershell, extract_powershell_manifest  # noqa: F401
 from graphify.extractors.razor import extract_razor  # noqa: F401
 from graphify.extractors.rust import extract_rust  # noqa: F401
+from graphify.extractors.salesforce_meta_xml import extract_salesforce_meta_xml, is_salesforce_meta_xml_path  # noqa: F401
 from graphify.extractors.sln import extract_sln  # noqa: F401
 from graphify.extractors.sql import extract_sql  # noqa: F401
 from graphify.extractors.terraform import extract_terraform  # noqa: F401
@@ -5391,6 +5392,13 @@ def _get_extractor(path: Path) -> Any | None:
     """Return the correct extractor function for a file, or None if unsupported."""
     if path.name.lower().endswith(".blade.php"):
         return extract_blade
+    # Salesforce source-format metadata (`Account.object-meta.xml`) carries the
+    # component kind in a compound suffix, not the extension, so it routes by
+    # filename like .blade.php above. Plain `.xml` stays unclaimed: claiming it
+    # would pull every pom.xml/web.xml in every repo into the graph, which is a
+    # separate decision from supporting Salesforce.
+    if is_salesforce_meta_xml_path(path):
+        return extract_salesforce_meta_xml
     # MCP config files (.mcp.json, claude_desktop_config.json, ...) are routed
     # by filename before generic .json dispatch so they get MCP-aware nodes
     # (servers, commands, packages, env vars) instead of opaque JSON keys.
@@ -7123,7 +7131,11 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
             for fname in filenames:
                 p = dp / fname
                 suffix = p.suffix
-                if (suffix in _EXTENSIONS or suffix.lower() in _EXTENSIONS) and not _ignored(p) and _resolves_under_root(p, containment_root):
+                # Salesforce metadata is dispatched by filename, not extension, so
+                # the extension gate alone would never collect it.
+                claimed = (suffix in _EXTENSIONS or suffix.lower() in _EXTENSIONS
+                           or is_salesforce_meta_xml_path(p))
+                if claimed and not _ignored(p) and _resolves_under_root(p, containment_root):
                     results.append(p)
         return sorted(results)
     # Walk with symlink following + cycle detection

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -7101,6 +7101,17 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
     if target.is_file():
         return [target] if _resolves_under_root(target, containment_root) else []
     _EXTENSIONS = set(_DISPATCH.keys())
+
+    def _claimed(p: Path) -> bool:
+        """Whether an extractor handles this file.
+
+        Salesforce metadata is dispatched by filename, not extension, so the
+        extension gate alone would never collect it. Shared by both walks below
+        — the symlink-following one used to miss the exception.
+        """
+        suffix = p.suffix
+        return (suffix in _EXTENSIONS or suffix.lower() in _EXTENSIONS
+                or is_salesforce_meta_xml_path(p))
     from graphify.detect import _is_ignored, _is_noise_dir, _load_graphifyignore
     ignore_root = root if root is not None else target
     patterns = _load_graphifyignore(ignore_root)
@@ -7130,12 +7141,7 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
             ]
             for fname in filenames:
                 p = dp / fname
-                suffix = p.suffix
-                # Salesforce metadata is dispatched by filename, not extension, so
-                # the extension gate alone would never collect it.
-                claimed = (suffix in _EXTENSIONS or suffix.lower() in _EXTENSIONS
-                           or is_salesforce_meta_xml_path(p))
-                if claimed and not _ignored(p) and _resolves_under_root(p, containment_root):
+                if _claimed(p) and not _ignored(p) and _resolves_under_root(p, containment_root):
                     results.append(p)
         return sorted(results)
     # Walk with symlink following + cycle detection
@@ -7155,8 +7161,7 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
         ]
         for fname in filenames:
             p = dp / fname
-            suffix = p.suffix
-            if (suffix in _EXTENSIONS or suffix.lower() in _EXTENSIONS) and not _ignored(p) and _resolves_under_root(p, containment_root):
+            if _claimed(p) and not _ignored(p) and _resolves_under_root(p, containment_root):
                 results.append(p)
     return sorted(results)
 

--- a/graphify/extractors/__init__.py
+++ b/graphify/extractors/__init__.py
@@ -28,6 +28,7 @@ from graphify.extractors.pascal_forms import extract_delphi_form, extract_lazaru
 from graphify.extractors.powershell import extract_powershell, extract_powershell_manifest
 from graphify.extractors.razor import extract_razor
 from graphify.extractors.rust import extract_rust
+from graphify.extractors.salesforce_meta_xml import extract_salesforce_meta_xml
 from graphify.extractors.sln import extract_sln
 from graphify.extractors.sql import extract_sql
 from graphify.extractors.terraform import extract_terraform
@@ -58,6 +59,7 @@ LANGUAGE_EXTRACTORS: dict[str, Callable[[Path], dict]] = {
     "powershell_manifest": extract_powershell_manifest,
     "razor": extract_razor,
     "rust": extract_rust,
+    "salesforce_meta_xml": extract_salesforce_meta_xml,
     "sln": extract_sln,
     "sql": extract_sql,
     "terraform": extract_terraform,

--- a/graphify/extractors/salesforce_meta_xml.py
+++ b/graphify/extractors/salesforce_meta_xml.py
@@ -34,9 +34,21 @@ _META_SUFFIX = "-meta.xml"
 _MAX_BYTES = 2 * 1024 * 1024
 
 
-def _is_safe(src: bytes) -> bool:
+def _unsafe_reason(src: bytes) -> str | None:
+    """Why this file must not be parsed, or None when it is fine.
+
+    The DOCTYPE/ENTITY screen matches ASCII bytes, so a UTF-16 encoded
+    declaration slips straight past it while ElementTree still honours the
+    encoding and expands the entity. A NUL byte is the reliable tell for
+    UTF-16/32, and Salesforce source format is always UTF-8, so refusing those
+    outright closes the hole without costing anything real.
+    """
+    if b"\x00" in src:
+        return "refusing non-UTF-8 XML (NUL byte: UTF-16/32)"
     lowered = src.lower()
-    return b"<!doctype" not in lowered and b"<!entity" not in lowered
+    if b"<!doctype" in lowered or b"<!entity" in lowered:
+        return "refusing XML with DOCTYPE/ENTITY declaration"
+    return None
 
 
 def _local(tag: str) -> str:
@@ -122,9 +134,9 @@ def extract_salesforce_meta_xml(path: Path) -> dict:
         return {"nodes": [], "edges": [], "error": f"cannot read {path}"}
     if len(src) > _MAX_BYTES:
         return {"nodes": [], "edges": [], "error": "metadata file too large"}
-    if not _is_safe(src):
-        return {"nodes": [], "edges": [],
-                "error": "refusing XML with DOCTYPE/ENTITY declaration"}
+    unsafe = _unsafe_reason(src)
+    if unsafe:
+        return {"nodes": [], "edges": [], "error": unsafe}
     try:
         root = ET.fromstring(src)
     except ET.ParseError as e:

--- a/graphify/extractors/salesforce_meta_xml.py
+++ b/graphify/extractors/salesforce_meta_xml.py
@@ -1,0 +1,210 @@
+"""Salesforce `*-meta.xml` extractor — the Salesforce subset of plain XML.
+
+Salesforce metadata is ordinary XML, so this is one generic element walk with no
+per-component-type logic: objects, fields, permission sets, layouts, flows and
+everything else go through the same code path, parsed with the stdlib XML
+parser and no new dependency.
+
+What a file DECLARES comes from its filename (``Memory__c.object-meta.xml``
+declares ``Memory__c``). What it REFERENCES comes from leaf element text, which
+is how Salesforce spells cross-component links::
+
+    <classAccesses>
+        <apexClass>NotifyUser</apexClass>   <- a reference to an Apex class
+        <enabled>true</enabled>             <- a value, not a reference
+    </classAccesses>
+
+References are emitted as sourceless placeholders, so the corpus-level rewire
+binds them to the real definition — the permission set above ends up pointing
+at ``NotifyUser.cls`` without this extractor knowing what a permission set is.
+"""
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from graphify.extractors.base import _file_stem, _make_id
+
+_META_SUFFIX = "-meta.xml"
+
+# Stdlib ElementTree does not cap entity expansion, so a crafted file could
+# trigger a billion-laughs DoS. Mirrors the project-XML screen in extract.py;
+# metadata emitted by the Salesforce CLI never declares a DTD or entity.
+_MAX_BYTES = 2 * 1024 * 1024
+
+
+def _is_safe(src: bytes) -> bool:
+    lowered = src.lower()
+    return b"<!doctype" not in lowered and b"<!entity" not in lowered
+
+
+def _local(tag: str) -> str:
+    """Strip the metadata namespace every Salesforce file declares."""
+    return tag.rsplit("}", 1)[-1] if tag.startswith("{") else tag
+
+
+# Sidecars for a companion file graphify already extracts itself (AgentMemory.cls
+# next to AgentMemory.cls-meta.xml). They carry only apiVersion/status, so parsing
+# them would mint a second node for a component another extractor already owns.
+# Kinds whose companion has NO extractor (a Visualforce .page, a static resource)
+# are deliberately absent: their metadata file is the only handle on them.
+_SIDECAR_KINDS = frozenset({"cls", "trigger", "js"})
+
+# Element names whose text names ANOTHER component. Custom API names are
+# recognised by their suffix instead (below), so this only has to cover
+# references to standard components — Apex classes, pages, standard objects.
+# Chosen from the element names that actually carry identifiers in real orgs.
+_REFERENCE_ELEMENTS = frozenset({
+    "apexClass", "apexPage", "apexTrigger", "object", "field", "fields",
+    "columns", "recordType", "flow", "tab", "layout", "relatedList",
+    "customPermission", "namedCredential", "externalCredential",
+    "application", "controller", "extensions", "targetObject", "sobjectType",
+})
+
+# Human-facing display text, never an API name. `fullName` and `name` are NOT
+# here: they usually restate the component's own name (dropped below by the
+# self-reference check), but `<name>CustomSetting__c</name>` in a custom-metadata
+# record is a genuine reference, so they go through the normal rules.
+_SELF_NAME_ELEMENTS = frozenset({"masterLabel", "label", "description", "motif"})
+
+# A name carrying one of these is always an API name, never an enum value, so
+# it is a reference wherever it appears — no element vocabulary needed.
+_CUSTOM_SUFFIXES = ("__c", "__mdt", "__e", "__x", "__b", "__r", "__Share", "__History")
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)*$")
+
+
+def _is_api_name(text: str) -> bool:
+    return bool(_IDENTIFIER_RE.match(text)) and not text.isupper()
+
+
+def is_salesforce_meta_xml_path(path: Path) -> bool:
+    """True for a Salesforce source-format metadata file this extractor owns.
+
+    Sidecars for a file another extractor already handles (``Foo.cls-meta.xml``)
+    are excluded, so dispatch and the file scan agree on one answer.
+    """
+    name = path.name
+    if not name.endswith(_META_SUFFIX):
+        return False
+    return _component_of(path)[1] not in _SIDECAR_KINDS
+
+
+def _component_of(path: Path) -> tuple[str, str]:
+    """``(name, kind)`` a metadata file declares, read from its filename."""
+    base = path.name[: -len(_META_SUFFIX)]
+    name, _, kind = base.rpartition(".")
+    return (name, kind) if name else (base, "")
+
+
+def _parent_object(path: Path) -> str | None:
+    """Owning object of a nested component (a field under ``objects/Foo/fields/``).
+
+    Found by looking for an ancestor directory that holds its own
+    ``<dir>.object-meta.xml``, so it needs no hardcoded folder names.
+    """
+    for ancestor in list(path.parents)[:4]:
+        if (ancestor / f"{ancestor.name}.object-meta.xml").is_file():
+            return ancestor.name
+    return None
+
+
+def extract_salesforce_meta_xml(path: Path) -> dict:
+    """Extract one Salesforce ``*-meta.xml`` file."""
+    name, kind = _component_of(path)
+    if kind in _SIDECAR_KINDS:
+        return {"nodes": [], "edges": []}
+
+    try:
+        src = path.read_bytes()
+    except OSError:
+        return {"nodes": [], "edges": [], "error": f"cannot read {path}"}
+    if len(src) > _MAX_BYTES:
+        return {"nodes": [], "edges": [], "error": "metadata file too large"}
+    if not _is_safe(src):
+        return {"nodes": [], "edges": [],
+                "error": "refusing XML with DOCTYPE/ENTITY declaration"}
+    try:
+        root = ET.fromstring(src)
+    except ET.ParseError as e:
+        return {"nodes": [], "edges": [], "error": f"XML parse error: {e}"}
+
+    str_path = str(path)
+    stem = _file_stem(path)
+    file_nid = _make_id(str_path)
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen_ids: set[str] = set()
+    seen_edges: set[tuple[str, str, str]] = set()
+
+    # First line each identifier appears on, so references get a location
+    # without a second pass over the tree.
+    line_of: dict[str, int] = {}
+    for lineno, line in enumerate(src.decode("utf-8", errors="replace").splitlines(), 1):
+        inner = line.strip()
+        if inner.startswith("<") and ">" in inner:
+            value = inner[inner.index(">") + 1:].rsplit("<", 1)[0].strip()
+            if value:
+                line_of.setdefault(value, lineno)
+
+    def add_node(nid: str, label: str, line: int) -> None:
+        if nid not in seen_ids:
+            seen_ids.add(nid)
+            nodes.append({"id": nid, "label": label, "file_type": "code",
+                          "source_file": str_path, "source_location": f"L{line}"})
+
+    def add_stub(nid: str, label: str) -> None:
+        """Sourceless placeholder for a component defined in another file.
+
+        Sourced stubs get their id salted per referencing file, which scatters
+        one component across a node per reference and leaves the real
+        definition unreferenced (the #1402/#2324 pattern).
+        """
+        if nid not in seen_ids:
+            seen_ids.add(nid)
+            nodes.append({"id": nid, "label": label, "file_type": "code",
+                          "source_file": "", "source_location": ""})
+
+    def add_edge(src_nid: str, tgt_nid: str, relation: str, line: int) -> None:
+        key = (src_nid, tgt_nid, relation)
+        if src_nid == tgt_nid or key in seen_edges:
+            return
+        seen_edges.add(key)
+        edges.append({"source": src_nid, "target": tgt_nid, "relation": relation,
+                      "confidence": "INFERRED", "source_file": str_path,
+                      "source_location": f"L{line}", "weight": 1.0})
+
+    add_node(file_nid, path.name, 1)
+    comp_nid = _make_id(stem, name)
+    add_node(comp_nid, name, 1)
+    add_edge(file_nid, comp_nid, "contains", 1)
+
+    owner = _parent_object(path)
+    if owner and owner != name:
+        owner_nid = _make_id(owner)
+        add_stub(owner_nid, owner)
+        add_edge(owner_nid, comp_nid, "contains", 1)
+
+    for el in root.iter():
+        if len(el):
+            continue
+        text = (el.text or "").strip()
+        if not text or not _is_api_name(text):
+            continue
+        tag = _local(el.tag)
+        if tag in _SELF_NAME_ELEMENTS:
+            continue
+        qualified = text.split(".")
+        by_suffix = any(text.endswith(s) for s in _CUSTOM_SUFFIXES)
+        if tag not in _REFERENCE_ELEMENTS and not by_suffix and len(qualified) == 1:
+            continue
+        line = line_of.get(text, 1)
+        for part in qualified:
+            if not _is_api_name(part) or part == name:
+                continue
+            ref_nid = _make_id(part)
+            add_stub(ref_nid, part)
+            add_edge(comp_nid, ref_nid, "references", line)
+
+    return {"nodes": nodes, "edges": edges}

--- a/tests/test_salesforce_meta_xml.py
+++ b/tests/test_salesforce_meta_xml.py
@@ -189,3 +189,18 @@ def test_permission_set_reaches_the_real_apex_class(tmp_path: Path):
             and by_id.get(e["target"], {}).get("label") == "NotifyUser"]
     assert hits, "no reference edge to NotifyUser"
     assert Path(by_id[hits[0]["target"]]["source_file"]).name == "NotifyUser.cls"
+
+
+def test_metadata_is_collected_when_following_symlinks(tmp_path: Path):
+    """Regression: collect_files has two walks, and only one had the exception.
+
+    The symlink-following walk gated on extension alone, so with
+    follow_symlinks=True every `*-meta.xml` was silently dropped.
+    """
+    from graphify.extract import collect_files
+
+    _write(tmp_path / "objects/Memory__c/Memory__c.object-meta.xml",
+           '<?xml version="1.0"?><CustomObject/>')
+    for follow in (False, True):
+        found = {p.name for p in collect_files(tmp_path, follow_symlinks=follow)}
+        assert "Memory__c.object-meta.xml" in found, f"dropped with follow={follow}"

--- a/tests/test_salesforce_meta_xml.py
+++ b/tests/test_salesforce_meta_xml.py
@@ -1,0 +1,191 @@
+"""Tests for the Salesforce ``*-meta.xml`` extractor."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify.detect import FileType, classify_file
+from graphify.extract import _get_extractor, extract
+from graphify.extractors.salesforce_meta_xml import (
+    extract_salesforce_meta_xml,
+    is_salesforce_meta_xml_path,
+)
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _labels(result: dict) -> set[str]:
+    return {n["label"] for n in result["nodes"]}
+
+
+def _refs(result: dict) -> set[str]:
+    by_id = {n["id"]: n for n in result["nodes"]}
+    return {by_id[e["target"]]["label"] for e in result["edges"]
+            if e["relation"] == "references"}
+
+
+PERMISSION_SET = """<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <classAccesses>
+        <apexClass>NotifyUser</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Memory__c.Content__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+</PermissionSet>
+"""
+
+CUSTOM_FIELD = """<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>IsShared__c</fullName>
+    <label>Is Shared</label>
+    <type>Checkbox</type>
+    <trackHistory>false</trackHistory>
+</CustomField>
+"""
+
+
+def test_component_name_comes_from_the_filename(tmp_path: Path):
+    f = _write(tmp_path / "MyOrgButlerUser.permissionset-meta.xml", PERMISSION_SET)
+    assert "MyOrgButlerUser" in _labels(extract_salesforce_meta_xml(f))
+
+
+def test_apex_class_grant_becomes_a_reference(tmp_path: Path):
+    f = _write(tmp_path / "MyOrgButlerUser.permissionset-meta.xml", PERMISSION_SET)
+    assert "NotifyUser" in _refs(extract_salesforce_meta_xml(f))
+
+
+def test_qualified_field_references_both_object_and_field(tmp_path: Path):
+    f = _write(tmp_path / "MyOrgButlerUser.permissionset-meta.xml", PERMISSION_SET)
+    refs = _refs(extract_salesforce_meta_xml(f))
+    assert {"Memory__c", "Content__c"} <= refs
+
+
+def test_values_are_not_references(tmp_path: Path):
+    """Negative control: enum and boolean element text must not become edges.
+
+    `true`, `Checkbox` and `Is Shared` are values, not component names. Turning
+    them into nodes would build god-nodes that every metadata file links to.
+    """
+    f = _write(tmp_path / "IsShared__c.field-meta.xml", CUSTOM_FIELD)
+    result = extract_salesforce_meta_xml(f)
+    assert _refs(result) == set()
+    assert _labels(result) == {"IsShared__c.field-meta.xml", "IsShared__c"}
+
+
+def test_display_text_is_not_a_reference(tmp_path: Path):
+    """A `<label>` is free text, even when it reads exactly like an API name.
+
+    Leaving a label at the API name is common, and it must not manufacture a
+    dependency on the component that happens to share that name.
+    """
+    f = _write(tmp_path / "Status__c.field-meta.xml",
+               '<?xml version="1.0"?><CustomField>'
+               "<fullName>Status__c</fullName><label>Memory__c</label>"
+               "<type>Picklist</type></CustomField>")
+    assert "Memory__c" not in _refs(extract_salesforce_meta_xml(f))
+
+
+def test_layout_pseudo_fields_are_not_references(tmp_path: Path):
+    """Negative control: a layout's ALL-CAPS tokens are not components.
+
+    `NAME` and `TASK.SUBJECT` are layout placeholders, not API names. They are
+    also not unique, so binding them would wire unrelated layouts together.
+    """
+    f = _write(tmp_path / "Task-Task Layout.layout-meta.xml",
+               '<?xml version="1.0"?><Layout><layoutSections><layoutColumns>'
+               "<layoutItems><field>NAME</field></layoutItems>"
+               "<layoutItems><field>TASK.SUBJECT</field></layoutItems>"
+               "</layoutColumns></layoutSections></Layout>")
+    refs = _refs(extract_salesforce_meta_xml(f))
+    assert refs == set(), f"expected no references, got {refs}"
+
+
+def test_custom_metadata_name_element_is_a_reference(tmp_path: Path):
+    """`<name>` carries a real reference in custom-metadata records."""
+    f = _write(tmp_path / "AccountHandler.md-meta.xml",
+               '<?xml version="1.0"?><CustomMetadata>'
+               "<values><field>Handler__c</field><value>CustomSetting__c</value></values>"
+               "<name>CustomSetting__c</name></CustomMetadata>")
+    assert "CustomSetting__c" in _refs(extract_salesforce_meta_xml(f))
+
+
+def test_referenced_components_are_sourceless(tmp_path: Path):
+    f = _write(tmp_path / "MyOrgButlerUser.permissionset-meta.xml", PERMISSION_SET)
+    result = extract_salesforce_meta_xml(f)
+    by_label = {n["label"]: n for n in result["nodes"]}
+    assert by_label["NotifyUser"]["source_file"] == ""
+    assert by_label["MyOrgButlerUser"]["source_file"].endswith("-meta.xml")
+
+
+def test_field_is_contained_by_its_object(tmp_path: Path):
+    obj = _write(tmp_path / "objects/Memory__c/Memory__c.object-meta.xml",
+                 '<?xml version="1.0"?><CustomObject/>')
+    field = _write(tmp_path / "objects/Memory__c/fields/IsShared__c.field-meta.xml",
+                   CUSTOM_FIELD)
+    result = extract_salesforce_meta_xml(field)
+    by_id = {n["id"]: n for n in result["nodes"]}
+    owners = {by_id[e["source"]]["label"] for e in result["edges"]
+              if e["relation"] == "contains"
+              and by_id[e["target"]]["label"] == "IsShared__c"}
+    assert "Memory__c" in owners
+    assert obj.exists()
+
+
+def test_apex_sidecar_is_left_to_the_apex_extractor(tmp_path: Path):
+    f = _write(tmp_path / "AgentMemory.cls-meta.xml",
+               '<?xml version="1.0"?><ApexClass><apiVersion>64.0</apiVersion></ApexClass>')
+    assert not is_salesforce_meta_xml_path(f)
+    assert extract_salesforce_meta_xml(f) == {"nodes": [], "edges": []}
+
+
+def test_plain_xml_is_not_claimed(tmp_path: Path):
+    """Negative control: only `*-meta.xml` is claimed.
+
+    Claiming `.xml` outright would sweep every pom.xml and web.xml in every
+    repository into the graph, which is a separate decision from Salesforce.
+    """
+    other = _write(tmp_path / "web.xml", "<web-app/>")
+    assert not is_salesforce_meta_xml_path(other)
+    assert classify_file(other) is None
+
+
+def test_metadata_takes_the_ast_path(tmp_path: Path):
+    f = _write(tmp_path / "Memory__c.object-meta.xml", '<?xml version="1.0"?><CustomObject/>')
+    assert classify_file(f) is FileType.CODE
+    assert _get_extractor(f) is extract_salesforce_meta_xml
+
+
+def test_doctype_is_refused(tmp_path: Path):
+    f = _write(tmp_path / "Evil.object-meta.xml",
+               '<?xml version="1.0"?><!DOCTYPE x [<!ENTITY a "b">]><CustomObject/>')
+    result = extract_salesforce_meta_xml(f)
+    assert result["nodes"] == [] and "DOCTYPE" in result["error"]
+
+
+def test_malformed_xml_reports_an_error(tmp_path: Path):
+    f = _write(tmp_path / "Broken.object-meta.xml", "<CustomObject><unclosed>")
+    result = extract_salesforce_meta_xml(f)
+    assert result["nodes"] == [] and "parse error" in result["error"]
+
+
+def test_permission_set_reaches_the_real_apex_class(tmp_path: Path):
+    """The grant must land on the class definition, not a name-only leaf."""
+    apex = _write(tmp_path / "classes/NotifyUser.cls",
+                  "public with sharing class NotifyUser {}\n")
+    perm = _write(tmp_path / "permissionsets/MyOrgButlerUser.permissionset-meta.xml",
+                  PERMISSION_SET)
+    result = extract([apex, perm], cache_root=tmp_path)
+
+    by_id = {n["id"]: n for n in result["nodes"]}
+    hits = [e for e in result["edges"]
+            if e["relation"] == "references"
+            and by_id.get(e["target"], {}).get("label") == "NotifyUser"]
+    assert hits, "no reference edge to NotifyUser"
+    assert Path(by_id[hits[0]["target"]]["source_file"]).name == "NotifyUser.cls"

--- a/tests/test_salesforce_meta_xml.py
+++ b/tests/test_salesforce_meta_xml.py
@@ -204,3 +204,25 @@ def test_metadata_is_collected_when_following_symlinks(tmp_path: Path):
     for follow in (False, True):
         found = {p.name for p in collect_files(tmp_path, follow_symlinks=follow)}
         assert "Memory__c.object-meta.xml" in found, f"dropped with follow={follow}"
+
+
+def test_utf16_doctype_is_refused(tmp_path: Path):
+    """The DOCTYPE screen matches ASCII bytes, so UTF-16 would walk past it.
+
+    ElementTree honours the encoding declaration and would expand the entity,
+    which is the billion-laughs hole the screen exists to close.
+    """
+    f = tmp_path / "Evil.object-meta.xml"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_bytes(
+        '<?xml version="1.0" encoding="UTF-16"?>'
+        '<!DOCTYPE x [<!ENTITY a "boom">]><CustomObject/>'.encode("utf-16"))
+    result = extract_salesforce_meta_xml(f)
+    assert result["nodes"] == [] and "UTF-8" in result["error"]
+
+
+def test_ordinary_utf8_metadata_is_still_accepted(tmp_path: Path):
+    """Guard the other direction: the encoding check must not reject real files."""
+    f = _write(tmp_path / "Memory__c.object-meta.xml",
+               '<?xml version="1.0" encoding="UTF-8"?><CustomObject/>')
+    assert "Memory__c" in _labels(extract_salesforce_meta_xml(f))


### PR DESCRIPTION
In a Salesforce codebase, `.cls` and `.trigger` are a minority of the files. Objects, fields, layouts, list views and permission sets hold a lot of the wiring, and none of it was in the graph — those files aren't classified at all today. On my-org-butler that's 34 files invisible out of 186 tracked.

Salesforce metadata is plain XML, so this is one generic element walk with the stdlib parser and no new dependency — no logic per component type. What a file declares comes from its filename. What it references comes from leaf element text, which is how Salesforce spells cross-component links:

```xml
<classAccesses>
    <apexClass>NotifyUser</apexClass>   <- a reference
    <enabled>true</enabled>             <- a value
</classAccesses>
```

References are emitted as sourceless placeholders, so the corpus rewire binds them to the real definition. The permission set above ends up pointing at `NotifyUser.cls` without this extractor knowing what a permission set is.

Telling references from values is the only real judgement here. Two rules, both derived from the element names that actually carry identifiers in real Salesforce codebases: anything with a Salesforce suffix (`__c`, `__mdt`, …) is always an API name, and for standard components there's a flat set of about twenty element names (`apexClass`, `object`, `field`, …). Everything else — `true`, `Checkbox`, `Large`, ALL-CAPS layout tokens like `TASK.SUBJECT` — is dropped. A 134-element object file yields one node.

Dispatch is by filename, following the existing `.blade.php` precedent, because the component kind sits in a compound suffix. Plain `.xml` stays unclaimed on purpose: claiming it would pull every pom.xml and web.xml in every repository into every graph, which is a separate decision. That does mean `collect_files` and `classify_file` each needed a filename check, since both gate on extension.

On my-org-butler, 186 tracked files: files in the graph 70 → 104, nodes 616 → 692, edges 618 → 702, of which 68 nodes come from metadata. `explain Content__c` returned nothing before — the field had no node. Now it returns the owning object plus the permission set, page layout and list view that use it.

Tests: 15, in `tests/test_salesforce_meta_xml.py`. Since the feature is new, "fails without the change" proves nothing, so I checked them by mutation instead — twelve plausible wrong implementations (stamping `source_file` on references, claiming all `.xml`, dropping the value filter, losing the owning-object lookup, swallowing parse errors, …), each caught by at least one test. That found a real bug on the first pass: `<name>` was being discarded as display text, which loses a genuine reference in custom-metadata records. Three negative controls: values must not become edges, ALL-CAPS layout tokens must not become components, and `web.xml` must not be claimed.

Known limitations. Flows contribute the objects and fields they touch but not their logic, and formula fields and validation rules hold expressions rather than plain names, so their field references aren't picked up. Salesforce names an object's tab after the object, so `Memory__c` exists as the object, the tab, and the shared name Apex points at; merging by name would be right sometimes and wrong sometimes, so nothing is merged — every edge is still reachable. `.cls-meta.xml` sidecars are skipped since the Apex extractor already owns those classes.

Independent of #3106; either can land first.
