### PR TITLE
fix(wiki): say when a god-node relation group was truncated (#3127)

### DIFF
--- a/graphify/wiki.py
+++ b/graphify/wiki.py
@@ -213,6 +213,15 @@ def _god_node_article(G: nx.Graph, nid: str, labels: dict[int, str], node_commun
         lines.append(f"### {rel}")
         for t in targets[:20]:
             lines.append(f"- {t}")
+        # The cap keeps god-node articles readable, but silently dropping the
+        # tail made the body disagree with the header's degree count with
+        # nothing telling the reader anything was cut (#3127). Entries are
+        # degree-sorted, so what is hidden is the low-degree tail.
+        if len(targets) > 20:
+            lines.append(
+                f"- *…and {len(targets) - 20} more `{rel}` "
+                f"connection(s) not listed (lowest-degree first to go)*"
+            )
         lines.append("")
 
     lines += ["---", "", f"*Part of the graphify knowledge wiki. See {_md_link('index', resolver)} to navigate.*"]

--- a/tests/test_wiki_truncation_indicator.py
+++ b/tests/test_wiki_truncation_indicator.py
@@ -1,0 +1,45 @@
+"""A god-node article says when a relation group was cut (#3127).
+
+`_god_node_article` caps each relation-type group at 20 entries. The header
+still reported the full degree, but the body silently dropped everything past
+20 with no indicator - a node with 26 `references` edges listed 20 and the
+reader had no way to know 6 were missing.
+"""
+from __future__ import annotations
+
+import networkx as nx
+
+from graphify.wiki import _god_node_article
+
+
+def _star(n_refs: int, n_other: int = 0):
+    G = nx.Graph()
+    G.add_node("hub", label="Hub", source_file="src/hub.py")
+    for i in range(n_refs):
+        G.add_node(f"r{i}", label=f"Ref{i}", source_file="src/r.py")
+        G.add_edge("hub", f"r{i}", relation="references", confidence="EXTRACTED")
+    for i in range(n_other):
+        G.add_node(f"s{i}", label=f"Share{i}", source_file="src/s.py")
+        G.add_edge("hub", f"s{i}", relation="shares_data_with", confidence="EXTRACTED")
+    return G
+
+
+def test_an_over_cap_group_names_how_much_was_cut():
+    text = _god_node_article(_star(26, 3), "hub", labels={})
+    assert text.count("- [") + text.count("- Ref") >= 20
+    assert "and 6 more `references` connection(s) not listed" in text
+    # the untouched small group carries no indicator
+    assert "more `shares_data_with`" not in text
+
+
+def test_the_header_degree_and_the_body_now_agree():
+    text = _god_node_article(_star(26, 3), "hub", labels={})
+    assert "29 connections" in text
+    listed = text.count("\n- ") - text.count("more `")
+    assert listed + 6 == 29
+
+
+def test_a_group_at_or_under_the_cap_has_no_indicator():
+    for n in (20, 5):
+        text = _god_node_article(_star(n), "hub", labels={})
+        assert "not listed" not in text


### PR DESCRIPTION
Closes #3127.

## The problem

`_god_node_article` caps each relation-type group at 20 entries. The article's header still reports the full degree, but the body silently dropped everything past 20 — a node with 26 `references` edges + 3 `shares_data_with` listed 23 entries under a "29 connections" header, with nothing telling the reader six were cut. Since neighbours are degree-sorted, what vanished was always the low-degree tail.

## The change

The cap stays (it is what keeps god-node articles readable). An over-cap group now ends with an explicit indicator:

```
- *…and 6 more `references` connection(s) not listed (lowest-degree first to go)*
```

so the body and the header agree, and the reader knows both that entries were cut and which kind.

## Tests

`tests/test_wiki_truncation_indicator.py` — 3 tests: an over-cap group names exactly how much was cut while the untouched small group carries no indicator; the header degree and the body now reconcile; and groups at or under the cap have no indicator. With the fix reverted, 1 of 3 fails (the other two pass by construction — they pin the cap and the header, which were already right). The full wiki suite is unchanged (49 passed together); the full suite matches the fresh `v8` (0.9.52) baseline.
