### PR TITLE
fix: protect against unverified semantic node loss

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -1615,11 +1615,37 @@ def merge_raw_extraction(
             return False  # unowned — carry forward
         return _prune_hit(sf)
 
+    # #3203: Check for unverified semantic shrink on re-extracted sources.
+    unverified_semantic_shrink: dict[str, tuple[int, int]] = {}
+    if new_sem_sources:
+        prior_sem_counts: dict[str, int] = {}
+        for n in existing_nodes:
+            if isinstance(n, dict) and not _is_ast_tier(n):
+                sf = n.get("source_file")
+                if sf:
+                    canon = _norm_source_file(sf, _eff_root) or sf
+                    prior_sem_counts[canon] = prior_sem_counts.get(canon, 0) + 1
+
+        fresh_sem_counts: dict[str, int] = {}
+        for n in new.get("nodes", []):
+            if isinstance(n, dict) and not _is_ast_tier(n):
+                sf = n.get("source_file")
+                if sf:
+                    canon = _norm_source_file(sf, _eff_root) or sf
+                    fresh_sem_counts[canon] = fresh_sem_counts.get(canon, 0) + 1
+
+        for canon_sf, fresh_count in fresh_sem_counts.items():
+            prior_count = prior_sem_counts.get(canon_sf, 0)
+            if prior_count > 1 and fresh_count < prior_count:
+                unverified_semantic_shrink[canon_sf] = (prior_count, fresh_count)
+
     new["nodes"] = [n for n in existing_nodes if not _dropped(n)] + list(new.get("nodes", []))
     new["edges"] = [e for e in existing_edges if not _dropped(e)] + list(new.get("edges", []))
     carried_hyper = [he for he in existing_hyperedges if not _dropped(he)]
     if carried_hyper or new.get("hyperedges"):
         new["hyperedges"] = carried_hyper + list(new.get("hyperedges", []))
+    if unverified_semantic_shrink:
+        new["_unverified_semantic_shrink"] = unverified_semantic_shrink
     return new
 
 
@@ -1718,6 +1744,35 @@ def build_merge(
     # never see the loss it is meant to catch.
     _disk_nodes = existing_nodes
     _disk_n = len(existing_nodes)
+
+    # #3203: Check for unverified semantic shrink on re-extracted sources.
+    # An existing source with prior semantic nodes (> 1) that produces strictly
+    # fewer semantic nodes in this extraction is flagged on G.graph so the CLI
+    # can arm the shrink guard and leave the source unstamped in the manifest.
+    unverified_semantic_shrink: dict[str, tuple[int, int]] = {}
+    if had_graph and new_sem_sources:
+        prior_sem_counts: dict[str, int] = {}
+        for n in _disk_nodes:
+            if isinstance(n, dict) and not _is_ast_tier(n):
+                sf = n.get("source_file")
+                if sf:
+                    canon = _norm_source_file(sf, _replace_root) or sf
+                    prior_sem_counts[canon] = prior_sem_counts.get(canon, 0) + 1
+
+        fresh_sem_counts: dict[str, int] = {}
+        for ch in new_chunks:
+            for n in ch.get("nodes", []):
+                if isinstance(n, dict) and not _is_ast_tier(n):
+                    sf = n.get("source_file")
+                    if sf:
+                        canon = _norm_source_file(sf, _replace_root) or sf
+                        fresh_sem_counts[canon] = fresh_sem_counts.get(canon, 0) + 1
+
+        for canon_sf, fresh_count in fresh_sem_counts.items():
+            prior_count = prior_sem_counts.get(canon_sf, 0)
+            if prior_count > 1 and fresh_count < prior_count:
+                unverified_semantic_shrink[canon_sf] = (prior_count, fresh_count)
+
     if new_sources:
         def _kept(item: dict) -> bool:
             sf = item.get("source_file")
@@ -1998,6 +2053,9 @@ def build_merge(
                 f"{_disk_n} → {G.number_of_nodes()} nodes. "
                 f"Pass prune_sources explicitly if you intend to remove them. (#479)"
             )
+
+    if unverified_semantic_shrink:
+        G.graph["_unverified_semantic_shrink"] = unverified_semantic_shrink
 
     return G
 

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -91,6 +91,7 @@ def _stamped_manifest_files(
     root: Path,
     partial_source_files: "set[str] | None" = None,
     failed_ast_sources: "set[str] | list[str] | None" = None,
+    unverified_semantic_sources: "set[str] | list[str] | None" = None,
 ) -> dict[str, list[str]]:
     """Manifest-safe files dict: only stamp semantic files that actually
     produced output (cache hit or fresh extraction). Files whose chunk failed
@@ -102,6 +103,11 @@ def _stamped_manifest_files(
     detect_incremental would see it "done" and never re-dispatch it, leaving the
     incomplete node set live forever on the warm-incremental path. Same #933
     mechanism: leave it unstamped and it is re-queued next run.
+
+    ``unverified_semantic_sources`` (#3203): files whose semantic extraction
+    under-produced compared to their prior representation (e.g. 3 -> 1 nodes).
+    They are excluded from stamping unless --allow-partial is set, so the next
+    incremental run retries them.
 
     Both sides of the membership test are resolved against the scan ``root``
     before comparing (#1897): node/edge/hyperedge ``source_file`` values are
@@ -142,6 +148,7 @@ def _stamped_manifest_files(
             if sf:
                 sem_extracted.add(_resolve(sf))
     partial_resolved = {_resolve(p) for p in (partial_source_files or set())}
+    unverified_resolved = {_resolve(p) for p in (unverified_semantic_sources or set())}
     failed_ast_resolved = {_resolve(p) for p in (failed_ast_sources or [])}
     sem_types = {"document", "paper", "image"}
     return {
@@ -150,7 +157,11 @@ def _stamped_manifest_files(
             if _resolve(f) not in failed_ast_resolved
             and (
                 ftype not in sem_types
-                or (_resolve(f) in sem_extracted and _resolve(f) not in partial_resolved)
+                or (
+                    _resolve(f) in sem_extracted
+                    and _resolve(f) not in partial_resolved
+                    and _resolve(f) not in unverified_resolved
+                )
             )
         ]
         for ftype, flist in files_by_type.items()
@@ -4066,6 +4077,33 @@ def dispatch_command(cmd: str) -> None:
                     # raw-dump this run's partial extraction over it.
                     print(f"error: {exc}", file=sys.stderr)
                     sys.exit(1)
+                _unverified_shrink = merged.get("_unverified_semantic_shrink")
+                if _unverified_shrink:
+                    if not cli_allow_partial:
+                        _extraction_incomplete = True
+                        _unverified_sources = set(_unverified_shrink.keys())
+                        _manifest_files = _stamped_manifest_files(
+                            files_by_type,
+                            sem_result,
+                            target,
+                            partial_source_files=_partial_semantic_files,
+                            failed_ast_sources=_failed_ast_sources,
+                            unverified_semantic_sources=_unverified_sources,
+                        )
+                        _stamped_semantic = {
+                            f for _flist in _manifest_files.values() for f in _flist
+                        }
+                        _cleared_semantic = {str(p) for p in semantic_files} - _stamped_semantic
+                    _shrink_details = ", ".join(
+                        f"'{sf}' ({prior} -> {fresh} nodes)"
+                        for sf, (prior, fresh) in sorted(_unverified_shrink.items())
+                    )
+                    print(
+                        f"[graphify extract] semantic extraction is incomplete: unverified semantic "
+                        f"shrink detected for {_shrink_details}. The shrink guard stays armed for "
+                        "this write; pass --allow-partial to overwrite a larger existing graph anyway.",
+                        file=sys.stderr,
+                    )
             merged["nodes"] = _dedupe_nodes(merged["nodes"])
             merged["edges"] = _dedupe_edges(merged["edges"])
             # Disambiguate colliding-basename file-node labels (#2032). This raw
@@ -4185,6 +4223,33 @@ def dispatch_command(cmd: str) -> None:
                     dedup_llm_backend=dedup_backend,
                     root=target,
                 )
+                _unverified_shrink = G.graph.get("_unverified_semantic_shrink") if hasattr(G, "graph") else None
+                if _unverified_shrink:
+                    if not cli_allow_partial:
+                        _extraction_incomplete = True
+                        _unverified_sources = set(_unverified_shrink.keys())
+                        _manifest_files = _stamped_manifest_files(
+                            files_by_type,
+                            sem_result,
+                            target,
+                            partial_source_files=_partial_semantic_files,
+                            failed_ast_sources=_failed_ast_sources,
+                            unverified_semantic_sources=_unverified_sources,
+                        )
+                        _stamped_semantic = {
+                            f for _flist in _manifest_files.values() for f in _flist
+                        }
+                        _cleared_semantic = {str(p) for p in semantic_files} - _stamped_semantic
+                    _shrink_details = ", ".join(
+                        f"'{sf}' ({prior} -> {fresh} nodes)"
+                        for sf, (prior, fresh) in sorted(_unverified_shrink.items())
+                    )
+                    print(
+                        f"[graphify extract] semantic extraction is incomplete: unverified semantic "
+                        f"shrink detected for {_shrink_details}. The shrink guard stays armed for "
+                        "this write; pass --allow-partial to overwrite a larger existing graph anyway.",
+                        file=sys.stderr,
+                    )
             except ValueError as exc:
                 # --no-dedup arms build_merge's #479 shrink guard, which refuses
                 # to drop nodes belonging to files this run neither re-extracted

--- a/tests/test_unverified_semantic_shrink.py
+++ b/tests/test_unverified_semantic_shrink.py
@@ -1,0 +1,317 @@
+"""Tests for unverified semantic document node shrink protection (#3203).
+
+When an incremental extraction produces strictly fewer semantic document nodes
+for an existing source file (prior > 1 and fresh < prior), it is treated as an
+unverified semantic shrink. build_merge flags the anomaly on G.graph so the CLI
+can arm the shrink guard (force=False) and prevent the under-produced source from
+being stamped in manifest.json, preserving the existing graph and allowing
+subsequent incremental runs to retry.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import pytest
+
+import graphify.__main__ as mainmod
+from graphify.build import build_merge, merge_raw_extraction
+import graphify.llm as llmmod
+
+
+def _sem_node(sf: str, name: str) -> dict:
+    """Semantic node without _origin."""
+    stem = sf.replace("/", "_").replace(".", "_")
+    return {
+        "id": f"{stem}_{name}",
+        "label": f"{sf} {name}",
+        "file_type": "document",
+        "source_file": sf,
+    }
+
+
+def _ast_node(sf: str, name: str) -> dict:
+    """AST node with _origin='ast'."""
+    stem = sf.replace("/", "_").replace(".", "_")
+    return {
+        "id": f"{stem}_{name}",
+        "label": f"{sf} {name}",
+        "file_type": "code",
+        "source_file": sf,
+        "_origin": "ast",
+    }
+
+
+def _write_graph(graph_path: Path, nodes, edges=()) -> None:
+    graph_path.parent.mkdir(parents=True, exist_ok=True)
+    graph_path.write_text(
+        json.dumps({"nodes": list(nodes), "edges": list(edges), "hyperedges": []}),
+        encoding="utf-8",
+    )
+
+
+# ── 1. Unit Tests for build_merge anomaly flagging ────────────────────────────
+
+def test_build_merge_flags_unverified_semantic_shrink(tmp_path):
+    """Semantic source with 3 prior nodes re-extracted with 1 node is flagged on G.graph."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(gp, [_sem_node("doc.md", f"n{i}") for i in range(3)])
+
+    chunk = {"nodes": [_sem_node("doc.md", "n0")], "edges": []}
+    G = build_merge([chunk], gp, dedup=False, root=tmp_path)
+
+    assert G.number_of_nodes() == 1
+    assert "_unverified_semantic_shrink" in G.graph
+    assert G.graph["_unverified_semantic_shrink"] == {"doc.md": (3, 1)}
+
+
+def test_build_merge_flags_shrink_when_surviving_id_is_renamed(tmp_path):
+    """Surviving semantic node renamed (n0 -> renamed_concept) still flags based on count."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(gp, [_sem_node("doc.md", f"sec_{i}") for i in range(3)])
+
+    chunk = {"nodes": [_sem_node("doc.md", "renamed_concept")], "edges": []}
+    G = build_merge([chunk], gp, dedup=False, root=tmp_path)
+
+    assert G.number_of_nodes() == 1
+    assert G.graph.get("_unverified_semantic_shrink") == {"doc.md": (3, 1)}
+
+
+def test_build_merge_own_file_shrink_remains_non_fatal(tmp_path):
+    """build_merge must NOT raise an exception on own-file shrink; it returns G."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(gp, [_sem_node("doc.md", f"n{i}") for i in range(10)])
+
+    chunk = {"nodes": [_sem_node("doc.md", "n0")], "edges": []}
+    G = build_merge([chunk], gp, dedup=False, root=tmp_path)
+    assert G.number_of_nodes() == 1
+
+
+def test_build_merge_does_not_flag_ast_code_shrink(tmp_path):
+    """Deterministic AST/code shrinkage (10 -> 1) is never flagged as unverified semantic shrink."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(gp, [_ast_node("mod.py", f"fn{i}") for i in range(10)])
+
+    chunk = {"nodes": [_ast_node("mod.py", "fn0")], "edges": []}
+    G = build_merge([chunk], gp, dedup=False, root=tmp_path)
+
+    assert G.number_of_nodes() == 1
+    assert "_unverified_semantic_shrink" not in G.graph
+
+
+def test_build_merge_equal_count_different_ids_not_flagged(tmp_path):
+    """10 -> 10 semantic nodes with completely different IDs is not flagged as a shrink."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(gp, [_sem_node("doc.md", f"old_{i}") for i in range(10)])
+
+    chunk = {"nodes": [_sem_node("doc.md", f"new_{i}") for i in range(10)], "edges": []}
+    G = build_merge([chunk], gp, dedup=False, root=tmp_path)
+
+    assert G.number_of_nodes() == 10
+    assert "_unverified_semantic_shrink" not in G.graph
+
+
+def test_build_merge_semantic_growth_not_flagged(tmp_path):
+    """Semantic growth (3 -> 4) is unaffected."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(gp, [_sem_node("doc.md", f"n{i}") for i in range(3)])
+
+    chunk = {"nodes": [_sem_node("doc.md", f"n{i}") for i in range(4)], "edges": []}
+    G = build_merge([chunk], gp, dedup=False, root=tmp_path)
+
+    assert G.number_of_nodes() == 4
+    assert "_unverified_semantic_shrink" not in G.graph
+
+
+def test_build_merge_aggregates_multiple_chunks_per_source(tmp_path):
+    """Multiple chunks for the same source are summed before comparison (2 + 2 = 4 >= 3 -> no shrink)."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(gp, [_sem_node("doc.md", f"n{i}") for i in range(3)])
+
+    chunk1 = {"nodes": [_sem_node("doc.md", "c1_a"), _sem_node("doc.md", "c1_b")], "edges": []}
+    chunk2 = {"nodes": [_sem_node("doc.md", "c2_a"), _sem_node("doc.md", "c2_b")], "edges": []}
+
+    G = build_merge([chunk1, chunk2], gp, dedup=False, root=tmp_path)
+    assert G.number_of_nodes() == 4
+    assert "_unverified_semantic_shrink" not in G.graph
+
+
+def test_build_merge_source_specific_growth_cannot_mask_shrink(tmp_path):
+    """Growth in B (3 -> 20) cannot mask unverified shrink in A (6 -> 2)."""
+    gp = tmp_path / "graphify-out" / "graph.json"
+    _write_graph(
+        gp,
+        [_sem_node("a.md", f"a{i}") for i in range(6)]
+        + [_sem_node("b.md", f"b{i}") for i in range(3)],
+    )
+
+    chunk_a = {"nodes": [_sem_node("a.md", f"a{i}") for i in range(2)], "edges": []}
+    chunk_b = {"nodes": [_sem_node("b.md", f"b{i}") for i in range(20)], "edges": []}
+
+    G = build_merge([chunk_a, chunk_b], gp, dedup=False, root=tmp_path)
+    assert G.number_of_nodes() == 22
+    assert G.graph.get("_unverified_semantic_shrink") == {"a.md": (6, 2)}
+
+
+def test_merge_raw_extraction_parity(tmp_path):
+    """merge_raw_extraction also flags unverified semantic shrink."""
+    gp = tmp_path / "graph.json"
+    _write_graph(gp, [_sem_node("doc.md", f"n{i}") for i in range(5)])
+
+    new = {"nodes": [_sem_node("doc.md", "n0")], "edges": [], "hyperedges": []}
+    merged = merge_raw_extraction(new, gp, root=tmp_path)
+
+    assert merged.get("_unverified_semantic_shrink") == {"doc.md": (5, 1)}
+
+
+# ── 2. Integration / CLI Tests for #3203 Behavior ─────────────────────────────
+
+def _run_cli():
+    try:
+        mainmod.main()
+    except SystemExit as exc:
+        return exc.code
+    return 0
+
+
+def test_3203_e2e_repro_protected_and_manifest_unstamped(tmp_path, monkeypatch, capsys):
+    """Reproduce #3203: Initial 3 nodes for README.md -> re-extracted with 1 node.
+    The shrink guard refuses the overwrite, exits 1, and README.md is not stamped.
+    """
+    corpus = tmp_path / "repo"
+    corpus.mkdir()
+    readme = corpus / "README.md"
+    guide = corpus / "GUIDE.md"
+    readme.write_text("# Readme\nInitial content\n", encoding="utf-8")
+    guide.write_text("# Guide\nGuide content\n", encoding="utf-8")
+
+    out_dir = corpus / "graphify-out"
+
+    # Step 1: Initial build (README: 3 nodes, GUIDE: 2 nodes)
+    def _mock_llm_run1(files, **kwargs):
+        on_chunk = kwargs.get("on_chunk_done")
+        res = {
+            "nodes": [
+                {"id": "readme_doc", "label": "Readme", "file_type": "document", "source_file": "README.md"},
+                {"id": "readme_sec1", "label": "Section 1", "file_type": "document", "source_file": "README.md"},
+                {"id": "readme_sec2", "label": "Section 2", "file_type": "document", "source_file": "README.md"},
+                {"id": "guide_doc", "label": "Guide", "file_type": "document", "source_file": "GUIDE.md"},
+                {"id": "guide_sec1", "label": "Guide Sec", "file_type": "document", "source_file": "GUIDE.md"},
+            ],
+            "edges": [], "hyperedges": [],
+            "input_tokens": 10, "output_tokens": 10, "uncovered_files": [],
+        }
+        if on_chunk:
+            on_chunk(0, 1, res)
+        return res
+
+    monkeypatch.setattr(llmmod, "extract_corpus_parallel", _mock_llm_run1)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake")
+
+    monkeypatch.setattr(mainmod.sys, "argv", ["graphify", "extract", str(corpus), "--backend", "claude"])
+    code1 = _run_cli()
+    assert code1 == 0
+
+    graph1 = json.loads((out_dir / "graph.json").read_text(encoding="utf-8"))
+    assert len(graph1["nodes"]) == 5
+
+    manifest1 = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert "README.md" in manifest1
+    initial_hash = manifest1["README.md"]["semantic_hash"]
+
+    # Step 2: Edit README.md and re-extract returning only 1 node
+    readme.write_text("# Readme\nEdited content\n", encoding="utf-8")
+
+    def _mock_llm_run2(files, **kwargs):
+        on_chunk = kwargs.get("on_chunk_done")
+        res = {
+            "nodes": [
+                {"id": "readme_doc_renamed", "label": "Readme Renamed", "file_type": "document", "source_file": "README.md"},
+            ],
+            "edges": [], "hyperedges": [],
+            "input_tokens": 10, "output_tokens": 5, "uncovered_files": [],
+        }
+        if on_chunk:
+            on_chunk(0, 1, res)
+        return res
+
+    monkeypatch.setattr(llmmod, "extract_corpus_parallel", _mock_llm_run2)
+    monkeypatch.setattr(mainmod.sys, "argv", ["graphify", "extract", str(corpus), "--backend", "claude"])
+
+    code2 = _run_cli()
+    # The shrink guard arms and refuses overwrite because graph shrinks 5 -> 3
+    assert code2 == 1
+
+    err = capsys.readouterr().err
+    assert "unverified semantic shrink detected for 'README.md' (3 -> 1 nodes)" in err
+    assert "Refusing to overwrite" in err
+
+    # The existing graph on disk is still the healthy 5-node graph
+    graph2 = json.loads((out_dir / "graph.json").read_text(encoding="utf-8"))
+    assert len(graph2["nodes"]) == 5
+
+    # Manifest is NOT stamped with the new hash for README.md
+    manifest2 = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest2["README.md"]["semantic_hash"] == initial_hash
+
+
+def test_3203_allow_partial_override_permits_intentional_reduction(tmp_path, monkeypatch, capsys):
+    """Passing --allow-partial permits an intentional semantic reduction and stamps manifest."""
+    corpus = tmp_path / "repo"
+    corpus.mkdir()
+    readme = corpus / "README.md"
+    readme.write_text("# Readme\nInitial content\n", encoding="utf-8")
+
+    out_dir = corpus / "graphify-out"
+
+    def _mock_llm_run1(files, **kwargs):
+        on_chunk = kwargs.get("on_chunk_done")
+        res = {
+            "nodes": [
+                {"id": "readme_doc", "label": "Readme", "file_type": "document", "source_file": "README.md"},
+                {"id": "readme_sec1", "label": "Section 1", "file_type": "document", "source_file": "README.md"},
+                {"id": "readme_sec2", "label": "Section 2", "file_type": "document", "source_file": "README.md"},
+            ],
+            "edges": [], "hyperedges": [],
+            "input_tokens": 10, "output_tokens": 10, "uncovered_files": [],
+        }
+        if on_chunk:
+            on_chunk(0, 1, res)
+        return res
+
+    monkeypatch.setattr(llmmod, "extract_corpus_parallel", _mock_llm_run1)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake")
+
+    monkeypatch.setattr(mainmod.sys, "argv", ["graphify", "extract", str(corpus), "--backend", "claude"])
+    code1 = _run_cli()
+    assert code1 == 0
+
+    # Re-extract with --allow-partial
+    readme.write_text("# Readme\nShortened content\n", encoding="utf-8")
+
+    def _mock_llm_run2(files, **kwargs):
+        on_chunk = kwargs.get("on_chunk_done")
+        res = {
+            "nodes": [
+                {"id": "readme_doc", "label": "Readme", "file_type": "document", "source_file": "README.md"},
+            ],
+            "edges": [], "hyperedges": [],
+            "input_tokens": 10, "output_tokens": 5, "uncovered_files": [],
+        }
+        if on_chunk:
+            on_chunk(0, 1, res)
+        return res
+
+    monkeypatch.setattr(llmmod, "extract_corpus_parallel", _mock_llm_run2)
+    monkeypatch.setattr(
+        mainmod.sys, "argv",
+        ["graphify", "extract", str(corpus), "--backend", "claude", "--allow-partial"],
+    )
+
+    code2 = _run_cli()
+    assert code2 == 0
+
+    # With override, the 1-node graph is persisted
+    graph = json.loads((out_dir / "graph.json").read_text(encoding="utf-8"))
+    assert len(graph["nodes"]) == 1


### PR DESCRIPTION
## Summary

Fixes #3203 by preventing an unexpectedly under-produced semantic document extraction from silently replacing a previously valid graph representation.

Previously, a semantic re-extraction could return fewer nodes than the previous extraction while still reporting a successful `stop` completion with valid JSON. Because the source had at least one resulting node, the existing incomplete-extraction checks considered the extraction complete, allowing the smaller representation to replace the existing graph.

## What changed

* Track semantic-tier node counts per source during `build_merge()` / `merge_raw_extraction()`.
* Compare the fresh extraction against the on-disk semantic baseline.
* Mark a source as **unverified** when:

  * the previous extraction contained more than one semantic node, and
  * the fresh extraction produces fewer semantic nodes.
* Propagate the anomaly to the CLI instead of making `build_merge()` fail.
* Arm the existing incomplete-extraction/shrink protection so the last known-good `graph.json` is preserved.
* Prevent affected sources from being stamped as complete in `manifest.json`, allowing them to be retried on a subsequent incremental run.
* Preserve `--allow-partial` as an explicit override for intentional reductions.

## Why this approach

A generic node-count shrink guard would recreate the false-positive behavior addressed by #1116, since legitimate edits can remove semantic nodes.

Exact node-ID matching was also avoided because semantic document IDs are LLM-generated and can legitimately change between extractions.

The new check therefore operates at the semantic source level and treats a reduction as **unverified rather than automatically invalid**. This allows the existing recovery path to protect the previous graph without making `build_merge()` itself responsible for deciding whether a document reduction was intentional.

AST/code-tier reductions remain unaffected.

## Testing

Added a dedicated regression suite covering:

* semantic node shrink detection
* renamed surviving semantic nodes
* non-fatal `build_merge()` behavior
* AST/code shrink exclusions
* equal-count semantic replacements
* semantic growth
* multi-chunk source aggregation
* source-specific shrink detection
* raw extraction parity
* end-to-end #3203 reproduction
* `--allow-partial` override

Relevant regression suites:

**88 tests passed.**
