### PR TITLE
fix(extract): link a PHP construction site to the class it constructs

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -997,7 +997,10 @@ _PHP_CONFIG = LanguageConfig(
     class_types=frozenset({"class_declaration"}),
     function_types=frozenset({"function_definition", "method_declaration"}),
     import_types=frozenset({"namespace_use_clause"}),
-    call_types=frozenset({"function_call_expression", "member_call_expression", "scoped_call_expression", "class_constant_access_expression"}),
+    # object_creation_expression (`new Foo(...)`) joins the call types so a
+    # method that only constructs a class, not calls it, still links to it
+    # (the PHP twin of the Java gap in #1373 and the C# one, #2998).
+    call_types=frozenset({"function_call_expression", "member_call_expression", "scoped_call_expression", "class_constant_access_expression", "object_creation_expression"}),
     static_prop_types=frozenset({"scoped_property_access_expression"}),
     helper_fn_names=frozenset({"config"}),
     container_bind_methods=frozenset({"bind", "singleton", "scoped", "instance"}),

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -5293,7 +5293,18 @@ def _extract_generic(
                                          metadata=call_meta)
             elif config.ts_module == "tree_sitter_php":
                 # PHP: distinguish call expression subtypes
-                if node.type == "function_call_expression":
+                if node.type == "object_creation_expression":
+                    # `new Foo(...)` — unlike Java's object_creation_expression,
+                    # tree-sitter-php exposes no named fields at all here (new,
+                    # name/qualified_name, and arguments are purely positional),
+                    # so the generic and Java branches' child_by_field_name calls
+                    # both come back empty and the construction site is dropped
+                    # (the PHP twin of the Java gap in #1373, and of the C# one).
+                    for child in node.children:
+                        if child.type in ("name", "qualified_name"):
+                            callee_name = _read_text(child, source).rsplit("\\", 1)[-1]
+                            break
+                elif node.type == "function_call_expression":
                     func_node = node.child_by_field_name("function")
                     if func_node:
                         callee_name = _read_text(func_node, source)

--- a/tests/test_php_object_creation.py
+++ b/tests/test_php_object_creation.py
@@ -1,0 +1,125 @@
+"""PHP `new Foo(...)` links the constructing method to Foo.
+
+`_PHP_CONFIG.call_types` never listed `object_creation_expression`, so a
+method that only constructed a class — never called a method on it — got no
+edge to it at all. Java has taken `new Foo(...)` as a call since #1373, C#
+caught up in #2998; PHP had not. Message-bus code is the sharpest case:
+`$bus->dispatch(new SomeCommand(...))` is exactly the shape where
+construction *is* the control flow, and none of it showed up (#3115).
+
+Unlike Java (`type` field) and C# (`type` field), tree-sitter-php exposes no
+named fields on `object_creation_expression` at all — `new`, the class name,
+and the argument list are purely positional — so this needed its own branch
+in `walk_calls` rather than reusing either existing one.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from graphify.extract import extract
+
+
+def _extract(tmp_path, files: dict[str, str]):
+    for name, body in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+    old = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        r = extract([Path(n) for n in files], cache_root=Path(tempfile.mkdtemp()))
+    finally:
+        os.chdir(old)
+    calls = {(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "calls"}
+    return calls, r
+
+
+def _find(r, label, id_contains):
+    return next(n["id"] for n in r["nodes"]
+                if n["label"] == label and id_contains in n["id"])
+
+
+def test_assignment_position_links_to_constructed_type(tmp_path):
+    calls, r = _extract(tmp_path, {"S.php": (
+        "<?php\n"
+        "class Foo { public function __construct(public int $x = 0) {} }\n"
+        "class Caller {\n"
+        "    public function run() { $a = new Foo(1); }\n"
+        "}\n"
+    )})
+    assert (_find(r, ".run()", "caller"), _find(r, "Foo", "foo")) in calls
+
+
+def test_argument_position_links_to_constructed_type(tmp_path):
+    # The message-bus shape from #3115: the constructed type never appears in
+    # a declared/assigned position, only as a call argument.
+    calls, r = _extract(tmp_path, {"S.php": (
+        "<?php\n"
+        "class Bar { public function __construct(public int $y = 0) {} }\n"
+        "class Caller {\n"
+        "    public function run(Bus $bus) { $bus->dispatch(new Bar(2)); }\n"
+        "}\n"
+    )})
+    assert (_find(r, ".run()", "caller"), _find(r, "Bar", "bar")) in calls
+
+
+def test_qualified_construction_names_the_last_segment(tmp_path):
+    calls, r = _extract(tmp_path, {"S.php": (
+        "<?php\n"
+        "namespace App;\n"
+        "class Baz { public static function create(): self { return new self(); } }\n"
+        "class Caller {\n"
+        "    public function run() { $c = new \\App\\Baz(); }\n"
+        "}\n"
+    )})
+    assert (_find(r, ".run()", "caller"), _find(r, "Baz", "baz")) in calls
+
+
+def test_static_call_still_resolves(tmp_path):
+    # Guard: adding object_creation_expression to call_types must not disturb
+    # the existing scoped_call_expression (Baz::create()) path.
+    calls, r = _extract(tmp_path, {"S.php": (
+        "<?php\n"
+        "class Baz { public static function create(): self { return new self(); } }\n"
+        "class Caller {\n"
+        "    public function run() { $c = Baz::create(); }\n"
+        "}\n"
+    )})
+    assert (_find(r, ".run()", "caller"), _find(r, "Baz", "baz")) in calls
+
+
+def test_member_call_still_resolves(tmp_path):
+    # Guard: member_call_expression ($obj->method()) must not be swept into
+    # the new object_creation_expression branch.
+    calls, r = _extract(tmp_path, {"S.php": (
+        "<?php\n"
+        "class Worker { public function work() {} }\n"
+        "class Caller {\n"
+        "    public function run(Worker $w) { $w->work(); }\n"
+        "}\n"
+    )})
+    assert (_find(r, ".run()", "caller"), _find(r, ".work()", "worker")) in calls
+
+
+def test_all_three_call_shapes_in_one_method(tmp_path):
+    # The exact repro from #3115: only the static call produced an edge
+    # before the fix; both `new` sites were silently dropped.
+    calls, r = _extract(tmp_path, {"S.php": (
+        "<?php\n"
+        "class Foo { public function __construct(public int $x = 0) {} }\n"
+        "class Bar { public function __construct(public int $y = 0) {} }\n"
+        "class Baz { public static function create(): self { return new self(); } }\n"
+        "class Caller {\n"
+        "    public function run(Bus $bus) {\n"
+        "        $a = new Foo(1);\n"
+        "        $bus->dispatch(new Bar(2));\n"
+        "        $c = Baz::create();\n"
+        "    }\n"
+        "}\n"
+    )})
+    run = _find(r, ".run()", "caller")
+    assert (run, _find(r, "Foo", "foo")) in calls
+    assert (run, _find(r, "Bar", "bar")) in calls
+    assert (run, _find(r, "Baz", "baz")) in calls


### PR DESCRIPTION
Fixes #3115.

## What

`_PHP_CONFIG.call_types` never listed `object_creation_expression`, so `new Foo(...)` never dispatched into `walk_calls` and a PHP method that only *constructs* a class — never calls a method on it — got no edge to it at all.

## Why

Same gap Java closed in #1373 and C# closed in #2998, just not caught up for PHP yet. The issue's own numbers make the practical cost concrete: on a 615-file Symfony/DDD codebase, 505 `new X(` sites across 178 classes had no edge, and on message-bus code specifically (`$bus->dispatch(new SomeCommand(...))`), 0 of 22 dispatch sites linked to the command they construct — exactly the shape where construction *is* the control flow.

## How

Added `object_creation_expression` to `_PHP_CONFIG.call_types` in `extract.py`.

That alone isn't sufficient, though — I checked how Java and C# handle the same node type in `walk_calls` (`extractors/engine.py`) before assuming the config change was the whole fix, since both needed a dedicated per-language branch there (their grammars expose the constructed type through a `type` field, which neither the generic nor either language's existing call-handling path reads by default). Confirmed empirically that tree-sitter-php's `object_creation_expression` is different again: it exposes **no named fields at all** — `new`, the class name, and the argument list are purely positional children (checked directly against the parsed tree, not just the grammar docs). So this needed its own branch: scan the node's children for a `name` or `qualified_name` type directly, keeping only the last namespace segment on a qualified name to match the existing `scoped_call_expression`/Java/C# convention for namespace-qualified names.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed

Reproduced the issue's exact repro (`Foo`/`Bar` constructed positionally, `Baz::create()` as the working control) via the CLI directly: 11 edges before the fix (only the static call), 13 after (both construction sites now present), confirmed with the extraction cache cleared between runs so the "before" run wasn't reusing cached "after" output.

Added `tests/test_php_object_creation.py`, 6 cases: assignment position, argument position (the message-bus shape from the issue), namespace-qualified construction, and two regression guards confirming `scoped_call_expression`/`member_call_expression` still resolve correctly with the new branch in place. Reverting only the two source files (keeping the tests) fails 4 of 6 — the 2 regression-guard tests correctly still pass, since that code path is untouched.

Ran the full existing PHP-related suite (`test_languages.py`, `test_php_type_resolution.py`, `test_multilang.py`, `test_csharp_object_creation.py` as a sanity check on the analogous C# path) plus the new file: 47 passed, 4 skipped, no regressions. Ran the broader `tests/` suite too; the only failure (`test_extract_code_only_cli.py::test_mixed_repo_without_key_errors_and_points_at_code_only`) reproduces identically on an unmodified checkout — it's an `openai` package availability difference in this environment, unrelated to this change.

`ruff check` clean on all three changed files. `ruff format --check` reports pre-existing (unmodified-baseline) formatting differences on the two source files unrelated to my diff, so I left formatting as-is rather than reformat unrelated code.
