### PR TITLE
fix(razor): resolve @inject types across files

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2447,7 +2447,7 @@ def _rewire_unique_stub_nodes(nodes: list[dict], edges: list[dict]) -> None:
         return target_fam is not None and target_fam != edge_fam
     for edge in edges:
         is_csharp_scoped_edge = (
-            str(edge.get("source_file", "")).endswith(".cs")
+            str(edge.get("source_file", "")).endswith((".cs", ".razor", ".cshtml"))
             and edge.get("relation") in csharp_scoped_relations
         )
         source = edge.get("source")
@@ -6476,9 +6476,10 @@ def extract(
     # Cross-file C# type-reference resolution: re-point dangling inherits/implements/
     # references edges left on shadow stubs, disambiguating same-named types by the
     # referencing file's `using` directives + enclosing namespace (mirrors Java #1318).
-    cs_paths = [p for p in paths if p.suffix == ".cs"]
+    _DOTNET_TYPE_EXTS = {".cs", ".razor", ".cshtml"}
+    cs_paths = [p for p in paths if p.suffix.lower() in _DOTNET_TYPE_EXTS]
     if cs_paths:
-        cs_results = [r for r, p in zip(per_file, paths) if p.suffix == ".cs"]
+        cs_results = [r for r, p in zip(per_file, paths) if p.suffix.lower() in _DOTNET_TYPE_EXTS]
         try:
             _resolve_csharp_type_references(cs_results, cs_paths, all_nodes, all_edges)
         except Exception as exc:

--- a/graphify/extractors/csharp.py
+++ b/graphify/extractors/csharp.py
@@ -149,8 +149,15 @@ def _resolve_cross_file_csharp_imports(
     ]
 
 
+_DOTNET_SOURCE_EXTS = (".cs", ".razor", ".cshtml")
+
+
 def _is_cs_file(value: object) -> bool:
     return isinstance(value, str) and value.endswith(".cs")
+
+
+def _is_dotnet_source_file(value: object) -> bool:
+    return isinstance(value, str) and value.endswith(_DOTNET_SOURCE_EXTS)
 
 
 def _metadata(value: object) -> dict:
@@ -194,11 +201,11 @@ class CsharpNameResolver:
             if not (
                 source_node
                 and isinstance(source_node.get("label"), str)
-                and source_node.get("label", "").endswith(".cs")
+                and source_node.get("label", "").endswith(_DOTNET_SOURCE_EXTS)
             ):
                 continue
             source_file = source_node.get("source_file")
-            if not _is_cs_file(source_file):
+            if not _is_dotnet_source_file(source_file):
                 continue
             metadata = _metadata(edge.get("metadata"))
             target_fqn = metadata.get("target_fqn")
@@ -405,7 +412,7 @@ def _resolve_csharp_type_references(
         if edge.get("relation") not in REPOINT_RELATIONS:
             continue
         source_file = edge.get("source_file")
-        if not _is_cs_file(source_file):
+        if not _is_dotnet_source_file(source_file):
             continue
         source_node = node_by_id.get(edge.get("source"))
         target_node = node_by_id.get(edge.get("target"))

--- a/graphify/extractors/razor.py
+++ b/graphify/extractors/razor.py
@@ -5,6 +5,7 @@ import re
 from pathlib import Path
 
 from graphify.extractors.base import _file_stem, _make_id
+from graphify.security import sanitize_metadata
 
 
 def extract_razor(path: Path) -> dict:
@@ -37,14 +38,86 @@ def extract_razor(path: Path) -> dict:
                       "weight": 1.0})
 
     for i, line in enumerate(src.splitlines(), 1):
-        m = re.match(r'@using\s+([\w.]+)', line)
+        m = re.match(r'@using\s+(.+)', line)
         if m:
-            _add_ref(m.group(1), "imports", i)
+            raw_using = m.group(1).strip().rstrip(";")
+            using_kind = "namespace"
+            alias = None
+            target_fqn = raw_using
+            if raw_using.startswith("static "):
+                using_kind = "static"
+                target_fqn = raw_using[len("static "):].strip()
+            elif "=" in raw_using:
+                lhs, rhs = raw_using.split("=", 1)
+                using_kind = "alias"
+                alias = lhs.strip()
+                target_fqn = rhs.strip()
+            if target_fqn:
+                tgt_nid = _make_id(target_fqn)
+                if tgt_nid and tgt_nid not in seen_ids:
+                    seen_ids.add(tgt_nid)
+                    nodes.append({"id": tgt_nid, "label": target_fqn,
+                                  "file_type": "code", "source_file": str_path,
+                                  "source_location": f"L{i}"})
+                md = {
+                    "using_kind": using_kind,
+                    "target_fqn": target_fqn,
+                    "scope_kind": "file",
+                    "scope_id": None,
+                }
+                if alias:
+                    md["alias"] = alias
+                edges.append({
+                    "source": file_nid,
+                    "target": tgt_nid,
+                    "relation": "imports",
+                    "context": "import",
+                    "confidence": "EXTRACTED",
+                    "source_file": str_path,
+                    "source_location": f"L{i}",
+                    "weight": 1.0,
+                    "metadata": sanitize_metadata({k: v for k, v in md.items() if v is not None}),
+                })
             continue
 
         m = re.match(r'@inject\s+([\w.<>\[\]]+)\s+(\w+)', line)
         if m:
-            _add_ref(m.group(1), "imports", i)
+            raw_type = m.group(1).strip()
+            base_type = raw_type.split("<", 1)[0].strip()
+            qualified = "." in base_type
+            if qualified:
+                prefix, _, ref_token = base_type.rpartition(".")
+            else:
+                prefix = ""
+                ref_token = base_type
+            if ref_token:
+                tgt_nid = _make_id(ref_token)
+                if tgt_nid and tgt_nid not in seen_ids:
+                    seen_ids.add(tgt_nid)
+                    nodes.append({
+                        "id": tgt_nid,
+                        "label": ref_token,
+                        "file_type": "code",
+                        "source_file": "",
+                        "source_location": "",
+                        "origin_file": str_path,
+                    })
+                md = {"ref_token": ref_token}
+                if qualified:
+                    md["qualified"] = True
+                    if prefix:
+                        md["ref_qualifier"] = prefix
+                edges.append({
+                    "source": file_nid,
+                    "target": tgt_nid,
+                    "relation": "references",
+                    "context": "field",
+                    "confidence": "EXTRACTED",
+                    "source_file": str_path,
+                    "source_location": f"L{i}",
+                    "weight": 1.0,
+                    "metadata": sanitize_metadata(md),
+                })
             continue
 
         m = re.match(r'@inherits\s+([\w.<>\[\]]+)', line)

--- a/tests/test_dotnet.py
+++ b/tests/test_dotnet.py
@@ -574,9 +574,114 @@ public static class Caller
 def test_razor_using_and_inject():
     r = extract_razor(FIXTURES / "sample.razor")
     assert "error" not in r
-    targets = {e["target"] for e in r["edges"] if e["relation"] == "imports"}
-    assert any("microsoft" in t for t in targets)
-    assert any("counterservice" in t.lower() for t in targets)
+    imports = {e["target"] for e in r["edges"] if e["relation"] == "imports"}
+    assert any("microsoft" in t for t in imports)
+    references = {e["target"] for e in r["edges"] if e["relation"] == "references"}
+    assert any("counterservice" in t.lower() for t in references)
+
+
+def test_razor_inject_cross_file_resolution(tmp_path: Path):
+    # A. Project-defined service resolution
+    svc = tmp_path / "WidgetService.cs"
+    svc.write_text("public class WidgetService {}\n", encoding="utf-8")
+    page = tmp_path / "AlphaPage.razor"
+    page.write_text("@page \"/alpha\"\n@inject WidgetService _widgets\n", encoding="utf-8")
+
+    result = extract([svc, page], cache_root=tmp_path)
+    svc_def = next(n for n in result["nodes"] if n.get("label") == "WidgetService" and n.get("source_file"))
+    page_node = next(n for n in result["nodes"] if n.get("label") == "AlphaPage.razor")
+
+    ref_edges = [
+        e for e in result["edges"]
+        if e.get("source") == page_node["id"] and e.get("relation") == "references"
+    ]
+    assert any(e.get("target") == svc_def["id"] for e in ref_edges)
+
+
+def test_razor_inject_multiple_razor_files_and_csharp_control(tmp_path: Path):
+    # B. Multiple Razor files referencing same canonical node
+    # C. Existing C# control pointing to same canonical node
+    services_dir = tmp_path / "Services"
+    pages_dir = tmp_path / "Pages"
+    services_dir.mkdir(parents=True, exist_ok=True)
+    pages_dir.mkdir(parents=True, exist_ok=True)
+
+    svc = services_dir / "WidgetService.cs"
+    svc.write_text("public class WidgetService {}\n", encoding="utf-8")
+    consumer = services_dir / "Consumer.cs"
+    consumer.write_text("public class Consumer(WidgetService widgets) {}\n", encoding="utf-8")
+    alpha = pages_dir / "AlphaPage.razor"
+    alpha.write_text("@inject WidgetService _widgets\n", encoding="utf-8")
+    beta = pages_dir / "BetaPage.razor"
+    beta.write_text("@inject WidgetService _widgets\n", encoding="utf-8")
+    gamma = pages_dir / "GammaPage.razor"
+    gamma.write_text("@inject WidgetService _widgets\n", encoding="utf-8")
+
+    result = extract([svc, consumer, alpha, beta, gamma], cache_root=tmp_path)
+    svc_def = next(n for n in result["nodes"] if n.get("label") == "WidgetService" and n.get("source_file"))
+
+    # Assert no sourceless stubs left behind for WidgetService
+    widget_nodes = [n for n in result["nodes"] if n.get("label") == "WidgetService"]
+    assert len(widget_nodes) == 1
+    assert widget_nodes[0]["id"] == svc_def["id"]
+
+    alpha_node = next(n for n in result["nodes"] if n.get("label") == "AlphaPage.razor")
+    beta_node = next(n for n in result["nodes"] if n.get("label") == "BetaPage.razor")
+    gamma_node = next(n for n in result["nodes"] if n.get("label") == "GammaPage.razor")
+    consumer_node = next(n for n in result["nodes"] if n.get("label") == "Consumer" and n.get("file_type") == "code")
+
+    for src_id in (alpha_node["id"], beta_node["id"], gamma_node["id"], consumer_node["id"]):
+        refs = [e for e in result["edges"] if e.get("source") == src_id and e.get("relation") == "references"]
+        assert any(e.get("target") == svc_def["id"] for e in refs)
+
+    cs_refs = [e for e in result["edges"] if e.get("relation") == "references" and e.get("target") == svc_def["id"]]
+    assert len(cs_refs) >= 4  # alpha, beta, gamma, consumer
+
+
+def test_razor_inject_with_explicit_using(tmp_path: Path):
+    # D. Explicit Razor @using with namespace scope
+    svc = tmp_path / "WidgetService.cs"
+    svc.write_text("namespace Demo.Services {\n    public class WidgetService {}\n}\n", encoding="utf-8")
+    page = tmp_path / "AlphaPage.razor"
+    page.write_text("@using Demo.Services\n@inject WidgetService _widgets\n", encoding="utf-8")
+
+    result = extract([svc, page], cache_root=tmp_path)
+    svc_def = next(n for n in result["nodes"] if n.get("label") == "WidgetService" and n.get("source_file"))
+    page_node = next(n for n in result["nodes"] if n.get("label") == "AlphaPage.razor")
+
+    # @using must remain an imports edge
+    using_edges = [
+        e for e in result["edges"]
+        if e.get("source") == page_node["id"] and e.get("relation") == "imports"
+    ]
+    assert using_edges
+
+    # @inject must resolve to WidgetService definition
+    ref_edges = [
+        e for e in result["edges"]
+        if e.get("source") == page_node["id"] and e.get("relation") == "references"
+    ]
+    assert any(e.get("target") == svc_def["id"] for e in ref_edges)
+
+
+def test_razor_inject_qualified_namespace(tmp_path: Path):
+    # Qualified @inject Demo.Services.WidgetService _widgets
+    svc = tmp_path / "Services" / "WidgetService.cs"
+    svc.parent.mkdir(parents=True, exist_ok=True)
+    svc.write_text("namespace Demo.Services {\n    public class WidgetService {}\n}\n", encoding="utf-8")
+    page = tmp_path / "Pages" / "AlphaPage.razor"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text("@inject Demo.Services.WidgetService _widgets\n", encoding="utf-8")
+
+    result = extract([svc, page], cache_root=tmp_path)
+    svc_def = next(n for n in result["nodes"] if n.get("label") == "WidgetService" and n.get("source_file"))
+    page_node = next(n for n in result["nodes"] if n.get("label") == "AlphaPage.razor")
+
+    ref_edges = [
+        e for e in result["edges"]
+        if e.get("source") == page_node["id"] and e.get("relation") == "references"
+    ]
+    assert any(e.get("target") == svc_def["id"] for e in ref_edges)
 
 
 def test_razor_components():


### PR DESCRIPTION
## Summary

Fixes #3187.

Blazor `.razor` and `.cshtml` `@inject` directives were previously emitted as file-local `imports` stubs and never reached the C# cross-file type resolver. This caused each Razor file to create a duplicate node for the same project-defined service.

This change:

* Emits `@inject` as a `references` edge with C# resolver metadata.
* Creates unresolved `@inject` stubs without a Razor-local `source_file`.
* Allows `.razor` and `.cshtml` files to participate in the existing C# type-resolution pass.
* Preserves `@using` as an `imports` edge while adding the metadata required for namespace scoping.
* Protects Razor C# references from premature generic stub rewiring.
* Adds end-to-end regression tests for single and multiple Razor consumers, C# consumers, explicit `@using`, and qualified namespaces.

## Validation

* `tests/test_dotnet.py tests/test_csharp_type_resolution.py` — **84 passed**
* `tests/test_languages.py -k "razor or csharp"` — **20 passed**
* `tests/test_extract.py` — **201 passed, 1 known Windows MAX_PATH failure**
* `git diff --check` — **clean**

The known `tests/test_extract.py` failure is Windows-specific (`MAX_PATH`) and unrelated to this change.
