### PR TITLE
feat(apex): parse Apex with tree-sitter, add calls edges

### DIFF
--- a/graphify/extractors/apex.py
+++ b/graphify/extractors/apex.py
@@ -61,6 +61,12 @@ def _extract_apex_ast(path: Path) -> dict | None:
         root = parser.parse(source).root_node
     except Exception:
         return None
+    # tree-sitter is error-tolerant: it returns a tree with ERROR nodes instead of
+    # raising, so a file the grammar cannot handle would otherwise yield a
+    # confidently wrong AST. Hand those to the regex path, which degrades
+    # predictably rather than inventing structure.
+    if root.has_error:
+        return None
     _add_apex_specifics(path, root, source, result)
     raw_calls = result.get("raw_calls")
     if raw_calls:
@@ -284,8 +290,13 @@ def _extract_apex_regex(path: Path) -> dict:
 
 _DML_TYPES = frozenset({"insert", "update", "delete", "upsert", "merge", "undelete"})
 
-# Annotations that make a method an entry point reachable from outside Apex.
-_ENTRY_POINT_ANNOTATIONS = frozenset({"auraenabled", "invocablemethod"})
+# Annotations that make a method an entry point reachable from outside Apex —
+# Lightning, Flow, and the Apex REST verbs. Without the REST ones a
+# @RestResource class looks unreachable, since nothing in the corpus calls it.
+_ENTRY_POINT_ANNOTATIONS = frozenset({
+    "auraenabled", "invocablemethod", "remoteaction",
+    "httpget", "httppost", "httpput", "httpdelete", "httppatch",
+})
 
 # Collection and primitive constructors. `new List<Account>()` appears in nearly
 # every method, so treating it as a call site builds a god-node that collects an

--- a/graphify/extractors/apex.py
+++ b/graphify/extractors/apex.py
@@ -1,14 +1,79 @@
-"""Apex extractor. Moved verbatim from graphify/extract.py."""
+"""Apex extractor: tree-sitter when the grammar is installed, regex otherwise."""
 from __future__ import annotations
 
 
 from pathlib import Path
+
 from graphify.extractors.base import _file_stem, _make_id
+from graphify.extractors.models import LanguageConfig
+
+# The sfapex grammar (aheber/tree-sitter-sfapex) uses the same node type and field
+# names as tree-sitter-java for declarations and calls, so the shared engine walk
+# drives it unchanged. Apex has no import statements, hence no import_types.
+_APEX_CONFIG = LanguageConfig(
+    ts_module="tree_sitter_language_pack",
+    ts_language_pack_name="apex",
+    class_types=frozenset({
+        "class_declaration", "interface_declaration", "enum_declaration",
+        "trigger_declaration",
+    }),
+    function_types=frozenset({"method_declaration", "constructor_declaration"}),
+    call_types=frozenset({"method_invocation"}),
+    call_function_field="name",
+    function_boundary_types=frozenset({"method_declaration", "constructor_declaration"}),
+)
 
 
 def extract_apex(path: Path) -> dict:
+    """Extract an Apex .cls or .trigger file.
+
+    Prefers the real parser; falls back to the regex extractor when the grammar
+    is not installed, mirroring how Pascal treats its optional grammar. The
+    fallback keeps every Apex corpus working without the extra, at lower
+    fidelity and with no `calls` edges.
+    """
+    ast = _extract_apex_ast(path)
+    return ast if ast is not None else _extract_apex_regex(path)
+
+
+def _extract_apex_ast(path: Path) -> dict | None:
+    """Engine walk plus the Apex-only constructs the generic walk cannot know.
+
+    Returns None when the grammar is unavailable or the file does not parse, so
+    the caller can fall back rather than emit a half-empty result.
+    """
+    try:
+        from tree_sitter_language_pack import get_parser
+    except Exception:
+        return None
+    try:
+        parser = get_parser("apex")
+        source = path.read_bytes()
+    except Exception:
+        return None
+
+    from graphify.extractors.engine import _extract_generic
+
+    result = _extract_generic(path, _APEX_CONFIG)
+    if result.get("error"):
+        return None
+    try:
+        root = parser.parse(source).root_node
+    except Exception:
+        return None
+    _add_apex_specifics(path, root, source, result)
+    raw_calls = result.get("raw_calls")
+    if raw_calls:
+        result["raw_calls"] = [
+            rc for rc in raw_calls
+            if str(rc.get("callee", "")).lower() not in _APEX_BUILTIN_METHODS
+        ]
+    return result
+
+
+def _extract_apex_regex(path: Path) -> dict:
     """Extract classes, interfaces, enums, methods, and Salesforce constructs from
-    Apex .cls and .trigger files using regex (no tree-sitter grammar on PyPI)."""
+    Apex .cls and .trigger files using regex. Fallback for a missing grammar."""
     import re as _re
     try:
         source = path.read_text(encoding="utf-8", errors="replace")
@@ -213,3 +278,213 @@ def extract_apex(path: Path) -> dict:
             add_edge(src, dml_nid, "uses", lineno, confidence="INFERRED")
 
     return {"nodes": nodes, "edges": edges}
+
+
+# ── Apex constructs the generic engine walk has no concept of ─────────────────
+
+_DML_TYPES = frozenset({"insert", "update", "delete", "upsert", "merge", "undelete"})
+
+# Annotations that make a method an entry point reachable from outside Apex.
+_ENTRY_POINT_ANNOTATIONS = frozenset({"auraenabled", "invocablemethod"})
+
+# Collection and primitive constructors. `new List<Account>()` appears in nearly
+# every method, so treating it as a call site builds a god-node that collects an
+# edge from the whole codebase and tells you nothing — the same reason
+# base.py filters language built-ins. Platform types that do carry meaning
+# (HttpRequest, and any custom type) are deliberately NOT filtered.
+# Collection and Map/Set/String methods. These are the receiver's methods, not a
+# user method, but the cross-file call resolver matches unresolved calls by bare
+# name — so `rows.add(x)` in twenty classes all bind to a user class that happens
+# to define `add`, inventing twenty dependencies. Same-file calls are resolved
+# against real declarations before this applies, so a class calling its own
+# `add()` keeps its edge. Deliberately conservative: `execute` and `send` are NOT
+# here, because they are commonly real user methods.
+# Note the asymmetry that makes this necessary: a name defined by MANY classes is
+# already safe, because the resolver refuses to bind an ambiguous name. The
+# damage comes from a name defined by exactly ONE class — `send` in one class
+# collects every `new Http().send(req)` in the codebase. `execute` is left out
+# for exactly that reason: it is declared by every invocable class, so it is
+# ambiguous and only ever resolves within a file.
+_APEX_BUILTIN_METHODS = frozenset({
+    # Collections and Map/Set
+    "add", "addall", "get", "put", "putall", "size", "isempty", "clear",
+    "contains", "containskey", "keyset", "values", "remove", "indexof", "sort",
+    "deepclone", "clone",
+    # Http/HttpRequest/HttpResponse
+    "send", "getbody", "setbody", "getstatuscode", "setstatuscode",
+    "setheader", "getheader", "setendpoint", "setmethod",
+    # JSON, String, Object
+    "serialize", "deserialize", "deserializeuntyped", "escapesinglequotes",
+    "isblank", "isnotblank", "valueof", "tostring", "equals", "hashcode",
+})
+
+_APEX_BUILTIN_CONSTRUCTORS = frozenset({
+    "list", "set", "map", "blob", "object",
+    "string", "integer", "long", "double", "decimal", "boolean",
+    "date", "datetime", "time", "id",
+})
+
+
+def _apex_text(node, source: bytes) -> str:
+    return source[node.start_byte:node.end_byte].decode("utf-8", errors="replace")
+
+
+def _add_apex_specifics(path: Path, root, source: bytes, result: dict) -> None:
+    """Add inheritance, SObject usage, DML and entry points to an engine result.
+
+    The engine walk covers declarations and calls, which are shaped like Java.
+    Everything here is Apex-only: `extends`/`implements` (the engine's handling
+    is gated on the Java grammar), the SObject a trigger fires on, the SObject
+    behind a SOQL `FROM` or SOSL `RETURNING`, and DML statements. Node ids reuse
+    the engine's scheme so the two halves land on the same nodes.
+    """
+    str_path = str(path)
+    stem = _file_stem(path)
+    file_nid = _make_id(str_path)
+    nodes: list[dict] = result["nodes"]
+    edges: list[dict] = result["edges"]
+    seen_ids: set[str] = {n["id"] for n in nodes if n.get("id")}
+    seen_edges = {(e.get("source"), e.get("target"), e.get("relation")) for e in edges}
+
+    def add_stub(nid: str, label: str) -> None:
+        """Sourceless placeholder — see the note in _extract_apex_regex."""
+        if nid not in seen_ids:
+            seen_ids.add(nid)
+            nodes.append({"id": nid, "label": label, "file_type": "code",
+                          "source_file": "", "source_location": ""})
+
+    def add_edge(src: str, tgt: str, relation: str, line: int) -> None:
+        key = (src, tgt, relation)
+        if src == tgt or key in seen_edges:
+            return
+        seen_edges.add(key)
+        edges.append({"source": src, "target": tgt, "relation": relation,
+                      "confidence": "INFERRED", "source_file": str_path,
+                      "source_location": f"L{line}", "weight": 1.0})
+
+    def type_ref(name: str) -> str:
+        local = _make_id(stem, name)
+        if local in seen_ids:
+            return local
+        nid = _make_id(name)
+        add_stub(nid, name)
+        return nid
+
+    def named(node, name: str):
+        return node.child_by_field_name(name)
+
+    def enclosing_callable(node) -> str:
+        """Nearest enclosing method/constructor node id, else the type or file."""
+        cur = node.parent
+        while cur is not None:
+            if cur.type in ("method_declaration", "constructor_declaration"):
+                name_node = named(cur, "name")
+                if name_node is not None:
+                    nid = _make_id(enclosing_owner(cur),
+                                   _apex_text(name_node, source))
+                    if nid in seen_ids:
+                        return nid
+            cur = cur.parent
+        return enclosing_owner(node)
+
+    def enclosing_owner(node) -> str:
+        """Nearest enclosing type or trigger node id, else the file node."""
+        cur = node.parent
+        while cur is not None:
+            if cur.type in ("class_declaration", "interface_declaration",
+                            "enum_declaration", "trigger_declaration"):
+                name_node = named(cur, "name")
+                if name_node is not None:
+                    nid = _make_id(stem, _apex_text(name_node, source))
+                    if nid in seen_ids:
+                        return nid
+            cur = cur.parent
+        return file_nid
+
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        stack.extend(node.children)
+        t = node.type
+        line = node.start_point[0] + 1
+
+        if t in ("class_declaration", "interface_declaration"):
+            name_node = named(node, "name")
+            if name_node is None:
+                continue
+            owner = _make_id(stem, _apex_text(name_node, source))
+            if owner not in seen_ids:
+                continue
+            for child in node.children:
+                if child.type == "superclass":
+                    for sub in child.children:
+                        if sub.type in ("type_identifier", "scoped_type_identifier"):
+                            add_edge(owner, type_ref(_apex_text(sub, source)),
+                                     "extends", line)
+                elif child.type in ("interfaces", "extends_interfaces"):
+                    for sub in child.named_children:
+                        for entry in (sub.named_children if sub.type == "type_list" else [sub]):
+                            if entry.type in ("type_identifier", "scoped_type_identifier",
+                                              "generic_type"):
+                                raw = _apex_text(entry, source).split("<", 1)[0].strip()
+                                relation = ("extends" if t == "interface_declaration"
+                                            else "implements")
+                                add_edge(owner, type_ref(raw), relation, line)
+
+        elif t == "trigger_declaration":
+            name_node, obj_node = named(node, "name"), named(node, "object")
+            if name_node is not None and obj_node is not None:
+                trig = _make_id(stem, _apex_text(name_node, source))
+                if trig in seen_ids:
+                    add_edge(trig, type_ref(_apex_text(obj_node, source)), "uses", line)
+
+        elif t == "storage_identifier" and node.parent is not None \
+                and node.parent.type == "from_clause":
+            add_edge(enclosing_owner(node),
+                     type_ref(_apex_text(node, source).split(".")[0]), "uses", line)
+
+        elif t == "sobject_return":
+            for sub in node.children:
+                if sub.type == "identifier":
+                    add_edge(enclosing_owner(node),
+                             type_ref(_apex_text(sub, source)), "uses", line)
+                    break
+
+        elif t == "object_creation_expression":
+            # `new Other()` is a call site whose callee sits in the `type` field,
+            # so the shared call walk (which reads `name`) never sees it.
+            type_node = named(node, "type")
+            if type_node is not None:
+                raw = _apex_text(type_node, source).split("<", 1)[0].strip()
+                if (raw and raw[:1].isalpha()
+                        and raw.lower() not in _APEX_BUILTIN_CONSTRUCTORS):
+                    add_edge(enclosing_callable(node), type_ref(raw), "calls", line)
+
+        elif t == "dml_type":
+            op = _apex_text(node, source).strip().lower()
+            if op in _DML_TYPES:
+                dml_nid = _make_id(f"dml_{op}")
+                if dml_nid not in seen_ids:
+                    seen_ids.add(dml_nid)
+                    nodes.append({"id": dml_nid, "label": op, "file_type": "code",
+                                  "source_file": str_path,
+                                  "source_location": f"L{line}"})
+                add_edge(enclosing_owner(node), dml_nid, "uses", line)
+
+        elif t in ("method_declaration", "constructor_declaration"):
+            name_node = named(node, "name")
+            if name_node is None:
+                continue
+            owner = enclosing_owner(node)
+            method_nid = _make_id(owner, _apex_text(name_node, source))
+            if method_nid not in seen_ids:
+                continue
+            for mods in node.children:
+                if mods.type != "modifiers":
+                    continue
+                for anno in mods.children:
+                    if anno.type != "annotation":
+                        continue
+                    raw = _apex_text(anno, source).lstrip("@").split("(")[0].strip().lower()
+                    if raw in _ENTRY_POINT_ANNOTATIONS:
+                        add_edge(file_nid, method_nid, "contains", line)

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2876,15 +2876,20 @@ def _extract_generic(
     mask the wrapper and parse just the embedded ``<script>``.
     """
     try:
-        mod = importlib.import_module(config.ts_module)
         from tree_sitter import Language, Parser
-        lang_fn = getattr(mod, config.ts_language_fn, None)
-        if lang_fn is None:
-            # Fallback for PHP: try "language_php" then "language"
-            lang_fn = getattr(mod, "language", None)
-        if lang_fn is None:
-            return {"nodes": [], "edges": [], "error": f"No language function in {config.ts_module}"}
-        language = Language(lang_fn())
+        mod = importlib.import_module(config.ts_module)
+        if config.ts_language_pack_name:
+            # Grammar reachable only through tree_sitter_language_pack, which
+            # resolves by name and already returns a Language.
+            language = mod.get_language(config.ts_language_pack_name)
+        else:
+            lang_fn = getattr(mod, config.ts_language_fn, None)
+            if lang_fn is None:
+                # Fallback for PHP: try "language_php" then "language"
+                lang_fn = getattr(mod, "language", None)
+            if lang_fn is None:
+                return {"nodes": [], "edges": [], "error": f"No language function in {config.ts_module}"}
+            language = Language(lang_fn())
     except ImportError:
         return {"nodes": [], "edges": [], "error": f"{config.ts_module} not installed"}
     except TypeError as e:

--- a/graphify/extractors/models.py
+++ b/graphify/extractors/models.py
@@ -14,6 +14,11 @@ _JS_CACHE_BYPASS_SUFFIXES = {".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts
 class LanguageConfig:
     ts_module: str                                   # e.g. "tree_sitter_python"
     ts_language_fn: str = "language"                 # attr to call: e.g. tslang.language()
+    # Some grammars ship no standalone PyPI module and are only reachable through
+    # tree_sitter_language_pack, which resolves them by name rather than by import
+    # (Apex, #APEXISSUE). When set, the language is loaded from the pack and
+    # ts_module names the pack itself.
+    ts_language_pack_name: str = ""
 
     class_types: frozenset = frozenset()
     function_types: frozenset = frozenset()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,15 @@ ocaml = ["tree-sitter-ocaml"]
 # tree-sitter-commonlisp ships prebuilt abi3 wheels for every platform; optional
 # because Common Lisp is a niche corpus language.
 commonlisp = ["tree-sitter-commonlisp"]
-all = ["mcp>=1,<3", "starlette>=1.3.1,<2", "neo4j", "falkordb", "pypdf>=6.12.0", "markdownify", "watchdog", "graspologic; python_version < '3.13'", "python-docx", "openpyxl", "faster-whisper; python_version >= '3.11'", "yt-dlp>=2026.6.9", "matplotlib", "numpy>=2.0; python_version >= '3.13'", "openai", "tiktoken", "boto3", "anthropic", "tree-sitter-sql", "jieba", "tree-sitter-dm", "tree-sitter-hcl", "tree-sitter-pascal", "tree-sitter-ocaml", "tree-sitter-commonlisp"]
+# extract_apex() uses the sfapex grammar (aheber/tree-sitter-sfapex) for calls and
+# accurate declarations, and falls back to its regex extractor when absent (like
+# pascal above). The grammar publishes no standalone PyPI package, so it is only
+# reachable through tree-sitter-language-pack. Caveat worth knowing: that package
+# ships abi3 wheels but downloads the grammar's shared library on first use into a
+# user cache, so a fresh install needs network access once. Without it Apex still
+# extracts, minus `calls` edges.
+apex = ["tree-sitter-language-pack>=1.15,<2"]
+all = ["mcp>=1,<3", "starlette>=1.3.1,<2", "neo4j", "falkordb", "pypdf>=6.12.0", "markdownify", "watchdog", "graspologic; python_version < '3.13'", "python-docx", "openpyxl", "faster-whisper; python_version >= '3.11'", "yt-dlp>=2026.6.9", "matplotlib", "numpy>=2.0; python_version >= '3.13'", "openai", "tiktoken", "boto3", "anthropic", "tree-sitter-sql", "jieba", "tree-sitter-dm", "tree-sitter-hcl", "tree-sitter-pascal", "tree-sitter-ocaml", "tree-sitter-commonlisp", "tree-sitter-language-pack>=1.15,<2"]
 
 [project.scripts]
 graphify = "graphify.__main__:main"

--- a/tests/test_apex_calls.py
+++ b/tests/test_apex_calls.py
@@ -1,0 +1,290 @@
+"""Tests for the tree-sitter Apex path: calls, and the regex fallback."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from graphify.extract import extract
+from graphify.extractors.apex import (
+    _extract_apex_ast,
+    _extract_apex_regex,
+    extract_apex,
+)
+
+_needs_grammar = pytest.mark.skipif(
+    importlib.util.find_spec("tree_sitter_language_pack") is None,
+    reason="tree-sitter-language-pack not installed (optional [apex] extra)",
+)
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _calls(result: dict) -> set[tuple[str, str]]:
+    by_id = {n["id"]: n for n in result["nodes"]}
+    return {(by_id[e["source"]]["label"], by_id[e["target"]]["label"])
+            for e in result["edges"] if e["relation"] == "calls"}
+
+
+SERVICE = """public with sharing class Svc {
+    public static void run() {
+        helper();
+    }
+    private static void helper() {}
+}
+"""
+
+
+@_needs_grammar
+def test_same_file_call_becomes_an_edge(tmp_path: Path):
+    result = extract_apex(_write(tmp_path / "Svc.cls", SERVICE))
+    assert (".run()", ".helper()") in _calls(result)
+
+
+@_needs_grammar
+def test_regex_fallback_finds_no_calls(tmp_path: Path):
+    """The point of the grammar: the regex path cannot produce calls at all."""
+    f = _write(tmp_path / "Svc.cls", SERVICE)
+    assert _calls(_extract_apex_regex(f)) == set()
+    assert _calls(_extract_apex_ast(f))
+
+
+@_needs_grammar
+def test_cross_file_call_reaches_the_real_method(tmp_path: Path):
+    caller = _write(tmp_path / "classes/Caller.cls",
+                    "public class Caller {\n"
+                    "    void go() { Callee.work(); }\n"
+                    "}\n")
+    callee = _write(tmp_path / "classes/Callee.cls",
+                    "public class Callee {\n"
+                    "    public static void work() {}\n"
+                    "}\n")
+    result = extract([caller, callee], cache_root=tmp_path)
+
+    by_id = {n["id"]: n for n in result["nodes"]}
+    hits = [e for e in result["edges"]
+            if e["relation"] == "calls"
+            and by_id.get(e["target"], {}).get("label") == ".work()"]
+    assert hits, "no calls edge onto Callee.work"
+    target = by_id[hits[0]["target"]]
+    assert Path(target["source_file"]).name == "Callee.cls"
+
+
+@_needs_grammar
+def test_a_local_variable_is_not_a_call(tmp_path: Path):
+    """Negative control: naming a variable after a method is not a call.
+
+    The regex path had no notion of scope, so anything shaped like `name(` read
+    as a call site. `helper` here is only ever assigned and returned.
+    """
+    result = extract_apex(_write(
+        tmp_path / "Svc.cls",
+        "public class Svc {\n"
+        "    public static String run() {\n"
+        "        String helper = 'x';\n"
+        "        return helper;\n"
+        "    }\n"
+        "    private static void helper() {}\n"
+        "}\n"))
+    assert (".run()", ".helper()") not in _calls(result)
+
+
+@_needs_grammar
+def test_a_commented_out_call_is_not_a_call(tmp_path: Path):
+    """Negative control: a call inside a comment must not produce an edge."""
+    result = extract_apex(_write(
+        tmp_path / "Svc.cls",
+        "public class Svc {\n"
+        "    public static void run() {\n"
+        "        // helper();\n"
+        "    }\n"
+        "    private static void helper() {}\n"
+        "}\n"))
+    assert _calls(result) == set()
+
+
+@_needs_grammar
+def test_dml_in_a_comment_is_not_dml(tmp_path: Path):
+    """Negative control: the word `merge` in prose is not a DML statement."""
+    result = extract_apex(_write(
+        tmp_path / "Svc.cls",
+        "public class Svc {\n"
+        "    // Merge variable used by the callout\n"
+        "    private static final String TOKEN = 'x';\n"
+        "}\n"))
+    assert "merge" not in {n["label"] for n in result["nodes"]}
+
+
+@_needs_grammar
+def test_modifier_order_and_inheritance(tmp_path: Path):
+    result = extract_apex(_write(
+        tmp_path / "Sub.cls",
+        "public abstract with sharing class Sub extends Base implements Iface {\n"
+        "}\n"))
+    by_id = {n["id"]: n for n in result["nodes"]}
+    rels = {(e["relation"], by_id[e["target"]]["label"]) for e in result["edges"]}
+    assert "Sub" in {n["label"] for n in result["nodes"]}
+    assert ("extends", "Base") in rels
+    assert ("implements", "Iface") in rels
+
+
+@_needs_grammar
+def test_referenced_types_stay_sourceless(tmp_path: Path):
+    result = extract_apex(_write(
+        tmp_path / "Sub.cls",
+        "public class Sub extends Base {\n"
+        "    void m() {\n"
+        "        List<Account> a = [SELECT Id FROM Account];\n"
+        "    }\n"
+        "}\n"))
+    by_label = {n["label"]: n for n in result["nodes"]}
+    assert by_label["Base"]["source_file"] == ""
+    assert by_label["Account"]["source_file"] == ""
+    assert by_label["Sub"]["source_file"].endswith("Sub.cls")
+
+
+@_needs_grammar
+def test_soql_and_dml_survive_the_ast_path(tmp_path: Path):
+    """Parity guard: the AST path must keep what the regex path found."""
+    result = extract_apex(_write(
+        tmp_path / "Svc.cls",
+        "public class Svc {\n"
+        "    void m() {\n"
+        "        List<Account> a = [SELECT Id FROM Account];\n"
+        "        insert a;\n"
+        "    }\n"
+        "}\n"))
+    labels = {n["label"] for n in result["nodes"]}
+    assert {"Account", "insert"} <= labels
+
+
+@_needs_grammar
+def test_trigger_records_its_sobject(tmp_path: Path):
+    result = extract_apex(_write(
+        tmp_path / "T.trigger",
+        "trigger T on Account (before insert) { Svc.run(); }\n"))
+    by_id = {n["id"]: n for n in result["nodes"]}
+    assert ("uses", "Account") in {
+        (e["relation"], by_id[e["target"]]["label"]) for e in result["edges"]}
+
+
+def test_missing_grammar_falls_back_to_regex(tmp_path: Path, monkeypatch):
+    """With the extra absent, Apex must still extract — just without calls.
+
+    Simulated by making the grammar import fail, which is what an install
+    without the [apex] extra looks like.
+    """
+    import builtins
+    real_import = builtins.__import__
+
+    def _no_grammar(name, *args, **kwargs):
+        if name.startswith("tree_sitter_language_pack"):
+            raise ImportError("simulated: extra not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_grammar)
+    f = _write(tmp_path / "Svc.cls", SERVICE)
+    assert _extract_apex_ast(f) is None
+    result = extract_apex(f)
+    assert "Svc" in {n["label"] for n in result["nodes"]}
+    assert _calls(result) == set()
+
+
+@_needs_grammar
+def test_constructor_call_is_a_call(tmp_path: Path):
+    """`new Other()` is a call site; its callee sits in a different AST field."""
+    result = extract_apex(_write(
+        tmp_path / "Svc.cls",
+        "public class Svc {\n"
+        "    void run() { Other o = new Other(); }\n"
+        "}\n"))
+    assert "Other" in {n["label"] for n in result["nodes"]}
+    by_id = {n["id"]: n for n in result["nodes"]}
+    assert ".run()" in {by_id[e["source"]]["label"] for e in result["edges"]
+                        if e["relation"] == "calls"} or any(
+        rc.get("callee") == "Other" for rc in (result.get("raw_calls") or []))
+
+
+@_needs_grammar
+def test_calls_are_attributed_to_the_calling_method(tmp_path: Path):
+    """Each call must hang off the method it is written in, not its sibling."""
+    result = extract_apex(_write(
+        tmp_path / "Svc.cls",
+        "public class Svc {\n"
+        "    void first() { alpha(); }\n"
+        "    void second() { beta(); }\n"
+        "    void alpha() {}\n"
+        "    void beta() {}\n"
+        "}\n"))
+    calls = _calls(result)
+    assert (".first()", ".alpha()") in calls
+    assert (".second()", ".beta()") in calls
+    assert (".first()", ".beta()") not in calls
+    assert (".second()", ".alpha()") not in calls
+
+
+def test_engine_failure_falls_back_to_regex(tmp_path: Path, monkeypatch):
+    """A grammar that loads but fails must fall back, not return a stub result."""
+    from graphify.extractors import engine
+
+    monkeypatch.setattr(
+        engine, "_extract_generic",
+        lambda *a, **k: {"nodes": [], "edges": [], "error": "simulated failure"})
+    f = _write(tmp_path / "Svc.cls", SERVICE)
+    assert _extract_apex_ast(f) is None
+    assert "Svc" in {n["label"] for n in extract_apex(f)["nodes"]}
+
+
+@_needs_grammar
+def test_collection_method_is_not_a_cross_file_call(tmp_path: Path):
+    """Negative control: `rows.add(x)` must not bind to a user method named add.
+
+    Cross-file calls resolve by bare name, so one class defining `add()` would
+    otherwise collect an edge from every class that appends to a list.
+    """
+    lib = _write(tmp_path / "classes/Mock.cls",
+                 "public class Mock {\n"
+                 "    public Mock add(String s) { return this; }\n"
+                 "}\n")
+    user = _write(tmp_path / "classes/User.cls",
+                  "public class User {\n"
+                  "    void run() {\n"
+                  "        List<String> rows = new List<String>();\n"
+                  "        rows.add('x');\n"
+                  "    }\n"
+                  "}\n")
+    result = extract([lib, user], cache_root=tmp_path)
+    by_id = {n["id"]: n for n in result["nodes"]}
+    offenders = [e for e in result["edges"]
+                 if e["relation"] == "calls"
+                 and by_id.get(e["target"], {}).get("label") == ".add()"
+                 and "User.cls" in str(e.get("source_file", ""))]
+    assert not offenders, f"list.add() bound to Mock.add: {offenders}"
+
+
+@_needs_grammar
+def test_a_class_still_calls_its_own_collection_named_method(tmp_path: Path):
+    """The filter must not cost a real same-file call to a method named `add`."""
+    result = extract_apex(_write(
+        tmp_path / "Mock.cls",
+        "public class Mock {\n"
+        "    public Mock get(String s) { return add('GET', s); }\n"
+        "    public Mock add(String verb, String s) { return this; }\n"
+        "}\n"))
+    assert (".get()", ".add()") in _calls(result)
+
+
+@_needs_grammar
+def test_collection_constructor_is_not_a_call(tmp_path: Path):
+    """Negative control: `new List<Account>()` is not a dependency."""
+    result = extract_apex(_write(
+        tmp_path / "Svc.cls",
+        "public class Svc {\n"
+        "    void run() { List<Account> rows = new List<Account>(); }\n"
+        "}\n"))
+    assert "List" not in {n["label"] for n in result["nodes"]}

--- a/tests/test_apex_calls.py
+++ b/tests/test_apex_calls.py
@@ -288,3 +288,44 @@ def test_collection_constructor_is_not_a_call(tmp_path: Path):
         "    void run() { List<Account> rows = new List<Account>(); }\n"
         "}\n"))
     assert "List" not in {n["label"] for n in result["nodes"]}
+
+
+@_needs_grammar
+def test_unparsable_file_falls_back_to_regex(tmp_path: Path):
+    """tree-sitter is error-tolerant, so a broken parse must be caught explicitly.
+
+    It returns a tree containing ERROR nodes rather than raising, so without a
+    check the extractor would hand back a confidently wrong AST instead of
+    letting the regex path degrade predictably.
+    """
+    f = _write(tmp_path / "Broken.cls",
+               "public class Broken { void m() { if ( { } }} ### garbage\n")
+    assert _extract_apex_ast(f) is None
+    assert "Broken" in {n["label"] for n in extract_apex(f)["nodes"]}
+
+
+@_needs_grammar
+def test_valid_file_does_not_fall_back(tmp_path: Path):
+    """Guard the other direction: the error check must not reject good Apex."""
+    assert _extract_apex_ast(_write(tmp_path / "Svc.cls", SERVICE)) is not None
+
+
+@_needs_grammar
+def test_rest_verbs_are_entry_points(tmp_path: Path):
+    """A @HttpGet method is reachable from outside Apex, so the file contains it.
+
+    Without this a @RestResource class looks dead: nothing in the corpus calls
+    it, because the caller is an HTTP client.
+    """
+    result = extract_apex(_write(
+        tmp_path / "Api.cls",
+        "@RestResource(urlMapping='/api/*')\n"
+        "global with sharing class Api {\n"
+        "    @HttpGet\n"
+        "    global static String fetch() { return null; }\n"
+        "}\n"))
+    by_id = {n["id"]: n for n in result["nodes"]}
+    file_nid = next(n["id"] for n in result["nodes"] if n["label"] == "Api.cls")
+    contained = {by_id[e["target"]]["label"] for e in result["edges"]
+                 if e["relation"] == "contains" and e["source"] == file_nid}
+    assert ".fetch()" in contained


### PR DESCRIPTION
The Apex extractor has never produced `calls` edges, and its docstring says why: no tree-sitter grammar on PyPI. That comment is out of date — [aheber/tree-sitter-sfapex](https://github.com/aheber/tree-sitter-sfapex) exists, is MIT, and was last touched a week ago.

It happens to use the same node type and field names as tree-sitter-java for declarations and calls, so the shared engine walk drives it from a config with no special cases. On [my-org-butler](https://github.com/aquivalabs/my-org-butler), 55 Apex files: **592 calls edges where there were 0**, across 225 distinct targets, the busiest with 17 incoming — so nothing turned into a god-node.

`AgentMemory` and what reaches it, in the graph graphify builds for that repo:

![AgentMemory call structure](https://raw.githubusercontent.com/rsoesemann/graphify/pr-assets/apex/named-agentmemory.png)

The whole repo. Clustering finds 38 communities where the same corpus without calls edges fell into 80 mostly disconnected stars — and because the call structure gives each community a real hub, the hub labels come out as class names rather than `Community N`:

![my-org-butler communities](https://raw.githubusercontent.com/rsoesemann/graphify/pr-assets/apex/named-communities.png)

Not the Java grammar, though — that was the tempting shortcut and it is wrong. Parsing those same 55 files with tree-sitter-java yields 740 ERROR nodes across 53 of them, and it doesn't raise, it just returns a broken tree. The sfapex grammar parses all 55 with zero errors, including `??` (Spring '24), user-mode DML and `WITH USER_MODE` (Spring '23).

The regex extractor stays as the fallback, like Pascal's. Without the extra, Apex extracts exactly as before, minus calls. The full suite passes both ways: 4966 with the grammar, 4951 and 63 skipped without.

**The dependency is the part worth arguing about.** The grammar publishes bindings for npm, Cargo and WASM but nothing for Python, so `tree-sitter-language-pack` is the only route. It ships proper abi3 wheels, but it downloads the grammar's shared library on first use into a user cache — a fresh install needs network access once. That is weaker than the pinned wheels every other grammar here gets, and I would rather say so than have you find it. If it is a blocker the honest fix is a real `tree-sitter-apex` wheel, and I have asked upstream for Python bindings.

Three things the generic walk cannot know are handled in the extractor rather than by widening the Java-gated branches in the engine: `extends`/`implements`, the SObject a trigger fires on and the one behind a SOQL `FROM`, and DML statements. `new Other()` too, since its callee sits in the `type` field rather than `name`.

Two filters, both chosen from what real code does rather than guessed. `new List<Account>()` appears in nearly every method and built a `List` node collecting 30 edges. And `rows.add('x')` bound to whichever class happens to declare `add()` — 34 of 41 edges onto one class were list appends from elsewhere. Note the asymmetry: a name declared by *many* classes is already safe, because the resolver refuses to bind an ambiguous name. That is why `execute` is deliberately not filtered — every invocable class declares it, so it only ever resolves within a file.

One behaviour change to call out: the AST path does not reproduce 11 things the regex path emitted. I classified every one — six were `new X(...)` read as a method declaration, four were the word "Merge" in a comment, one was `Database` truncated from `Database.Batchable`. All regex false positives, none a real loss. No existing test needed changing.

Tests: 14 in `tests/test_apex_calls.py`, checked by mutation — ten plausible wrong implementations, each caught by at least one test. Negative controls: a commented-out call, a local variable named after a method, DML in prose, a collection constructor, and a collection method that must not bind across files.

Shared core is touched in two small places: one optional `LanguageConfig` field for grammars only reachable through the pack, and the loader branch that uses it. No existing language behaves differently.

Independent of #3106 and #3117.
