### PR TITLE
Route get_node through the same resolver as get_neighbors

### DIFF
--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -1362,6 +1362,31 @@ def find_node_ambiguity(G: nx.Graph, label: str) -> list[str]:
     return []
 
 
+def _resolve_single_node(G: nx.Graph, label: str) -> tuple[str | None, str | None]:
+    """Shared node resolution for the get_node / get_neighbors tools.
+
+    Returns ``(node_id, None)`` when *label* resolves to a single winner via the
+    tiered `_find_node` ranking, or ``(None, message)`` when there is no match or
+    the winning tier spans several source files. Routing both tools through this
+    keeps get_node from silently returning a `G.nodes()` iteration-order match for
+    a hub name while get_neighbors reports the same lookup as ambiguous (#ADR-0001).
+    """
+    matches = _find_node(G, label)
+    if not matches:
+        return None, f"No node matching '{label}' found."
+    rivals = find_node_ambiguity(G, label)
+    if rivals:
+        listing = "\n".join(
+            f"  {G.nodes[r].get('source_file') or r}\n    id: {r}" for r in rivals
+        )
+        return None, (
+            f"Ambiguous: '{label}' matches {len(rivals)} nodes in different files.\n"
+            f"{listing}\n"
+            "Retry with the repo-relative path or the full node id."
+        )
+    return matches[0], None
+
+
 def _shortest_path_text(G: nx.Graph, arguments: dict) -> str:
     """Body of the `shortest_path` MCP tool (module-level so tests can call it
     without an mcp install).
@@ -1759,11 +1784,10 @@ def _build_server(graph_path: str):
 
     def _tool_get_node(arguments: dict) -> str:
         label = arguments["label"].lower()
-        matches = [(nid, d) for nid, d in G.nodes(data=True)
-                   if label in (d.get("label") or "").lower() or label == nid.lower()]
-        if not matches:
-            return f"No node matching '{label}' found."
-        nid, d = matches[0]
+        nid, err = _resolve_single_node(G, label)
+        if err:
+            return err
+        d = G.nodes[nid]
         # Sanitise every LLM-derived field before concatenation (F-010).
         return "\n".join([
             f"Node: {sanitize_label(d.get('label', nid))}",
@@ -1783,20 +1807,9 @@ def _build_server(graph_path: str):
     def _tool_get_neighbors(arguments: dict) -> str:
         label = arguments["label"].lower()
         rel_filter = arguments.get("relation_filter", "").lower()
-        matches = _find_node(G, label)
-        if not matches:
-            return f"No node matching '{label}' found."
-        rivals = find_node_ambiguity(G, label)
-        if rivals:
-            listing = "\n".join(
-                f"  {G.nodes[r].get('source_file') or r}\n    id: {r}" for r in rivals
-            )
-            return (
-                f"Ambiguous: '{label}' matches {len(rivals)} nodes in different files.\n"
-                f"{listing}\n"
-                "Retry with the repo-relative path or the full node id."
-            )
-        nid = matches[0]
+        nid, err = _resolve_single_node(G, label)
+        if err:
+            return err
         lines = [f"Neighbors of {sanitize_label(G.nodes[nid].get('label', nid))}:"]
         def _edge_at(d: dict) -> str:
             # Edge location = the relation SITE (call/import line) in the source

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1711,3 +1711,27 @@ def test_underscore_query_does_not_let_a_single_token_outrank_the_real_match():
     scored = _score_nodes(G, _query_terms("user_service_client"))
     assert scored, "the multi-token query must match the full-label node"
     assert scored[0][1] == "real", f"a single-token node out-ranked the real match: {scored}"
+
+
+def test_resolve_single_node_shared_by_get_node_and_get_neighbors():
+    """ADR-0001 finding 1: the resolver both tools now use returns an Ambiguous
+    message when the winning tier spans multiple files, a clean node id for a
+    unique label, and a not-found message otherwise."""
+    from graphify.serve import _resolve_single_node
+
+    G = nx.Graph()
+    G.add_node("a", label="extract", source_file="a/x.py")
+    G.add_node("b", label="extract", source_file="b/y.py")
+    G.add_node("u", label="unique_helper", source_file="c/z.py")
+
+    nid, err = _resolve_single_node(G, "extract")
+    assert nid is None
+    assert err.startswith("Ambiguous:")
+
+    nid, err = _resolve_single_node(G, "unique_helper")
+    assert err is None
+    assert nid == "u"
+
+    nid, err = _resolve_single_node(G, "nonexistent")
+    assert nid is None
+    assert "No node matching" in err

--- a/tests/test_serve_http.py
+++ b/tests/test_serve_http.py
@@ -361,3 +361,37 @@ def test_cli_api_key_from_env(monkeypatch):
     monkeypatch.setattr(serve_mod, "serve_http", lambda gp, **k: captured.update(**k))
     serve_mod._main(["g.json", "--transport", "http"])
     assert captured["api_key"] == "from-env"
+
+
+def _ambiguous_graph_file(tmp_path: Path) -> str:
+    """A graph where the label 'extract' matches two nodes in different files."""
+    graph = {
+        "directed": True,
+        "nodes": [
+            {"id": "a", "label": "extract", "community": 0, "source_file": "a/x.py"},
+            {"id": "b", "label": "extract", "community": 0, "source_file": "b/y.py"},
+            {"id": "u", "label": "unique_helper", "community": 0, "source_file": "c/z.py"},
+        ],
+        "edges": [
+            {"source": "a", "target": "u", "relation": "calls", "confidence": "EXTRACTED"},
+        ],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph), encoding="utf-8")
+    return str(p)
+
+
+def test_get_node_and_get_neighbors_agree_on_ambiguous_label(tmp_path):
+    """ADR-0001 finding 1: get_node must not silently return a G.nodes()
+    iteration-order match for a hub name while get_neighbors reports the same
+    lookup as ambiguous. Both now route through the shared resolver."""
+    app = serve_mod._build_http_app(_ambiguous_graph_file(tmp_path), json_response=True)
+    with _client(app) as client:
+        headers = _init_session(client)
+        node = _call_tool(client, headers, "get_node", {"label": "extract"}, rid=2)
+        neighbors = _call_tool(client, headers, "get_neighbors", {"label": "extract"}, rid=3)
+        assert node.startswith("Ambiguous:"), node
+        assert neighbors.startswith("Ambiguous:"), neighbors
+        # A unique label still resolves cleanly on get_node.
+        unique = _call_tool(client, headers, "get_node", {"label": "unique_helper"}, rid=4)
+        assert "Node: unique_helper" in unique, unique


### PR DESCRIPTION
## Summary

Route the MCP `get_node` tool through the same node resolver as `get_neighbors`, so both tools resolve a `label` the same way. Previously `get_node` did a raw substring scan over `G.nodes(data=True)` and returned `matches[0]` — an arbitrary match determined by graph iteration order — while `get_neighbors` used tiered matching plus ambiguity detection. For a hub name that matches several nodes in different files, the two tools gave different answers.

Fixes https://github.com/Graphify-Labs/graphify/issues/3160

## What changed

- Added one module-level helper, `_resolve_single_node(G, label)`, that does the tiered `_find_node` match plus the cross-file `find_node_ambiguity` check and returns `(node_id, None)` for a clean winner or `(None, message)` for no-match / ambiguity.
- `_tool_get_node` now routes through it — replacing the substring-scan + `[0]`. It returns the tiered winner, or the same `Ambiguous — retry with the repo-relative path or the full node id` message `get_neighbors` already used, when the winning tier spans multiple files.
- `_tool_get_neighbors` now calls the same helper. **Its behaviour and messages are unchanged** — the resolution logic it already had just moved into the shared function, so both tools have one resolution contract.

## Why

`find_node_ambiguity` exists specifically so that `[0]`-of-a-tie doesn't present one arbitrary file as "the answer". `get_node` never went through it, so a hub lookup (e.g. `extract`) silently returned whichever `extract_*` helper came first in `G.nodes()` order — and a graph rebuild that reorders nodes could change the answer.

## Testing

- New unit test for `_resolve_single_node` (ambiguous → message, unique → id, missing → not-found) — runs offline, passes.
- New HTTP end-to-end test: `get_node` and `get_neighbors` both report "Ambiguous" for a cross-file label and both resolve a unique label cleanly.
- Existing serve tests pass (`test_serve.py`: 146 passed). ruff clean.


## Notes

- Root cause and fix were identified using Cursor (Composer 2.5) + [Vinv AI](https://vinv.ai/)