### PR TITLE
fix(install): emit a bare hook command for project-scoped installs (#3129)

### DIFF
--- a/graphify/install.py
+++ b/graphify/install.py
@@ -285,12 +285,14 @@ def _print_project_git_add_hint(paths: list[Path]) -> None:
     print()
     print("Project-scoped install. Add to version control:")
     print(f"  git add {' '.join(unique)}")
-def _claude_pretooluse_hooks(strict: bool = False) -> "list[dict]":
+def _claude_pretooluse_hooks(strict: bool = False, project: bool = False) -> "list[dict]":
     """graphify's Claude/Codebuddy PreToolUse hooks, resolved at install time.
 
     The command invokes `graphify hook-guard <search|read>` via the absolute exe
-    path (`_resolve_graphify_exe`), so it parses under sh, cmd.exe and PowerShell
-    alike — this is the #522 fix, and mirrors the codex hook. Matchers are
+    path (`_resolve_graphify_exe`) — or, for a project-scoped install, via the
+    bare `graphify` command, since that config gets committed (#3129). Either
+    form parses under sh, cmd.exe and PowerShell alike — this is the #522 fix,
+    and mirrors the codex hook. Matchers are
     "Bash|Grep" and "Read|Glob" and the command always contains "graphify", so the
     existing install/uninstall filters find and replace both old bash hooks and
     these. "Grep" is in the search matcher because current Claude Code routes
@@ -301,7 +303,7 @@ def _claude_pretooluse_hooks(strict: bool = False) -> "list[dict]":
     first raw read per session (Claude Code only). The ``GRAPHIFY_HOOK_STRICT`` env
     var can force it on or off at runtime without a reinstall.
     """
-    exe = _resolve_graphify_exe()
+    exe = _resolve_graphify_exe(project=project)
     if " " in exe and not exe.startswith('"'):
         exe = f'"{exe}"'
     read_cmd = f"{exe} hook-guard read" + (" --strict" if strict else "")
@@ -689,9 +691,13 @@ _CLAUDE_MD_MARKER = "## graphify"
 _CODEBUDDY_MD_MARKER = "## graphify"
 _AGENTS_MD_MARKER = "## graphify"
 _GEMINI_MD_MARKER = "## graphify"
-def _gemini_hook() -> dict:
-    """Gemini CLI BeforeTool hook, resolved to a shell-agnostic `graphify` call."""
-    exe = _resolve_graphify_exe()
+def _gemini_hook(project: bool = False) -> dict:
+    """Gemini CLI BeforeTool hook, resolved to a shell-agnostic `graphify` call.
+
+    A project-scoped install emits the bare command, since .gemini/settings.json
+    is then committed and an installing machine's path is wrong there (#3129).
+    """
+    exe = _resolve_graphify_exe(project=project)
     if " " in exe and not exe.startswith('"'):
         exe = f'"{exe}"'
     return {
@@ -721,7 +727,7 @@ def gemini_install(project_dir: Path | None = None, *, project: bool = False) ->
 
     # Always re-install the Gemini hook so an older payload (e.g. pre-issue-#580
     # wording) is replaced on upgrade.
-    _install_gemini_hook(project_dir)
+    _install_gemini_hook(project_dir, project=project)
     if project:
         _print_project_git_add_hint([_project_scope_root(skill_dst, project_dir), project_dir / "GEMINI.md", project_dir / ".gemini"])
     print()
@@ -769,7 +775,7 @@ def _write_settings_with_backup(settings_path: Path, settings: dict) -> None:
         backup = settings_path.with_name(settings_path.name + ".graphify-bak")
         shutil.copy2(settings_path, backup)
     settings_path.write_text(output, encoding="utf-8")
-def _install_gemini_hook(project_dir: Path) -> None:
+def _install_gemini_hook(project_dir: Path, project: bool = False) -> None:
     settings_path = project_dir / ".gemini" / "settings.json"
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings = _read_settings_for_merge(settings_path)
@@ -782,7 +788,7 @@ def _install_gemini_hook(project_dir: Path) -> None:
     hooks["BeforeTool"] = [
         h for h in before_tool if "graphify" not in str(h)
     ]
-    hooks["BeforeTool"].append(_gemini_hook())
+    hooks["BeforeTool"].append(_gemini_hook(project=project))
     _write_settings_with_backup(settings_path, settings)
     print("  .gemini/settings.json  ->  BeforeTool hook registered")
 def _uninstall_gemini_hook(project_dir: Path) -> None:
@@ -1397,8 +1403,16 @@ def _uninstall_opencode_plugin(project_dir: Path) -> None:
             config.pop("plugin")
         config_file.write_text(json.dumps(config, indent=2), encoding="utf-8")
         print(f"  {_OPENCODE_CONFIG_PATH}  ->  plugin deregistered")
-def _resolve_graphify_exe() -> str:
+def _resolve_graphify_exe(project: bool = False) -> str:
     """Return the absolute path to the graphify executable, with forward slashes.
+
+    With *project* set, return the bare ``graphify`` command instead. A
+    project-scoped install writes hook config the installer then tells the user
+    to commit, so an absolute path resolved from the installing machine is wrong
+    for every other clone: it names a directory that does not exist there, and
+    the drive letter and ``.EXE`` casing do not even survive between two Windows
+    checkouts. A committed hook refers to ``graphify`` the way it would refer to
+    ``git`` or ``node``, and PATH resolves it per machine (#3129).
 
     Falls back to bare 'graphify' if resolution fails. Using an absolute path
     ensures the hook works in environments where the venv Scripts/ directory is
@@ -1413,6 +1427,8 @@ def _resolve_graphify_exe() -> str:
     ``.replace`` is a no-op on POSIX where paths already use forward slashes.
     """
     import shutil
+    if project:
+        return "graphify"
     found = shutil.which("graphify")
     if not found:
         # Derive from sys.executable: same Scripts/ (Windows) or bin/ (Unix) dir
@@ -1423,14 +1439,18 @@ def _resolve_graphify_exe() -> str:
                 found = str(candidate)
                 break
     return (found or "graphify").replace("\\", "/")
-def _install_codex_hook(project_dir: Path) -> None:
-    """Add graphify PreToolUse hook to .codex/hooks.json."""
+def _install_codex_hook(project_dir: Path, project: bool = False) -> None:
+    """Add graphify PreToolUse hook to .codex/hooks.json.
+
+    A project-scoped install emits the bare command, since .codex/hooks.json is
+    then committed and an installing machine's path is wrong there (#3129).
+    """
     hooks_path = project_dir / ".codex" / "hooks.json"
     hooks_path.parent.mkdir(parents=True, exist_ok=True)
 
     existing = _read_settings_for_merge(hooks_path)
 
-    graphify_exe = _resolve_graphify_exe()
+    graphify_exe = _resolve_graphify_exe(project=project)
     hook_entry = {
         "hooks": {
             "PreToolUse": [
@@ -1472,7 +1492,7 @@ def _uninstall_codex_hook(project_dir: Path) -> None:
     existing["hooks"]["PreToolUse"] = filtered
     hooks_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
     print(f"  .codex/hooks.json  ->  PreToolUse hook removed")
-def _agents_install(project_dir: Path, platform: str) -> None:
+def _agents_install(project_dir: Path, platform: str, project: bool = False) -> None:
     """Write the graphify section to the local AGENTS.md for always-on platforms."""
     target = (project_dir or Path(".")) / "AGENTS.md"
 
@@ -1491,7 +1511,7 @@ def _agents_install(project_dir: Path, platform: str) -> None:
         print(f"graphify section written to {target.resolve()}")
 
     if platform == "codex":
-        _install_codex_hook(project_dir or Path("."))
+        _install_codex_hook(project_dir or Path("."), project=project)
     elif platform == "opencode":
         _install_opencode_plugin(project_dir or Path("."))
     elif platform == "kilo":
@@ -1555,7 +1575,7 @@ def _project_install(platform_name: str, project_dir: Path | None = None, strict
     platform_name = _canonical_platform(platform_name)
     if platform_name in ("claude", "windows"):
         install(platform=platform_name, project=True, project_dir=project_dir)
-        claude_install(project_dir, strict=strict)
+        claude_install(project_dir, strict=strict, project=True)
         _print_project_git_add_hint([project_dir / ".claude", project_dir / "CLAUDE.md"])
     elif platform_name == "gemini":
         gemini_install(project_dir, project=True)
@@ -1567,7 +1587,7 @@ def _project_install(platform_name: str, project_dir: Path | None = None, strict
         _print_project_git_add_hint([project_dir / ".kiro"])
     elif platform_name in ("aider", "amp", "codex", "opencode", "claw", "droid", "trae", "trae-cn", "hermes"):
         skill_dst = _copy_skill_file(platform_name, project=True, project_dir=project_dir)
-        _agents_install(project_dir, platform_name)
+        _agents_install(project_dir, platform_name, project=True)
         hint_paths = [_project_scope_root(skill_dst, project_dir), project_dir / "AGENTS.md"]
         if platform_name == "opencode":
             hint_paths.append(project_dir / ".opencode")
@@ -1708,7 +1728,7 @@ def _kilo_uninstall(project_dir: Path) -> None:
     _agents_uninstall(project_dir or Path("."), platform="kilo")
     removed = _kilo_uninstall_global()
     print("; ".join(removed) if removed else "nothing to remove")
-def claude_install(project_dir: Path | None = None, strict: bool = False) -> None:
+def claude_install(project_dir: Path | None = None, strict: bool = False, project: bool = False) -> None:
     """Write the graphify section to the local CLAUDE.md."""
     target = (project_dir or Path(".")) / "CLAUDE.md"
 
@@ -1728,7 +1748,7 @@ def claude_install(project_dir: Path | None = None, strict: bool = False) -> Non
 
     # Always re-install the Claude Code PreToolUse hook so an old hook
     # payload (e.g. pre-issue-#580 wording) is replaced on upgrade.
-    _install_claude_hook(project_dir or Path("."), strict=strict)
+    _install_claude_hook(project_dir or Path("."), strict=strict, project=project)
 
     print()
     print("Claude Code will now check the knowledge graph before answering")
@@ -1736,8 +1756,12 @@ def claude_install(project_dir: Path | None = None, strict: bool = False) -> Non
     if strict:
         print("Strict mode: the first raw file read per session is blocked until")
         print("one `graphify query` runs (toggle with GRAPHIFY_HOOK_STRICT=0).")
-def _install_claude_hook(project_dir: Path, strict: bool = False) -> None:
-    """Add graphify PreToolUse hook to .claude/settings.json."""
+def _install_claude_hook(project_dir: Path, strict: bool = False, project: bool = False) -> None:
+    """Add graphify PreToolUse hook to .claude/settings.json.
+
+    A project-scoped install emits the bare command, since .claude/settings.json
+    is then committed and an installing machine's path is wrong there (#3129).
+    """
     settings_path = project_dir / ".claude" / "settings.json"
     settings_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -1751,7 +1775,7 @@ def _install_claude_hook(project_dir: Path, strict: bool = False) -> None:
         _refuse_to_modify(settings_path)
 
     hooks["PreToolUse"] = [h for h in pre_tool if not (isinstance(h, dict) and h.get("matcher") in ("Glob|Grep", "Bash", "Bash|Grep", "Read|Glob") and "graphify" in str(h))]
-    hooks["PreToolUse"].extend(_claude_pretooluse_hooks(strict=strict))
+    hooks["PreToolUse"].extend(_claude_pretooluse_hooks(strict=strict, project=project))
     _write_settings_with_backup(settings_path, settings)
     _mode = " (strict)" if strict else ""
     print(f"  .claude/settings.json  ->  PreToolUse hooks registered (Bash|Grep search + Read/Glob){_mode}")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1218,3 +1218,126 @@ def test_codex_hook_command_is_a_real_cli_subcommand(tmp_path):
             f"codex hook registers {subcommand!r}, which the CLI does not dispatch "
             f"(#2165). Known commands: {sorted(dispatched)}"
         )
+
+
+# --- #3129: project-scoped installs must not embed a machine-absolute path ----
+#
+# `--project` writes hook config that the installer then tells the user to
+# commit ("Add to version control: git add ..."). An exe path resolved from the
+# installing machine is wrong in every other clone, and the drive letter and
+# .EXE casing do not even survive between two Windows checkouts. The committed
+# hook must name `graphify` and let PATH resolve it, the way the git-hook layer
+# already does with `command -v graphify` (hooks.py). The user-profile install
+# is deliberately left alone: it stays on the machine that wrote it, and an
+# absolute path is what makes the hook work where the venv Scripts/ dir is not
+# on PATH (e.g. the VS Code Codex extension on Windows).
+
+_PROJECT_HOOK_FILES = {
+    "claude": ".claude/settings.json",
+    "codex": ".codex/hooks.json",
+    "gemini": ".gemini/settings.json",
+}
+
+
+def _hook_commands(text: str) -> list:
+    """Every hook command string in a settings/hooks JSON document."""
+    import json as _json
+
+    doc = _json.loads(text)
+    found = []
+    for groups in doc.get("hooks", {}).values():
+        for group in groups:
+            for hook in group.get("hooks", []):
+                if "command" in hook:
+                    found.append(hook["command"])
+    return found
+
+
+def _run_project_install(project, home, platform):
+    from graphify.__main__ import main
+
+    with patch("graphify.__main__.Path.home", return_value=home):
+        with patch("sys.argv", ["graphify", "install", "--project", "--platform", platform]):
+            main()
+
+
+@pytest.mark.parametrize("platform", sorted(_PROJECT_HOOK_FILES))
+def test_project_install_hook_command_is_portable(tmp_path, monkeypatch, platform):
+    """A committed hook must carry no absolute path, drive letter or .EXE casing."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    # Resolution would otherwise find a real graphify on this machine; pin it so
+    # the assertion fails loudly if the project path ever resolves again.
+    monkeypatch.setattr("shutil.which", lambda _name: r"C:\Users\installer\graphify.EXE")
+
+    _run_project_install(project, home, platform)
+
+    commands = _hook_commands((project / _PROJECT_HOOK_FILES[platform]).read_text(encoding="utf-8"))
+    assert commands, f"{platform} project install registered no hook command"
+    for command in commands:
+        assert command.startswith("graphify "), command
+        assert ":" not in command, f"drive letter / absolute path leaked: {command}"
+        assert "\\" not in command, f"backslash path leaked: {command}"
+        assert ".exe" not in command.lower(), f"platform exe casing leaked: {command}"
+        assert "installer" not in command, f"installing user's path leaked: {command}"
+
+
+@pytest.mark.parametrize("platform", sorted(_PROJECT_HOOK_FILES))
+def test_user_profile_install_still_resolves_absolute_path(tmp_path, monkeypatch, platform):
+    """The non-project install keeps the resolved path (#522/#1987 behaviour)."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setattr("shutil.which", lambda _name: r"C:\Users\installer\graphify.EXE")
+
+    from graphify.__main__ import main
+
+    with patch("graphify.__main__.Path.home", return_value=home):
+        with patch("sys.argv", ["graphify", platform, "install"]):
+            main()
+
+    commands = _hook_commands((project / _PROJECT_HOOK_FILES[platform]).read_text(encoding="utf-8"))
+    assert commands, f"{platform} install registered no hook command"
+    for command in commands:
+        assert command.startswith("C:/Users/installer/graphify.EXE "), command
+
+
+@pytest.mark.parametrize("platform", sorted(_PROJECT_HOOK_FILES))
+def test_project_install_is_idempotent(tmp_path, monkeypatch, platform):
+    """Installing twice leaves byte-identical config (no churn on re-install)."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setattr("shutil.which", lambda _name: r"C:\Users\installer\graphify.EXE")
+    target = project / _PROJECT_HOOK_FILES[platform]
+
+    _run_project_install(project, home, platform)
+    first = target.read_text(encoding="utf-8")
+    _run_project_install(project, home, platform)
+
+    assert target.read_text(encoding="utf-8") == first
+
+
+def test_project_uninstall_removes_the_bare_hook_command(tmp_path, monkeypatch):
+    """The uninstall filter matches on "graphify", so a bare command still goes."""
+    from graphify.__main__ import main
+
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setattr("shutil.which", lambda _name: r"C:\Users\installer\graphify.EXE")
+
+    _run_project_install(project, home, "claude")
+    settings = project / ".claude" / "settings.json"
+    assert any("hook-guard" in c for c in _hook_commands(settings.read_text(encoding="utf-8")))
+
+    with patch("graphify.__main__.Path.home", return_value=home):
+        with patch("sys.argv", ["graphify", "claude", "uninstall", "--project"]):
+            main()
+
+    assert not [c for c in _hook_commands(settings.read_text(encoding="utf-8")) if "graphify" in c]


### PR DESCRIPTION
## Summary

`graphify install --project` resolves the graphify executable to an absolute path from the
installing user's environment and writes that path into hook configuration that the installer
then instructs the user to commit. Those paths are invalid for every other contributor and for CI.

Refs #3129, which reports this for Codex, with the Claude Code occurrence noted in the thread.
That issue is filed against a plain `graphify install`, so this PR does not close it — it fixes
the `--project` case only, for the reason already discussed there: a user-profile install lands
somewhere nobody else is expected to share, whereas `--project` carries the explicit expectation
that others contribute to that checkout. See "Scope" below.

To be clear about what is and isn't at issue: `hook-guard` itself is sound. It handles the Grep
tool payload shape that defeats a naive command matcher, and its read mode does per-file staleness
detection. Path handling at install time is the only defect here.

## Reproduction

Clean `git init` repositories, no prior graphify configuration:

```bash
mkdir gfx-claude && cd gfx-claude && git init .
graphify install --project --platform claude
cat .claude/settings.json
```

```json
{
  "hooks": {
    "PreToolUse": [
      { "matcher": "Bash|Grep",
        "hooks": [ { "type": "command",
                     "command": "C:/Users/<user>/.local/bin/graphify.EXE hook-guard search" } ] },
      { "matcher": "Read|Glob",
        "hooks": [ { "type": "command",
                     "command": "C:/Users/<user>/.local/bin/graphify.EXE hook-guard read" } ] }
    ]
  }
}
```

The same run prints:

```
Project-scoped install. Add to version control:
  git add .claude/ CLAUDE.md
```

`graphify install --project --platform codex` writes the same shape into `.codex/hooks.json`
(`... graphify.EXE hook-check`), and `--platform gemini` into `.gemini/settings.json`
(`... graphify.EXE hook-guard gemini`).

## Why this is wrong

`--project` exists to produce a shared, version-controlled setup. That is precisely the case in
which an absolute path cannot be correct. A committed hook pointing into one developer's home
directory fails silently for everyone else: the configuration is present and syntactically valid,
so nothing looks broken, but every matching tool call fails to run the hook.

The drive letter and `.EXE` casing also make the value non-portable between two Windows checkouts,
not only across operating systems. And each machine that reinstalls rewrites the entry with its own
path, churning a shared file.

## Affected platforms

Three platforms write a hook command through the shared `_resolve_graphify_exe()`, so the defect is
in that shared layer rather than in any one platform's config writer:

| Platform | File | Command |
|---|---|---|
| claude | `.claude/settings.json` | `hook-guard search` / `hook-guard read` |
| codex | `.codex/hooks.json` | `hook-check` |
| gemini | `.gemini/settings.json` | `hook-guard gemini` |

Codex and Claude are both already noted on #3129; Gemini appears not to have been, and falls out of
the same shared resolver.

`codebuddy` shares `_claude_pretooluse_hooks()` but has no project-scoped hook path
(`graphify install --project --platform codebuddy` writes no `.codebuddy/settings.json`), so it is
unaffected by this change.

## The change

Project-scoped installs emit the bare command:

```json
"command": "graphify hook-guard search"
```

PATH resolves it, the way a committed config refers to `git` or `node`. `_resolve_graphify_exe()`
takes a `project` flag that is threaded through the three hook builders and set only at the
`--project` entry points in `_project_install()`.

This follows a convention the codebase already uses rather than introducing a new mechanism: the
git-hook layer resolves the binary at runtime with `GRAPHIFY_BIN=$(command -v graphify)`
(`graphify/hooks.py`), and `skill-agents.md` does the same with `which graphify`. Baking a path at
install time is the outlier.

**The user-profile install is unchanged.** That location is not one other people are expected to
share, and the resolved absolute path is what makes the hook work where the venv `Scripts/`
directory is not on PATH — the VS Code Codex extension on Windows, per the existing docstring. A
regression test pins that behaviour.

## Anticipated objection

*A bare command breaks when `graphify` is not on a contributor's PATH.*

That is not a regression. A missing binary and a wrong absolute path both fail the hook; the
difference is diagnosis. `graphify: command not found` names the problem, whereas a path into
another developer's home directory gives the reader nothing to work with and reads like a
deliberate configuration choice. The bare command fails more loudly and more usefully than what
ships today. This argument applies only to the committed case, which is why the user-profile path
is left alone.

## Scope

Deliberately narrow. Two further defects were observed in the same files and are **not** included
here, to keep this reviewable:

1. Generated config ends without a trailing newline (`\ No newline at end of file`), adding diff
   noise to committed JSON.
2. Installing over an existing, differing hook command replaces it with no diff, no warning, and no
   indication that a customised value was overwritten.

Happy to open those separately.

This PR also does not address the non-`--project` half of #3129. That report's reproduction is a
plain `graphify install`, and `graphify codex install` without the flag still writes an absolute
path into `.codex/hooks.json` in the working directory. Per the discussion on that issue, the
absolute path is defensible there — that install is not aimed at a location others are expected to
maintain — and the case is further entangled with #2164, which reports that these installs write
into the cwd rather than a user config directory at all. Left for a maintainer call rather than
silently bundled, which is why this is `Refs` and not `Fixes`.

Related: #3009 fixes the same class of defect for `.githooks/*` by moving the interpreter path into
a gitignored sidecar. That approach fits there because git hooks run in GUI clients and CI where
PATH is unreliable; these hooks are executed by the agent harness in the user's own shell, where
the documented install puts `graphify` on PATH.

## Tests

Added to `tests/test_install.py`, asserting on generated content rather than mocked calls:

- `test_project_install_hook_command_is_portable` (claude, codex, gemini) — no absolute path, no
  drive letter, no backslash, no `.EXE` casing, no leak of the installing user's path.
- `test_user_profile_install_still_resolves_absolute_path` (claude, codex, gemini) — the
  non-project install still emits the resolved path, so the fix does not regress the case where
  that is correct.
- `test_project_install_is_idempotent` (claude, codex, gemini) — installing twice leaves
  byte-identical config.
- `test_project_uninstall_removes_the_bare_hook_command` — the uninstall filter matches on
  `"graphify"`, so a bare command is still stripped.

Verified these fail without the fix: the three `..._is_portable` cases fail on clean `v8` and pass
with the change; the rest pass either way, as guards.

Full suite was run on Windows: 4935 passed, 31 failed, 104 skipped. All 31 failures are
pre-existing and unrelated (fifo/unix-socket, symlinks, shell metacharacters, ollama retries). I
verified this by running the same suite against clean `v8` and diffing the failure sets — identical,
zero introduced and zero fixed. Per the README, exact CI parity needs Linux; the Ubuntu matrix will
confirm. `ruff check` and the blocking `skillgen --check` / `--schema-singleton` jobs pass.
