### PR TITLE
docs(hooks): explain why DETACHED_PROCESS must not return (Win11 focus-steal)

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -246,7 +246,14 @@ except Exception as exc:
 # the real rebuild fully detached and returns immediately, so the hook never
 # blocks. POSIX uses start_new_session (the setsid equivalent); Windows uses
 # CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP, breaking away from any job object
-# when allowed. This payload is carried inside a shell double-quoted -c argument,
+# when allowed. Do NOT 'simplify' CREATE_NO_WINDOW back into DETACHED_PROCESS:
+# on Windows 11 with Windows Terminal as the default console host, a
+# console-less python still gets a VISIBLE console allocated when its runtime
+# touches the console API during startup (ctrl-handler installation), popping
+# an empty Terminal window over whatever the user is doing - once per commit,
+# for the whole rebuild. Reproduced via GetConsoleWindow(): DETACHED_PROCESS
+# child reports a visible hwnd, CREATE_NO_WINDOW child reports none (3bac3df).
+# This payload is carried inside a shell double-quoted -c argument,
 # so it deliberately uses only single-quoted Python strings (no ", $, ` or \\).
 _LAUNCHER_TEMPLATE = """\
 import os, subprocess, sys


### PR DESCRIPTION
## What

Comment-only change. `3bac3df` replaced `DETACHED_PROCESS` with `CREATE_NO_WINDOW` for the detached rebuild child in `_LAUNCHER_TEMPLATE`, but neither that commit message nor the surrounding code explains **why** the old flag was wrong — which invites a future "simplification" back to `DETACHED_PROCESS`. This pins the rationale next to the flags.

## The bug being documented

We reproduced this on a Windows 11 machine (Windows Terminal as the default console host) with the pre-`3bac3df` hooks:

- The detached rebuild python spawned with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` **still gets a visible console allocated** — an empty Windows Terminal window titled with the python executable path appears once per commit / branch switch and stays open for the whole (minutes-long) rebuild.
- For a user in a fullscreen game this window steals input focus on every single commit an agent makes.

Mechanism: `DETACHED_PROCESS` leaves the child console-less, but the Python runtime touches the console API during startup (ctrl-handler installation), and Windows 11 then allocates a console — hosted visibly by Windows Terminal.

Empirical proof (probe child reports its own console state):

| creationflags | `GetConsoleWindow()` | `IsWindowVisible` |
|---|---|---|
| `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` | non-NULL hwnd | **True** |
| `CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP` | NULL | False |

After switching the live hooks to `CREATE_NO_WINDOW`, the same rebuild runs fully invisible and the log output is unchanged.

## Why a comment and not code

The code fix already exists (`3bac3df`, released in 0.9.29) — this PR only documents the reasoning so it survives future refactors. No behavior change, no test change.