### PR TITLE
fix(cluster): canonicalise edge endpoints before sorting in _partition

### DIFF
--- a/graphify/cluster.py
+++ b/graphify/cluster.py
@@ -33,11 +33,21 @@ def _partition(G: nx.Graph, resolution: float = 1.0) -> dict[str, int]:
     """
     stable = nx.Graph()
     stable.add_nodes_from(sorted(G.nodes(), key=str))
+    # Canonicalise the endpoint pair before sorting. On an undirected graph the
+    # (u, v) orientation each edge is yielded with comes from adjacency
+    # iteration, which follows CPython's per-process string-hash order - so the
+    # SAME edge appears as (A, B) in one run and (B, A) in the next. Sorting on
+    # the raw pair therefore does not canonicalise anything: the edge lands in a
+    # different position, `stable` is built in a different insertion order, and
+    # Louvain - order-sensitive even with a fixed seed - can return a different
+    # grouping. Measured on a 914-node graph: identical input, identical
+    # first-pass partition, but the cohesion-split pass produced 70 communities
+    # under PYTHONHASHSEED=1 and 69 under =2. Sorting the pair itself removes
+    # the dependency; for nx.Graph the orientation carries no meaning anyway.
     edge_rows = sorted(
         G.edges(data=True),
         key=lambda row: (
-            str(row[0]),
-            str(row[1]),
+            *sorted((str(row[0]), str(row[1]))),
             json.dumps(row[2], sort_keys=True, ensure_ascii=False, default=str),
         ),
     )


### PR DESCRIPTION
﻿`_partition` sorts a graph's edges before inserting them into a fresh `stable`
graph, so that clustering sees a deterministic insertion order. The sort key is
the raw `(str(u), str(v), attrs)` triple.

On an **undirected** graph the orientation each edge is yielded with comes from
adjacency iteration, which follows CPython's per-process string-hash order. The
same edge is therefore yielded as `(A, B)` in one process and `(B, A)` in the
next, and sorting on the raw pair does not canonicalise it: the edge lands in a
different position, `stable` is built in a different insertion order, and Louvain
— order-sensitive even with `seed=42` — can return a different grouping.

For `nx.Graph` the orientation carries no meaning, so sorting the pair itself is
safe and removes the dependency.

## Evidence

Measured on a 914-node / 1823-edge documentation graph, with a byte-identical
input graph in every run:

| | |
|---|---|
| `_partition` on the full graph | identical under every seed (33 groups, same fingerprint) |
| `cluster()` overall | **74 / 73 / 73 / 73** communities over four hash seeds |
| the diverging stage | the cohesion re-split, which calls `_partition` again on a subgraph view — **70** groups under `PYTHONHASHSEED=1` vs **69** under `=2` |
| after this change | four seeds, one identical grouping |

Downstream this was not cosmetic: rebuilding the same graph from the same inputs
produced 69–71 communities with up to 43 nodes in a differently named one, so any
published "community X contains Y" statement was a statement about one build.
Note that the community *count* does not detect it — two drifting builds both
reported 71 with different members.

## Two things this is not

- Not the seed. `seed=42` / `random_seed=42` are set and correct; the input order
  varied underneath them.
- Not `build()`'s node order. That is identical under every hash seed. Node order
  in an exported `graph.json` only *looks* unstable because `to_json` sorts nodes
  by their serialised form, `community` included — it follows the drift rather
  than causing it.

## No regression test, deliberately

I wrote one and it passed without the fix, so I removed it rather than ship a
test that proves nothing. Reproducing the fault needs a graph ambiguous enough
for Louvain to be order-sensitive *and* large enough to trigger the cohesion
re-split: a ring of equal cliques, a low-cohesion hub graph, and this repo's own
`tests/fixtures/extraction.json` all cluster identically with and without the
change. If you have a fixture in that size class I am happy to add one.
