### PR TITLE
fix(tree): bound Expand All by a node budget

### DIFF
--- a/graphify/tree_html.py
+++ b/graphify/tree_html.py
@@ -30,6 +30,10 @@ Implementation notes:
     cap fires so very wide directories stay usable.
   - The first-level palette is auto-populated from the live top-level
     directories so each gets a stable accent colour.
+  - Expand All is bounded by ``DEFAULT_EXPAND_ALL_BUDGET`` nodes. A full
+    expansion of a large graph mounts every descendant in a single D3
+    join and wedges the renderer, so the button fills the budget
+    breadth-first and says how many nodes it left collapsed.
 """
 
 from __future__ import annotations
@@ -41,6 +45,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 DEFAULT_MAX_CHILDREN = 200
+# Expand All mounts every descendant in one D3 join. Past a few thousand
+# nodes that blocks the renderer for good, so the button expands
+# breadth-first up to this many nodes and reports what it left closed.
+DEFAULT_EXPAND_ALL_BUDGET = 5000
 
 
 # ── Tree builder (filesystem hierarchy → JSON) ──────────────────
@@ -216,6 +224,11 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
     .controls {{
       margin: 20px 0 15px 24px;
     }}
+    #expand-status {{
+      margin-left: 4px;
+      font-size: 0.9rem;
+      color: #4a5b6b;
+    }}
     button {{
       margin-right: 10px;
       padding: 8px 18px;
@@ -274,6 +287,7 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
     <button onclick="expandAll()">Expand All</button>
     <button onclick="collapseAll()">Collapse All</button>
     <button onclick="resetView()">Reset View</button>
+    <span id="expand-status"></span>
   </div>
   <div id="tree-container">
     <svg id="tree-svg" width="{svg_width}" height="{svg_height}"></svg>
@@ -281,6 +295,7 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
 
   <script src="https://d3js.org/d3.v7.min.js"></script>
   <script>
+    const EXPAND_ALL_NODE_BUDGET = {expand_all_budget};
     const initialJsonData = {data_json};
 
     function transformData(jsonData) {{
@@ -377,7 +392,30 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
 
     function collapseBranch(d) {{ if (d.children) {{ d._children = d.children; d._children.forEach(collapseBranch); d.children = null; }} }}
     function expandBranch(d) {{ if (d._children) {{ d.children = d._children; d._children = null; }} if (d.children) {{ d.children.forEach(expandBranch); }} }}
-    window.expandAll = () => {{ expandBranch(rootNode); updateTree(rootNode); }};
+    function countExpanded(d) {{ const kids = d.children || d._children; if (!kids) return 1; let n = 1; for (const k of kids) {{ n += countExpanded(k); }} return n; }}
+    function expandWithinBudget(d, budget) {{
+      let mounted = 1;
+      const queue = [d];
+      let head = 0;
+      while (head < queue.length) {{
+        const cur = queue[head++];
+        const kids = cur.children || cur._children;
+        if (!kids || !kids.length) continue;
+        if (mounted + kids.length > budget) continue;
+        if (cur._children) {{ cur.children = cur._children; cur._children = null; }}
+        mounted += kids.length;
+        for (const k of cur.children) {{ queue.push(k); }}
+      }}
+      return mounted;
+    }}
+    function setExpandStatus(msg) {{ const el = document.getElementById("expand-status"); if (el) {{ el.textContent = msg; }} }}
+    window.expandAll = () => {{
+      const total = countExpanded(rootNode);
+      if (total <= EXPAND_ALL_NODE_BUDGET) {{ expandBranch(rootNode); updateTree(rootNode); setExpandStatus(""); return; }}
+      const mounted = expandWithinBudget(rootNode, EXPAND_ALL_NODE_BUDGET);
+      updateTree(rootNode);
+      setExpandStatus(`Expanded ${{mounted.toLocaleString()}} of ${{total.toLocaleString()}} nodes. Click any node to open the rest.`);
+    }};
     window.collapseAll = () => {{ if (rootNode.children) {{ rootNode.children.forEach(collapseBranch); }} updateTree(rootNode); }};
     window.resetView = () => {{ if (rootNode.children) {{ rootNode.children.forEach(d_child => {{ if (d_child.children || d_child._children) {{ collapseBranch(d_child); }} }}); }} if (rootNode._children && !rootNode.children) {{ rootNode.children = rootNode._children; rootNode._children = null; }} updateTree(rootNode); }};
 
@@ -567,6 +605,7 @@ def emit_html(
     header: str,
     svg_width: int = 6000,
     svg_height: int = 8000,
+    expand_all_budget: int = DEFAULT_EXPAND_ALL_BUDGET,
 ) -> str:
     # Escape </script> sequences so embedded JSON cannot break out of the
     # <script> tag, and HTML-escape values that land in <title>/<h1>.
@@ -576,6 +615,7 @@ def emit_html(
         header=_html.escape(header),
         svg_width=svg_width,
         svg_height=svg_height,
+        expand_all_budget=int(expand_all_budget),
         data_json=data_json,
     )
 

--- a/tests/test_tree_html.py
+++ b/tests/test_tree_html.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from graphify.tree_html import build_tree
+from graphify.tree_html import build_tree, emit_html
 
 PYTHON = sys.executable
 
@@ -111,3 +111,38 @@ def test_tree_cli_partial_match_root_succeeds(tmp_path):
     r = _run(["tree", "--root", "pkg"], tmp_path)
     assert r.returncode == 0, r.stderr
     assert (tmp_path / "graphify-out" / "GRAPH_TREE.html").exists()
+
+
+# ── Expand All budget ─────────────────────────────────────────────────────────
+
+UNBOUNDED = "window.expandAll = () => { expandBranch(rootNode); updateTree(rootNode); };"
+
+
+def _wide_tree(n_files: int):
+    return build_tree(_graph({f"pkg/mod{i}.py": f"sym{i}" for i in range(n_files)}))
+
+
+def test_expand_all_does_not_mount_the_whole_tree_in_one_join():
+    """Expand All used to be expandBranch(rootNode) with no ceiling. On a
+    257k-node graph that is ~709k SVG elements in a single D3 join and the
+    renderer never recovers, so the handler must go through a budget."""
+    html = emit_html(_wide_tree(20), title="t", header="h")
+
+    assert UNBOUNDED not in html
+    assert "expandWithinBudget(rootNode, EXPAND_ALL_NODE_BUDGET)" in html
+
+
+def test_expand_all_budget_is_emitted_and_overridable():
+    from graphify.tree_html import DEFAULT_EXPAND_ALL_BUDGET
+
+    default_html = emit_html(_wide_tree(5), title="t", header="h")
+    assert f"const EXPAND_ALL_NODE_BUDGET = {DEFAULT_EXPAND_ALL_BUDGET};" in default_html
+
+    custom_html = emit_html(_wide_tree(5), title="t", header="h", expand_all_budget=1234)
+    assert "const EXPAND_ALL_NODE_BUDGET = 1234;" in custom_html
+
+
+def test_expand_all_reports_what_it_left_collapsed():
+    html = emit_html(_wide_tree(5), title="t", header="h")
+    assert 'id="expand-status"' in html
+    assert "setExpandStatus(" in html


### PR DESCRIPTION
## Problem

`Expand All` in `GRAPH_TREE.html` calls `expandBranch(rootNode)`, which walks the whole hierarchy un-collapsing every node, then hands the result to `updateTree()` as one D3 join.

On a real monorepo graph (257,584 nodes, 655,085 edges, built with `--max-children 120`) that is:

| | |
|---|---|
| tree nodes when fully expanded | 236,474 |
| leaves | 206,384 |
| SVG elements mounted in one join | ~709,000 (`g` + `circle` + `text`) |
| SVG height requested | 8,255,540 px |

Every one of those nodes also gets a 500ms transition. The renderer wedges and does not come back. Measured over CDP against the generated file:

```
t+5s     Runtime.evaluate timed out
t+60s    Runtime.evaluate timed out
t+270s   Runtime.evaluate timed out
```

No JS error is thrown, so the console stays empty and the tab simply stops responding. `Collapse All` and `Reset View` are unaffected, and small graphs are fine (eva-service, 2,152 graph nodes, expands to 1,983 tree nodes and 73,140 px without trouble). So the button only breaks on the graphs the tree view is most useful for.

## Fix

`graphify/tree_html.py` only.

- New module constant `DEFAULT_EXPAND_ALL_BUDGET = 5000`, emitted into the page as `EXPAND_ALL_NODE_BUDGET` and overridable through `emit_html(..., expand_all_budget=N)`.
- `countExpanded(d)` measures the fully-expanded size before anything touches the DOM.
- Under the budget, behaviour is unchanged: `expandBranch(rootNode)` exactly as before.
- Over it, `expandWithinBudget()` opens breadth-first until the budget is full, so the shallow structure (the part you actually want from "expand all") opens and the deep tails stay collapsed and still clickable.
- An `#expand-status` span says what was left closed, following the same convention as the existing `(+N more)` truncation leaf for `--max-children`.

The same monorepo file after the change, driven the same way:

```
5,000 nodes mounted, SVG height 191,640 px, ~10s, page responsive
status: "Expanded 5,000 of 236,474 nodes. Click any node to open the rest."
```

## Test

`tests/test_tree_html.py`, three cases:

- `test_expand_all_does_not_mount_the_whole_tree_in_one_join` asserts the old unbounded handler is gone from the emitted HTML and the budgeted call is present.
- `test_expand_all_budget_is_emitted_and_overridable` covers the default and the `expand_all_budget=` override.
- `test_expand_all_reports_what_it_left_collapsed` covers the status element.

All three fail on `main` and pass with the change.

Full suite: 4,749 passed, 24 failed, 235 skipped. The same 24 fail on unmodified `main` in this environment (missing `terraform` and `ollama` extras plus skillgen fixtures), so the set is unchanged by this PR.

## Not included

No `--expand-all-budget` CLI flag, to keep the diff on the bug. The value is a module constant and a keyword argument, so adding a flag next to `--max-children` is a one-liner if you want one.
