### PR TITLE
fix(install): actionable stale-skill warning; back up a diverged SKILL.md (#3144)

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -160,8 +160,26 @@ def __getattr__(name: str) -> str:
 
 
 
-def _check_skill_version(skill_dst: Path) -> None:
-    """Warn if the installed skill is from an older graphify version."""
+def _check_skill_version(skill_dst: Path, platform_names: "list[str] | None" = None) -> None:
+    """Warn if the installed skill is from an older graphify version.
+
+    ``platform_names`` are the platforms installing into this destination
+    (resolved here when not given - the call site passes one positional
+    argument only, because tests stub this function with one-arg lambdas), so
+    the warning can name the exact command that refreshes THIS copy (#3144):
+    a plain `graphify install` only refreshes the detected platform, and a
+    stale marker at another platform's destination made the warning permanent
+    - the user followed the advice, the warning stayed, and only editing the
+    marker by hand cleared it.
+    """
+    if platform_names is None:
+        try:
+            platform_names = [
+                name for name in _PLATFORM_CONFIG
+                if _platform_skill_destination(name) == skill_dst
+            ]
+        except Exception:
+            platform_names = []
     version_file = skill_dst.parent / ".graphify_version"
     try:
         if not version_file.exists():
@@ -203,7 +221,16 @@ def _check_skill_version(skill_dst: Path) -> None:
                 file=sys.stderr,
             )
         else:
-            print(f"  warning: skill is from graphify {installed}, package is {__version__}. Run 'graphify install' to update.", file=sys.stderr)
+            _cmd = (
+                f"graphify install --platform {platform_names[0]}"
+                if platform_names else "graphify install"
+            )
+            print(
+                f"  warning: skill at {skill_dst.parent} is from graphify {installed}, "
+                f"package is {__version__}. Run '{_cmd}' to update it "
+                f"(a plain 'graphify install' refreshes only the detected platform).",
+                file=sys.stderr,
+            )
 
 
 def _version_tuple(version: str) -> tuple[int, ...]:

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -211,6 +211,19 @@ def _copy_skill_file(platform_name: str, *, project: bool = False, project_dir: 
         if orphan_refs.exists():
             shutil.rmtree(orphan_refs)
 
+    # A SKILL.md that differs from what is about to be written may carry the
+    # user's local edits (a tuned description:, extra guidance); replacing it
+    # wholesale with only "skill installed ->" for output read like a no-op
+    # while the edits were gone (#3144). Keep one .bak beside it and say so.
+    # Every upgrade differs too - the .bak is overwritten each install, so it
+    # always holds exactly the previous copy.
+    try:
+        if skill_dst.exists() and skill_dst.read_bytes() != skill_src.read_bytes():
+            backup = skill_dst.with_suffix(skill_dst.suffix + ".bak")
+            shutil.copy2(skill_dst, backup)
+            print(f"  previous copy    ->  {backup} (differed from the packaged skill)")
+    except OSError:
+        pass  # a failed backup must not block the install
     # SKILL.md last (crash-safety), via an atomic temp + rename.
     tmp_dst = skill_dst.with_suffix(skill_dst.suffix + ".tmp")
     try:

--- a/tests/test_install_version_warning.py
+++ b/tests/test_install_version_warning.py
@@ -1,0 +1,100 @@
+"""#3144: the stale-skill warning must be actionable, and local SKILL.md
+edits must not vanish without a trace.
+
+A plain `graphify install` refreshes only the detected platform, so a stale
+`.graphify_version` at ANOTHER platform's destination made the warning
+permanent: it named no path, its advice ("run graphify install") did not
+touch that copy, and only editing the marker by hand cleared it. And a
+reinstall replaced a user-edited SKILL.md wholesale — no diff, no prompt,
+no backup — while printing a line that read like a successful no-op.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import graphify.__main__ as mainmod
+from graphify.install import __version__
+from graphify.install import _copy_skill_file, _platform_skill_destination
+
+
+# ---------------------------------------------------------------------------
+# The warning
+# ---------------------------------------------------------------------------
+
+def _stale(tmp_path):
+    d = tmp_path / "skills" / "graphify"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("---\nname: graphify\n---\nbody\n", encoding="utf-8")
+    (d / ".graphify_version").write_text("0.8.36", encoding="utf-8")
+    return d / "SKILL.md"
+
+
+def test_the_warning_names_the_stale_destination_and_the_exact_command(tmp_path, capsys):
+    mainmod._check_skill_version(_stale(tmp_path), platform_names=["antigravity"])
+    err = capsys.readouterr().err
+    assert "0.8.36" in err and __version__ in err
+    assert str(tmp_path / "skills" / "graphify") in err, "the stale path must be named"
+    assert "graphify install --platform antigravity" in err
+    assert "only the detected platform" in err
+
+
+def test_without_a_platform_name_the_generic_command_is_kept(tmp_path, capsys):
+    mainmod._check_skill_version(_stale(tmp_path))
+    err = capsys.readouterr().err
+    assert "graphify install" in err
+
+
+def test_a_current_skill_stays_silent(tmp_path, capsys):
+    skill = _stale(tmp_path)
+    (skill.parent / ".graphify_version").write_text(__version__, encoding="utf-8")
+    mainmod._check_skill_version(skill, platform_names=["claude"])
+    assert capsys.readouterr().err == ""
+
+
+# ---------------------------------------------------------------------------
+# The backup
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def sandbox_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    if sys.platform == "win32":
+        monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+def test_a_locally_edited_skill_is_backed_up_and_announced(sandbox_home, capsys):
+    _copy_skill_file("claude")
+    dst = _platform_skill_destination("claude")
+    assert dst.exists()
+    original = dst.read_text(encoding="utf-8")
+    dst.write_text(original + "\nCUSTOM LOCAL EDIT\n", encoding="utf-8")
+    capsys.readouterr()
+
+    _copy_skill_file("claude")
+    out = capsys.readouterr().out
+    backup = dst.with_suffix(dst.suffix + ".bak")
+    assert backup.exists(), "the previous copy must be kept"
+    assert "CUSTOM LOCAL EDIT" in backup.read_text(encoding="utf-8")
+    assert "CUSTOM LOCAL EDIT" not in dst.read_text(encoding="utf-8")
+    assert "previous copy" in out and str(backup) in out
+
+
+def test_an_unmodified_reinstall_writes_no_backup(sandbox_home, capsys):
+    _copy_skill_file("claude")
+    dst = _platform_skill_destination("claude")
+    capsys.readouterr()
+    _copy_skill_file("claude")
+    out = capsys.readouterr().out
+    assert not dst.with_suffix(dst.suffix + ".bak").exists()
+    assert "previous copy" not in out
+
+
+def test_the_version_stamp_is_written_beside_the_skill(sandbox_home):
+    _copy_skill_file("claude")
+    dst = _platform_skill_destination("claude")
+    assert (dst.parent / ".graphify_version").read_text(encoding="utf-8") == __version__


### PR DESCRIPTION
Closes #3144.

## Status of the two reported defects on 0.9.52

**Part 1 (the `--platform X` stamp)** is already half-fixed upstream: I audited all 18 platform destinations in a sandboxed HOME on 0.9.52 and every `install --platform X` now writes `.graphify_version` beside its SKILL.md. What remains — and what actually made the warning *permanent* — is the other half of the report: the version check iterates **every** platform destination, a plain `graphify install` refreshes only the *detected* one, and the warning named neither the stale path nor a command that would fix it. So the user follows the advice, the warning stays, and only hand-editing the marker clears it.

**Part 2 (silent overwrite)** reproduces exactly as filed: appending a local edit to `~/.claude/skills/graphify/SKILL.md` and re-running `install --platform claude` replaced it wholesale — no backup, no message beyond `skill installed  ->  …`, which reads like a no-op.

## The change

1. The stale-skill warning now names the destination and the exact command:

   ```
   warning: skill at C:\Users\me\.agents\skills\graphify is from graphify 0.8.36, package is 0.9.52.
   Run 'graphify install --platform antigravity' to update it (a plain 'graphify install'
   refreshes only the detected platform).
   ```

   The check loop passes each destination's platform name(s) through, so shared directories still warn once.

2. When the on-disk SKILL.md differs from what is about to be written, the previous copy is kept as `SKILL.md.bak` and announced (`previous copy -> … (differed from the packaged skill)`). Every upgrade differs too, so the `.bak` is simply overwritten each install and always holds exactly the previous copy; an unmodified reinstall writes no backup and stays quiet. A failed backup never blocks the install.

## Tests

`tests/test_install_version_warning.py` — 6 tests: the warning names the stale path, the `--platform` command and the "only the detected platform" caveat; the generic command is kept when no platform name is known; a current skill stays silent; a locally-edited skill is backed up with the edit intact, announced, and replaced; an unmodified reinstall writes no backup; and the version stamp lands beside the skill. With the fix reverted, 3 of 6 fail. The install/uninstall suites are otherwise unchanged (the 6 pre-existing Windows-only failures excepted, same as baseline); the full suite matches the fresh `v8` (0.9.52) baseline.
