### PR TITLE
fix(commonlisp): derive node ids from the full path stem

### DIFF
--- a/graphify/extractors/commonlisp.py
+++ b/graphify/extractors/commonlisp.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import warnings
 from pathlib import Path
 
-from graphify.extractors.base import _make_id
+from graphify.extractors.base import _file_stem, _make_id
 
 
 # Standard CL definer forms that introduce data/type/variable bindings
@@ -84,7 +84,11 @@ def extract_commonlisp(path: Path) -> dict:
     except Exception as e:
         return {"nodes": [], "edges": [], "error": str(e)}
 
-    stem = path.stem
+    # Path-qualified, not the bare `path.stem`: same-named .lisp files in
+    # different directories must not collide (#1504). Pre-collapsed through
+    # `_make_id` because `_cl_id` would otherwise map the `/` separators to
+    # `_slash` via _CL_CHAR_MAP.
+    stem = _make_id(_file_stem(path))
     str_path = str(path)
     nodes: list[dict] = []
     edges: list[dict] = []

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -3974,3 +3974,25 @@ def test_zig_enum_and_union_methods_are_extracted(tmp_path):
         for e in r["edges"] if e["relation"] == "calls"
     }
     assert (".area()", "helper()") in calls, "call from union method body dropped"
+
+
+@_needs_commonlisp
+def test_cl_ids_are_path_qualified_across_directories(tmp_path):
+    """Two same-named .lisp files in DIFFERENT directories must mint distinct
+    ids (#1504). The prefix was derived from the bare `path.stem`, so both
+    `a/sample.lisp` and `b/sample.lisp` minted `sample` / `sample_init`; when
+    they land in separate extract batches (what `graphify update` does) build()
+    merges them and one file's nodes are dropped."""
+    a = tmp_path / "a" / "sample.lisp"
+    b = tmp_path / "b" / "sample.lisp"
+    for p in (a, b):
+        p.parent.mkdir(parents=True)
+        p.write_text("(defun init (x) (+ x 1))\n")
+
+    ids_a = {n["id"] for n in extract_commonlisp(a)["nodes"]}
+    ids_b = {n["id"] for n in extract_commonlisp(b)["nodes"]}
+
+    assert not (ids_a & ids_b), (
+        f"same-named .lisp files in different dirs must not share ids, "
+        f"got overlap {sorted(ids_a & ids_b)}"
+    )


### PR DESCRIPTION
`extract_commonlisp` builds its id prefix from the bare `path.stem`, so `a/sample.lisp` and `b/sample.lisp` both mint `sample` / `sample_init`. Every other extractor uses `_file_stem(path)`, which preserves the full repo-relative path for exactly this reason (#1504) — `commonlisp.py` never imported it. It looks like the line predates the port out of `extract.py` and came along unchanged.

### Impact

Not cosmetic — nodes are lost. The in-batch collision rescue hides it when both files land in one `extract()` call, but incremental `graphify update` extracts in separate batches:

```
=== SEPARATE batches (what incremental update does) ===
  [a] 'sample'  'sample_init'   <- a/sample.lisp
  [b] 'sample'  'sample_init'   <- b/sample.lisp
  COLLIDING IDS ACROSS BATCHES: ['sample', 'sample_init']

=== merged graph: 2 nodes (expected 4) ===
```

`build()` merges last-writer-wins and `b/sample.lisp` disappears. It does warn loudly, which is how I found it.

The id-remap post-pass doesn't cover this either: it rewrites absolute-path-derived ids (#502), and a bare stem matches none of its keys.

This also means any graph containing a `.lisp` file trips `graph_has_legacy_ids`, so `query`/`serve` print the "pre-#1504 node-ID scheme" nudge on a freshly built graph. On this repo, `tests/fixtures/sample.lisp` alone was enough.

### The fix

```python
stem = _make_id(_file_stem(path))
```

Pre-collapsed through `_make_id` rather than passed to `_cl_id` raw, because `_CL_CHAR_MAP` maps `/` to `_slash` — the naive `stem = _file_stem(path)` that matches the other extractors yields `tests_slashfixtures_slashsample_init`. Pre-collapsing is idempotent under `_cl_id` and leaves the CL operator-char handling intact (`upi=` -> `upi_eq`, verified via `header_eq` / `header_lt` in the existing fixture).

### Testing

Added `test_cl_ids_are_path_qualified_across_directories`, modelled on the existing `test_decldef_merge_does_not_merge_across_directories`. Red/green verified by reverting the one-line change: fails with `overlap ['sample', 'sample_init']`, passes with it.

`uv run pytest tests/ -q` — 5086 passed, 11 skipped, 0 failed.

One note for reviewers: the AST cache is keyed by content hash, so after this lands a graph built with an older graphify keeps the old ids until `graphify-out/cache/ast` is cleared. The cache dir is version-stamped (`v0.9.50-s2`), so a release bump handles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
