### PR TITLE
fix(hooks): resolve merge-driver output path from .graphifyrc, skip gitignored graph.json

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -472,7 +472,17 @@ def _persist_out_dir(root: Path, out: str) -> None:
     hardcoded default, so the common case (no override) never touches the
     file. Preserves every other line untouched (mirrors _register_merge_driver's
     own append-don't-clobber behavior for .gitattributes).
+
+    Raises ValueError for a value containing a newline/carriage-return
+    instead of writing it: `.graphifyrc` is line-based, so such a value would
+    inject an extra, attacker- or accident-controlled line into the file (and
+    from there, via _merge_attr_line, into .gitattributes) rather than being
+    stored as the single `out_dir` line it looks like. GRAPHIFY_OUT is
+    ordinarily just a directory name, but it can come from an arbitrary env
+    var, so this is checked rather than assumed.
     """
+    if "\n" in out or "\r" in out:
+        raise ValueError(f"GRAPHIFY_OUT contains a newline, refusing to persist: {out!r}")
     rc_path = root / ".graphifyrc"
     lines: list[str] = []
     if rc_path.is_file():
@@ -730,7 +740,7 @@ def _register_merge_driver(root: Path) -> str:
     if GRAPHIFY_OUT and GRAPHIFY_OUT != "graphify-out":
         try:
             _persist_out_dir(root, GRAPHIFY_OUT)
-        except OSError:
+        except (OSError, ValueError):
             pass  # best-effort; the merge driver config above still applies this run
 
     line = _merge_attr_line()
@@ -756,8 +766,42 @@ def _register_merge_driver(root: Path) -> str:
     return f"registered ({line})"
 
 
+def _clear_persisted_out_dir(root: Path) -> bool:
+    """Remove the `out_dir=` line from <root>/.graphifyrc, if present.
+
+    A persisted out_dir intentionally survives GRAPHIFY_OUT being unset (that
+    is the whole point — it's what lets a later shell/CI job resolve the same
+    directory without the env var). But that means there was previously no
+    way back to the default short of hand-editing .graphifyrc; `hook
+    uninstall` now doubles as that reset, mirroring how it already clears the
+    merge-driver git config and .gitattributes line.
+    """
+    rc_path = root / ".graphifyrc"
+    if not rc_path.is_file():
+        return False
+    content = rc_path.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    kept = [
+        raw for raw in lines
+        if not (
+            (stripped := raw.strip())
+            and not stripped.startswith("#")
+            and "=" in stripped
+            and stripped.split("=", 1)[0].strip() == "out_dir"
+        )
+    ]
+    if kept == lines:
+        return False
+    if kept:
+        rc_path.write_text("\n".join(kept) + "\n", encoding="utf-8", newline="\n")
+    else:
+        rc_path.unlink()
+    return True
+
+
 def _unregister_merge_driver(root: Path) -> str:
-    """Remove the merge-driver git config keys and the .gitattributes line."""
+    """Remove the merge-driver git config keys, .gitattributes line, and any
+    persisted out_dir override."""
     import subprocess as _sp
     for key in ("merge.graphify.name", "merge.graphify.driver"):
         try:
@@ -768,22 +812,33 @@ def _unregister_merge_driver(root: Path) -> str:
             )
         except OSError:
             pass
+    out_dir_cleared = _clear_persisted_out_dir(root)
+
     attrs = root / ".gitattributes"
     if not attrs.exists():
-        return "not registered - nothing to remove."
+        return (
+            "not registered - nothing to remove."
+            if not out_dir_cleared
+            else "removed persisted out_dir (no .gitattributes entry to remove)"
+        )
     content = attrs.read_text(encoding="utf-8")
     kept = [
         raw for raw in content.splitlines()
         if not _has_merge_attr(raw)
     ]
+    suffix = " (and cleared persisted out_dir)" if out_dir_cleared else ""
     if kept == content.splitlines():
-        return "gitattributes entry not found - nothing to remove."
+        return (
+            "gitattributes entry not found - nothing to remove."
+            if not out_dir_cleared
+            else f"gitattributes entry not found{suffix}"
+        )
     if kept:
         # Other entries survive; the file stays.
         attrs.write_text("\n".join(kept) + "\n", encoding="utf-8", newline="\n")
-        return "removed from .gitattributes (other entries preserved)"
+        return f"removed from .gitattributes (other entries preserved){suffix}"
     attrs.unlink()
-    return "removed (.gitattributes deleted - no other entries)"
+    return f"removed (.gitattributes deleted - no other entries){suffix}"
 
 
 def _merge_driver_status(root: Path) -> str:

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -584,7 +584,18 @@ def _persist_out_dir(root: Path, out: str) -> None:
     lines: list[str] = []
     existing_value = None
     if rc_path.is_file():
-        content = rc_path.read_text(encoding="utf-8")
+        try:
+            content = rc_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            # A corrupted/non-UTF-8 existing .graphifyrc can't be preserved
+            # (its other lines, if any, aren't recoverable), but that must
+            # not crash hook install over it — start fresh and write just
+            # the out_dir line. The current sole caller already wraps this
+            # call in `except (OSError, ValueError)` (UnicodeDecodeError is
+            # a ValueError subclass), so this specific path isn't reachable
+            # today — guarded here anyway so it stays true for any future
+            # caller that doesn't happen to wrap it the same way.
+            content = ""
         for raw in content.splitlines():
             stripped = raw.strip()
             if stripped and not stripped.startswith("#") and "=" in stripped:
@@ -756,19 +767,25 @@ def _pinned_python() -> str:
     return sys.executable
 
 
-def _merge_attr_line() -> str:
+def _merge_attr_line(root: Path) -> str:
     """The .gitattributes line assigning the graphify merge driver to graph.json.
 
-    The graph lives under the configured output directory (graphify.paths,
-    resolved from GRAPHIFY_OUT env var or a persisted .graphifyrc out_dir —
-    see _persist_out_dir / graphify.paths._read_persisted_out_dir). gitattributes
-    patterns are repo-relative, so an absolute output-dir override cannot be
-    expressed there — fall back to the default name in that case. A `..`-
-    ascending relative path can't be expressed either: hook install (via
-    _git_root) always resolves the correct repo root regardless of invocation
-    directory, but a persisted out_dir re-expressed relative to *this*
-    process's cwd (see _read_persisted_out_dir) can legitimately be
-    `../../out-dir` when invoked from a nested subdirectory — same fallback.
+    The graph lives under the configured output directory. Prefers the
+    persisted override re-expressed relative to `root` (see
+    graphify.paths._read_persisted_out_dir_for_root) over the raw
+    GRAPHIFY_OUT env var/cwd-relative fallback: gitattributes patterns are
+    always interpreted relative to the repo root by git, never relative to
+    wherever a command was invoked from, so reusing the cwd-relative form
+    here would produce a `..`-ascending path (see below) whenever `hook
+    install` runs from a subdirectory of a repo with a persisted override —
+    landing on the wrong default instead of the actual persisted directory.
+
+    gitattributes patterns are repo-relative, so an absolute output-dir
+    override cannot be expressed there — fall back to the default name in
+    that case. A `..`-ascending relative path can't be expressed either —
+    same fallback (this can still legitimately occur: no persisted override
+    at all, falling through to a cwd-relative GRAPHIFY_OUT set directly via
+    the env var while invoked from a subdirectory).
 
     Any whitespace in GRAPHIFY_OUT (not just newline/carriage-return) gets
     the same fallback: a `.gitattributes` line is whitespace-separated
@@ -785,15 +802,26 @@ def _merge_attr_line() -> str:
     function (_register_merge_driver, _merge_driver_status) a safe way to
     recover the path: with no space possible before `/graph.json`, that
     split can never land anywhere but the intended boundary.
+
+    A directory name containing a gitattributes glob metacharacter
+    (`*?[]!`) or a leading `#` gets the same fallback too: embedded
+    unescaped into the pattern, these change what the pattern MATCHES
+    (`*` and `?` glob, `[...]` is a character class, a leading `!`
+    negates, a leading `#` makes the whole line a comment) rather than
+    being treated as a literal path segment — e.g. GRAPHIFY_OUT="*" would
+    produce the pattern `*/graph.json`, matching graph.json under every
+    top-level directory instead of one literally named "*".
     """
-    from graphify.paths import GRAPHIFY_OUT
-    out = GRAPHIFY_OUT
+    from graphify.paths import GRAPHIFY_OUT, _read_persisted_out_dir_for_root
+    out = _read_persisted_out_dir_for_root(root) or GRAPHIFY_OUT
     if (
         not out
         or Path(out).is_absolute()
         or "\\" in out
         or ".." in Path(out).parts
         or any(c.isspace() for c in out)
+        or any(c in out for c in "*?[]!")
+        or out.startswith("#")
     ):
         out = "graphify-out"
     return f"{out.rstrip('/')}/graph.json merge=graphify"
@@ -895,7 +923,7 @@ def _register_merge_driver(root: Path) -> str:
         except (OSError, ValueError):
             pass  # best-effort; the merge driver config above still applies this run
 
-    line = _merge_attr_line()
+    line = _merge_attr_line(root)
     graph_relpath = line.split(" ", 1)[0]
     if _is_gitignored(root, graph_relpath):
         # #2595: a merge driver for an ignored, untracked file never runs —
@@ -1032,7 +1060,7 @@ def _merge_driver_status(root: Path) -> str:
     if cfg_ok and attr_ok:
         return "registered"
     if cfg_ok:
-        graph_relpath = _merge_attr_line().split(" ", 1)[0]
+        graph_relpath = _merge_attr_line(root).split(" ", 1)[0]
         if _is_gitignored(root, graph_relpath):
             # Intentional (#2595): install skipped the .gitattributes line
             # because the target is ignored/untracked, so a merge driver for

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -465,9 +465,17 @@ def _load_graphifyrc(root: Path) -> dict[str, str | int]:
             # hand-edits the file to clear an override, and this key is read
             # unconditionally by `install()`; raising here would make hook
             # install itself impossible to run over a harmless stale line.
-            # Matches graphify.paths._read_persisted_out_dir's own handling
-            # of the same file/key.
-            if val:
+            #
+            # No consumer reads cfg["out_dir"] today (install()/status() only
+            # use viz_node_limit) — but this parses the same file and key
+            # graphify.paths._read_persisted_out_dir does, and that function
+            # refuses an absolute or `..`-escaping value for a concrete
+            # reason (.graphifyrc is repo-committed, untrusted content). A
+            # future caller reading this dict must inherit that same
+            # refusal automatically rather than needing to remember to
+            # re-derive it, so it is enforced here too even though nothing
+            # currently depends on it.
+            if val and not Path(val).is_absolute() and ".." not in Path(val).parts:
                 cfg["out_dir"] = val
     return cfg
 
@@ -553,6 +561,7 @@ def _persist_out_dir(root: Path, out: str) -> None:
     if rc_path.is_symlink():
         raise ValueError(f"refusing to write through a symlinked .graphifyrc: {rc_path}")
     lines: list[str] = []
+    existing_value = None
     if rc_path.is_file():
         content = rc_path.read_text(encoding="utf-8")
         for raw in content.splitlines():
@@ -560,8 +569,14 @@ def _persist_out_dir(root: Path, out: str) -> None:
             if stripped and not stripped.startswith("#") and "=" in stripped:
                 key = stripped.split("=", 1)[0].strip()
                 if key == "out_dir":
+                    existing_value = stripped.split("=", 1)[1].strip()
                     continue  # replaced below with the current value
             lines.append(raw)
+    if existing_value == out:
+        # Nothing to do: `hook install` re-run with an unchanged GRAPHIFY_OUT
+        # (the common case once persisted) would otherwise rewrite .graphifyrc
+        # on every run with byte-identical content — needless I/O/mtime churn.
+        return
     lines.append(f"out_dir={out}")
     if not _write_text_no_symlink(rc_path, "\n".join(lines) + "\n"):
         raise ValueError(f"refusing to write through a symlinked .graphifyrc: {rc_path}")

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -1,9 +1,9 @@
 # git hook integration - install/uninstall graphify post-commit and post-checkout hooks
 from __future__ import annotations
-import errno
 import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 _HOOK_MARKER = "# graphify-hook-start"
@@ -473,29 +473,42 @@ def _load_graphifyrc(root: Path) -> dict[str, str | int]:
 
 
 def _write_text_no_symlink(path: Path, content: str) -> bool:
-    """Write `content` to `path`, refusing to follow a symlink at the final
-    path component. Returns True if written, False if `path` is a symlink.
+    """Write `content` to `path` atomically, without writing through a
+    symlink at the final path component. Returns True if written, False if
+    `path` is a symlink.
 
-    A separate `path.is_symlink()` check followed by a plain `write_text()`
-    call leaves a race window open: something could replace `path` with a
-    symlink between the check and the write. `O_NOFOLLOW` closes that window
-    by making the open() call itself atomically fail (ELOOP) if the final
-    component is a symlink — there is no gap to win a race in. POSIX only;
-    Windows lacks O_NOFOLLOW, so this degrades to a plain create/truncate
-    there (no worse than the check-then-write pattern it replaces, and
-    unprivileged symlink creation is a materially different threat there).
+    Writes to a temp file in the same directory, then `os.replace()`s it
+    into place. This gets two properties in one step, both needed and
+    neither provided by opening `path` directly (even with O_NOFOLLOW):
+
+    - Atomicity: an in-place open+truncate+write leaves a window, between
+      the truncate and the write completing, where a concurrent reader
+      (another graphify process, a git hook) sees an empty file instead of
+      either the old or the new content. `os.replace()` is a single
+      directory-entry swap; no reader ever observes a partial state.
+    - No write-through-symlink, without needing O_NOFOLLOW (POSIX-only) at
+      all: `os.replace(src, dst)` replaces whatever directory entry `dst`
+      names — symlink or regular file — it does not resolve `dst` and write
+      through it. So even if something races a symlink into place between
+      the `is_symlink()` check below and the replace, the replace still
+      only ever touches that directory entry, never the symlink's target.
+      The check is therefore an early, friendlier bail-out for the callers
+      here (a clear "refuse to write through a symlink" instead of a
+      generic failure), not the actual safety boundary.
     """
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
+    if path.is_symlink():
+        return False
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
     try:
-        fd = os.open(str(path), flags, 0o644)
-    except OSError as exc:
-        if hasattr(os, "O_NOFOLLOW") and exc.errno == errno.ELOOP:
-            return False
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+            f.write(content)
+        os.replace(tmp, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
         raise
-    with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
-        f.write(content)
     return True
 
 
@@ -721,13 +734,21 @@ def _merge_attr_line() -> str:
     process's cwd (see _read_persisted_out_dir) can legitimately be
     `../../out-dir` when invoked from a nested subdirectory — same fallback.
 
-    A newline/carriage-return in GRAPHIFY_OUT gets the same fallback. This
-    function is the actual place a corrupted value would land in
-    `.gitattributes` — _persist_out_dir rejecting a newline before writing
-    `.graphifyrc` does not stop THIS function from reading the same raw
-    GRAPHIFY_OUT (env var, never persisted) and building the line from it
-    regardless, since it runs unconditionally after the persist attempt,
-    swallowed or not.
+    Any whitespace in GRAPHIFY_OUT (not just newline/carriage-return) gets
+    the same fallback: a `.gitattributes` line is whitespace-separated
+    fields (`pattern attr1 attr2 ...`), so a space in `out` would split the
+    line into more fields than intended — part of the directory name would
+    parse as an extra attribute rather than as part of the pattern. This
+    function is also the actual place any such corrupted value would land
+    in `.gitattributes` — _persist_out_dir rejecting a newline before
+    writing `.graphifyrc` does not stop THIS function from reading the same
+    raw GRAPHIFY_OUT (env var, never persisted) and building the line from
+    it regardless, since it runs unconditionally after the persist attempt,
+    swallowed or not. Guaranteeing `out` is whitespace-free here is also
+    what makes the plain `line.split(" ", 1)[0]` used by callers of this
+    function (_register_merge_driver, _merge_driver_status) a safe way to
+    recover the path: with no space possible before `/graph.json`, that
+    split can never land anywhere but the intended boundary.
     """
     from graphify.paths import GRAPHIFY_OUT
     out = GRAPHIFY_OUT
@@ -736,8 +757,7 @@ def _merge_attr_line() -> str:
         or Path(out).is_absolute()
         or "\\" in out
         or ".." in Path(out).parts
-        or "\n" in out
-        or "\r" in out
+        or any(c.isspace() for c in out)
     ):
         out = "graphify-out"
     return f"{out.rstrip('/')}/graph.json merge=graphify"
@@ -861,7 +881,13 @@ def _clear_persisted_out_dir(root: Path) -> bool:
         # Best-effort here (return False, not raise) — the rest of uninstall
         # (git config, .gitattributes) must still proceed.
         return False
-    content = rc_path.read_text(encoding="utf-8")
+    try:
+        content = rc_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        # A corrupted/non-UTF-8 .graphifyrc must not make `hook uninstall`
+        # itself fail — best-effort, same as the symlink case above; the
+        # rest of uninstall (git config, .gitattributes) must still proceed.
+        return False
     lines = content.splitlines()
     kept = [
         raw for raw in lines

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -428,6 +428,9 @@ def _load_graphifyrc(root: Path) -> dict[str, str | int]:
 
     Supported options:
       viz_node_limit: integer >= 0 (e.g. viz_node_limit=0)
+      out_dir: string, a persisted GRAPHIFY_OUT override (see graphify.paths);
+        written by _register_merge_driver so a non-default output directory
+        survives into shells/CI jobs that never export the env var.
     """
     rc_path = root / ".graphifyrc"
     if not rc_path.is_file():
@@ -455,7 +458,34 @@ def _load_graphifyrc(root: Path) -> dict[str, str | int]:
                     f"Invalid viz_node_limit in {rc_path} at line {line_num}: {val!r}. "
                     f"Must be a non-negative integer."
                 ) from exc
+        elif key == "out_dir":
+            if not val:
+                raise ValueError(f"Invalid out_dir in {rc_path} at line {line_num}: empty value")
+            cfg["out_dir"] = val
     return cfg
+
+
+def _persist_out_dir(root: Path, out: str) -> None:
+    """Append/update ``out_dir=<out>`` in <root>/.graphifyrc.
+
+    Only called when GRAPHIFY_OUT resolved to something other than the
+    hardcoded default, so the common case (no override) never touches the
+    file. Preserves every other line untouched (mirrors _register_merge_driver's
+    own append-don't-clobber behavior for .gitattributes).
+    """
+    rc_path = root / ".graphifyrc"
+    lines: list[str] = []
+    if rc_path.is_file():
+        content = rc_path.read_text(encoding="utf-8")
+        for raw in content.splitlines():
+            stripped = raw.strip()
+            if stripped and not stripped.startswith("#") and "=" in stripped:
+                key = stripped.split("=", 1)[0].strip()
+                if key == "out_dir":
+                    continue  # replaced below with the current value
+            lines.append(raw)
+    lines.append(f"out_dir={out}")
+    rc_path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
 
 
 def _git_root(path: Path) -> Path | None:
@@ -615,15 +645,37 @@ def _merge_attr_line() -> str:
     """The .gitattributes line assigning the graphify merge driver to graph.json.
 
     The graph lives under the configured output directory (graphify.paths,
-    GRAPHIFY_OUT env override). gitattributes patterns are repo-relative, so an
-    absolute output-dir override cannot be expressed there — fall back to the
-    default name in that case.
+    resolved from GRAPHIFY_OUT env var or a persisted .graphifyrc out_dir —
+    see _persist_out_dir / graphify.paths._read_persisted_out_dir). gitattributes
+    patterns are repo-relative, so an absolute output-dir override cannot be
+    expressed there — fall back to the default name in that case.
     """
     from graphify.paths import GRAPHIFY_OUT
     out = GRAPHIFY_OUT
     if not out or Path(out).is_absolute() or "\\" in out:
         out = "graphify-out"
     return f"{out.rstrip('/')}/graph.json merge=graphify"
+
+
+def _is_gitignored(root: Path, relative_path: str) -> bool:
+    """True if `relative_path` (repo-relative) is excluded by gitignore rules.
+
+    A merge driver registered for an ignored path is dead weight (#2595): git
+    never tracks the file, so `git merge`/`git pull` never invoke any merge
+    driver for it, and the .gitattributes line just sits there re-adding itself
+    on every `hook install` re-run. Best-effort: any failure (git missing,
+    not a repo) reports "not ignored" so callers fall back to the previous,
+    always-register behavior rather than silently skipping registration.
+    """
+    import subprocess as _sp
+    try:
+        result = _sp.run(
+            ["git", "-C", str(root), "check-ignore", "-q", "--", relative_path],
+            capture_output=True,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
 
 
 def _has_merge_attr(content: str) -> bool:
@@ -671,7 +723,25 @@ def _register_merge_driver(root: Path) -> str:
     except (OSError, _sp.CalledProcessError) as exc:
         return f"not registered (git config failed: {exc})"
 
+    # Persist a non-default GRAPHIFY_OUT so a later `hook install`/`hook status`
+    # run in a shell that never exported the env var still resolves the same
+    # output directory this one did (see graphify.paths._read_persisted_out_dir).
+    from graphify.paths import GRAPHIFY_OUT
+    if GRAPHIFY_OUT and GRAPHIFY_OUT != "graphify-out":
+        try:
+            _persist_out_dir(root, GRAPHIFY_OUT)
+        except OSError:
+            pass  # best-effort; the merge driver config above still applies this run
+
     line = _merge_attr_line()
+    graph_relpath = line.split(" ", 1)[0]
+    if _is_gitignored(root, graph_relpath):
+        # #2595: a merge driver for an ignored, untracked file never runs —
+        # git has nothing to merge. Registering it just dirties .gitattributes
+        # and re-adds itself on every re-run. git config above is left in
+        # place (harmless, and needed if the path is later un-ignored).
+        return f"skipped ({graph_relpath} is gitignored — merge driver would never run)"
+
     attrs = root / ".gitattributes"
     if attrs.exists():
         content = attrs.read_text(encoding="utf-8")
@@ -732,6 +802,12 @@ def _merge_driver_status(root: Path) -> str:
     if cfg_ok and attr_ok:
         return "registered"
     if cfg_ok:
+        graph_relpath = _merge_attr_line().split(" ", 1)[0]
+        if _is_gitignored(root, graph_relpath):
+            # Intentional (#2595): install skipped the .gitattributes line
+            # because the target is ignored/untracked, so a merge driver for
+            # it would never run. Not a broken state — do not report it as one.
+            return f"not applicable ({graph_relpath} is gitignored — no merge driver needed)"
         return "partially registered (git config set, .gitattributes line missing)"
     if attr_ok:
         return "partially registered (.gitattributes line set, git config missing)"

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -1,5 +1,6 @@
 # git hook integration - install/uninstall graphify post-commit and post-checkout hooks
 from __future__ import annotations
+import errno
 import os
 import re
 import sys
@@ -459,10 +460,43 @@ def _load_graphifyrc(root: Path) -> dict[str, str | int]:
                     f"Must be a non-negative integer."
                 ) from exc
         elif key == "out_dir":
-            if not val:
-                raise ValueError(f"Invalid out_dir in {rc_path} at line {line_num}: empty value")
-            cfg["out_dir"] = val
+            # An empty value is treated as absent, not invalid — unlike
+            # viz_node_limit, a blank `out_dir=` is a plausible way someone
+            # hand-edits the file to clear an override, and this key is read
+            # unconditionally by `install()`; raising here would make hook
+            # install itself impossible to run over a harmless stale line.
+            # Matches graphify.paths._read_persisted_out_dir's own handling
+            # of the same file/key.
+            if val:
+                cfg["out_dir"] = val
     return cfg
+
+
+def _write_text_no_symlink(path: Path, content: str) -> bool:
+    """Write `content` to `path`, refusing to follow a symlink at the final
+    path component. Returns True if written, False if `path` is a symlink.
+
+    A separate `path.is_symlink()` check followed by a plain `write_text()`
+    call leaves a race window open: something could replace `path` with a
+    symlink between the check and the write. `O_NOFOLLOW` closes that window
+    by making the open() call itself atomically fail (ELOOP) if the final
+    component is a symlink — there is no gap to win a race in. POSIX only;
+    Windows lacks O_NOFOLLOW, so this degrades to a plain create/truncate
+    there (no worse than the check-then-write pattern it replaces, and
+    unprivileged symlink creation is a materially different threat there).
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(str(path), flags, 0o644)
+    except OSError as exc:
+        if hasattr(os, "O_NOFOLLOW") and exc.errno == errno.ELOOP:
+            return False
+        raise
+    with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+        f.write(content)
+    return True
 
 
 def _persist_out_dir(root: Path, out: str) -> None:
@@ -486,11 +520,22 @@ def _persist_out_dir(root: Path, out: str) -> None:
     `.graphifyrc` as a symlink to an arbitrary path (e.g. a shell profile or
     cron file) and have `hook install` — routinely run, with no reason for a
     user to suspect it writes anything — overwrite whatever that symlink
-    points at. Refusing is a one-line check; silently following would make
-    the write target attacker-controlled.
+    points at. Uses `_write_text_no_symlink` for the actual write so a
+    symlink swapped in after this check (but before the write) is still
+    caught, rather than trusting a single earlier check-then-write.
+
+    Refuses to persist an absolute path at all: `.graphifyrc` is repo-
+    committed, and an absolute out_dir committed there would silently
+    redirect every collaborator's graphify output the moment they clone the
+    repo and run any command — no explicit opt-in, unlike an env var the
+    user sets for themselves. `graphify.paths._read_persisted_out_dir`
+    refuses to honor an absolute persisted value for the same reason; not
+    writing one here is the same policy applied at the source.
     """
     if "\n" in out or "\r" in out:
         raise ValueError(f"GRAPHIFY_OUT contains a newline, refusing to persist: {out!r}")
+    if Path(out).is_absolute():
+        raise ValueError(f"refusing to persist an absolute GRAPHIFY_OUT to .graphifyrc: {out!r}")
     rc_path = root / ".graphifyrc"
     if rc_path.is_symlink():
         raise ValueError(f"refusing to write through a symlinked .graphifyrc: {rc_path}")
@@ -505,7 +550,8 @@ def _persist_out_dir(root: Path, out: str) -> None:
                     continue  # replaced below with the current value
             lines.append(raw)
     lines.append(f"out_dir={out}")
-    rc_path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+    if not _write_text_no_symlink(rc_path, "\n".join(lines) + "\n"):
+        raise ValueError(f"refusing to write through a symlinked .graphifyrc: {rc_path}")
 
 
 def _git_root(path: Path) -> Path | None:
@@ -674,10 +720,25 @@ def _merge_attr_line() -> str:
     directory, but a persisted out_dir re-expressed relative to *this*
     process's cwd (see _read_persisted_out_dir) can legitimately be
     `../../out-dir` when invoked from a nested subdirectory — same fallback.
+
+    A newline/carriage-return in GRAPHIFY_OUT gets the same fallback. This
+    function is the actual place a corrupted value would land in
+    `.gitattributes` — _persist_out_dir rejecting a newline before writing
+    `.graphifyrc` does not stop THIS function from reading the same raw
+    GRAPHIFY_OUT (env var, never persisted) and building the line from it
+    regardless, since it runs unconditionally after the persist attempt,
+    swallowed or not.
     """
     from graphify.paths import GRAPHIFY_OUT
     out = GRAPHIFY_OUT
-    if not out or Path(out).is_absolute() or "\\" in out or ".." in Path(out).parts:
+    if (
+        not out
+        or Path(out).is_absolute()
+        or "\\" in out
+        or ".." in Path(out).parts
+        or "\n" in out
+        or "\r" in out
+    ):
         out = "graphify-out"
     return f"{out.rstrip('/')}/graph.json merge=graphify"
 
@@ -814,9 +875,12 @@ def _clear_persisted_out_dir(root: Path) -> bool:
     if kept == lines:
         return False
     if kept:
-        rc_path.write_text("\n".join(kept) + "\n", encoding="utf-8", newline="\n")
-    else:
-        rc_path.unlink()
+        # _write_text_no_symlink re-checks at the actual write, closing the
+        # race between the is_symlink() check above and this write.
+        return _write_text_no_symlink(rc_path, "\n".join(kept) + "\n")
+    # Removing a symlink deletes the link itself, never its target — no
+    # write-through-symlink risk here, unlike the write above.
+    rc_path.unlink()
     return True
 
 

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -578,6 +578,19 @@ def _persist_out_dir(root: Path, out: str) -> None:
         # ignored the next time anyone reads it back. Refuse at the source
         # instead of writing something immediately useless.
         raise ValueError(f"refusing to persist a `..`-escaping GRAPHIFY_OUT: {out!r}")
+    if _unsafe_as_gitattributes_pattern(out):
+        # Same "don't write something a reader will just ignore" reasoning
+        # as the `..` check above: _merge_attr_line falls back to the
+        # default for whitespace or a gitattributes glob metacharacter
+        # (*?[]! or a leading #), so persisting one here just writes a
+        # value the very next .gitattributes generation will discard.
+        # (Absolute/backslash/`..` are re-checked here too via the shared
+        # predicate, but those already raised above with a more specific
+        # message — this branch is only reachable for whitespace/glob.)
+        raise ValueError(
+            f"refusing to persist a GRAPHIFY_OUT unsafe for .gitattributes "
+            f"(whitespace or a glob metacharacter): {out!r}"
+        )
     rc_path = root / ".graphifyrc"
     if rc_path.is_symlink():
         raise ValueError(f"refusing to write through a symlinked .graphifyrc: {rc_path}")
@@ -767,6 +780,39 @@ def _pinned_python() -> str:
     return sys.executable
 
 
+def _unsafe_as_gitattributes_pattern(out: str) -> bool:
+    """True if `out` can't safely become the pattern half of a
+    `.gitattributes` line (`<out>/graph.json merge=graphify`).
+
+    Shared by `_merge_attr_line` (falls back to the default name) and
+    `_persist_out_dir` (refuses to persist at all) so the two can't drift:
+    a value `_merge_attr_line` would reject anyway is also refused at
+    write time, matching the same "don't persist something a reader will
+    just ignore" reasoning already applied to `..`-escaping and absolute
+    values.
+
+    - Absolute, backslash-containing, or `..`-ascending: not expressible as
+      a repo-relative gitattributes pattern at all.
+    - Whitespace: a gitattributes line is whitespace-separated fields, so a
+      space would split the pattern from part of itself, parsing as an
+      extra unintended attribute.
+    - A glob metacharacter (`*?[]!`) or a leading `#`: embedded unescaped,
+      these change what the pattern MATCHES (`*`/`?` glob, `[...]` is a
+      character class, a leading `!` negates) or make the whole line a
+      comment, rather than being treated as a literal path segment — e.g.
+      `out="*"` would produce `*/graph.json`, matching under every
+      top-level directory instead of one literally named `"*"`.
+    """
+    return (
+        Path(out).is_absolute()
+        or "\\" in out
+        or ".." in Path(out).parts
+        or any(c.isspace() for c in out)
+        or any(c in out for c in "*?[]!")
+        or out.startswith("#")
+    )
+
+
 def _merge_attr_line(root: Path) -> str:
     """The .gitattributes line assigning the graphify merge driver to graph.json.
 
@@ -814,15 +860,7 @@ def _merge_attr_line(root: Path) -> str:
     """
     from graphify.paths import GRAPHIFY_OUT, _read_persisted_out_dir_for_root
     out = _read_persisted_out_dir_for_root(root) or GRAPHIFY_OUT
-    if (
-        not out
-        or Path(out).is_absolute()
-        or "\\" in out
-        or ".." in Path(out).parts
-        or any(c.isspace() for c in out)
-        or any(c in out for c in "*?[]!")
-        or out.startswith("#")
-    ):
+    if not out or _unsafe_as_gitattributes_pattern(out):
         out = "graphify-out"
     return f"{out.rstrip('/')}/graph.json merge=graphify"
 

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -480,10 +480,20 @@ def _persist_out_dir(root: Path, out: str) -> None:
     stored as the single `out_dir` line it looks like. GRAPHIFY_OUT is
     ordinarily just a directory name, but it can come from an arbitrary env
     var, so this is checked rather than assumed.
+
+    Also raises ValueError instead of writing through a symlinked
+    `.graphifyrc`: it is repo-committed content, so a cloned repo could ship
+    `.graphifyrc` as a symlink to an arbitrary path (e.g. a shell profile or
+    cron file) and have `hook install` — routinely run, with no reason for a
+    user to suspect it writes anything — overwrite whatever that symlink
+    points at. Refusing is a one-line check; silently following would make
+    the write target attacker-controlled.
     """
     if "\n" in out or "\r" in out:
         raise ValueError(f"GRAPHIFY_OUT contains a newline, refusing to persist: {out!r}")
     rc_path = root / ".graphifyrc"
+    if rc_path.is_symlink():
+        raise ValueError(f"refusing to write through a symlinked .graphifyrc: {rc_path}")
     lines: list[str] = []
     if rc_path.is_file():
         content = rc_path.read_text(encoding="utf-8")
@@ -658,11 +668,16 @@ def _merge_attr_line() -> str:
     resolved from GRAPHIFY_OUT env var or a persisted .graphifyrc out_dir —
     see _persist_out_dir / graphify.paths._read_persisted_out_dir). gitattributes
     patterns are repo-relative, so an absolute output-dir override cannot be
-    expressed there — fall back to the default name in that case.
+    expressed there — fall back to the default name in that case. A `..`-
+    ascending relative path can't be expressed either: hook install (via
+    _git_root) always resolves the correct repo root regardless of invocation
+    directory, but a persisted out_dir re-expressed relative to *this*
+    process's cwd (see _read_persisted_out_dir) can legitimately be
+    `../../out-dir` when invoked from a nested subdirectory — same fallback.
     """
     from graphify.paths import GRAPHIFY_OUT
     out = GRAPHIFY_OUT
-    if not out or Path(out).is_absolute() or "\\" in out:
+    if not out or Path(out).is_absolute() or "\\" in out or ".." in Path(out).parts:
         out = "graphify-out"
     return f"{out.rstrip('/')}/graph.json merge=graphify"
 
@@ -778,6 +793,12 @@ def _clear_persisted_out_dir(root: Path) -> bool:
     """
     rc_path = root / ".graphifyrc"
     if not rc_path.is_file():
+        return False
+    if rc_path.is_symlink():
+        # Same write-hijack concern as _persist_out_dir: don't write cleaned
+        # content through a repo-committed symlink to an arbitrary target.
+        # Best-effort here (return False, not raise) — the rest of uninstall
+        # (git config, .gitattributes) must still proceed.
         return False
     content = rc_path.read_text(encoding="utf-8")
     lines = content.splitlines()

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -475,7 +475,12 @@ def _load_graphifyrc(root: Path) -> dict[str, str | int]:
             # refusal automatically rather than needing to remember to
             # re-derive it, so it is enforced here too even though nothing
             # currently depends on it.
-            if val and not Path(val).is_absolute() and ".." not in Path(val).parts:
+            # is_absolute_any_platform (not plain Path.is_absolute()): this
+            # value is untrusted repo-committed content that could have been
+            # authored on either OS — see that function's docstring
+            # "EXCEPTION" paragraph.
+            from graphify.paths import is_absolute_any_platform
+            if val and not is_absolute_any_platform(val) and ".." not in Path(val).parts:
                 cfg["out_dir"] = val
     return cfg
 
@@ -555,8 +560,24 @@ def _persist_out_dir(root: Path, out: str) -> None:
     """
     if "\n" in out or "\r" in out:
         raise ValueError(f"GRAPHIFY_OUT contains a newline, refusing to persist: {out!r}")
-    if Path(out).is_absolute():
+    # is_absolute_any_platform (not plain Path.is_absolute()): the value
+    # written here is read back by graphify.paths._read_persisted_out_dir on
+    # whatever machine/OS clones this repo next, which already refuses an
+    # any-platform-absolute value regardless of which host wrote it — a
+    # value this host doesn't consider absolute but another platform does
+    # (e.g. a POSIX host persisting "C:/shared") would be written here only
+    # to be immediately refused by every reader. See that function's
+    # docstring "EXCEPTION" paragraph.
+    from graphify.paths import is_absolute_any_platform
+    if is_absolute_any_platform(out):
         raise ValueError(f"refusing to persist an absolute GRAPHIFY_OUT to .graphifyrc: {out!r}")
+    if ".." in Path(out).parts:
+        # Every reader of this key (graphify.paths._read_persisted_out_dir,
+        # this module's own _load_graphifyrc) refuses a `..`-escaping value —
+        # persisting one anyway would just write a line that is silently
+        # ignored the next time anyone reads it back. Refuse at the source
+        # instead of writing something immediately useless.
+        raise ValueError(f"refusing to persist a `..`-escaping GRAPHIFY_OUT: {out!r}")
     rc_path = root / ".graphifyrc"
     if rc_path.is_symlink():
         raise ValueError(f"refusing to write through a symlinked .graphifyrc: {rc_path}")
@@ -800,13 +821,33 @@ def _is_gitignored(root: Path, relative_path: str) -> bool:
 
 
 def _has_merge_attr(content: str) -> bool:
-    """True if a (non-comment) `<...>graph.json ... merge=graphify` line exists."""
+    """True if a (non-comment) `<...>graph.json ... merge=graphify` line exists.
+
+    A gitattributes pattern containing whitespace is written C-quoted
+    (git's own convention, e.g. `"my dir/graph.json" merge=graphify`) — a
+    naive `line.split()` shatters a quoted pattern across multiple fields
+    (`'"my'`, `'dir/graph.json"'`, ...), none of which end with
+    `"graph.json"`, so a legitimately quoted pre-existing entry would be
+    missed and treated as unregistered. `_merge_attr_line` itself never
+    generates a quoted line (GRAPHIFY_OUT is validated whitespace-free
+    before it gets there), but this function also has to recognize an entry
+    someone else authored by hand for a path that genuinely needs quoting.
+    """
     for raw in content.splitlines():
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
-        fields = line.split()
-        if fields and fields[0].endswith("graph.json") and "merge=graphify" in fields[1:]:
+        if line.startswith('"'):
+            end = line.find('"', 1)
+            if end == -1:
+                continue  # unterminated quote — malformed, not a match
+            pattern, rest = line[1:end], line[end + 1:].split()
+        else:
+            fields = line.split()
+            if not fields:
+                continue
+            pattern, rest = fields[0], fields[1:]
+        if pattern.endswith("graph.json") and "merge=graphify" in rest:
             return True
     return False
 
@@ -938,7 +979,15 @@ def _unregister_merge_driver(root: Path) -> str:
             )
         except OSError:
             pass
-    out_dir_cleared = _clear_persisted_out_dir(root)
+    try:
+        out_dir_cleared = _clear_persisted_out_dir(root)
+    except OSError:
+        # Best-effort, matching the git-config unset above: an unlink()
+        # failure (permission, a concurrent process removing the file, a
+        # cross-device rename inside _write_text_no_symlink) must not abort
+        # the rest of uninstall — the git config and .gitattributes cleanup
+        # below are unrelated and should still happen regardless.
+        out_dir_cleared = False
 
     attrs = root / ".gitattributes"
     if not attrs.exists():

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -87,40 +87,55 @@ def _read_persisted_out_dir() -> str | None:
     the env var themselves — this refusal is specific to a value arriving
     from repo-committed content, not the feature.
     """
-    rc_path = _find_graphifyrc(Path.cwd())
-    if rc_path is None:
-        return None
+    # Everything below is wrapped in one outer guard rather than scattering
+    # per-call try/excepts: `Path.cwd()` raises OSError (FileNotFoundError)
+    # if the invocation directory itself has been deleted out from under the
+    # process (rarer, but real — a shell left open in a directory a script
+    # elsewhere just rm -rf'd, common in CI teardown), and building a path
+    # from a value containing an embedded NUL byte — a valid-UTF-8 string can
+    # still contain one — raises ValueError from the OS layer the first time
+    # it reaches a syscall (`.resolve()` below), not at the earlier
+    # `read_text()`/`Path(val).is_absolute()` checks. Both must degrade to
+    # "no override", per this function's own contract, not propagate and
+    # abort `graphify.paths` import for every command anywhere near the repo.
     try:
-        content = rc_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return None
-    for raw in content.splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, _, val = line.partition("=")
-        if key.strip() != "out_dir":
-            continue
-        val = val.strip()
-        if not val:
+        rc_path = _find_graphifyrc(Path.cwd())
+        if rc_path is None:
             return None
-        if Path(val).is_absolute():
-            return None  # repo-committed absolute path — refuse, don't honor
-        # Relative: anchor to the repo root (this .graphifyrc's own directory),
-        # not wherever this process happens to be invoked from — GRAPHIFY_OUT
-        # is otherwise always resolved relative to cwd, so re-express the
-        # repo-root-relative value in those terms when they differ.
-        repo_root = rc_path.parent.resolve()
-        target = (repo_root / val).resolve()
         try:
-            target.relative_to(repo_root)
-        except ValueError:
-            return None  # escapes the repo root via `..` — refuse, don't honor
-        try:
-            return os.path.relpath(target, Path.cwd())
-        except ValueError:
-            return str(target)  # e.g. different drives on Windows
-    return None
+            content = rc_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+        for raw in content.splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            if key.strip() != "out_dir":
+                continue
+            val = val.strip()
+            if not val:
+                return None
+            if Path(val).is_absolute():
+                return None  # repo-committed absolute path — refuse, don't honor
+            # Relative: anchor to the repo root (this .graphifyrc's own
+            # directory), not wherever this process happens to be invoked
+            # from — GRAPHIFY_OUT is otherwise always resolved relative to
+            # cwd, so re-express the repo-root-relative value in those terms
+            # when they differ.
+            repo_root = rc_path.parent.resolve()
+            target = (repo_root / val).resolve()
+            try:
+                target.relative_to(repo_root)
+            except ValueError:
+                return None  # escapes the repo root via `..` — refuse, don't honor
+            try:
+                return os.path.relpath(target, Path.cwd())
+            except ValueError:
+                return str(target)  # e.g. different drives on Windows
+        return None
+    except (OSError, ValueError):
+        return None
 
 
 _env_graphify_out = os.environ.get("GRAPHIFY_OUT")

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -35,8 +35,28 @@ import tempfile
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 
+def _find_graphifyrc(start: Path) -> Path | None:
+    """Walk up from `start` looking for `.graphifyrc`, the same way git itself
+    walks up looking for `.git` — so a command run from a subdirectory of the
+    repo still finds the repo-root file `_register_merge_driver` writes to
+    (`root` there is always the git root, never the invocation cwd).
+
+    Capped at the filesystem root; a `.git` directory also stops the walk
+    early (no reason to keep climbing past the repo boundary into unrelated
+    parent directories, e.g. `/home/user` for a repo at `/home/user/proj`).
+    """
+    current = start.resolve()
+    for parent in (current, *current.parents):
+        candidate = parent / ".graphifyrc"
+        if candidate.is_file():
+            return candidate
+        if (parent / ".git").exists():
+            return None
+    return None
+
+
 def _read_persisted_out_dir() -> str | None:
-    """Read ``out_dir=`` from ``./.graphifyrc`` if present.
+    """Read ``out_dir=`` from the nearest ``.graphifyrc`` above cwd, if present.
 
     Deliberately minimal and independent of ``graphify.hooks._load_graphifyrc``
     (which also parses ``viz_node_limit``) to avoid a hooks<->paths import
@@ -44,9 +64,14 @@ def _read_persisted_out_dir() -> str | None:
     runs at import time, before any lazy import could resolve it. Malformed or
     unreadable files degrade to "no override" rather than raising — this must
     never block module import.
+
+    Injection (a value that would add an unintended `.gitattributes` line) is
+    rejected at the write site (``graphify.hooks._persist_out_dir``), not
+    here — a value read back via ``str.splitlines()`` can never itself
+    contain a newline, so a line-based check on this side is a no-op.
     """
-    rc_path = Path(".graphifyrc")
-    if not rc_path.is_file():
+    rc_path = _find_graphifyrc(Path.cwd())
+    if rc_path is None:
         return None
     try:
         content = rc_path.read_text(encoding="utf-8")

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -105,15 +105,76 @@ def _find_graphifyrc(start: Path) -> Path | None:
     return None
 
 
-def _read_persisted_out_dir() -> str | None:
-    """Read ``out_dir=`` from the nearest ``.graphifyrc`` above cwd, if present.
+def _resolve_persisted_out_dir_target(rc_path: Path) -> Path | None:
+    """Read and validate ``out_dir=`` from ``rc_path``, returning an
+    absolute, safe target directory, or ``None`` if absent/empty/invalid/
+    untrusted.
 
-    Deliberately minimal and independent of ``graphify.hooks._load_graphifyrc``
-    (which also parses ``viz_node_limit``) to avoid a hooks<->paths import
-    cycle: ``hooks`` already imports ``GRAPHIFY_OUT`` from this module, and this
-    runs at import time, before any lazy import could resolve it. Malformed or
-    unreadable files degrade to "no override" rather than raising — this must
-    never block module import.
+    Shared validation core for ``_read_persisted_out_dir`` (cwd-relative,
+    for the general ``GRAPHIFY_OUT`` fallback) and
+    ``_read_persisted_out_dir_for_root`` (repo-root-relative, for
+    ``.gitattributes`` generation) — the security-relevant checks (refusing
+    an absolute or ``..``-escaping value) live in exactly one place so the
+    two callers can't drift apart, the way three separate near-duplicates
+    of this logic already had to be caught and re-synced across earlier
+    revisions of this file and ``graphify.hooks``.
+
+    ``.graphifyrc`` is repo-committed, untrusted content (this project
+    already reads it for ``viz_node_limit``) — unlike ``GRAPHIFY_OUT`` the
+    env var, which a user sets for themselves, this file can arrive
+    unreviewed via ``git clone`` and applies the moment ANY graphify command
+    runs, with no action from the user beyond that clone. A *relative*
+    value is anchored to the repo root (``rc_path.parent`` — where
+    ``_register_merge_driver`` always resolves and writes it) and refused
+    outright if it escapes that root via ``..``. An *absolute* value
+    (checked cross-platform via ``is_absolute_any_platform``, not plain
+    ``Path.is_absolute()`` — see that function's docstring "EXCEPTION"
+    paragraph) is refused outright too — unlike a relative one it can't even
+    be checked against the repo boundary, and a committed absolute path
+    would silently redirect every collaborator's output the instant they
+    clone the repo. ``_register_merge_driver`` never persists one for the
+    same reason (`graphify.hooks._persist_out_dir`); an absolute
+    ``GRAPHIFY_OUT`` still works exactly as before when a user sets the env
+    var themselves — this refusal is specific to a value arriving from
+    repo-committed content, not the feature.
+    """
+    try:
+        content = rc_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        if key.strip() != "out_dir":
+            continue
+        val = val.strip()
+        if not val:
+            return None
+        if is_absolute_any_platform(val):
+            return None  # repo-committed absolute path — refuse, don't honor
+        repo_root = rc_path.parent.resolve()
+        target = (repo_root / val).resolve()
+        try:
+            target.relative_to(repo_root)
+        except ValueError:
+            return None  # escapes the repo root via `..` — refuse, don't honor
+        return target
+    return None
+
+
+def _read_persisted_out_dir() -> str | None:
+    """Read ``out_dir=`` from the nearest ``.graphifyrc`` above cwd, if
+    present, re-expressed relative to the current working directory.
+
+    Deliberately independent of ``graphify.hooks._load_graphifyrc`` (which
+    also parses ``viz_node_limit``) to avoid a hooks<->paths import cycle:
+    ``hooks`` already imports ``GRAPHIFY_OUT`` from this module, and this
+    runs at import time, before any lazy import could resolve it. Malformed
+    or unreadable files degrade to "no override" rather than raising — this
+    must never block module import. See ``_resolve_persisted_out_dir_target``
+    for the untrusted-repo-content refusal policy this applies.
 
     Injection via a literal newline in the value (which would add an
     unintended `.gitattributes` line) is rejected at the write site
@@ -121,21 +182,15 @@ def _read_persisted_out_dir() -> str | None:
     ``str.splitlines()`` can never itself contain a newline, so a line-based
     check on this side is a no-op.
 
-    ``.graphifyrc`` is repo-committed, untrusted content (this project already
-    reads it for ``viz_node_limit``) — unlike ``GRAPHIFY_OUT`` the env var,
-    which a user sets for themselves, this file can arrive unreviewed via
-    ``git clone`` and applies the moment ANY graphify command runs, with no
-    action from the user beyond that clone. A *relative* value is anchored to
-    the repo root (``rc_path.parent`` — where ``_register_merge_driver``
-    always resolves and writes it) and refused outright if it escapes that
-    root via ``..``. An *absolute* value is refused outright too — unlike a
-    relative one it can't even be checked against the repo boundary, and a
-    committed absolute path would silently redirect every collaborator's
-    output the instant they clone the repo. ``_register_merge_driver`` never
-    persists one for the same reason (`graphify.hooks._persist_out_dir`); an
-    absolute ``GRAPHIFY_OUT`` still works exactly as before when a user sets
-    the env var themselves — this refusal is specific to a value arriving
-    from repo-committed content, not the feature.
+    This is the general-purpose ``GRAPHIFY_OUT`` fallback, used for
+    resolving files relative to wherever the process was invoked — for
+    generating a ``.gitattributes`` pattern instead, which git always
+    interprets relative to the repo root regardless of invocation
+    directory, use ``_read_persisted_out_dir_for_root`` instead (re-
+    expressing relative to cwd here can legitimately produce a
+    `..`-ascending path when invoked from a subdirectory, which is correct
+    for opening a file from that cwd but not expressible as a gitattributes
+    pattern).
     """
     # Everything below is wrapped in one outer guard rather than scattering
     # per-call try/excepts: `Path.cwd()` raises OSError (FileNotFoundError)
@@ -144,51 +199,55 @@ def _read_persisted_out_dir() -> str | None:
     # elsewhere just rm -rf'd, common in CI teardown), and building a path
     # from a value containing an embedded NUL byte — a valid-UTF-8 string can
     # still contain one — raises ValueError from the OS layer the first time
-    # it reaches a syscall (`.resolve()` below), not at the earlier
-    # `read_text()`/`Path(val).is_absolute()` checks. Both must degrade to
-    # "no override", per this function's own contract, not propagate and
-    # abort `graphify.paths` import for every command anywhere near the repo.
+    # it reaches a syscall (inside ``_resolve_persisted_out_dir_target``).
+    # Both must degrade to "no override", per this function's own contract,
+    # not propagate and abort `graphify.paths` import for every command
+    # anywhere near the repo.
     try:
         rc_path = _find_graphifyrc(Path.cwd())
         if rc_path is None:
             return None
-        try:
-            content = rc_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        target = _resolve_persisted_out_dir_target(rc_path)
+        if target is None:
             return None
-        for raw in content.splitlines():
-            line = raw.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, _, val = line.partition("=")
-            if key.strip() != "out_dir":
-                continue
-            val = val.strip()
-            if not val:
-                return None
-            if is_absolute_any_platform(val):
-                # Cross-platform check (not plain Path.is_absolute()): this
-                # value is untrusted repo-committed content that could have
-                # been authored on either OS — see is_absolute_any_platform's
-                # docstring "EXCEPTION" paragraph for why the usual
-                # local-filesystem guidance doesn't apply to this one check.
-                return None  # repo-committed absolute path — refuse, don't honor
-            # Relative: anchor to the repo root (this .graphifyrc's own
-            # directory), not wherever this process happens to be invoked
-            # from — GRAPHIFY_OUT is otherwise always resolved relative to
-            # cwd, so re-express the repo-root-relative value in those terms
-            # when they differ.
-            repo_root = rc_path.parent.resolve()
-            target = (repo_root / val).resolve()
-            try:
-                target.relative_to(repo_root)
-            except ValueError:
-                return None  # escapes the repo root via `..` — refuse, don't honor
-            try:
-                return os.path.relpath(target, Path.cwd())
-            except ValueError:
-                return str(target)  # e.g. different drives on Windows
+        try:
+            return os.path.relpath(target, Path.cwd())
+        except ValueError:
+            return str(target)  # e.g. different drives on Windows
+    except (OSError, ValueError):
         return None
+
+
+def _read_persisted_out_dir_for_root(root: Path) -> str | None:
+    """Like ``_read_persisted_out_dir``, but returns the persisted value
+    relative to ``root`` (the git repo root) instead of the current working
+    directory — for ``.gitattributes`` pattern generation specifically.
+
+    git always interprets a ``.gitattributes`` pattern relative to the repo
+    root, never relative to wherever a command happened to be invoked from.
+    ``_read_persisted_out_dir``'s cwd-relative form is correct for its own
+    purpose (opening a file from the current process's cwd), but reusing it
+    for the pattern too meant `graphify.hooks._merge_attr_line` could
+    receive a `..`-ascending path whenever `hook install` ran from a
+    subdirectory of a repo with a persisted override — which its own
+    `..`-ascending fallback then (correctly, given that input) turned into
+    the wrong default `graphify-out/graph.json`, instead of the actual
+    persisted directory. Looks only at ``root / ".graphifyrc"`` directly
+    (no walking up further) since that is exactly where
+    ``_persist_out_dir`` always writes it, keyed off the same ``root`` a
+    caller here already resolved via ``_git_root``.
+    """
+    try:
+        rc_path = root / ".graphifyrc"
+        if not rc_path.is_file():
+            return None
+        target = _resolve_persisted_out_dir_target(rc_path)
+        if target is None:
+            return None
+        try:
+            return os.path.relpath(target, root.resolve())
+        except ValueError:
+            return str(target)
     except (OSError, ValueError):
         return None
 

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -74,21 +74,25 @@ def _read_persisted_out_dir() -> str | None:
     ``.graphifyrc`` is repo-committed, untrusted content (this project already
     reads it for ``viz_node_limit``) — unlike ``GRAPHIFY_OUT`` the env var,
     which a user sets for themselves, this file can arrive unreviewed via
-    ``git clone``. A *relative* value is therefore anchored to the repo root
-    (``rc_path.parent`` — where ``_register_merge_driver`` always resolves and
-    writes it) and refused outright if it escapes that root via ``..``, rather
-    than letting a cloned repo redirect graphify's file writes anywhere on
-    disk. An *absolute* value is returned as-is: that is an existing,
-    documented, intentional feature (shared/CI output setups, see module
-    docstring) with the same trust level ``GRAPHIFY_OUT`` itself already has,
-    and predates this persistence mechanism.
+    ``git clone`` and applies the moment ANY graphify command runs, with no
+    action from the user beyond that clone. A *relative* value is anchored to
+    the repo root (``rc_path.parent`` — where ``_register_merge_driver``
+    always resolves and writes it) and refused outright if it escapes that
+    root via ``..``. An *absolute* value is refused outright too — unlike a
+    relative one it can't even be checked against the repo boundary, and a
+    committed absolute path would silently redirect every collaborator's
+    output the instant they clone the repo. ``_register_merge_driver`` never
+    persists one for the same reason (`graphify.hooks._persist_out_dir`); an
+    absolute ``GRAPHIFY_OUT`` still works exactly as before when a user sets
+    the env var themselves — this refusal is specific to a value arriving
+    from repo-committed content, not the feature.
     """
     rc_path = _find_graphifyrc(Path.cwd())
     if rc_path is None:
         return None
     try:
         content = rc_path.read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
     for raw in content.splitlines():
         line = raw.strip()
@@ -101,7 +105,7 @@ def _read_persisted_out_dir() -> str | None:
         if not val:
             return None
         if Path(val).is_absolute():
-            return val
+            return None  # repo-committed absolute path — refuse, don't honor
         # Relative: anchor to the repo root (this .graphifyrc's own directory),
         # not wherever this process happens to be invoked from — GRAPHIFY_OUT
         # is otherwise always resolved relative to cwd, so re-express the

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -12,6 +12,17 @@ hardcoded the literal ``"graphify-out"`` and silently ignored the override
 once at import time, matching the previous per-module constants — set
 ``GRAPHIFY_OUT`` before the process starts (the normal worktree/shared-output
 flow) and every reader honours it.
+
+``GRAPHIFY_OUT`` only takes effect when exported in the *current* shell. A
+project that customized its output directory once (env var set at build time)
+gets silently reset to the default the moment someone runs a graphify command
+from a fresh shell, CI job, or IDE-launched terminal that doesn't export it —
+notably ``graphify hook install``, whose generated ``.gitattributes`` merge-
+driver line then points at the wrong path and never fires (#2595-adjacent).
+``graphify hook install`` persists a non-default value to ``./.graphifyrc``
+(``out_dir=...``) precisely so later invocations in a different shell still
+resolve correctly; that persisted value is the third fallback here, below the
+env var and above the hardcoded default.
 """
 
 from __future__ import annotations
@@ -23,7 +34,38 @@ import stat
 import tempfile
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
-GRAPHIFY_OUT = os.environ.get("GRAPHIFY_OUT", "graphify-out")
+
+def _read_persisted_out_dir() -> str | None:
+    """Read ``out_dir=`` from ``./.graphifyrc`` if present.
+
+    Deliberately minimal and independent of ``graphify.hooks._load_graphifyrc``
+    (which also parses ``viz_node_limit``) to avoid a hooks<->paths import
+    cycle: ``hooks`` already imports ``GRAPHIFY_OUT`` from this module, and this
+    runs at import time, before any lazy import could resolve it. Malformed or
+    unreadable files degrade to "no override" rather than raising — this must
+    never block module import.
+    """
+    rc_path = Path(".graphifyrc")
+    if not rc_path.is_file():
+        return None
+    try:
+        content = rc_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        if key.strip() == "out_dir":
+            val = val.strip()
+            return val or None
+    return None
+
+
+GRAPHIFY_OUT = (
+    os.environ.get("GRAPHIFY_OUT") or _read_persisted_out_dir() or "graphify-out"
+)
 
 
 def _atomic_replace(path: "str | Path", write_fn) -> None:

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -196,13 +196,16 @@ def _read_persisted_out_dir() -> str | None:
     # per-call try/excepts: `Path.cwd()` raises OSError (FileNotFoundError)
     # if the invocation directory itself has been deleted out from under the
     # process (rarer, but real — a shell left open in a directory a script
-    # elsewhere just rm -rf'd, common in CI teardown), and building a path
-    # from a value containing an embedded NUL byte — a valid-UTF-8 string can
+    # elsewhere just rm -rf'd, common in CI teardown); building a path from
+    # a value containing an embedded NUL byte — a valid-UTF-8 string can
     # still contain one — raises ValueError from the OS layer the first time
-    # it reaches a syscall (inside ``_resolve_persisted_out_dir_target``).
-    # Both must degrade to "no override", per this function's own contract,
-    # not propagate and abort `graphify.paths` import for every command
-    # anywhere near the repo.
+    # it reaches a syscall; and a symlink loop anywhere in the path being
+    # resolved (`.graphifyrc` is repo-committed, so a cloned repo could ship
+    # one deliberately) raises RuntimeError specifically — pathlib's own
+    # exception for this, not OSError. All three (inside `_find_graphifyrc`
+    # and `_resolve_persisted_out_dir_target`) must degrade to "no override",
+    # per this function's own contract, not propagate and abort
+    # `graphify.paths` import for every command anywhere near the repo.
     try:
         rc_path = _find_graphifyrc(Path.cwd())
         if rc_path is None:
@@ -214,7 +217,7 @@ def _read_persisted_out_dir() -> str | None:
             return os.path.relpath(target, Path.cwd())
         except ValueError:
             return str(target)  # e.g. different drives on Windows
-    except (OSError, ValueError):
+    except (OSError, ValueError, RuntimeError):
         return None
 
 
@@ -248,7 +251,7 @@ def _read_persisted_out_dir_for_root(root: Path) -> str | None:
             return os.path.relpath(target, root.resolve())
         except ValueError:
             return str(target)
-    except (OSError, ValueError):
+    except (OSError, ValueError, RuntimeError):
         return None
 
 

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -65,10 +65,23 @@ def _read_persisted_out_dir() -> str | None:
     unreadable files degrade to "no override" rather than raising — this must
     never block module import.
 
-    Injection (a value that would add an unintended `.gitattributes` line) is
-    rejected at the write site (``graphify.hooks._persist_out_dir``), not
-    here — a value read back via ``str.splitlines()`` can never itself
-    contain a newline, so a line-based check on this side is a no-op.
+    Injection via a literal newline in the value (which would add an
+    unintended `.gitattributes` line) is rejected at the write site
+    (``graphify.hooks._persist_out_dir``), not here — a value read back via
+    ``str.splitlines()`` can never itself contain a newline, so a line-based
+    check on this side is a no-op.
+
+    ``.graphifyrc`` is repo-committed, untrusted content (this project already
+    reads it for ``viz_node_limit``) — unlike ``GRAPHIFY_OUT`` the env var,
+    which a user sets for themselves, this file can arrive unreviewed via
+    ``git clone``. A *relative* value is therefore anchored to the repo root
+    (``rc_path.parent`` — where ``_register_merge_driver`` always resolves and
+    writes it) and refused outright if it escapes that root via ``..``, rather
+    than letting a cloned repo redirect graphify's file writes anywhere on
+    disk. An *absolute* value is returned as-is: that is an existing,
+    documented, intentional feature (shared/CI output setups, see module
+    docstring) with the same trust level ``GRAPHIFY_OUT`` itself already has,
+    and predates this persistence mechanism.
     """
     rc_path = _find_graphifyrc(Path.cwd())
     if rc_path is None:
@@ -82,14 +95,35 @@ def _read_persisted_out_dir() -> str | None:
         if not line or line.startswith("#") or "=" not in line:
             continue
         key, _, val = line.partition("=")
-        if key.strip() == "out_dir":
-            val = val.strip()
-            return val or None
+        if key.strip() != "out_dir":
+            continue
+        val = val.strip()
+        if not val:
+            return None
+        if Path(val).is_absolute():
+            return val
+        # Relative: anchor to the repo root (this .graphifyrc's own directory),
+        # not wherever this process happens to be invoked from — GRAPHIFY_OUT
+        # is otherwise always resolved relative to cwd, so re-express the
+        # repo-root-relative value in those terms when they differ.
+        repo_root = rc_path.parent.resolve()
+        target = (repo_root / val).resolve()
+        try:
+            target.relative_to(repo_root)
+        except ValueError:
+            return None  # escapes the repo root via `..` — refuse, don't honor
+        try:
+            return os.path.relpath(target, Path.cwd())
+        except ValueError:
+            return str(target)  # e.g. different drives on Windows
     return None
 
 
+_env_graphify_out = os.environ.get("GRAPHIFY_OUT")
 GRAPHIFY_OUT = (
-    os.environ.get("GRAPHIFY_OUT") or _read_persisted_out_dir() or "graphify-out"
+    _env_graphify_out
+    if _env_graphify_out is not None
+    else (_read_persisted_out_dir() or "graphify-out")
 )
 
 

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -35,6 +35,56 @@ import tempfile
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 
+def is_absolute_any_platform(p: "str | Path | None") -> bool:
+    """Whether *p* is absolute under POSIX **or** Windows rules.
+
+    ``Path.is_absolute()`` and ``os.path.isabs()`` answer for the HOST os only,
+    which is the wrong question for a path that was *stored* — a ``source_file``
+    in ``graph.json``, a ``prune_sources`` entry, a cache key. Those travel
+    between machines (build in Docker/CI, update on a Windows workstation, or
+    the reverse), so the host's rules do not describe the string in hand:
+
+    - On Windows, ``WindowsPath("/home/ci/repo/docs/a.md").is_absolute()`` is
+      False — no drive letter — so a Linux-built graph's absolute paths read as
+      relative and get baked into node IDs or joined under the scan root (#2618).
+    - On POSIX, ``PosixPath("C:/Users/u/a.md").is_absolute()`` is False for the
+      mirror-image reason (#2197, #1789).
+
+    ``os.path.isabs`` is additionally not stable across supported interpreters:
+    Python 3.13 changed ``ntpath.isabs`` so a path starting with a single slash
+    is no longer absolute, where 3.10–3.12 said it was. The project supports
+    >=3.10, so a guard written on it silently means different things per version.
+
+    Answering for both platforms is the conservative choice for stored paths:
+    treating a path as absolute at worst declines to relativize it (the string is
+    kept as-is), whereas treating an absolute path as relative corrupts identity.
+    Covers drive-letter, UNC, and POSIX-root forms with either separator.
+
+    NOTE: this is for STORED/portable paths. Code resolving a path against the
+    real local filesystem (``cli``, ``detect``, ``hooks``) must keep using
+    ``Path.is_absolute()`` — there the host's rules are exactly right.
+
+    EXCEPTION: a value read from ``.graphifyrc`` and being checked ONLY to
+    decide whether to refuse it as untrusted repo-committed content (see
+    ``_read_persisted_out_dir`` below, and ``graphify.hooks._persist_out_dir``
+    / ``_load_graphifyrc``) is itself a stored/portable value, not a path
+    being resolved against this machine's filesystem — ``.graphifyrc`` can be
+    authored on Windows and read on POSIX or vice versa. Using plain
+    ``Path.is_absolute()`` there let a Windows-absolute value like
+    ``C:/shared`` slip past the refusal on POSIX (and the POSIX-absolute
+    mirror slip past it on Windows), since neither host recognizes the
+    other's absolute form. Those three refusal checks use this function;
+    only the later resolution steps in the same functions (joining onto the
+    repo root, ``.resolve()``, ``relative_to``) keep using plain
+    ``Path.is_absolute()``, since those genuinely do resolve against this
+    process's real filesystem.
+    """
+    if not p:
+        return False
+    s = str(p)
+    return PurePosixPath(s).is_absolute() or PureWindowsPath(s).is_absolute()
+
+
 def _find_graphifyrc(start: Path) -> Path | None:
     """Walk up from `start` looking for `.graphifyrc`, the same way git itself
     walks up looking for `.git` — so a command run from a subdirectory of the
@@ -116,7 +166,12 @@ def _read_persisted_out_dir() -> str | None:
             val = val.strip()
             if not val:
                 return None
-            if Path(val).is_absolute():
+            if is_absolute_any_platform(val):
+                # Cross-platform check (not plain Path.is_absolute()): this
+                # value is untrusted repo-committed content that could have
+                # been authored on either OS — see is_absolute_any_platform's
+                # docstring "EXCEPTION" paragraph for why the usual
+                # local-filesystem guidance doesn't apply to this one check.
                 return None  # repo-committed absolute path — refuse, don't honor
             # Relative: anchor to the repo root (this .graphifyrc's own
             # directory), not wherever this process happens to be invoked
@@ -429,41 +484,6 @@ def default_graph_json() -> str:
     the path is passed explicitly (#1423).
     """
     return str(out_path("graph.json"))
-
-
-def is_absolute_any_platform(p: "str | Path | None") -> bool:
-    """Whether *p* is absolute under POSIX **or** Windows rules.
-
-    ``Path.is_absolute()`` and ``os.path.isabs()`` answer for the HOST os only,
-    which is the wrong question for a path that was *stored* — a ``source_file``
-    in ``graph.json``, a ``prune_sources`` entry, a cache key. Those travel
-    between machines (build in Docker/CI, update on a Windows workstation, or
-    the reverse), so the host's rules do not describe the string in hand:
-
-    - On Windows, ``WindowsPath("/home/ci/repo/docs/a.md").is_absolute()`` is
-      False — no drive letter — so a Linux-built graph's absolute paths read as
-      relative and get baked into node IDs or joined under the scan root (#2618).
-    - On POSIX, ``PosixPath("C:/Users/u/a.md").is_absolute()`` is False for the
-      mirror-image reason (#2197, #1789).
-
-    ``os.path.isabs`` is additionally not stable across supported interpreters:
-    Python 3.13 changed ``ntpath.isabs`` so a path starting with a single slash
-    is no longer absolute, where 3.10–3.12 said it was. The project supports
-    >=3.10, so a guard written on it silently means different things per version.
-
-    Answering for both platforms is the conservative choice for stored paths:
-    treating a path as absolute at worst declines to relativize it (the string is
-    kept as-is), whereas treating an absolute path as relative corrupts identity.
-    Covers drive-letter, UNC, and POSIX-root forms with either separator.
-
-    NOTE: this is for STORED/portable paths. Code resolving a path against the
-    real local filesystem (``cli``, ``detect``, ``hooks``) must keep using
-    ``Path.is_absolute()`` — there the host's rules are exactly right.
-    """
-    if not p:
-        return False
-    s = str(p)
-    return PurePosixPath(s).is_absolute() or PureWindowsPath(s).is_absolute()
 
 
 # Legacy Windows path ceiling. Unless long-path support is enabled *and* every

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1713,3 +1713,105 @@ def test_graphify_out_survives_embedded_null_byte_in_out_dir(tmp_path, monkeypat
         assert paths_mod.GRAPHIFY_OUT == "graphify-out"
     finally:
         importlib.reload(paths_mod)
+
+
+# --- sixth review round: quoted gitattributes entries, dot-dot persistence,
+# uninstall resilience, cross-platform absolute detection (Graphify PR review
+# round 6) ---
+
+def test_has_merge_attr_recognizes_quoted_entry(tmp_path):
+    """A gitattributes pattern with whitespace is C-quoted by convention —
+    a naive whitespace split must not miss an existing quoted entry and
+    treat it as unregistered."""
+    from graphify.hooks import _has_merge_attr
+
+    assert _has_merge_attr('"my dir/graph.json" merge=graphify') is True
+
+
+def test_has_merge_attr_still_recognizes_unquoted_entry():
+    from graphify.hooks import _has_merge_attr
+
+    assert _has_merge_attr("graphify-out/graph.json merge=graphify") is True
+
+
+def test_has_merge_attr_ignores_unterminated_quote():
+    from graphify.hooks import _has_merge_attr
+
+    assert _has_merge_attr('"unterminated/graph.json merge=graphify') is False
+
+
+def test_register_merge_driver_does_not_duplicate_quoted_entry(tmp_path):
+    """A pre-existing, hand-authored quoted entry must be recognized as
+    already registered — not duplicated with a second unquoted line."""
+    from graphify.hooks import _register_merge_driver
+
+    repo = _make_git_repo(tmp_path)
+    attrs = repo / ".gitattributes"
+    attrs.write_text('"graphify-out/graph.json" merge=graphify\n', encoding="utf-8")
+    result = _register_merge_driver(repo)
+    assert "already registered" in result
+    assert attrs.read_text(encoding="utf-8").count("merge=graphify") == 1
+
+
+def test_persist_out_dir_refuses_dotdot_value(tmp_path):
+    """Every reader of this key refuses a `..`-escaping value — persisting
+    one anyway would just write a line silently ignored on the next read."""
+    from graphify.hooks import _persist_out_dir
+
+    with pytest.raises(ValueError, match=r"\.\."):
+        _persist_out_dir(tmp_path, "../shared-graphs")
+    assert not (tmp_path / ".graphifyrc").exists()
+
+
+def test_unregister_merge_driver_survives_clear_out_dir_oserror(tmp_path, monkeypatch):
+    """A failure clearing the persisted out_dir (e.g. unlink() denied by a
+    concurrent process) must not abort the rest of uninstall — git config
+    and .gitattributes cleanup are unrelated and should still happen."""
+    from graphify.hooks import install, uninstall
+    import graphify.hooks as hooks_mod
+
+    repo = _make_git_repo(tmp_path)
+    install(repo)
+
+    def _boom(root):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(hooks_mod, "_clear_persisted_out_dir", _boom)
+    result = uninstall(repo)  # must not raise
+    assert "removed" in result.lower()
+    assert not (repo / ".git" / "hooks" / "post-commit").exists()
+
+
+def test_persist_out_dir_refuses_windows_absolute_path_on_posix(tmp_path):
+    """A Windows-absolute value must be refused even on a POSIX host — plain
+    Path.is_absolute() only recognizes the CURRENT host's absolute forms,
+    but this value is untrusted repo-committed content that could have been
+    authored on either OS."""
+    from graphify.hooks import _persist_out_dir
+
+    with pytest.raises(ValueError, match="absolute"):
+        _persist_out_dir(tmp_path, "C:/shared-graphs")
+
+
+def test_load_graphifyrc_ignores_windows_absolute_out_dir_on_posix(tmp_path):
+    from graphify.hooks import _load_graphifyrc
+
+    rc = tmp_path / ".graphifyrc"
+    rc.write_text("out_dir=C:/shared-graphs\n", encoding="utf-8")
+    cfg = _load_graphifyrc(tmp_path)
+    assert "out_dir" not in cfg
+
+
+def test_read_persisted_out_dir_refuses_windows_absolute_value_on_posix(tmp_path, monkeypatch):
+    import importlib
+    import graphify.paths as paths_mod
+
+    monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".graphifyrc").write_text("out_dir=C:/shared-graphs\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    importlib.reload(paths_mod)
+    try:
+        assert paths_mod.GRAPHIFY_OUT == "graphify-out"
+    finally:
+        importlib.reload(paths_mod)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1888,3 +1888,67 @@ def test_register_merge_driver_correct_from_subdirectory_with_persisted_out_dir(
     assert "registered" in result
     attrs = (repo / ".gitattributes").read_text(encoding="utf-8")
     assert attrs.strip() == ".planning/graphs/graph.json merge=graphify"
+
+
+# --- eighth review round: whitespace/glob rejection at persist time, symlink-
+# loop RuntimeError (Graphify PR review round 8). "is_absolute_any_platform
+# removed" findings were false positives again — same as last round, verified
+# via direct import + full test_paths.py pass, no code change needed.
+
+@pytest.mark.parametrize("bad_value", [
+    "my custom-out",       # space
+    "custom\tout",         # tab
+    "custom*out",          # glob star
+    "custom?out",          # glob question mark
+    "custom[out]",         # character class
+    "!custom-out",         # leading negation
+    "#custom-out",         # leading comment marker
+])
+def test_persist_out_dir_refuses_unsafe_gitattributes_values(tmp_path, bad_value):
+    """Every such value would just make _merge_attr_line fall back to the
+    default anyway — persisting it is immediately useless, same reasoning
+    already applied to `..`-escaping and absolute values."""
+    from graphify.hooks import _persist_out_dir
+
+    with pytest.raises(ValueError, match="unsafe for .gitattributes"):
+        _persist_out_dir(tmp_path, bad_value)
+    assert not (tmp_path / ".graphifyrc").exists()
+
+
+def test_read_persisted_out_dir_survives_symlink_loop(tmp_path, monkeypatch):
+    """A symlink loop in the .graphifyrc's ancestry (repo-committed content
+    could ship one deliberately) raises RuntimeError from Path.resolve() —
+    pathlib's own exception for this, not OSError — must degrade to
+    'no override', not crash module import."""
+    import importlib
+    import graphify.paths as paths_mod
+
+    monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".graphifyrc").write_text("out_dir=.planning/graphs\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    def _boom(self):
+        raise RuntimeError("Symlink loop from '...'")
+
+    monkeypatch.setattr("pathlib.Path.resolve", _boom)
+    importlib.reload(paths_mod)  # must not raise
+    try:
+        assert paths_mod.GRAPHIFY_OUT == "graphify-out"
+    finally:
+        monkeypatch.undo()
+        importlib.reload(paths_mod)
+
+
+def test_read_persisted_out_dir_for_root_survives_symlink_loop(tmp_path, monkeypatch):
+    from graphify.hooks import _persist_out_dir
+
+    repo = _make_git_repo(tmp_path)
+    _persist_out_dir(repo, ".planning/graphs")
+    import graphify.paths as paths_mod
+
+    def _boom(self):
+        raise RuntimeError("Symlink loop from '...'")
+
+    monkeypatch.setattr("pathlib.Path.resolve", _boom)
+    assert paths_mod._read_persisted_out_dir_for_root(repo) is None  # must not raise

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1454,21 +1454,21 @@ def test_graphify_out_empty_env_var_preserved_not_overridden(tmp_path, monkeypat
         importlib.reload(paths_mod)
 
 
-def test_merge_attr_line_falls_back_on_dotdot_ascending_path(monkeypatch):
+def test_merge_attr_line_falls_back_on_dotdot_ascending_path(tmp_path, monkeypatch):
     """A `..`-ascending GRAPHIFY_OUT can't be expressed as a gitattributes
     pattern (same reason an absolute path can't) — must fall back to default."""
     from graphify.hooks import _merge_attr_line
     import graphify.paths as paths_mod
 
     monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", "../../shared-graphs")
-    assert _merge_attr_line() == "graphify-out/graph.json merge=graphify"
+    assert _merge_attr_line(tmp_path) == "graphify-out/graph.json merge=graphify"
 
 
 # --- third review round: .gitattributes still reachable via raw newline,
 # TOCTOU on symlink checks, lenient empty out_dir, absolute persisted paths,
 # and non-UTF8 .graphifyrc crashing import (Graphify PR review round 3) ---
 
-def test_merge_attr_line_falls_back_on_newline_graphify_out(monkeypatch):
+def test_merge_attr_line_falls_back_on_newline_graphify_out(tmp_path, monkeypatch):
     """The actual injection point: _persist_out_dir rejecting a newline before
     writing .graphifyrc does not stop _merge_attr_line from reading the SAME
     raw (never-persisted) GRAPHIFY_OUT and writing it into .gitattributes."""
@@ -1476,7 +1476,7 @@ def test_merge_attr_line_falls_back_on_newline_graphify_out(monkeypatch):
     import graphify.paths as paths_mod
 
     monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", "custom\nout_dir=/etc/injected")
-    assert _merge_attr_line() == "graphify-out/graph.json merge=graphify"
+    assert _merge_attr_line(tmp_path) == "graphify-out/graph.json merge=graphify"
 
 
 def test_write_text_no_symlink_refuses_symlink(tmp_path):
@@ -1581,7 +1581,7 @@ def test_write_text_no_symlink_cleans_up_tmp_on_write_failure(tmp_path, monkeypa
     assert leftovers == [], f"temp file leaked: {leftovers}"
 
 
-def test_merge_attr_line_falls_back_on_space_in_graphify_out(monkeypatch):
+def test_merge_attr_line_falls_back_on_space_in_graphify_out(tmp_path, monkeypatch):
     """A space in GRAPHIFY_OUT would split the gitattributes line into more
     fields than intended (pattern attr1 attr2 ...) — same fallback as an
     absolute or `..`-ascending path."""
@@ -1589,15 +1589,15 @@ def test_merge_attr_line_falls_back_on_space_in_graphify_out(monkeypatch):
     import graphify.paths as paths_mod
 
     monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", "my custom-out")
-    assert _merge_attr_line() == "graphify-out/graph.json merge=graphify"
+    assert _merge_attr_line(tmp_path) == "graphify-out/graph.json merge=graphify"
 
 
-def test_merge_attr_line_falls_back_on_tab_in_graphify_out(monkeypatch):
+def test_merge_attr_line_falls_back_on_tab_in_graphify_out(tmp_path, monkeypatch):
     from graphify.hooks import _merge_attr_line
     import graphify.paths as paths_mod
 
     monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", "custom\tout")
-    assert _merge_attr_line() == "graphify-out/graph.json merge=graphify"
+    assert _merge_attr_line(tmp_path) == "graphify-out/graph.json merge=graphify"
 
 
 def test_clear_persisted_out_dir_survives_non_utf8_graphifyrc(tmp_path):
@@ -1815,3 +1815,76 @@ def test_read_persisted_out_dir_refuses_windows_absolute_value_on_posix(tmp_path
         assert paths_mod.GRAPHIFY_OUT == "graphify-out"
     finally:
         importlib.reload(paths_mod)
+
+
+# --- seventh review round: non-UTF8 existing .graphifyrc on persist, glob
+# metacharacters in gitattributes patterns, repo-root-relative merge-attr
+# generation (Graphify PR review round 7). Findings "Removed cross-platform
+# absolute-path helper" and "Removed public path helper" were false
+# positives from moving is_absolute_any_platform earlier in paths.py (a
+# move, not a removal) — verified via existing test_paths.py coverage and
+# a direct import check, no test needed for a non-bug.
+
+def test_persist_out_dir_survives_non_utf8_existing_content(tmp_path):
+    """A corrupted/non-UTF-8 EXISTING .graphifyrc must not crash persisting
+    a new value — the current sole caller already tolerates this via its own
+    except (OSError, ValueError), but guarded internally too so it stays
+    true for any future caller."""
+    from graphify.hooks import _persist_out_dir, _load_graphifyrc
+
+    rc = tmp_path / ".graphifyrc"
+    rc.write_bytes(b"\xff\xfe\x00bad")
+    _persist_out_dir(tmp_path, "custom-out")  # must not raise
+    assert _load_graphifyrc(tmp_path).get("out_dir") == "custom-out"
+
+
+@pytest.mark.parametrize("glob_char", ["*", "?", "[", "]", "!"])
+def test_merge_attr_line_falls_back_on_glob_metacharacter(tmp_path, monkeypatch, glob_char):
+    """A glob metacharacter in GRAPHIFY_OUT changes what the gitattributes
+    PATTERN matches instead of being a literal path segment — e.g. "*"
+    would match graph.json under every top-level directory."""
+    from graphify.hooks import _merge_attr_line
+    import graphify.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", f"custom{glob_char}out")
+    assert _merge_attr_line(tmp_path) == "graphify-out/graph.json merge=graphify"
+
+
+def test_merge_attr_line_falls_back_on_leading_hash(tmp_path, monkeypatch):
+    """A leading # would make the whole generated .gitattributes line a
+    comment — silently registering nothing while reporting success."""
+    from graphify.hooks import _merge_attr_line
+    import graphify.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", "#custom-out")
+    assert _merge_attr_line(tmp_path) == "graphify-out/graph.json merge=graphify"
+
+
+def test_merge_attr_line_uses_repo_root_relative_persisted_value_from_subdir(tmp_path):
+    """The exact interaction bug: a persisted out_dir re-expressed relative
+    to a nested cwd is a `..`-ascending path that _merge_attr_line's own
+    guard then (correctly, given that input) falls back to default for —
+    but the actual .gitattributes line generated from `root` should use
+    the persisted directory, not silently revert to the wrong default."""
+    from graphify.hooks import _merge_attr_line, _persist_out_dir
+
+    repo = _make_git_repo(tmp_path)
+    _persist_out_dir(repo, ".planning/graphs")
+    assert _merge_attr_line(repo) == ".planning/graphs/graph.json merge=graphify"
+
+
+def test_register_merge_driver_correct_from_subdirectory_with_persisted_out_dir(tmp_path, monkeypatch):
+    """End-to-end: hook install run from a subdirectory of a repo that
+    already has a persisted out_dir must generate the correct
+    .gitattributes line, not fall back to the wrong default."""
+    from graphify.hooks import _persist_out_dir, _register_merge_driver
+
+    repo = _make_git_repo(tmp_path)
+    _persist_out_dir(repo, ".planning/graphs")
+    subdir = repo / "src" / "nested"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+    result = _register_merge_driver(repo)
+    assert "registered" in result
+    attrs = (repo / ".gitattributes").read_text(encoding="utf-8")
+    assert attrs.strip() == ".planning/graphs/graph.json merge=graphify"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1287,3 +1287,98 @@ def test_read_persisted_out_dir_env_var_takes_precedence(tmp_path, monkeypatch):
     finally:
         monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
         importlib.reload(paths_mod)
+
+
+# --- review follow-up: root-walk resolution, injection guard, uninstall reset ---
+# (Graphify PR review on #3207: _read_persisted_out_dir used cwd instead of
+# walking to the repo root; a newline in GRAPHIFY_OUT could inject an extra
+# .gitattributes line; a persisted out_dir had no way back to default.)
+
+def test_read_persisted_out_dir_found_from_subdirectory(tmp_path, monkeypatch):
+    """A .graphifyrc at the repo root is found when invoked from a subdir —
+    mirrors how _register_merge_driver always writes to the git root, not cwd."""
+    import importlib
+    import graphify.paths as paths_mod
+
+    monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".graphifyrc").write_text("out_dir=.planning/graphs\n", encoding="utf-8")
+    subdir = tmp_path / "src" / "nested"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+    importlib.reload(paths_mod)
+    try:
+        assert paths_mod.GRAPHIFY_OUT == ".planning/graphs"
+    finally:
+        importlib.reload(paths_mod)
+
+
+def test_read_persisted_out_dir_stops_at_git_boundary(tmp_path, monkeypatch):
+    """A .graphifyrc outside the repo (in some unrelated parent directory)
+    must never be picked up — the walk stops at the first .git it meets."""
+    import importlib
+    import graphify.paths as paths_mod
+
+    monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+    (tmp_path / ".graphifyrc").write_text("out_dir=should-not-be-used\n", encoding="utf-8")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    monkeypatch.chdir(repo)
+    importlib.reload(paths_mod)
+    try:
+        assert paths_mod.GRAPHIFY_OUT == "graphify-out"
+    finally:
+        importlib.reload(paths_mod)
+
+
+def test_persist_out_dir_rejects_newline(tmp_path):
+    """A GRAPHIFY_OUT containing a newline must never reach the file verbatim —
+    it would inject an unrelated extra line into .graphifyrc/.gitattributes."""
+    from graphify.hooks import _persist_out_dir
+
+    with pytest.raises(ValueError, match="newline"):
+        _persist_out_dir(tmp_path, "custom-out\nout_dir=/etc/injected")
+    assert not (tmp_path / ".graphifyrc").exists()
+
+
+def test_register_merge_driver_swallows_persist_value_error(tmp_path, monkeypatch):
+    """A malformed GRAPHIFY_OUT must not abort hook install — the merge-driver
+    git config registration this run still applies even if persistence is skipped."""
+    from graphify.hooks import _register_merge_driver
+    import graphify.paths as paths_mod
+
+    repo = _make_git_repo(tmp_path)
+    monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", "bad\nvalue")
+    result = _register_merge_driver(repo)  # must not raise
+    assert not (repo / ".graphifyrc").exists()
+    assert "registered" in result or "skipped" in result
+
+
+def test_uninstall_clears_persisted_out_dir(tmp_path, monkeypatch):
+    """hook uninstall is the way back to default after a persisted out_dir —
+    there was previously no path back short of hand-editing .graphifyrc."""
+    from graphify.hooks import _register_merge_driver, _unregister_merge_driver, _load_graphifyrc
+    import graphify.paths as paths_mod2
+
+    repo = _make_git_repo(tmp_path)
+    monkeypatch.setattr(paths_mod2, "GRAPHIFY_OUT", "custom-out")
+    _register_merge_driver(repo)
+    assert _load_graphifyrc(repo).get("out_dir") == "custom-out"
+
+    result = _unregister_merge_driver(repo)
+    assert "out_dir" in result
+    assert _load_graphifyrc(repo).get("out_dir") is None
+
+
+def test_uninstall_preserves_other_graphifyrc_keys_while_clearing_out_dir(tmp_path):
+    from graphify.hooks import _persist_out_dir, _unregister_merge_driver, _load_graphifyrc
+
+    repo = _make_git_repo(tmp_path)
+    rc = repo / ".graphifyrc"
+    rc.write_text("viz_node_limit=0\n", encoding="utf-8")
+    _persist_out_dir(repo, "custom-out")
+    _unregister_merge_driver(repo)
+    cfg = _load_graphifyrc(repo)
+    assert cfg.get("out_dir") is None
+    assert cfg.get("viz_node_limit") == 0

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1180,13 +1180,16 @@ def test_load_graphifyrc_reads_out_dir(tmp_path):
     assert cfg.get("out_dir") == ".planning/graphs"
 
 
-def test_load_graphifyrc_rejects_empty_out_dir(tmp_path):
+def test_load_graphifyrc_treats_empty_out_dir_as_absent(tmp_path):
+    """An empty out_dir= must not crash install() over a harmless stale line —
+    unlike viz_node_limit, blank is a plausible hand-edit meaning 'cleared',
+    and this key is read unconditionally on every hook install."""
     from graphify.hooks import _load_graphifyrc
 
     rc = tmp_path / ".graphifyrc"
     rc.write_text("out_dir=\n", encoding="utf-8")
-    with pytest.raises(ValueError, match="Invalid out_dir"):
-        _load_graphifyrc(tmp_path)
+    cfg = _load_graphifyrc(tmp_path)
+    assert "out_dir" not in cfg
 
 
 def test_persist_out_dir_writes_new_file(tmp_path):
@@ -1459,3 +1462,85 @@ def test_merge_attr_line_falls_back_on_dotdot_ascending_path(monkeypatch):
 
     monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", "../../shared-graphs")
     assert _merge_attr_line() == "graphify-out/graph.json merge=graphify"
+
+
+# --- third review round: .gitattributes still reachable via raw newline,
+# TOCTOU on symlink checks, lenient empty out_dir, absolute persisted paths,
+# and non-UTF8 .graphifyrc crashing import (Graphify PR review round 3) ---
+
+def test_merge_attr_line_falls_back_on_newline_graphify_out(monkeypatch):
+    """The actual injection point: _persist_out_dir rejecting a newline before
+    writing .graphifyrc does not stop _merge_attr_line from reading the SAME
+    raw (never-persisted) GRAPHIFY_OUT and writing it into .gitattributes."""
+    from graphify.hooks import _merge_attr_line
+    import graphify.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", "custom\nout_dir=/etc/injected")
+    assert _merge_attr_line() == "graphify-out/graph.json merge=graphify"
+
+
+def test_write_text_no_symlink_refuses_symlink(tmp_path):
+    from graphify.hooks import _write_text_no_symlink
+
+    target = tmp_path / "elsewhere.txt"
+    target.write_text("do not touch\n", encoding="utf-8")
+    link = tmp_path / "linked.txt"
+    link.symlink_to(target)
+
+    assert _write_text_no_symlink(link, "new content\n") is False
+    assert target.read_text(encoding="utf-8") == "do not touch\n"
+
+
+def test_write_text_no_symlink_writes_normal_file(tmp_path):
+    from graphify.hooks import _write_text_no_symlink
+
+    path = tmp_path / "plain.txt"
+    assert _write_text_no_symlink(path, "hello\n") is True
+    assert path.read_text(encoding="utf-8") == "hello\n"
+
+
+def test_persist_out_dir_refuses_absolute_path(tmp_path):
+    """.graphifyrc is repo-committed; an absolute out_dir there would silently
+    redirect every collaborator's output the moment they clone and run
+    graphify. Refused at the write site so it can never even be committed
+    through graphify's own tooling."""
+    from graphify.hooks import _persist_out_dir
+
+    with pytest.raises(ValueError, match="absolute"):
+        _persist_out_dir(tmp_path, "/etc/shared-graphs")
+    assert not (tmp_path / ".graphifyrc").exists()
+
+
+def test_read_persisted_out_dir_refuses_absolute_value(tmp_path, monkeypatch):
+    """Defense in depth: even a hand-crafted/malicious .graphifyrc with an
+    absolute out_dir (never went through _persist_out_dir) must not be
+    honored on read."""
+    import importlib
+    import graphify.paths as paths_mod
+
+    monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".graphifyrc").write_text("out_dir=/etc/shared-graphs\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    importlib.reload(paths_mod)
+    try:
+        assert paths_mod.GRAPHIFY_OUT == "graphify-out"
+    finally:
+        importlib.reload(paths_mod)
+
+
+def test_graphify_out_survives_non_utf8_graphifyrc(tmp_path, monkeypatch):
+    """A corrupted/binary .graphifyrc must degrade to 'no override', not crash
+    module import for every graphify command run anywhere near this repo."""
+    import importlib
+    import graphify.paths as paths_mod
+
+    monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".graphifyrc").write_bytes(b"out_dir=\xff\xfe\x00bad")
+    monkeypatch.chdir(tmp_path)
+    importlib.reload(paths_mod)  # must not raise
+    try:
+        assert paths_mod.GRAPHIFY_OUT == "graphify-out"
+    finally:
+        importlib.reload(paths_mod)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1621,3 +1621,95 @@ def test_uninstall_survives_non_utf8_graphifyrc(tmp_path):
     result = uninstall(repo)  # must not raise
     assert "removed" in result.lower()
     assert not (repo / ".git" / "hooks" / "post-commit").exists()
+
+
+# --- fifth review round: hooks.py's out_dir reader kept in sync with paths.py's
+# refusal policy, idempotent persistence, cwd-unavailable and NUL-byte crashes
+# in module import (Graphify PR review round 5) ---
+
+def test_load_graphifyrc_ignores_absolute_out_dir(tmp_path):
+    """No current consumer reads cfg['out_dir'], but this parses the same
+    file/key graphify.paths._read_persisted_out_dir does, and that function
+    refuses an absolute value for a concrete reason — keep them in sync so a
+    future consumer doesn't silently reintroduce the vulnerability."""
+    from graphify.hooks import _load_graphifyrc
+
+    rc = tmp_path / ".graphifyrc"
+    rc.write_text("out_dir=/etc/shared-graphs\n", encoding="utf-8")
+    cfg = _load_graphifyrc(tmp_path)
+    assert "out_dir" not in cfg
+
+
+def test_load_graphifyrc_ignores_dotdot_out_dir(tmp_path):
+    from graphify.hooks import _load_graphifyrc
+
+    rc = tmp_path / ".graphifyrc"
+    rc.write_text("out_dir=../../etc/evil\n", encoding="utf-8")
+    cfg = _load_graphifyrc(tmp_path)
+    assert "out_dir" not in cfg
+
+
+def test_load_graphifyrc_accepts_safe_relative_out_dir(tmp_path):
+    from graphify.hooks import _load_graphifyrc
+
+    rc = tmp_path / ".graphifyrc"
+    rc.write_text("out_dir=.planning/graphs\n", encoding="utf-8")
+    cfg = _load_graphifyrc(tmp_path)
+    assert cfg.get("out_dir") == ".planning/graphs"
+
+
+def test_persist_out_dir_skips_rewrite_when_unchanged(tmp_path):
+    """A repeated `hook install` with the same GRAPHIFY_OUT must not rewrite
+    .graphifyrc every time (needless I/O/mtime churn on the common case)."""
+    from graphify.hooks import _persist_out_dir
+
+    _persist_out_dir(tmp_path, "custom-out")
+    rc = tmp_path / ".graphifyrc"
+    mtime_before = rc.stat().st_mtime_ns
+    _persist_out_dir(tmp_path, "custom-out")  # same value again
+    assert rc.stat().st_mtime_ns == mtime_before
+
+
+def test_persist_out_dir_still_rewrites_when_value_changes(tmp_path):
+    from graphify.hooks import _persist_out_dir, _load_graphifyrc
+
+    _persist_out_dir(tmp_path, "old-out")
+    _persist_out_dir(tmp_path, "new-out")
+    assert _load_graphifyrc(tmp_path).get("out_dir") == "new-out"
+
+
+def test_graphify_out_survives_cwd_deleted(tmp_path, monkeypatch):
+    """A shell left open in a directory something else deleted must not
+    crash graphify.paths import — Path.cwd() raises FileNotFoundError."""
+    import importlib
+    import graphify.paths as paths_mod
+
+    monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+    monkeypatch.setattr(
+        "pathlib.Path.cwd",
+        classmethod(lambda cls: (_ for _ in ()).throw(FileNotFoundError("cwd gone"))),
+    )
+    importlib.reload(paths_mod)  # must not raise
+    try:
+        assert paths_mod.GRAPHIFY_OUT == "graphify-out"
+    finally:
+        importlib.reload(paths_mod)
+
+
+def test_graphify_out_survives_embedded_null_byte_in_out_dir(tmp_path, monkeypatch):
+    """A valid-UTF-8 .graphifyrc value can still contain an embedded NUL
+    byte, which raises ValueError from the OS layer the first time it
+    reaches a real filesystem call (Path.resolve()) — must degrade to
+    'no override', not crash import."""
+    import importlib
+    import graphify.paths as paths_mod
+
+    monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".graphifyrc").write_text("out_dir=bad\x00dir\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    importlib.reload(paths_mod)  # must not raise
+    try:
+        assert paths_mod.GRAPHIFY_OUT == "graphify-out"
+    finally:
+        importlib.reload(paths_mod)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1294,25 +1294,6 @@ def test_read_persisted_out_dir_env_var_takes_precedence(tmp_path, monkeypatch):
 # walking to the repo root; a newline in GRAPHIFY_OUT could inject an extra
 # .gitattributes line; a persisted out_dir had no way back to default.)
 
-def test_read_persisted_out_dir_found_from_subdirectory(tmp_path, monkeypatch):
-    """A .graphifyrc at the repo root is found when invoked from a subdir —
-    mirrors how _register_merge_driver always writes to the git root, not cwd."""
-    import importlib
-    import graphify.paths as paths_mod
-
-    monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
-    (tmp_path / ".git").mkdir()
-    (tmp_path / ".graphifyrc").write_text("out_dir=.planning/graphs\n", encoding="utf-8")
-    subdir = tmp_path / "src" / "nested"
-    subdir.mkdir(parents=True)
-    monkeypatch.chdir(subdir)
-    importlib.reload(paths_mod)
-    try:
-        assert paths_mod.GRAPHIFY_OUT == ".planning/graphs"
-    finally:
-        importlib.reload(paths_mod)
-
-
 def test_read_persisted_out_dir_stops_at_git_boundary(tmp_path, monkeypatch):
     """A .graphifyrc outside the repo (in some unrelated parent directory)
     must never be picked up — the walk stops at the first .git it meets."""
@@ -1382,3 +1363,99 @@ def test_uninstall_preserves_other_graphifyrc_keys_while_clearing_out_dir(tmp_pa
     cfg = _load_graphifyrc(repo)
     assert cfg.get("out_dir") is None
     assert cfg.get("viz_node_limit") == 0
+
+
+# --- second review round: repo-root anchoring, escape refusal, symlink guard,
+# empty-env-var edge case (Graphify PR review round 2 on #3207) ---
+
+def test_persist_out_dir_refuses_symlinked_graphifyrc(tmp_path):
+    from graphify.hooks import _persist_out_dir
+
+    target = tmp_path / "elsewhere.txt"
+    target.write_text("do not touch\n", encoding="utf-8")
+    rc_link = tmp_path / ".graphifyrc"
+    rc_link.symlink_to(target)
+
+    with pytest.raises(ValueError, match="symlink"):
+        _persist_out_dir(tmp_path, "custom-out")
+    assert target.read_text(encoding="utf-8") == "do not touch\n"
+
+
+def test_clear_persisted_out_dir_refuses_symlinked_graphifyrc(tmp_path):
+    from graphify.hooks import _clear_persisted_out_dir
+
+    target = tmp_path / "elsewhere.txt"
+    target.write_text("out_dir=untouched\n", encoding="utf-8")
+    rc_link = tmp_path / ".graphifyrc"
+    rc_link.symlink_to(target)
+
+    assert _clear_persisted_out_dir(tmp_path) is False
+    assert target.read_text(encoding="utf-8") == "out_dir=untouched\n"
+
+
+def test_read_persisted_out_dir_relative_value_reexpressed_for_subdir_invocation(tmp_path, monkeypatch):
+    """A repo-root-relative out_dir must resolve to the SAME directory whether
+    invoked from the repo root or a nested subdirectory — not a naive
+    cwd-relative join, which would silently create a phantom directory."""
+    import importlib
+    import graphify.paths as paths_mod
+
+    monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".graphifyrc").write_text("out_dir=.planning/graphs\n", encoding="utf-8")
+    subdir = tmp_path / "src" / "nested"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+    importlib.reload(paths_mod)
+    try:
+        resolved = (subdir / paths_mod.GRAPHIFY_OUT).resolve()
+        assert resolved == (tmp_path / ".planning" / "graphs").resolve()
+    finally:
+        importlib.reload(paths_mod)
+
+
+def test_read_persisted_out_dir_refuses_dotdot_escape(tmp_path, monkeypatch):
+    """A relative out_dir that climbs above the repo root via `..` must be
+    refused, not honored — .graphifyrc is repo-committed, untrusted content."""
+    import importlib
+    import graphify.paths as paths_mod
+
+    monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".graphifyrc").write_text("out_dir=../../etc/evil\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    importlib.reload(paths_mod)
+    try:
+        assert paths_mod.GRAPHIFY_OUT == "graphify-out"
+    finally:
+        importlib.reload(paths_mod)
+
+
+def test_graphify_out_empty_env_var_preserved_not_overridden(tmp_path, monkeypatch):
+    """GRAPHIFY_OUT="" (explicitly set, even if empty) must behave like the
+    pre-persistence os.environ.get(key, default) contract: present-but-empty
+    wins over any fallback, it does not fall through to the persisted/default
+    value the way `os.environ.get(...) or fallback` would."""
+    import importlib
+    import graphify.paths as paths_mod
+
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".graphifyrc").write_text("out_dir=should-not-win\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GRAPHIFY_OUT", "")
+    importlib.reload(paths_mod)
+    try:
+        assert paths_mod.GRAPHIFY_OUT == ""
+    finally:
+        monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+        importlib.reload(paths_mod)
+
+
+def test_merge_attr_line_falls_back_on_dotdot_ascending_path(monkeypatch):
+    """A `..`-ascending GRAPHIFY_OUT can't be expressed as a gitattributes
+    pattern (same reason an absolute path can't) — must fall back to default."""
+    from graphify.hooks import _merge_attr_line
+    import graphify.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", "../../shared-graphs")
+    assert _merge_attr_line() == "graphify-out/graph.json merge=graphify"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1544,3 +1544,80 @@ def test_graphify_out_survives_non_utf8_graphifyrc(tmp_path, monkeypatch):
         assert paths_mod.GRAPHIFY_OUT == "graphify-out"
     finally:
         importlib.reload(paths_mod)
+
+
+# --- fourth review round: atomic write (truncate visibility), whitespace
+# injection, non-UTF8 uninstall crash (Graphify PR review round 4) ---
+
+def test_write_text_no_symlink_leaves_no_tmp_file_on_success(tmp_path):
+    from graphify.hooks import _write_text_no_symlink
+
+    path = tmp_path / "plain.txt"
+    assert _write_text_no_symlink(path, "hello\n") is True
+    leftovers = [p for p in tmp_path.iterdir() if p.name != "plain.txt"]
+    assert leftovers == []
+
+
+def test_write_text_no_symlink_overwrites_existing_content(tmp_path):
+    from graphify.hooks import _write_text_no_symlink
+
+    path = tmp_path / "plain.txt"
+    path.write_text("old\n", encoding="utf-8")
+    assert _write_text_no_symlink(path, "new\n") is True
+    assert path.read_text(encoding="utf-8") == "new\n"
+
+
+def test_write_text_no_symlink_cleans_up_tmp_on_write_failure(tmp_path, monkeypatch):
+    from graphify.hooks import _write_text_no_symlink
+
+    def _boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("os.fdopen", _boom)
+    path = tmp_path / "plain.txt"
+    with pytest.raises(OSError):
+        _write_text_no_symlink(path, "content\n")
+    leftovers = list(tmp_path.iterdir())
+    assert leftovers == [], f"temp file leaked: {leftovers}"
+
+
+def test_merge_attr_line_falls_back_on_space_in_graphify_out(monkeypatch):
+    """A space in GRAPHIFY_OUT would split the gitattributes line into more
+    fields than intended (pattern attr1 attr2 ...) — same fallback as an
+    absolute or `..`-ascending path."""
+    from graphify.hooks import _merge_attr_line
+    import graphify.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", "my custom-out")
+    assert _merge_attr_line() == "graphify-out/graph.json merge=graphify"
+
+
+def test_merge_attr_line_falls_back_on_tab_in_graphify_out(monkeypatch):
+    from graphify.hooks import _merge_attr_line
+    import graphify.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", "custom\tout")
+    assert _merge_attr_line() == "graphify-out/graph.json merge=graphify"
+
+
+def test_clear_persisted_out_dir_survives_non_utf8_graphifyrc(tmp_path):
+    """hook uninstall must not crash over a corrupted .graphifyrc — same
+    leniency as the read side in graphify.paths."""
+    from graphify.hooks import _clear_persisted_out_dir
+
+    rc = tmp_path / ".graphifyrc"
+    rc.write_bytes(b"out_dir=\xff\xfe\x00bad")
+    assert _clear_persisted_out_dir(tmp_path) is False
+
+
+def test_uninstall_survives_non_utf8_graphifyrc(tmp_path):
+    """End-to-end: hook uninstall must complete (removing hooks/git config/
+    .gitattributes) even when .graphifyrc itself is corrupted."""
+    from graphify.hooks import install, uninstall
+
+    repo = _make_git_repo(tmp_path)
+    install(repo)
+    (repo / ".graphifyrc").write_bytes(b"out_dir=\xff\xfe\x00bad")
+    result = uninstall(repo)  # must not raise
+    assert "removed" in result.lower()
+    assert not (repo / ".git" / "hooks" / "post-commit").exists()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1167,3 +1167,123 @@ def test_rebuild_bodies_tolerate_a_bom_in_graphify_root(name, body):
     assert "encoding='utf-8')" not in body, (
         f"{name} rebuild body still has a BOM-intolerant read"
     )
+
+
+# --- merge-driver out_dir persistence + gitignore skip (#2595) -------------
+
+def test_load_graphifyrc_reads_out_dir(tmp_path):
+    from graphify.hooks import _load_graphifyrc
+
+    rc = tmp_path / ".graphifyrc"
+    rc.write_text("out_dir=.planning/graphs\n", encoding="utf-8")
+    cfg = _load_graphifyrc(tmp_path)
+    assert cfg.get("out_dir") == ".planning/graphs"
+
+
+def test_load_graphifyrc_rejects_empty_out_dir(tmp_path):
+    from graphify.hooks import _load_graphifyrc
+
+    rc = tmp_path / ".graphifyrc"
+    rc.write_text("out_dir=\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Invalid out_dir"):
+        _load_graphifyrc(tmp_path)
+
+
+def test_persist_out_dir_writes_new_file(tmp_path):
+    from graphify.hooks import _persist_out_dir, _load_graphifyrc
+
+    _persist_out_dir(tmp_path, ".planning/graphs")
+    cfg = _load_graphifyrc(tmp_path)
+    assert cfg.get("out_dir") == ".planning/graphs"
+
+
+def test_persist_out_dir_preserves_other_keys_and_replaces_existing(tmp_path):
+    from graphify.hooks import _persist_out_dir, _load_graphifyrc
+
+    rc = tmp_path / ".graphifyrc"
+    rc.write_text("viz_node_limit=0\nout_dir=old-dir\n", encoding="utf-8")
+    _persist_out_dir(tmp_path, "new-dir")
+    cfg = _load_graphifyrc(tmp_path)
+    assert cfg.get("viz_node_limit") == 0
+    assert cfg.get("out_dir") == "new-dir"
+    # exactly one out_dir line, not two
+    lines = [l for l in rc.read_text(encoding="utf-8").splitlines() if l.startswith("out_dir=")]
+    assert lines == ["out_dir=new-dir"]
+
+
+def test_register_merge_driver_persists_nondefault_graphify_out(tmp_path, monkeypatch):
+    from graphify.hooks import _register_merge_driver, _load_graphifyrc
+    import graphify.paths as paths_mod
+
+    repo = _make_git_repo(tmp_path)
+    monkeypatch.setattr(paths_mod, "GRAPHIFY_OUT", "custom-out")
+    _register_merge_driver(repo)
+    cfg = _load_graphifyrc(repo)
+    assert cfg.get("out_dir") == "custom-out"
+    assert (repo / ".gitattributes").read_text(encoding="utf-8").strip() == (
+        "custom-out/graph.json merge=graphify"
+    )
+
+
+def test_register_merge_driver_skips_default_out_dir_persistence(tmp_path):
+    """No .graphifyrc noise for the common case (no override in play)."""
+    from graphify.hooks import _register_merge_driver
+
+    repo = _make_git_repo(tmp_path)
+    _register_merge_driver(repo)
+    assert not (repo / ".graphifyrc").exists()
+
+
+def test_register_merge_driver_skips_gitignored_target(tmp_path):
+    """#2595: a merge driver for an ignored, untracked path never runs."""
+    from graphify.hooks import _register_merge_driver, _merge_driver_status
+
+    repo = _make_git_repo(tmp_path)
+    (repo / ".gitignore").write_text("graphify-out/\n", encoding="utf-8")
+    result = _register_merge_driver(repo)
+    assert "skipped" in result
+    assert "gitignored" in result
+    assert not (repo / ".gitattributes").exists()
+    status = _merge_driver_status(repo)
+    assert status.startswith("not applicable")
+
+
+def test_register_merge_driver_registers_when_not_gitignored(tmp_path):
+    from graphify.hooks import _register_merge_driver, _merge_driver_status
+
+    repo = _make_git_repo(tmp_path)
+    result = _register_merge_driver(repo)
+    assert result.startswith("registered")
+    assert _merge_driver_status(repo) == "registered"
+
+
+def test_read_persisted_out_dir_used_when_env_var_unset(tmp_path, monkeypatch):
+    """paths.GRAPHIFY_OUT falls back to .graphifyrc when the env var is absent —
+    the exact gap that let a fresh shell/CI job silently reset a project's
+    customized output directory (#2595-adjacent)."""
+    import importlib
+    import graphify.paths as paths_mod
+
+    monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".graphifyrc").write_text("out_dir=.planning/graphs\n", encoding="utf-8")
+    importlib.reload(paths_mod)
+    try:
+        assert paths_mod.GRAPHIFY_OUT == ".planning/graphs"
+    finally:
+        importlib.reload(paths_mod)  # restore real cwd/env for later tests
+
+
+def test_read_persisted_out_dir_env_var_takes_precedence(tmp_path, monkeypatch):
+    import importlib
+    import graphify.paths as paths_mod
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".graphifyrc").write_text("out_dir=.planning/graphs\n", encoding="utf-8")
+    monkeypatch.setenv("GRAPHIFY_OUT", "env-wins")
+    importlib.reload(paths_mod)
+    try:
+        assert paths_mod.GRAPHIFY_OUT == "env-wins"
+    finally:
+        monkeypatch.delenv("GRAPHIFY_OUT", raising=False)
+        importlib.reload(paths_mod)


### PR DESCRIPTION
## Summary

- `graphify.paths.GRAPHIFY_OUT` reads the env var once at import and falls back straight to the hardcoded default. Nothing persists a customized value, so `hook install` run from a fresh shell or CI job silently writes a `.gitattributes` merge-driver line for `graphify-out/graph.json` even on a project whose graph lives somewhere else. The merge driver then never fires, and `hook status` still reports it as registered.
- Fixes this by persisting a non-default `GRAPHIFY_OUT` to `.graphifyrc` (`out_dir=...`) the first time `hook install` sees one, and extending the resolution order to env var → `.graphifyrc[out_dir]` → default. `.graphifyrc` already exists for `viz_node_limit`; this reuses it instead of adding a second config mechanism.
- While in the same function, skips writing the `.gitattributes` line at all when the resolved path is gitignored — a merge driver for an untracked file can never run. `hook status` now reports `"not applicable"` for that case instead of the misleading `"partially registered"`.

Fixes #3206. Closes #2595.

Not touching #2008, #2841, or #2986 — each already has an open PR (#2064, #2858, #3108 respectively) from another contributor; this stays scoped to `_register_merge_driver`/`GRAPHIFY_OUT` resolution to avoid overlapping with that work.

## Why

Ran `graphify hook install` on a project that has always used a non-default output directory and found the generated `.gitattributes` line pointed at a file that doesn't exist. `hook status` reported everything fine. Confirmed at HEAD (`680e3ed`) that nothing compares the resolved path against what the project actually uses — the bug is in `GRAPHIFY_OUT` resolution itself, not specific to `hook install`.

## Test plan

- [x] `pytest tests/test_hooks.py tests/test_paths.py` — 157 passed
- [x] `pytest tests/` (full suite) — 5018 passed, 72 skipped; 8 pre-existing failures, all `tree_sitter_hcl`-dependent Terraform tests, reproduced against a clean stash of the same base commit (unrelated to this change)
- [x] `ruff check graphify/hooks.py graphify/paths.py` — clean
- [x] `pyright graphify/hooks.py graphify/paths.py` — 0 errors
- [x] Manually reproduced the wrong-path bug and confirmed the fix in a scratch repo:
  ```
  git init -q && GRAPHIFY_OUT=custom-graphs graphify hook install   # correct in this shell
  # new shell, GRAPHIFY_OUT unset
  graphify hook install   # now correctly reads custom-graphs from .graphifyrc
  cat .gitattributes      # custom-graphs/graph.json merge=graphify
  ```
