### PR TITLE
feat: add Robot Framework file support

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -42,7 +42,7 @@ _MTIME_COARSE_S = 2.0
 _MTIME_SUBSECOND_S = 0.05
 
 CODE_EXTENSIONS = {'.py', '.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs', '.ejs', '.ets', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.cu', '.cuh', '.metal', '.rb', '.rake', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.psm1', '.psd1', '.ex', '.exs', '.m', '.mm', '.ml', '.mli', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.svh', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json', '.tf', '.tfvars', '.hcl', '.dm', '.dme', '.dmi', '.dmm', '.dmf', '.sln', '.slnx', '.csproj', '.fsproj', '.vbproj', '.xaml', '.razor', '.cshtml', '.cls', '.trigger', '.lisp', '.cl', '.lsp', '.asd'}
-DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.skill', '.txt', '.rst', '.html', '.yaml', '.yml'}
+DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.skill', '.txt', '.rst', '.html', '.yaml', '.yml', '.robot', '.resource'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}
 OFFICE_EXTENSIONS = {'.docx', '.xlsx'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -48,6 +48,7 @@ from graphify.extractors.go import _GO_PREDECLARED_FUNCS, extract_go  # noqa: F4
 from graphify.extractors.json_config import extract_json  # noqa: F401
 from graphify.extractors.commonlisp import extract_commonlisp  # noqa: F401
 from graphify.extractors.markdown import extract_markdown, _MD_LINK_INDEX_CACHE  # noqa: F401
+from graphify.extractors.robot import extract_robot  # noqa: F401
 from graphify.extractors.ocaml import extract_ocaml  # noqa: F401
 from graphify.extractors.pascal_forms import extract_delphi_form, extract_lazarus_form  # noqa: F401
 from graphify.extractors.powershell import extract_powershell, extract_powershell_manifest  # noqa: F401
@@ -5424,6 +5425,8 @@ _DISPATCH: dict[str, Any] = {
     ".mdx": extract_markdown,
     ".qmd": extract_markdown,
     ".skill": extract_markdown,
+    ".robot": extract_robot,
+    ".resource": extract_robot,
     ".pas": extract_pascal,
     ".pp": extract_pascal,
     ".dpr": extract_pascal,

--- a/graphify/extractors/__init__.py
+++ b/graphify/extractors/__init__.py
@@ -27,6 +27,7 @@ from graphify.extractors.pascal import extract_pascal
 from graphify.extractors.pascal_forms import extract_delphi_form, extract_lazarus_form
 from graphify.extractors.powershell import extract_powershell, extract_powershell_manifest
 from graphify.extractors.razor import extract_razor
+from graphify.extractors.robot import extract_robot
 from graphify.extractors.rust import extract_rust
 from graphify.extractors.sln import extract_sln
 from graphify.extractors.sql import extract_sql
@@ -52,6 +53,7 @@ LANGUAGE_EXTRACTORS: dict[str, Callable[[Path], dict]] = {
     "julia": extract_julia,
     "lazarus_form": extract_lazarus_form,
     "markdown": extract_markdown,
+    "robot": extract_robot,
     "objc": extract_objc,
     "pascal": extract_pascal,
     "powershell": extract_powershell,

--- a/graphify/extractors/robot.py
+++ b/graphify/extractors/robot.py
@@ -1,0 +1,121 @@
+"""Structural extraction for Robot Framework ``.robot`` and ``.resource`` files.
+
+Robot Framework files are executable test specifications, but they do not have a
+Tree-sitter grammar in Graphify's dependency set.  This module deliberately
+models their stable document structure rather than attempting to interpret
+keyword implementations or variable values.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from graphify.extractors.base import _file_stem, _make_id
+
+_SECTION_RE = re.compile(r"^\s*\*\*\*\s+(.+?)\s+\*\*\*\s*$", re.IGNORECASE)
+_ENTITY_RE = re.compile(r"^\S(?:.*\S)?$")
+_SECTION_NAMES = {
+    "settings": "settings",
+    "variables": "variables",
+    "test cases": "test_cases",
+    "tasks": "tasks",
+    "keywords": "keywords",
+    "comments": "comments",
+}
+
+
+def extract_robot(path: Path) -> dict:
+    """Extract Robot Framework suite sections and named test/keyword entities.
+
+    The file itself is the root document node.  Section nodes contain named
+    tests, tasks, and user keywords; settings and variables are represented as
+    leaf nodes because their rows have no nested declaration structure.
+    Executable keyword rows are intentionally not emitted as nodes: resolving
+    them would require Robot's runtime/library semantics and would create noisy
+    edges for built-in keywords.
+    """
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        return {"nodes": [], "edges": [], "error": str(exc)}
+
+    source_file = str(path)
+    stem = _file_stem(path)
+    file_id = _make_id(source_file)
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen: set[str] = set()
+
+    def add_node(label: str, line: int, kind: str, *id_parts: str) -> str:
+        nid = _make_id(stem, *id_parts) if id_parts else file_id
+        if nid in seen:
+            nid = _make_id(stem, kind, f"L{line}")
+        if nid in seen:
+            return nid
+        seen.add(nid)
+        nodes.append({
+            "id": nid,
+            "label": label,
+            "file_type": "document",
+            "node_kind": kind,
+            "source_file": source_file,
+            "source_location": f"L{line}",
+        })
+        return nid
+
+    def add_edge(parent: str, child: str, line: int) -> None:
+        edges.append({
+            "source": parent,
+            "target": child,
+            "relation": "contains",
+            "confidence": "EXTRACTED",
+            "source_file": source_file,
+            "source_location": f"L{line}",
+            "weight": 1.0,
+        })
+
+    seen.add(file_id)
+    nodes.append({
+        "id": file_id,
+        "label": path.name,
+        "file_type": "document",
+        "node_kind": "page",
+        "source_file": source_file,
+        "source_location": "L1",
+    })
+
+    current_section: tuple[str, str] | None = None
+    for line_number, raw in enumerate(lines, 1):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        section_match = _SECTION_RE.match(raw)
+        if section_match:
+            title = section_match.group(1).strip()
+            section_key = _SECTION_NAMES.get(title.casefold(), title.casefold().replace(" ", "_"))
+            section_id = add_node(title, line_number, "section", section_key)
+            add_edge(file_id, section_id, line_number)
+            current_section = (section_key, section_id)
+            continue
+
+        if current_section is None:
+            continue
+        section_key, parent_id = current_section
+        # Robot declaration rows are unindented.  Indented rows are settings,
+        # arguments, or executable keyword calls and are intentionally skipped.
+        if raw[:1].isspace() or not _ENTITY_RE.match(raw):
+            continue
+
+        if section_key in {"test_cases", "tasks", "keywords"}:
+            kind = "test" if section_key == "test_cases" else "task" if section_key == "tasks" else "keyword"
+            entity_id = add_node(stripped, line_number, kind, kind, stripped, f"L{line_number}")
+            add_edge(parent_id, entity_id, line_number)
+        elif section_key in {"settings", "variables"}:
+            entity_id = add_node(stripped, line_number, "setting" if section_key == "settings" else "variable", section_key, stripped, f"L{line_number}")
+            add_edge(parent_id, entity_id, line_number)
+
+    return {"nodes": nodes, "edges": edges}
+
+
+__all__ = ["extract_robot"]

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -3441,3 +3441,8 @@ def test_globstar_matcher_leaves_no_reference_cycle():
     finally:
         gc.enable()
     assert collected == 0, f"globstar matcher leaked {collected} cyclic objects per run"
+
+
+def test_classify_robot_framework_files():
+    assert classify_file(Path("acceptance.robot")) == FileType.DOCUMENT
+    assert classify_file(Path("shared.resource")) == FileType.DOCUMENT

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -376,6 +376,77 @@ def test_extract_does_not_rewire_constructor_method_to_same_named_class(tmp_path
     )
 
 
+# ── Robot Framework extractor tests ───────────────────────────────────────────
+
+
+def test_robot_framework_dispatch():
+    from graphify.extract import _get_extractor
+    from graphify.extractors.robot import extract_robot
+
+    assert _get_extractor(Path("acceptance.robot")) is extract_robot
+    assert _get_extractor(Path("shared.resource")) is extract_robot
+
+
+def test_robot_framework_structure(tmp_path):
+    from graphify.extractors.robot import extract_robot
+
+    path = tmp_path / "acceptance.robot"
+    path.write_text(
+        "*** Settings ***\n"
+        "Documentation    Login acceptance tests\n"
+        "Library          Browser\n"
+        "\n"
+        "*** Test Cases ***\n"
+        "Successful login\n"
+        "    New Page       https://example.test/login\n"
+        "    Fill Text      id=user    alice\n"
+        "    Click          id=submit\n"
+        "\n"
+        "*** Keywords ***\n"
+        "Login as a valid user\n"
+        "    Fill Text      id=user    alice\n"
+        "    Click          id=submit\n"
+    )
+
+    result = extract_robot(path)
+    labels = {node["label"]: node for node in result["nodes"]}
+
+    assert labels["acceptance.robot"]["node_kind"] == "page"
+    assert labels["Settings"]["node_kind"] == "section"
+    assert labels["Test Cases"]["node_kind"] == "section"
+    assert labels["Keywords"]["node_kind"] == "section"
+    assert labels["Successful login"]["node_kind"] == "test"
+    assert labels["Login as a valid user"]["node_kind"] == "keyword"
+    assert "New Page       https://example.test/login" not in labels
+
+    edges = {(edge["source"], edge["target"], edge["relation"]) for edge in result["edges"]}
+    assert (labels["acceptance.robot"]["id"], labels["Settings"]["id"], "contains") in edges
+    assert (labels["Test Cases"]["id"], labels["Successful login"]["id"], "contains") in edges
+    assert (labels["Keywords"]["id"], labels["Login as a valid user"]["id"], "contains") in edges
+
+
+def test_robot_framework_resource_sections_and_comments(tmp_path):
+    from graphify.extractors.robot import extract_robot
+
+    path = tmp_path / "shared.resource"
+    path.write_text(
+        "# Shared browser keywords\n"
+        "*** Variables ***\n"
+        "${BASE_URL}    https://example.test\n"
+        "*** Keywords ***\n"
+        "Open application\n"
+        "    No Operation\n"
+    )
+
+    result = extract_robot(path)
+    labels = [node["label"] for node in result["nodes"]]
+    assert "Variables" in labels
+    assert "${BASE_URL}    https://example.test" in labels
+    assert "Open application" in labels
+    assert "# Shared browser keywords" not in labels
+    assert "No Operation" not in labels
+
+
 def test_collect_files_from_dir():
     from graphify.extract import _DISPATCH
     files = collect_files(FIXTURES)


### PR DESCRIPTION
## Summary

Add first-class structural support for Robot Framework suite and resource files.

Previously, `.robot` and `.resource` files were unclassified and skipped during corpus discovery. This change recognizes both extensions and extracts their stable document structure without adding a parser dependency.

## Changes

- Classify `.robot` and `.resource` files as documents.
- - Add a dependency-free Robot Framework extractor.
- - Model the file as a document root with section nodes for Settings, Variables, Test Cases, Tasks, Keywords, and Comments.
- - Model named tests, tasks, user keywords, settings, and variables as child nodes.
- - Preserve source locations and standard `contains` edges.
- - Ignore comments, blank lines, and indented executable keyword rows to avoid noisy graph nodes.
- - Add dispatch, registry, classification, and structural regression tests.
## Scope note

Gherkin `.feature` support is already covered by open pull request #2414, so this PR avoids overlapping that work while adding the complementary Robot Framework format used by the same testing domain.

## Verification

- `uv run pytest tests/test_detect.py -k robot_framework -q`
- - `uv run pytest tests/test_extract.py -k robot_framework -q`
- - `uv run pytest tests/test_detect.py tests/test_extract.py -q`
- - `uv run ruff check graphify/detect.py graphify/extract.py graphify/extractors/__init__.py graphify/extractors/robot.py tests/test_detect.py tests/test_extract.py`
- - `git diff --check`
All focused tests passed, all 466 tests in the two affected test modules passed, lint passed, and an end-to-end extraction smoke test passed.