### PR TITLE
fix(extract): fully rescan code with --force --code-only

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -3252,16 +3252,17 @@ def dispatch_command(cmd: str) -> None:
         # --force: full scan, not the manifest-gated incremental diff — a warm
         # unchanged tree would otherwise dispatch zero files (#1894).
         incremental_mode = incremental_mode and not force
-        # #2923: --force --code-only must NOT drop the existing semantic layer.
-        # The AST pass is fully replaced (full re-scan, semantic cache reads
-        # skipped), but the semantic pass is itself skipped entirely, so
-        # doc/paper/image nodes from the existing graph carry forward via the
-        # incremental merge (build_merge / merge_raw_extraction keep them
-        # because no new semantic-tier sources are dispatched). Without this,
-        # a single --code-only --force silently erases every doc/paper/image
-        # node plus its connected hyperedges.
+        # #2923/#3125: --force --code-only must NOT drop the existing semantic layer.
+        # The AST pass is fully replaced (full code re-scan, AST extraction on all
+        # code files), but the semantic pass is skipped, so doc/paper/image nodes
+        # from the existing graph carry forward via the merge (build_merge /
+        # merge_raw_extraction keep them because no new semantic-tier sources
+        # are dispatched). We do NOT set incremental_mode = True here because that
+        # would run _detect_incremental and drop unchanged code files from the AST
+        # pass; instead we keep incremental_mode = False so all code files are
+        # scanned, while merge_existing_graph below ensures build_merge still runs.
+        merge_existing_graph = incremental_mode or (code_only and existing_graph_path.exists())
         if force and code_only and existing_graph_path.exists():
-            incremental_mode = True
             print(
                 "[graphify extract] --force --code-only: full AST re-scan, "
                 "existing semantic layer preserved (no semantic pass this run)"
@@ -3378,6 +3379,12 @@ def dispatch_command(cmd: str) -> None:
             excluded_files = []
             graph_stale_sources = []
             unchanged_total = 0
+            if existing_graph_path.exists():
+                _seen_files = {f for _fl in files_by_type.values() for f in _fl}
+                _seen_files.update(detection.get("unclassified", []))
+                graph_stale_sources = _stale_graph_sources(
+                    existing_graph_path, target, _seen_files, detection=detection
+                )
 
         semantic_files = doc_files + paper_files + image_files
         # --code-only: index code (pure local AST, no key) and skip the semantic
@@ -4012,7 +4019,7 @@ def dispatch_command(cmd: str) -> None:
                 stages.total()
                 sys.exit(0)
 
-            if incremental_mode:
+            if merge_existing_graph:
                 # #2169: this raw path used to write ONLY this run's extraction
                 # over graph.json — on an incremental run that is just the
                 # changed files, silently dropping every node/edge owned by an
@@ -4140,7 +4147,7 @@ def dispatch_command(cmd: str) -> None:
         from graphify.export import to_json as _to_json
         from graphify.analyze import god_nodes as _god_nodes, surprising_connections as _surprising
         dedup_backend = backend if dedup_llm else None
-        if incremental_mode:
+        if merge_existing_graph:
             # Prune everything the current scan no longer covers: genuinely
             # deleted manifest rows, excluded-but-alive manifest rows (#1908),
             # and the graph's own stale sources — which catches files that

--- a/tests/test_extract_code_only_cli.py
+++ b/tests/test_extract_code_only_cli.py
@@ -373,3 +373,61 @@ def test_code_only_force_prunes_removed_semantic_files(tmp_path):
         "NOTES.txt was deleted from disk; its semantic nodes must be pruned "
         "(#2923 follow-up)"
     )
+
+
+def test_code_only_force_rescan_re_resolves_tsconfig_paths_and_preserves_semantics(tmp_path: Path):
+    """#3125 regression: `extract --code-only --force` over an existing graph
+    must perform a full code/AST re-scan so updated tsconfig paths take effect on
+    unchanged .ts files, while preserving the existing semantic layer (#2923).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    src = repo / "src"
+    src.mkdir()
+    (src / "utils.ts").write_text("export const helper = 42;\n")
+    (src / "index.ts").write_text("import { helper } from '@/utils';\nconsole.log(helper);\n")
+    (repo / "tsconfig.json").write_text(json.dumps({"compilerOptions": {"target": "es2020"}}))
+
+    # 1. Initial extract --code-only
+    r1 = _run(repo, "--code-only", "--no-cluster")
+    assert r1.returncode == 0, r1.stderr
+    graph_path = repo / "graphify-out" / "graph.json"
+    g1 = json.loads(graph_path.read_text(encoding="utf-8"))
+    edges1 = [(e["source"], e["target"]) for e in g1.get("edges", g1.get("links", []))]
+    assert not any(src == "src_index" and ("src_utils" in tgt or "helper" in tgt) for src, tgt in edges1), (
+        "alias import @/utils must not resolve without tsconfig paths mapping"
+    )
+
+    # 2. Seed a semantic file and node into graph.json to verify semantic preservation (#2923)
+    (repo / "ARCH.md").write_text("# Architecture\nDesign notes.\n")
+    g1["nodes"].append({
+        "id": "doc_arch", "label": "Architecture", "type": "concept",
+        "source_file": "ARCH.md", "origin": "SEMANTIC", "_origin": "semantic"
+    })
+    graph_path.write_text(json.dumps(g1), encoding="utf-8")
+
+    # 3. Modify only tsconfig.json to add baseUrl and paths alias
+    (repo / "tsconfig.json").write_text(json.dumps({
+        "compilerOptions": {
+            "target": "es2020",
+            "baseUrl": ".",
+            "paths": {"@/*": ["src/*"]}
+        }
+    }))
+
+    # 4. Run extract --code-only --force
+    r2 = _run(repo, "--code-only", "--force", "--no-cluster")
+    assert r2.returncode == 0, r2.stderr
+
+    g2 = json.loads(graph_path.read_text(encoding="utf-8"))
+    edges2 = [(e["source"], e["target"]) for e in g2.get("edges", g2.get("links", []))]
+    # Verify the import edge now exists
+    assert any(src == "src_index" and ("src_utils" in tgt or "helper" in tgt) for src, tgt in edges2), (
+        "extract --code-only --force must re-resolve alias imports after tsconfig paths change (#3125)"
+    )
+
+    # Verify the semantic entity was preserved
+    nodes2 = {n.get("id") for n in g2.get("nodes", [])}
+    assert "doc_arch" in nodes2, (
+        "existing semantic nodes must survive --code-only --force (#2923/#3125)"
+    )


### PR DESCRIPTION
## Summary

Fixes #3125.

`graphify extract --force --code-only` could leave TypeScript/JavaScript
module-resolution results stale after a `tsconfig.json` change.

The problem was not a persistent module-resolution cache. `--force
--code-only` was re-enabling incremental file detection in order to preserve
the existing semantic layer. As a result, unchanged code files were skipped
entirely and their previous AST/resolution results remained in the graph.

This change separates those two concerns:

- `--force --code-only` now performs a full code/AST scan.
- The existing semantic layer is still preserved through the existing merge
  path.
- Normal incremental extraction behavior is unchanged.
- Normal `--force` behavior is unchanged.

## Root cause

Before this change, `--force --code-only` explicitly set:

```python
incremental_mode = True
````

That caused the incremental detector to omit unchanged source files.

For example, after changing a TypeScript `paths` mapping:

```text
tsconfig.json changed
        ↓
incremental detection
        ↓
unchanged .ts files skipped
        ↓
old resolution/AST edges retained
```

Deleting `graphify-out/` happened to fix the problem because it forced a
clean extraction.

## Fix

The extraction path now distinguishes:

* whether files should be scanned incrementally, and
* whether the existing graph should be merged/preserved.

`--force --code-only` keeps incremental detection disabled so all code files
are rescanned, while `merge_existing_graph` ensures the existing semantic
layer is preserved.

Stale graph sources are also identified during the full scan so deleted or
excluded files can still be pruned correctly.

## Regression test

Added coverage for the complete scenario:

1. Extract a project with an unresolved TypeScript alias.
2. Change only `tsconfig.json` to add the corresponding `paths` mapping.
3. Run `extract --code-only --force`.
4. Verify the import edge is now resolved.
5. Verify an existing semantic node remains in the graph.

## Validation

* `tests/test_extract_code_only_cli.py`: **13 passed**
* `tests/test_js_import_resolution.py tests/test_build.py tests/test_cache.py`:
  **219 passed, 8 skipped**
* Focused regression test: **1 passed**
* `git diff --check`: clean

## Scope

No changes were made to the module-resolution implementation, cache layer,
or incremental detector. The fix is isolated to the extraction/merge
semantics for `--force --code-only`.


