### PR TITLE
fix(elixir): extract functions whose only clause has a when guard (#3111)

### DIFF
--- a/graphify/extractors/elixir.py
+++ b/graphify/extractors/elixir.py
@@ -128,6 +128,19 @@ def extract_elixir(path: Path) -> dict:
             func_name = None
             if arguments_node:
                 for child in arguments_node.children:
+                    # tree-sitter-elixir wraps a guarded head
+                    # (`def f(x) when guard`) in `binary_operator`;
+                    # without unwrapping, a function whose only clause
+                    # carries `when` is dropped (#3111).
+                    while child.type == "binary_operator":
+                        head = None
+                        for sub in child.children:
+                            if sub.type in ("call", "identifier", "binary_operator"):
+                                head = sub
+                                break
+                        if head is None:
+                            break
+                        child = head
                     if child.type == "call":
                         for sub in child.children:
                             if sub.type == "identifier":

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1440,6 +1440,47 @@ def test_elixir_method_edges():
     assert len(methods) >= 3
 
 
+def test_elixir_guarded_single_clause_is_extracted(tmp_path):
+    """A function whose only clause has a `when` guard must still get a node.
+
+    tree-sitter-elixir wraps `def f(x) when guard` in a `binary_operator`,
+    so the head is not a direct `call` child of `arguments`. Multi-clause
+    functions survive via an unguarded clause; a single guarded clause
+    was dropped entirely (#3111).
+    """
+    src = tmp_path / "demo.ex"
+    src.write_text(
+        "defmodule Demo do\n"
+        "  def plain(x) do\n"
+        "    x + 1\n"
+        "  end\n"
+        "\n"
+        "  def guarded(x) when is_integer(x) do\n"
+        "    x + 1\n"
+        "  end\n"
+        "\n"
+        "  def mixed(x) when is_integer(x) do\n"
+        "    x + 1\n"
+        "  end\n"
+        "\n"
+        "  def mixed(_), do: :error\n"
+        "\n"
+        "  defp guarded_private(x) when is_binary(x) do\n"
+        "    String.upcase(x)\n"
+        "  end\n"
+        "end\n"
+    )
+    r = extract_elixir(src)
+    assert "error" not in r
+    labels = {(n.get("label") or "").rstrip("()") for n in r["nodes"]}
+    assert "plain" in labels
+    assert "mixed" in labels
+    assert "guarded" in labels, f"single-clause guarded def dropped: {sorted(labels)}"
+    assert "guarded_private" in labels, (
+        f"single-clause guarded defp dropped: {sorted(labels)}"
+    )
+
+
 # ── Objective-C ──────────────────────────────────────────────────────────────
 from graphify.extract import extract_objc
 


### PR DESCRIPTION
## Summary

The Elixir AST extractor silently drops every function whose **only** clause carries a `when` guard. On a real 2,900-file Elixir/Phoenix codebase this hid 19 of 582 functions (every function of that shape) from the graph. No error is raised; the node is never created.

## Problem

tree-sitter-elixir wraps a guarded head in a `binary_operator`:

- `def plain(x) do ...` → `arguments` children = `['call']`
- `def guarded(x) when is_integer(x) do ...` → `arguments` children = `['binary_operator']`

The extractor only looked for a direct `call`/`identifier` child of `arguments`, so `func_name` stayed `None` and the function was dropped. Multi-clause functions survived via an unguarded clause, which is why this was easy to miss.

## Fix

Unwrap `binary_operator` (the `when` guard) to the left-hand head before reading the function name. Scoped to `def`/`defp` name extraction; the rest of the walker is unchanged.

This is independent of open #2970 (single-line `def f(x), do: ...` call-graph bodies). That PR does not unwrap guarded heads.

## Verification

```
uv run --frozen pytest tests/test_languages.py -k elixir -q
```

9 passed, including `test_elixir_guarded_single_clause_is_extracted` covering:

| case | shape | extracted |
|---|---|---|
| A | single clause, no guard | still extracted |
| B | single clause, `when` guard | now extracted |
| C | multi-clause, one guarded | still extracted |
| D | `defp`, single clause, `when` guard | now extracted |

## Reproduction (before fix)

```elixir
defmodule Demo do
  def guarded(x) when is_integer(x) do
    x + 1
  end
end
```

`extract_elixir` produced `Demo` and `demo.ex` only — no `guarded` node.

Fixes #3111
