### PR TITLE
fix(cli): hook-guard search detection matches executed commands, not prose (#3121)

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -677,6 +677,79 @@ def _mark_session_denied(session_id: str) -> bool:
         return False
 
 
+_SEARCH_COMMANDS = frozenset({
+    "grep", "egrep", "fgrep", "zgrep", "rg", "ripgrep", "find", "fd", "ack", "ag",
+})
+# Prefix words that wrap another command; the real executable follows them.
+_COMMAND_WRAPPERS = frozenset({
+    "sudo", "command", "exec", "nohup", "time", "nice", "ionice", "env",
+    "xargs", "timeout", "stdbuf", "doas",
+})
+_HEREDOC_OPEN_RE = re.compile(r"<<-?\s*(['\"]?)(\w+)\1")
+
+
+def _bash_invokes_search(cmd_str: str) -> bool:
+    """Whether a Bash command actually RUNS a search tool (#3121).
+
+    The old test was a plain substring scan over the whole command string,
+    including quoted arguments and heredoc bodies - so `git commit -m "add
+    flag support"` fired ("flag " contains "ag "), prose containing "find "
+    fired, and a design doc written via heredoc fired if its body mentioned
+    grep. Every false positive injects a nudge where graphify has nothing to
+    contribute and trains the agent to skim the line.
+
+    Decide on the command's executed tokens instead: drop heredoc bodies and
+    quoted spans, split on shell operators, and match the executable at each
+    command position (wrappers like sudo/xargs/env skipped; `git grep` and
+    `VAR=x grep ...` still count; a search-tool name inside prose does not).
+    """
+    text = cmd_str
+    # Drop heredoc bodies: from the line after `<<WORD` through the line that
+    # is exactly WORD. An unterminated heredoc drops to the end of the string.
+    m = _HEREDOC_OPEN_RE.search(text)
+    while m:
+        nl_idx = text.find("\n", m.end())
+        if nl_idx == -1:
+            break
+        term = re.compile(r"^\s*" + re.escape(m.group(2)) + r"\s*$", re.MULTILINE)
+        t = term.search(text, nl_idx + 1)
+        if t is None:
+            # Unterminated heredoc: everything after the opener line is body.
+            text = text[: nl_idx + 1]
+            break
+        text = text[: nl_idx + 1] + text[t.end():]
+        m = _HEREDOC_OPEN_RE.search(text, nl_idx + 1)
+    # Drop quoted spans (backslash escapes inside double quotes are irrelevant
+    # here - anything quoted is an argument, never the executable).
+    text = re.sub(r"'[^']*'", " ", text)
+    text = re.sub(r'"[^"]*"', " ", text)
+    # Split into command segments at shell operators / substitution boundaries.
+    for segment in re.split(r"[|;&\n]|\$\(|`|\(|\)|\{|\}", text):
+        tokens = segment.split()
+        i = 0
+        while i < len(tokens):
+            tok = tokens[i]
+            if "=" in tok.split("/")[-1] and not tok.startswith(("-", "/")):
+                i += 1  # VAR=value prefix
+                continue
+            name = tok.replace("\\", "/").rsplit("/", 1)[-1].lower()
+            name = name[:-4] if name.endswith(".exe") else name
+            if name in _COMMAND_WRAPPERS:
+                i += 1
+                # skip the wrapper's own flags (`xargs -0`, `env -i`)
+                while i < len(tokens) and tokens[i].startswith("-"):
+                    i += 1
+                continue
+            if name in _SEARCH_COMMANDS:
+                return True
+            if name == "git" and any(
+                t2 == "grep" for t2 in tokens[i + 1:i + 4] if not t2.startswith("-")
+            ):
+                return True
+            break  # first real token decides this segment
+    return False
+
+
 def _run_hook_guard(kind: str, strict: bool = False) -> None:
     """Shell-agnostic PreToolUse guard (#522).
 
@@ -725,13 +798,13 @@ def _run_hook_guard(kind: str, strict: bool = False) -> None:
             # the Bash tool carries `command`, while Claude Code's dedicated
             # Grep tool carries `pattern` (plus optional path/glob) and no
             # command — a Grep call IS a content search by definition, so it
-            # nudges whenever a graph exists. For Bash, keep matching the same
-            # set the old `case` matched: *grep*, *ripgrep*, and rg/find/fd/
-            # ack/ag as a token (name followed by a space). Nudge-only, even in
-            # strict mode — see the docstring.
+            # nudges whenever a graph exists. For Bash, decide on the
+            # command's EXECUTED tokens (#3121): the old whole-string
+            # substring scan fired on quoted prose ('add flag support'
+            # contains "ag ") and on heredoc bodies that merely mention
+            # grep. Nudge-only, even in strict mode — see the docstring.
             is_grep_tool = not cmd_str and bool(t.get("pattern"))
-            is_bash_search = any(tok in cmd_str for tok in (
-                "grep", "ripgrep", "rg ", "find ", "fd ", "ack ", "ag "))
+            is_bash_search = bool(cmd_str) and _bash_invokes_search(cmd_str)
             if (is_grep_tool or is_bash_search) and out_path("graph.json").is_file():
                 sys.stdout.write(_SEARCH_NUDGE)
         elif kind == "read":

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -51,7 +51,6 @@ def _invoke(kind, payload, tmp_path, monkeypatch, *, graph=True, out_name="graph
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize("command", [
     "grep -rn foo .",
-    "pgrep -f server",          # contains 'grep'
     "egrep pattern file",       # contains 'grep'
     "fgrep lit file",           # contains 'grep'
     "ls -la | grep foo",        # piped
@@ -73,6 +72,10 @@ def test_search_nudges(command, tmp_path, monkeypatch):
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize("command", [
     "",                          # empty
+    # pgrep searches PROCESSES, not file content - the old substring scan
+    # nudged on it only because the string contains 'grep' (#3121); the graph
+    # has nothing to offer a process lookup.
+    "pgrep -f server",
     "ls -la",
     "git status",
     "cat README.md",

--- a/tests/test_hook_guard_token_match.py
+++ b/tests/test_hook_guard_token_match.py
@@ -1,0 +1,92 @@
+"""The Bash search guard fires on executed commands, not on prose (#3121).
+
+`_run_hook_guard` decided "is this a search?" with a substring scan over the
+whole command string — quoted arguments and heredoc bodies included. So
+`git commit -m "add flag support"` fired ("flag " contains "ag "), a PR body
+containing "you can find it here" fired, and writing a design doc that
+mentions grep fired on the write. Each false positive injects a nudge where
+graphify has nothing to say, training the agent to skim the line where it is
+right.
+"""
+from __future__ import annotations
+
+import pytest
+
+try:
+    from graphify.cli import _bash_invokes_search
+except ImportError:  # pre-fix tree
+    _bash_invokes_search = None
+
+pytestmark = pytest.mark.skipif(_bash_invokes_search is None, reason="pre-fix tree")
+
+
+@pytest.mark.parametrize("cmd", [
+    "grep -rn foo .",
+    "rg foo",
+    "rg.exe foo src",
+    "/usr/bin/grep -c x f",
+    "egrep 'a|b' f",
+    "fd -e py",
+    "ack pattern",
+    "ag pattern src/",
+    "find . -name '*.py'",
+    "git grep TODO",
+    "git -C repo grep TODO",
+    "cat f.txt | grep needle",
+    "make build && grep -q ok build.log",
+    "sudo grep root /etc/passwd",
+    "xargs -0 grep -l pattern",
+    "FOO=1 grep x f",
+    "echo done; rg leftover",
+    "result=$(grep -c x f)",
+])
+def test_real_searches_fire(cmd):
+    assert _bash_invokes_search(cmd) is True
+
+
+@pytest.mark.parametrize("cmd", [
+    "git commit -m x",
+    "git log -S foo",
+    'git commit -m "add flag support"',          # "flag " contains "ag "
+    'gh pr create --body "you can find it here"',
+    'echo "see grep docs"',
+    "cat asdfd file",                             # "fd " inside a word boundary trap
+    "python manage.py runserver",
+    "cargo build --release",
+    "./gradlew test",
+    "echo 'grep is a fine tool'",
+    "printf 'use find sparingly'",
+    "magick convert x.png y.jpg",
+])
+def test_prose_and_lookalikes_stay_quiet(cmd):
+    assert _bash_invokes_search(cmd) is False
+
+
+def test_a_heredoc_body_mentioning_search_tools_stays_quiet():
+    cmd = (
+        "cat > docs/design.md <<'EOF'\n"
+        "# Search strategy\n"
+        "We use grep and rg for quick scans; find . -name works too.\n"
+        "EOF\n"
+    )
+    assert _bash_invokes_search(cmd) is False
+
+
+def test_a_search_after_a_heredoc_still_fires():
+    cmd = (
+        "cat > notes.txt <<'EOF'\n"
+        "nothing here\n"
+        "EOF\n"
+        "grep -rn needle src/\n"
+    )
+    assert _bash_invokes_search(cmd) is True
+
+
+def test_an_unterminated_heredoc_cannot_fire_from_its_body():
+    cmd = "cat <<'EOF'\nall of this is grep prose with find . in it\n"
+    assert _bash_invokes_search(cmd) is False
+
+
+def test_quoted_command_names_do_not_fire():
+    assert _bash_invokes_search('echo "grep -rn foo ."') is False
+    assert _bash_invokes_search("echo 'rg pattern'") is False


### PR DESCRIPTION
Closes #3121.

## The problem

The Bash search nudge decided "is this a search?" with a plain substring scan over the whole command string — quoted arguments and heredoc bodies included:

```python
is_bash_search = any(tok in cmd_str for tok in (
    "grep", "ripgrep", "rg ", "find ", "fd ", "ack ", "ag "))
```

So `git commit -m "add flag support"` fired (`"flag "` contains `"ag "`), `gh pr create --body "you can find it here"` fired, and writing a design doc via heredoc fired if its body merely mentioned grep — the self-inflicting case for anyone documenting their own graphify use. Every false positive injects a nudge where graphify has nothing to say, and trains the agent to skim the line where it *is* right.

## The change

`_bash_invokes_search` decides on the command's **executed tokens**, the shape the issue suggested:

- heredoc bodies are dropped (`<<WORD` through the terminator line; an unterminated heredoc drops to the end);
- quoted spans are dropped — anything quoted is an argument, never the executable;
- the rest splits on shell operators (`| ; & newline $( ` ( ) { }`), and the executable at each command position is matched against the search set (`grep`/`egrep`/`fgrep`/`zgrep`/`rg`/`ripgrep`/`find`/`fd`/`ack`/`ag`), with `VAR=x` prefixes and wrappers (`sudo`, `xargs`, `env`, `command`, `exec`, `nohup`, `time`, `timeout`, …) skipped, paths and `.exe` suffixes normalised, and `git grep` recognised.

Fails toward "not a search": the guard is a nudge, and a missed nudge costs less than an ignored one.

One judgment call in the existing tests: `test_hook_guard.py` listed `pgrep -f server` under commands that MUST nudge, annotated `# contains 'grep'` — pinning the substring mechanism, not a behaviour. `pgrep` searches *processes*, which the graph cannot answer, so the case moves to the must-stay-silent list with a comment saying why.

## Tests

`tests/test_hook_guard_token_match.py` — 34 tests: 18 real search shapes that must fire (paths, `.exe`, pipes, `&&`, `;`, command substitution, `sudo`/`xargs`/env-prefix, `git grep`, `git -C repo grep`) and 16 that must stay quiet (the issue's exact false positives, look-alike words, quoted command names, a heredoc'd design doc, a search *after* a heredoc still firing, and an unterminated heredoc never firing from its body). With the fix reverted the module skips (the helper doesn't exist pre-fix); `tests/test_hook_guard.py`'s 100+ behavioural cases pass against the new matcher (103 together). The full suite matches the fresh `v8` (0.9.52) baseline.
