### PR TITLE
fix: reject POM entity declarations

### DIFF
--- a/graphify/manifest_ingest.py
+++ b/graphify/manifest_ingest.py
@@ -269,6 +269,11 @@ def _parse_gomod(text: str) -> dict | None:
 
 
 def _parse_pom(text: str) -> dict | None:
+    # ElementTree does not cap entity expansion, so reject declarations before
+    # parsing rather than allowing a crafted POM to consume excessive memory.
+    lowered = text.lower()
+    if "<!doctype" in lowered or "<!entity" in lowered:
+        raise ValueError("refusing XML with DOCTYPE/ENTITY declaration")
     # Drop the default namespace so findtext/findall don't need the {uri} prefix.
     text = re.sub(r'\sxmlns="[^"]*"', '', text, count=1)
     root = ET.fromstring(text)

--- a/tests/test_manifest_ingest.py
+++ b/tests/test_manifest_ingest.py
@@ -64,7 +64,7 @@ def test_gomod_parses_module_and_requires(tmp_path):
     assert "pkg_github_com_x_y" in deps and "pkg_github_com_a_b" in deps
 
 
-def test_pom_parses_artifact_and_deps(tmp_path):
+def test_namespaced_pom_parses_artifact_and_deps(tmp_path):
     p = _write(tmp_path / "pom.xml",
                '<project xmlns="http://maven.apache.org/POM/4.0.0">\n'
                '  <groupId>com.acme</groupId>\n  <artifactId>widget</artifactId>\n  <version>2.0</version>\n'
@@ -73,6 +73,15 @@ def test_pom_parses_artifact_and_deps(tmp_path):
     r = extract_package_manifest(p)
     assert _pkg_nodes(r)[0]["label"] == "com.acme:widget"
     assert any(e["target"] == "pkg_org_lib_core" for e in r["edges"])
+
+
+def test_pom_with_internal_entity_is_rejected_before_parsing(tmp_path):
+    p = _write(tmp_path / "pom.xml",
+               '<!DOCTYPE project [<!ENTITY artifact "expanded-widget">]>\n'
+               '<project><artifactId>&artifact;</artifactId></project>\n')
+    r = extract_package_manifest(p)
+    assert r["nodes"] == [] and r["edges"] == []
+    assert r["error"] == "manifest parse error: refusing XML with DOCTYPE/ENTITY declaration"
 
 
 # ── #1377: a package referenced by N manifests is ONE node ───────────────────


### PR DESCRIPTION
> This pull request was posted by codex-tui using gpt-5.6-sol on behalf of David.

## Summary

- reject Maven POMs containing DTD or entity declarations before `ElementTree` parsing
- preserve ordinary default-namespaced POM ingestion
- add an internal-entity regression test

Fixes #3224.

## Validation

- `uv run --frozen pytest tests/test_manifest_ingest.py` — pass
- changed-file pre-commit hooks — pass
- `GRAPHIFY_MAX_WORKERS=2 uv run --frozen graphify update .` — pass
