### PR TITLE
fix(dedup): merge cross-file entity nodes typed by their file's extension (#296)

### DIFF
--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -306,34 +306,43 @@ def _defines_id(node: dict) -> bool:
 # one of its sections. The markdown extractor stamps these precisely because
 # `file_type` cannot carry the distinction, and both are file-anchored in the
 # #1284 sense — two files' `## Decisions` sections are two sections (#3094).
+#
+# PRODUCER CONTRACT: an extractor that mints a node standing for a *part* of its
+# source file (a section, a sheet, a slide) must stamp one of these. The gate
+# below reads an unstamped node as an entity, so an unstamped structural node is
+# eligible to merge with its namesake in another file.
 _FILE_STRUCTURE_NODE_KINDS = frozenset({"page", "heading"})
 
 
-def _provably_not_file_structure(node: dict) -> bool:
-    """True only when the node is PROVABLY an entity found inside its file,
-    rather than a structural part of the file itself (#296).
+def _reads_as_file_entity(node: dict) -> bool:
+    """True when the node reads as an entity found inside its file, rather than
+    as the file itself or a stamped structural part of it (#296).
 
-    Two things disqualify a node, and either alone is enough:
+    Be precise about what is proven and what is assumed, because the two halves
+    differ in strength:
 
-    * It is its file's OWN node. ``_id_prefixes`` enumerates the ID a node
-      standing for ``source_file`` itself would carry, in every spelling a
-      stored path may take (absolute, repo-relative, or the pre-#1504 bare
+    * PROVEN — it is not its file's OWN node. ``_id_prefixes`` enumerates the ID
+      a node standing for ``source_file`` itself would carry, in every spelling
+      a stored path may take (absolute, repo-relative, or the pre-#1504 bare
       stem). A file's own node IS one of those; an entity extracted from that
-      file carries an ``_<entity>`` suffix, so it never equals one.
-    * It is a section of the file — ``node_kind: "heading"`` — or the file node
-      the extractor labelled outright, ``node_kind: "page"``. Repeated headings
-      across sibling documents are distinct sections, not duplicates
-      (#1284, re-verified on #3094), and stay blocked.
+      file carries an ``_<entity>`` suffix, so it never equals one. This is a
+      reconstruction, not a heuristic.
+    * ASSUMED — it is not a section of the file. That rests on ``node_kind``,
+      which only a producer that stamps it can attest. `heading`/`page` are
+      honoured when present, but ABSENCE OF THE MARKER IS NOT PROOF OF
+      ENTITY-NESS: a producer minting sub-file nodes without stamping
+      `node_kind` (see the contract above) yields structural nodes that this
+      returns True for, and two such nodes sharing a label in different files
+      would merge. The conservative fix is on the producer side — stamp
+      `node_kind` — not a guess here about what an unstamped node meant.
 
-    Fail-safe by construction: a node that cannot be checked (no ID, no
-    provenance) answers False and stays blocked, so this can only ever *narrow*
-    the set of nodes the cross-file gate treats as file-anchored — never widen
-    it on a guess.
+    A node that cannot be checked at all (no ID, no provenance) answers False
+    and stays blocked.
     """
     nid = node.get("id") or ""
     source_file = node.get("source_file") or ""
     if not nid or not source_file:
-        return False  # unprovable — leave the file-anchored block in place
+        return False  # uncheckable — leave the file-anchored block in place
     if node.get("node_kind") in _FILE_STRUCTURE_NODE_KINDS:
         return False  # the extractor says this node is part of the file's structure
     return nid not in _id_prefixes(source_file)
@@ -670,8 +679,8 @@ def deduplicate_entities(
         # it is provably safe (#2182). `concept` is the one file_type meant to
         # unify across files (#1284) — code is keyed by ID (#1205) and
         # image/paper labels are often shared basenames (logo.png), so both stay
-        # blocked. rationale/document join `concept` here ONLY when the node is
-        # provably not part of its file's own structure (#296): a file-anchored
+        # blocked. rationale/document join `concept` here ONLY when the node
+        # reads as an entity inside its file (#296): a file-anchored
         # *file_type* does not make an individual node file-anchored. An entity
         # extracted from a note — a person, a project — inherits `document` from
         # the file's extension, not from anything about itself, so in note-heavy
@@ -688,7 +697,7 @@ def deduplicate_entities(
             (n for n in group
              if (n.get("file_type") == "concept"
                  or (n.get("file_type") in _FILE_ANCHORED_NONCODE
-                     and _provably_not_file_structure(n)))
+                     and _reads_as_file_entity(n)))
              and (n.get("source_file") or "")
              and _entropy(n.get("label", "")) >= _ENTROPY_THRESHOLD),
             key=lambda n: n["id"],

--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -301,6 +301,44 @@ def _defines_id(node: dict) -> bool:
                for prefix in _id_prefixes(source_file))
 
 
+# `node_kind` values marking a node that is STRUCTURE of its source file rather
+# than an entity mentioned inside it: `page` is the file's own node, `heading`
+# one of its sections. The markdown extractor stamps these precisely because
+# `file_type` cannot carry the distinction, and both are file-anchored in the
+# #1284 sense — two files' `## Decisions` sections are two sections (#3094).
+_FILE_STRUCTURE_NODE_KINDS = frozenset({"page", "heading"})
+
+
+def _provably_not_file_structure(node: dict) -> bool:
+    """True only when the node is PROVABLY an entity found inside its file,
+    rather than a structural part of the file itself (#296).
+
+    Two things disqualify a node, and either alone is enough:
+
+    * It is its file's OWN node. ``_id_prefixes`` enumerates the ID a node
+      standing for ``source_file`` itself would carry, in every spelling a
+      stored path may take (absolute, repo-relative, or the pre-#1504 bare
+      stem). A file's own node IS one of those; an entity extracted from that
+      file carries an ``_<entity>`` suffix, so it never equals one.
+    * It is a section of the file — ``node_kind: "heading"`` — or the file node
+      the extractor labelled outright, ``node_kind: "page"``. Repeated headings
+      across sibling documents are distinct sections, not duplicates
+      (#1284, re-verified on #3094), and stay blocked.
+
+    Fail-safe by construction: a node that cannot be checked (no ID, no
+    provenance) answers False and stays blocked, so this can only ever *narrow*
+    the set of nodes the cross-file gate treats as file-anchored — never widen
+    it on a guess.
+    """
+    nid = node.get("id") or ""
+    source_file = node.get("source_file") or ""
+    if not nid or not source_file:
+        return False  # unprovable — leave the file-anchored block in place
+    if node.get("node_kind") in _FILE_STRUCTURE_NODE_KINDS:
+        return False  # the extractor says this node is part of the file's structure
+    return nid not in _id_prefixes(source_file)
+
+
 # Path-segment lifecycle markers used by _collision_rank (#2532). Lower penalty
 # wins. Without them, pure lexical source_file order makes ``plans/_done/…``
 # beat ``plans/in-progress/…`` because "_" < "i" in ASCII. Active-vs-archived
@@ -630,14 +668,27 @@ def deduplicate_entities(
                 exact_merges += len(file_group) - 1
         # Cross-file residue: union exact matches across files, but only where
         # it is provably safe (#2182). `concept` is the one file_type meant to
-        # unify across files (#1284) — code is keyed by ID (#1205), rationale/
-        # document are file-anchored (#1284), and image/paper labels are often
-        # shared basenames (logo.png). Provenance is required (#1178), and the
-        # entropy gate mirrors Pass 2 so short generic labels ("API") stay
-        # distinct. Sorting by id keeps the winner order-independent.
+        # unify across files (#1284) — code is keyed by ID (#1205) and
+        # image/paper labels are often shared basenames (logo.png), so both stay
+        # blocked. rationale/document join `concept` here ONLY when the node is
+        # provably not part of its file's own structure (#296): a file-anchored
+        # *file_type* does not make an individual node file-anchored. An entity
+        # extracted from a note — a person, a project — inherits `document` from
+        # the file's extension, not from anything about itself, so in note-heavy
+        # corpora almost no entity node is typed `concept` and this merge never
+        # got to run on them. A file's own node and its headings still never
+        # merge (#1284, #3094).
+        # Provenance is required (#1178), and the entropy gate mirrors Pass 2 so
+        # short generic labels ("API") stay distinct — both untouched here.
+        # Scoped to this exact-normalization pass: Pass 2's fuzzy
+        # `_crossfile_fileanchored_blocked` is unchanged, so #1284's
+        # near-identical boilerplate and heading siblings stay blocked.
+        # Sorting by id keeps the winner order-independent.
         mergeable = sorted(
             (n for n in group
-             if n.get("file_type") == "concept"
+             if (n.get("file_type") == "concept"
+                 or (n.get("file_type") in _FILE_ANCHORED_NONCODE
+                     and _provably_not_file_structure(n)))
              and (n.get("source_file") or "")
              and _entropy(n.get("label", "")) >= _ENTROPY_THRESHOLD),
             key=lambda n: n["id"],

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1219,31 +1219,32 @@ def test_same_word_variant_helper():
 _CYRIL_VARIANTS = ["@cyrilXBT", "@cyrilxbt", "cyrilXBT"]
 
 
-def test_provably_not_file_structure_helper():
-    """The predicate proves entity-ness, and answers False whenever it cannot
-    (#296): a file's own node, a structural `page`/`heading` node, and any node
-    missing an id or provenance all stay treated as file-anchored."""
-    from graphify.dedup import _provably_not_file_structure
+def test_reads_as_file_entity_helper():
+    """A file's own node, a stamped `page`/`heading` node, and any node missing
+    an id or provenance all stay treated as file-anchored (#296). The own-node
+    half is a reconstruction and holds for every stored-path spelling; the
+    structural half rests on the producer stamping `node_kind`."""
+    from graphify.dedup import _reads_as_file_entity
     # An entity extracted from a note: `<path>_<entity>` never equals the path.
-    assert _provably_not_file_structure(
+    assert _reads_as_file_entity(
         {"id": "journal_2024_03_01_cyrilxbt", "label": "@cyrilXBT",
          "source_file": "journal/2024-03-01.md"})
     # The file's own node, in each spelling a stored source_file may take.
-    assert not _provably_not_file_structure(
+    assert not _reads_as_file_entity(
         {"id": "journal_2024_03_01", "source_file": "journal/2024-03-01.md"})
-    assert not _provably_not_file_structure(
+    assert not _reads_as_file_entity(
         {"id": "2024_03_01", "source_file": "journal/2024-03-01.md"})  # pre-#1504 bare stem
-    assert not _provably_not_file_structure(
+    assert not _reads_as_file_entity(
         {"id": "vault_journal_2024_03_01", "source_file": 'C:\\vault\\journal\\2024-03-01.md'})
     # The markdown extractor states it outright, for the file and its sections.
-    assert not _provably_not_file_structure(
+    assert not _reads_as_file_entity(
         {"id": "anything", "node_kind": "page", "source_file": "docs/a.md"})
-    assert not _provably_not_file_structure(
+    assert not _reads_as_file_entity(
         {"id": "docs_a_decisions", "node_kind": "heading",
          "label": "Decisions", "source_file": "docs/a.md"})
     # Unprovable -- no id, or no provenance.
-    assert not _provably_not_file_structure({"id": "", "source_file": "docs/a.md"})
-    assert not _provably_not_file_structure({"id": "docs_a_thing", "source_file": ""})
+    assert not _reads_as_file_entity({"id": "", "source_file": "docs/a.md"})
+    assert not _reads_as_file_entity({"id": "docs_a_thing", "source_file": ""})
 
 
 def test_dedup_merges_crossfile_document_entity_variants():
@@ -1368,3 +1369,18 @@ def test_dedup_never_merges_repeated_headings_across_files():
     )
     assert {n["source_file"] for n in result_nodes} == {
         "docs/a.md", "docs/b.md", "docs/c.md"}
+
+
+def test_reads_as_file_entity_trusts_the_node_kind_stamp_only():
+    """The documented limit of the structural half (#296): `node_kind` is what
+    marks a sub-file node, so an UNSTAMPED structural node reads as an entity.
+    Pinned deliberately — the fix for such a producer is to stamp `node_kind`,
+    and this test is what fails if the predicate is ever quietly changed to
+    guess instead."""
+    from graphify.dedup import _reads_as_file_entity
+    stamped = {"id": "book_xlsx_summary", "label": "Summary (sheet)",
+               "node_kind": "heading", "source_file": "book.xlsx"}
+    unstamped = dict(stamped)
+    del unstamped["node_kind"]
+    assert not _reads_as_file_entity(stamped)
+    assert _reads_as_file_entity(unstamped)

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -851,13 +851,18 @@ _RATIONALE_BOILER = ("Django app config for apps.platform.cards. No business "
 
 
 @pytest.mark.parametrize("a,b", [
-    ({"id": "d1", "label": "Getting Started Installation Guide",
+    # #296 narrowed the document/rationale rows here to their boundary case: an
+    # identical label on two nodes that are provably NOT their files' own nodes
+    # now merges (that is the bug the concept-only gate was causing). What must
+    # still never merge is a file's OWN node, so these two rows now carry the
+    # ids the file nodes themselves would be minted with.
+    ({"id": "docs_a", "label": "Getting Started Installation Guide",
       "file_type": "document", "source_file": "docs/a.md"},
-     {"id": "d2", "label": "Getting Started Installation Guide",
+     {"id": "docs_b", "label": "Getting Started Installation Guide",
       "file_type": "document", "source_file": "docs/b.md"}),
-    ({"id": "r1", "label": _RATIONALE_BOILER,
+    ({"id": "apps_platform_cards_apps", "label": _RATIONALE_BOILER,
       "file_type": "rationale", "source_file": "apps/platform/cards/apps.py"},
-     {"id": "r2", "label": _RATIONALE_BOILER,
+     {"id": "apps_platform_cores_apps", "label": _RATIONALE_BOILER,
       "file_type": "rationale", "source_file": "apps/platform/cores/apps.py"}),
     ({"id": "backend_a_render_frame", "label": "render_frame",
       "file_type": "code", "source_file": "backend_a.py"},
@@ -879,12 +884,15 @@ _RATIONALE_BOILER = ("Django app config for apps.platform.cards. No business "
       "file_type": "concept", "source_file": "doc1.md"},
      {"id": "api_b", "label": "API",
       "file_type": "concept", "source_file": "doc2.md"}),
-], ids=["document", "rationale", "code", "image-basename", "concept-image-mixed",
-        "empty-source-file", "low-entropy-concept"])
+], ids=["document-own-file-node", "rationale-own-file-node", "code",
+        "image-basename", "concept-image-mixed", "empty-source-file",
+        "low-entropy-concept"])
 def test_crossfile_identical_labels_stay_distinct_for_guarded_types(a, b):
-    """The #2182 fix is gated to high-entropy `concept` nodes with provenance
-    on BOTH sides. Identical labels must NOT merge for: file-anchored types
-    (document/rationale, #1284), code (#1205), images sharing a basename in
+    """The #2182 cross-file merge requires provenance and high entropy on BOTH
+    sides, and #296 widened its type gate only as far as nodes provably not
+    their file's own node. Identical labels must still NOT merge for: a
+    document/rationale node that IS its file's own node (#296, the boundary of
+    #1284's file-anchored guard), code (#1205), images sharing a basename in
     different dirs, mixed concept+image pairs, provenance-less nodes (#1178),
     and low-entropy generic labels."""
     result_nodes, _ = deduplicate_entities([dict(a), dict(b)], [], communities={})
@@ -1196,3 +1204,167 @@ def test_same_word_variant_helper():
     # Accepted trade: a length-differing 5-char spelling variant reads as two
     # words and stays unmerged, per the never-merge-distinct-entities bar.
     assert not _same_word_variant("colour", "color")
+
+
+# -- #296: cross-file merge for entity nodes typed by their file's extension --
+#
+# Reported shape: per-file extraction over a note vault mints one node per
+# mention of the same person/project, and they never merge. Normalization was
+# never the problem -- `_norm` already buckets the variants together -- the
+# Pass 1 cross-file union was gated to `file_type == "concept"`, and an entity
+# pulled out of a `.md` note inherits `document` from the file's extension, not
+# from anything about the entity. The @cyrilXBT variant family below is the
+# reported corpus's shape, reduced to the spellings that occur in it.
+
+_CYRIL_VARIANTS = ["@cyrilXBT", "@cyrilxbt", "cyrilXBT"]
+
+
+def test_provably_not_file_structure_helper():
+    """The predicate proves entity-ness, and answers False whenever it cannot
+    (#296): a file's own node, a structural `page`/`heading` node, and any node
+    missing an id or provenance all stay treated as file-anchored."""
+    from graphify.dedup import _provably_not_file_structure
+    # An entity extracted from a note: `<path>_<entity>` never equals the path.
+    assert _provably_not_file_structure(
+        {"id": "journal_2024_03_01_cyrilxbt", "label": "@cyrilXBT",
+         "source_file": "journal/2024-03-01.md"})
+    # The file's own node, in each spelling a stored source_file may take.
+    assert not _provably_not_file_structure(
+        {"id": "journal_2024_03_01", "source_file": "journal/2024-03-01.md"})
+    assert not _provably_not_file_structure(
+        {"id": "2024_03_01", "source_file": "journal/2024-03-01.md"})  # pre-#1504 bare stem
+    assert not _provably_not_file_structure(
+        {"id": "vault_journal_2024_03_01", "source_file": 'C:\\vault\\journal\\2024-03-01.md'})
+    # The markdown extractor states it outright, for the file and its sections.
+    assert not _provably_not_file_structure(
+        {"id": "anything", "node_kind": "page", "source_file": "docs/a.md"})
+    assert not _provably_not_file_structure(
+        {"id": "docs_a_decisions", "node_kind": "heading",
+         "label": "Decisions", "source_file": "docs/a.md"})
+    # Unprovable -- no id, or no provenance.
+    assert not _provably_not_file_structure({"id": "", "source_file": "docs/a.md"})
+    assert not _provably_not_file_structure({"id": "docs_a_thing", "source_file": ""})
+
+
+def test_dedup_merges_crossfile_document_entity_variants():
+    """The reported bug (#296): case/prefix variants of one entity, extracted
+    from three different notes and typed `document` by extension, must collapse
+    to a single node."""
+    nodes = [
+        {"id": "journal_2024_03_0%d_cyrilxbt" % i, "label": variant,
+         "file_type": "document", "source_file": "journal/2024-03-0%d.md" % i}
+        for i, variant in enumerate(_CYRIL_VARIANTS, start=1)
+    ]
+    result_nodes, _ = deduplicate_entities(nodes, [], communities={})
+    assert len(result_nodes) == 1, (
+        "cross-file `document` entity variants did not merge -- the #296 gate "
+        "widening is not reaching Pass 1's cross-file residue"
+    )
+
+
+def test_dedup_merges_crossfile_rationale_entity_variants():
+    """`rationale` rides the same gate as `document` (#296): entity nodes of
+    that type, provably not their files' own nodes, merge on an exact label."""
+    nodes = [
+        {"id": "svc_alpha_py_retention_window", "label": "Retention Window",
+         "file_type": "rationale", "source_file": "svc/alpha.py"},
+        {"id": "svc_beta_py_retention_window", "label": "retention window",
+         "file_type": "rationale", "source_file": "svc/beta.py"},
+    ]
+    result_nodes, _ = deduplicate_entities(nodes, [], communities={})
+    assert len(result_nodes) == 1
+
+
+def test_dedup_never_merges_a_files_own_node_away():
+    """The boundary the widened gate is defined against (#296): a curated note
+    whose OWN node carries the entity's label must survive as its own node, even
+    when a same-label entity node exists in another file."""
+    nodes = [
+        # The curated page: its id is exactly the slugified source path.
+        {"id": "people_cyrilxbt", "label": "@cyrilXBT",
+         "file_type": "document", "source_file": "people/@cyrilXBT.md"},
+        # A mention of the same entity, extracted from a journal note.
+        {"id": "journal_2024_03_01_cyrilxbt", "label": "cyrilXBT",
+         "file_type": "document", "source_file": "journal/2024-03-01.md"},
+    ]
+    result_nodes, _ = deduplicate_entities(nodes, [], communities={})
+    assert len(result_nodes) == 2, (
+        "a file's own node merged away -- the #296 widening must never reach it"
+    )
+    assert {n["id"] for n in result_nodes} == {
+        "people_cyrilxbt", "journal_2024_03_01_cyrilxbt"}
+
+
+def test_dedup_never_merges_two_files_own_nodes():
+    """Two README.md in different folders are genuinely two documents (#1284's
+    original reasoning), and stay two under #296."""
+    nodes = [
+        {"id": "web_readme", "label": "README.md", "file_type": "document",
+         "node_kind": "page", "source_file": "web/README.md"},
+        {"id": "api_readme", "label": "README.md", "file_type": "document",
+         "node_kind": "page", "source_file": "api/README.md"},
+    ]
+    result_nodes, _ = deduplicate_entities(nodes, [], communities={})
+    assert len(result_nodes) == 2
+
+
+def test_dedup_crossfile_entity_merge_keeps_the_entropy_gate():
+    """Entropy guard untouched (#296): a short generic label stays distinct for
+    `document` entity nodes exactly as it does for `concept`."""
+    nodes = [
+        {"id": "docs_a_api", "label": "API", "file_type": "document",
+         "source_file": "docs/a.md"},
+        {"id": "docs_b_api", "label": "API", "file_type": "document",
+         "source_file": "docs/b.md"},
+    ]
+    result_nodes, _ = deduplicate_entities(nodes, [], communities={})
+    assert len(result_nodes) == 2
+
+
+def test_dedup_crossfile_entity_merge_keeps_the_provenance_gate():
+    """Provenance guard untouched (#296, #1178): without a source_file the node
+    cannot be proven to be an entity, so it stays out of the merge."""
+    nodes = [
+        {"id": "orphan_cyrilxbt", "label": "@cyrilXBT",
+         "file_type": "document", "source_file": ""},
+        {"id": "journal_2024_03_01_cyrilxbt", "label": "cyrilXBT",
+         "file_type": "document", "source_file": "journal/2024-03-01.md"},
+    ]
+    result_nodes, _ = deduplicate_entities(nodes, [], communities={})
+    assert len(result_nodes) == 2
+
+
+def test_dedup_crossfile_fuzzy_fileanchored_block_is_untouched():
+    """#296 widens only the exact-normalization pass. Pass 2's fuzzy
+    `_crossfile_fileanchored_blocked` is unchanged, so near-identical (not
+    identical) document labels in different files still stay distinct -- the
+    #1284 guard keeps doing its job on entity nodes too."""
+    nodes = [
+        {"id": "docs_a_guide", "label": "Getting Started Installation Guide",
+         "file_type": "document", "source_file": "docs/a.md"},
+        {"id": "docs_b_setup", "label": "Getting Started Installation Setup",
+         "file_type": "document", "source_file": "docs/b.md"},
+    ]
+    result_nodes, _ = deduplicate_entities(nodes, [], communities={})
+    assert len(result_nodes) == 2
+
+
+def test_dedup_never_merges_repeated_headings_across_files():
+    """#3094's verification case must keep holding under #296: sibling documents
+    that each carry the same `## Decisions` / `## Next steps` sections keep one
+    heading node per file, attributed to that file."""
+    nodes = [
+        {"id": "docs_%s_%s" % (doc, slug), "label": heading,
+         "file_type": "document", "node_kind": "heading",
+         "source_file": "docs/%s.md" % doc}
+        for doc in ("a", "b", "c")
+        for slug, heading in (("decisions", "Decisions"),
+                              ("next_steps", "Next steps"))
+    ]
+    result_nodes, _ = deduplicate_entities(nodes, [], communities={})
+    assert len(result_nodes) == 6, (
+        "repeated headings merged across files -- #296 must not reach section "
+        "nodes (#1284, #3094)"
+    )
+    assert {n["source_file"] for n in result_nodes} == {
+        "docs/a.md", "docs/b.md", "docs/c.md"}


### PR DESCRIPTION
Running graphify over a note vault leaves the same person or project sitting in the graph as many separate nodes — `@cyrilXBT`, `@cyrilxbt` and `cyrilXBT` all survive as distinct entities, one per file that mentions them. Community detection then splits what should be one cluster into fragments and god-node analysis misses the real hubs, because a single entity's mentions are scattered across aliases; on the graph measured in #296 this left 1,741 collision groups unmerged.

Normalization is not what fails. `_norm` already casefolds and collapses `[\W_]+`, so all three spellings key to `cyrilxbt` and land in the same Pass 1 bucket. The bucket is then discarded, because the cross-file union added in #2182 is gated on `file_type == "concept"` — and an entity the extractor pulls out of a `.md` note inherits `document` from the file's extension, not from anything about the entity. Note-heavy corpora do not have a canonicalization problem that code repos lack; they have the same one, but almost none of their entity nodes are typed `concept`, so the cross-file merge that already exists never gets to run on them.

## Repro

```python
from graphify.dedup import deduplicate_entities

nodes = [
    {"id": "journal_2024_03_01_cyrilxbt", "label": "@cyrilXBT",
     "file_type": "document", "source_file": "journal/2024-03-01.md"},
    {"id": "journal_2024_03_02_cyrilxbt", "label": "@cyrilxbt",
     "file_type": "document", "source_file": "journal/2024-03-02.md"},
    {"id": "journal_2024_03_03_cyrilxbt", "label": "cyrilXBT",
     "file_type": "document", "source_file": "journal/2024-03-03.md"},
]
print(len(deduplicate_entities(nodes, [], communities={})[0]))
```

Before: `3`. After: `1`. Flip `file_type` to `"concept"` on all three and it already printed `1` before this change — the type is the only thing separating them.

## Evidence

Upstream HEAD `33362d969292b57eda82f3fbd9eb5f3f5bc9bbc2` (0.9.53), `graphify/dedup.py:640` — the `n.get("file_type") == "concept"` filter on the Pass 1 cross-file `mergeable` list. The measurement behind the numbers above is in #296: https://github.com/Graphify-Labs/graphify/issues/296#issuecomment-5388969434 — classifying every surviving cross-file `_norm`-collision group by which gate rejects it gave 1,741 blocked by this filter, 2 by the entropy gate and 0 by provenance, and of 39,627 `document` nodes exactly 0 were their own file's node.

@adelaidasofia asked for option 1 of the three sketched there:

> On your three options, 1 is the one I would want: widen the gate to entity nodes that are provably not the file's own node, entropy and provenance guards untouched. It keeps merge policy conservative and needs nothing retyped upstream.

That is what this implements — nothing retyped, no migration, no new subcommand.

## The predicate

"Provably not the file's own node" needs something concrete, and `dedup.py` did not model it. It turns out not to need any new extractor coupling: `_id_prefixes` already enumerates the ID a node standing for `source_file` itself would carry, in every spelling a stored path may take (absolute, repo-relative, or the pre-#1504 bare stem). A file's own node IS one of those; an entity extracted from that file carries an `_<entity>` suffix and never equals one.

The new `_reads_as_file_entity` requires two things, and either one failing keeps the node blocked:

* **Proven** — it is not its file's own node, by the `_id_prefixes` reconstruction above. This is a reconstruction, not a heuristic, and it holds for every spelling a stored `source_file` may take.
* **Assumed** — it is not a section of the file: `node_kind: "heading"`, or `"page"` for the file node the markdown extractor labels outright.

I have kept those two labelled separately in the code rather than calling the whole thing "provable", because the second half is only as good as the `node_kind` stamp. **Absence of the marker is not proof of entity-ness**: a producer that mints a node standing for part of its file without stamping `node_kind` — `detect.py`'s per-sheet `document` nodes are the in-tree example — yields structural nodes this predicate reads as entities, and two of them sharing a label in different files would merge. I did not paper over that with a guess about what an unstamped node meant; the conservative fix is on the producer side, so the PR states a short producer contract next to `_FILE_STRUCTURE_NODE_KINDS` and pins the stamped/unstamped split in a test, `test_reads_as_file_entity_trusts_the_node_kind_stamp_only`. Happy to stamp the `detect.py` path too if you would rather close it here — I left it alone because that code sits behind a not-yet-wired feature flag.

The second condition is why the widening does not touch the guard verified in #3094. Repeated `## Decisions` / `## Next steps` sections across sibling documents are distinct sections, not duplicates; `node_kind` exists precisely because `file_type` cannot carry that distinction, so it is the field that separates a heading from an entity found in the same file. Three documents each carrying both headings still yield six heading nodes, each attributed to its own file — there is a test for exactly that shape.

A node that cannot be checked (no ID, no provenance) answers `False` and stays blocked. The predicate can therefore only ever *narrow* what the gate treats as file-anchored, never widen it on a guess.

## What is deliberately unchanged

The entropy and provenance guards are byte-untouched, and the widened rows go through them exactly as `concept` rows do. `code` (#1205) is still keyed by ID and never enters Pass 1 at all; `image`/`paper` still stay blocked, so shared basenames like `logo.png` in two directories do not merge. Pass 2's fuzzy `_crossfile_fileanchored_blocked` is untouched, so #1284's near-identical parallel-module boilerplate stays blocked — the widening is scoped to the exact-normalization pass, where the label is identical after normalization rather than merely similar.

The survivor heuristic ("prefer the node with non-generated body content as the merge target") is not in this PR. `_pick_winner` picks on ID shape and `dedup.py` never sees body content, so doing it properly is its own change; a file's own node — usually the hand-curated note — is held out of the merge entirely here rather than being made to win it.

## Effect

* The fixture above: 3 nodes to 1.
* On a 15,197-node mixed code-and-markdown graph, cross-file exact-normalization groups that merge go 8 to 32 and nodes collapsed 27 to 52, with 133 `document`/`rationale` nodes held back by the predicate as file structure.

## Tests

Added to `tests/test_dedup.py`, all in the repo's existing style:

* `test_reads_as_file_entity_helper` — the predicate proves entity-ness and answers `False` whenever it cannot: the file's own node in each stored-path spelling, `page` and `heading` nodes, and nodes missing an ID or provenance.
* `test_dedup_merges_crossfile_document_entity_variants` — the reported shape, three spellings across three notes, collapsing to one.
* `test_dedup_merges_crossfile_rationale_entity_variants` — `rationale` rides the same gate.
* `test_dedup_never_merges_a_files_own_node_away` — the boundary: a curated note whose own node carries the entity's label survives alongside a mention of it elsewhere.
* `test_dedup_never_merges_two_files_own_nodes` — two `README.md` stay two documents.
* `test_dedup_never_merges_repeated_headings_across_files` — the #3094 verification case.
* `test_dedup_crossfile_entity_merge_keeps_the_entropy_gate` / `..._provenance_gate` — negative controls proving those guards still fire on the widened rows.
* `test_dedup_crossfile_fuzzy_fileanchored_block_is_untouched` — Pass 2 still blocks near-identical cross-file document labels.
* `test_reads_as_file_entity_trusts_the_node_kind_stamp_only` — pins the documented limit above: a stamped structural node stays blocked, an unstamped one reads as an entity.

Two existing rows in `test_crossfile_identical_labels_stay_distinct_for_guarded_types` changed meaning and are updated rather than deleted: the `document` and `rationale` rows asserted that an identical label never merges cross-file for those types, which is the behaviour this PR is changing. They now carry the IDs the files' own nodes would be minted with, so they keep guarding those types at the boundary that still holds, and the ids are renamed `document-own-file-node` / `rationale-own-file-node` to say so.

Verified both directions: with `dedup.py` reverted the two merge tests fail; with the `_reads_as_file_entity` call stubbed out the four own-node/heading tests fail.

`pytest tests/ -q` was run on the clean base commit and again on this branch, on the same machine: **17 failed, 5250 passed** before and **17 failed, 5259 passed** after — the same 17 failures, identical sets, and +9 passed for the tests added here (a tenth landed in the follow-up commit). Those 17 are pre-existing on `v8` in this environment (Windows: `os.mkfifo`/unix-socket/symlink cases in `test_non_regular_files.py`, POSIX-path install/uninstall cases, and two unicode-normalization tests) and are unrelated to this change — no test that passed on the baseline fails after it. `ruff check` passes and `python -m tools.skillgen --check` is clean.

Addresses the option-1 half of #296. The issue as filed also asks for a configurable canonicalization subcommand and edge-dedup pass, which this does not add, so it should not auto-close.
