### PR TITLE
test(falkordb): skip when the port answers but is not FalkorDB

### DIFF
--- a/tests/test_falkordb_integration.py
+++ b/tests/test_falkordb_integration.py
@@ -5,8 +5,10 @@ Runs for real against `falkordb/falkordb:latest`:
     docker run -d -p 6379:6379 falkordb/falkordb:latest
     uv run pytest tests/test_falkordb_integration.py -q
 
-The test auto-skips when the `falkordb` SDK is not installed or no FalkorDB is
-reachable, so it is a no-op in the default CI (which runs no external services).
+The test auto-skips when the `falkordb` SDK is not installed, no server is
+reachable, or the server that answers is not FalkorDB, so it is a no-op in the
+default CI (which runs no external services) and on a dev box that already has
+a plain Redis on 6379.
 Host/port are overridable via FALKORDB_HOST / FALKORDB_PORT.
 """
 from __future__ import annotations
@@ -26,13 +28,25 @@ GRAPH_NAME = "graphify_test"
 
 
 def _connect():
-    """Return a connected FalkorDB client, or skip if none is reachable."""
+    """Return a connected FalkorDB client, or skip if none is reachable.
+
+    ``ping()`` only proves *something* answers on the port. A plain Redis -- or
+    an SSH tunnel forwarding one -- replies to PING but has no graph module, so
+    the guard passed and the tests FAILED on `unknown command 'GRAPH.QUERY'`
+    instead of skipping. ``GRAPH.LIST`` identifies the service rather than mere
+    liveness: it is read-only, creates no keys, and anything that is not
+    FalkorDB/RedisGraph rejects it as an unknown command.
+    """
     try:
         db = falkordb.FalkorDB(host=HOST, port=PORT)
         db.connection.ping()
-        return db
     except Exception as e:  # pragma: no cover - depends on local environment
-        pytest.skip(f"no FalkorDB reachable at {HOST}:{PORT} ({e})")
+        pytest.skip(f"no server reachable at {HOST}:{PORT} ({e})")
+    try:
+        db.connection.execute_command("GRAPH.LIST")
+    except Exception as e:  # pragma: no cover - depends on local environment
+        pytest.skip(f"server at {HOST}:{PORT} is not FalkorDB, no graph module ({e})")
+    return db
 
 
 @pytest.fixture()


### PR DESCRIPTION
`_connect()` guards on `ping()`, which only proves *something* answers on 6379. A plain Redis — or an SSH tunnel forwarding one, which is what I hit — replies to PING but has no graph module, so the guard passes and both tests **fail** on `unknown command 'GRAPH.QUERY'` instead of skipping.

The module docstring says these are a no-op outside CI. That holds only because CI has *nothing* on 6379: the guard was validated against the empty case, never against a wrong occupant. A dev box with a Redis already on that port is exactly where it breaks.

### The fix

Probe `GRAPH.LIST` after the ping, so the guard identifies the *service* rather than mere liveness. It is read-only, creates no keys, and anything that is not FalkorDB/RedisGraph rejects it as an unknown command:

| probe | FalkorDB | plain Redis |
|---|---|---|
| `PING` | ✅ True | ✅ True — the bug |
| `GRAPH.LIST` | ✅ `[]` | ❌ `unknown command` |
| `MODULE LIST` | ✅ has `graph` | ✅ `[]` — succeeds on both, needs content parsing |

The two failure modes now skip with distinct messages (unreachable vs. wrong service).

### Testing

Verified against all three environments, including the one that matters most — a guard that always skips would "fix" the failure while silently disabling the tests forever:

```
plain Redis on the port   -> 2 skipped  (was 2 failed)
falkordb/falkordb:latest  -> 2 passed   (guard does not over-skip)
nothing listening         -> 2 skipped
```

`uv run pytest tests/ -q` — 5086 passed, 11 skipped, 0 failed.

No automated regression test: reproducing this needs a wrong-service-on-the-port, i.e. the external service the default CI deliberately avoids. Happy to add one behind a marker if you'd prefer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
