### PR TITLE
Fix stale deepseek-v4-flash pricing and build_merge docstring

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -1633,7 +1633,11 @@ def build_merge(
     dedup_llm_backend: str | None = None,
     root: str | Path | None = None,
 ) -> nx.Graph:
-    """Load existing graph.json, merge new chunks into it, and save back.
+    """Load existing graph.json and return it merged with ``new_chunks``.
+
+    Does NOT write to disk — the caller persists the result, e.g. via
+    ``export.to_json(G, communities, graph_path, force=True)`` after
+    clustering. ``graph_path`` is read-only here.
 
     Re-extracted files REPLACE their prior contribution per tier (#2333/#2336):
     a source_file present in new_chunks has its existing nodes/edges dropped

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -172,7 +172,10 @@ BACKENDS: dict[str, dict] = {
         "default_model": "deepseek-v4-flash",
         "env_key": "DEEPSEEK_API_KEY",
         "model_env_key": "GRAPHIFY_DEEPSEEK_MODEL",
-        "pricing": {"input": 0.14, "output": 0.28},  # USD per 1M tokens (v4-flash)
+        "pricing": {"input": 0.44, "output": 1.32},  # USD per 1M tokens (v4-flash,
+        # peak, cache miss). Peak is 01:00-04:00 and 06:00-10:00 UTC Mon-Fri;
+        # all other hours are off-peak at half these rates. A cache hit is
+        # $0.014/1M in. Source: api-docs.deepseek.com/quick_start/pricing
         # deepseek-reasoner silently ignores temperature; deepseek-chat / v4-flash
         # accept 0-2, so sending 0 is safe. Note: deepseek-v4-flash (and v4-pro) have
         # thinking ENABLED by default (verified against the live API, #1621) — set


### PR DESCRIPTION
Two independent fixes, both verified against primary sources on 2026-08-29.

### 1. `deepseek-v4-flash` pricing is stale (`graphify/llm.py`)

The backend is priced at `$0.14 / $0.28` per 1M tokens. That is DeepSeek **V3** pricing. Per the [published table](https://api-docs.deepseek.com/quick_start/pricing), `deepseek-v4-flash` is:

| | off-peak | peak |
|---|---|---|
| input (cache miss) | $0.22 | **$0.44** |
| output | $0.66 | **$1.32** |

So `estimate_cost` under-reports a v4-flash run by roughly **3x on input and 4.7x on output**. On a real corpus this is the difference between a run reading as free and reading as real money.

Changed to the peak/cache-miss rates, consistent with how the other backends here are priced (undiscounted list price). Added an inline note for the peak window (01:00-04:00 and 06:00-10:00 UTC Mon-Fri, all other hours half price) and the cache-hit rate, since neither is derivable from the two numbers alone.

### 2. `build_merge` docstring promises a write it never performs (`graphify/build.py`)

The docstring opens with "Load existing graph.json, merge new chunks into it, and **save back**." The function ends at `return G`. `graph_path` is only ever read.

Following the docstring leaves the on-disk graph silently unchanged — the call succeeds, the returned graph is correct, and nothing persists. I lost a merge to this before checking the source.

The runbooks already do the right thing (`build_merge` → `cluster` → `to_json`), so this is a docs-only fix documenting the actual contract rather than a behaviour change — callers who already persist are unaffected.

### Notes

No test asserts either value, so nothing in the suite changes. I was not able to run the full suite locally (no pytest in the environment I patched from) — happy to iterate if CI flags anything.
