### PR TITLE
fix(apex): match commas, spaces, and dots in method return types

### DIFF
--- a/graphify/extractors/apex.py
+++ b/graphify/extractors/apex.py
@@ -73,8 +73,13 @@ def extract_apex(path: Path) -> dict:
         r"^\s*trigger\s+(\w+)\s+on\s+(\w+)\s*\(",
         _re.IGNORECASE,
     )
+    # Return type: base token (dotted names, arrays) plus an optional <...>
+    # generic group that may hold commas, spaces, and one nested level. A bare
+    # character class cannot match "Map<String, Object>" (comma, space) or
+    # "Database.QueryLocator" (dot), silently dropping those methods.
+    _RETTYPE = r"[\w.\[\]]+(?:\s*<[^;{}()=]*>)?"
     method_re = _re.compile(
-        rf"^{_ANNOTATION}\s*{_ACCESS}{_MOD}\s*(?:static\s+)?[\w<>\[\]]+\s+(\w+)\s*\([^)]*\)\s*(?:throws\s+\w+\s*)?\{{?",
+        rf"^{_ANNOTATION}\s*{_ACCESS}{_MOD}\s*(?:static\s+)?{_RETTYPE}\s+(\w+)\s*\([^)]*\)\s*(?:throws\s+\w+\s*)?\{{?",
         _re.IGNORECASE,
     )
     annotation_re = _re.compile(r"@(\w+)", _re.IGNORECASE)

--- a/tests/fixtures/sample.cls
+++ b/tests/fixtures/sample.cls
@@ -41,6 +41,18 @@ public with sharing class AccountService {
         delete old;
     }
 
+    public static Map<String, Object> getAccountSummary(Id accountId) {
+        return new Map<String, Object>{ 'id' => accountId };
+    }
+
+    public Database.QueryLocator start(Database.BatchableContext bc) {
+        return Database.getQueryLocator('SELECT Id FROM Account');
+    }
+
+    private static List<Map<String, Id>> buildNameIndex() {
+        return new List<Map<String, Id>>();
+    }
+
     @isTest
     static void testGetAccounts() {
         List<Account> result = getAccounts('Customer');

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -3399,6 +3399,18 @@ def test_apex_method_extraction():
     assert any("createAccounts" in l for l in labels)
     assert any("deleteOldAccounts" in l for l in labels)
 
+
+def test_apex_method_generic_and_dotted_return_types():
+    # Regression: return types containing commas/spaces (Map<String, Object>),
+    # dots (Database.QueryLocator), or nested generics (List<Map<String, Id>>)
+    # were silently dropped because the return type was matched by a single
+    # character class with no comma, space, or dot.
+    r = extract_apex(FIXTURES / "sample.cls")
+    labels = _labels(r)
+    assert any("getAccountSummary" in l for l in labels)
+    assert ".start()" in labels
+    assert any("buildNameIndex" in l for l in labels)
+
 def test_apex_contains_and_method_relations():
     r = extract_apex(FIXTURES / "sample.cls")
     relations = _relations(r)


### PR DESCRIPTION
Fixes #3217

### Problem

`method_re` in the Apex extractor matches the return type with a single character class, `[\w<>\[\]]+`, which cannot contain a comma, space, or dot. Any method returning `Map<String, Object>`, `Database.QueryLocator`, `List<Map<String, Id>>`, or an inner/dotted type is silently dropped — no node, no edges, no warning. In practice that includes every `Database.Batchable` `start()` and the common `@AuraEnabled Map<String, Object>` controller pattern.

### Fix

Replace the return-type token with a base token plus an optional generic group:

```python
_RETTYPE = r"[\w.\[\]]+(?:\s*<[^;{}()=]*>)?"
```

Excluding `;{}()=` inside `<...>` keeps non-signature lines from matching: declarations with initializers (`Map<Id, X> m = new Map<Id, X>();`), calls, and control flow all still fail to match, and the existing `_CONTROL_FLOW` name filter is unchanged.

### Verification

- New regression test `test_apex_method_generic_and_dotted_return_types` **fails on the old pattern, passes on the new one** (fixture extended with the three shapes).
- All pre-existing apex tests pass (14/14 with the new one).
- Full `tests/test_languages.py` run produces an **identical failure set with and without this change** in my environment (pre-existing, unrelated to apex).
- Scanned against a 455-file production Salesforce codebase: the old pattern's match set is **strictly contained** in the new one (0 regressions), and **512 recovered lines** are all genuine method signatures — none lacking a comma, dot, or generic in the return type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
