### PR TITLE
fix(hooks): enforce repository setup gates

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -339,6 +339,11 @@ GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
 
 [ "${GRAPHIFY_SKIP_HOOK:-0}" = "1" ] && exit 0
 
+_GFY_OUT="${GRAPHIFY_OUT:-graphify-out}"
+if [ ! -f "$_GFY_OUT/graph.json" ]; then
+    exit 0
+fi
+
 """ + _WORKTREE_GUARD + """
 CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD 2>/dev/null)
 if [ -z "$CHANGED" ]; then
@@ -396,8 +401,9 @@ fi
 # branch switch but leaves the tree unchanged ΓÇö nothing to rebuild (#2421).
 [ "$PREV_HEAD" = "$NEW_HEAD" ] && exit 0
 
-# Only run if graphify-out/ exists (graph has been built before)
-if [ ! -d "graphify-out" ]; then
+# Only run if a graph has been built before
+_GFY_OUT="${GRAPHIFY_OUT:-graphify-out}"
+if [ ! -f "$_GFY_OUT/graph.json" ]; then
     exit 0
 fi
 
@@ -537,6 +543,43 @@ def _hooks_dir(root: Path) -> Path:
     return d
 
 
+def _validate_hook_can_append(
+    hook_path: Path,
+    marker: str,
+    marker_end: str,
+) -> None:
+    """Reject an existing hook whose original body ends in a terminal command."""
+    if not hook_path.exists():
+        return
+
+    content = hook_path.read_text(encoding="utf-8")
+    original = content
+    start_idx = content.find(marker)
+    if start_idx != -1:
+        end_idx = content.find(marker_end, start_idx) if marker_end else -1
+        if end_idx != -1:
+            end_idx += len(marker_end)
+            original = content[:start_idx] + content[end_idx:]
+        else:
+            original = content[:start_idx]
+
+    last_command = next(
+        (
+            line.strip()
+            for line in reversed(original.splitlines())
+            if line.strip() and not line.lstrip().startswith("#")
+        ),
+        "",
+    )
+    if re.match(r"^(?:exec|exit|return)(?:\s|$)", last_command):
+        raise RuntimeError(
+            f"Cannot append graphify to {hook_path}: the existing hook ends "
+            f"with terminal command {last_command!r}. Replace that command "
+            f"with a non-terminal invocation that preserves its exit status, "
+            f"then rerun 'graphify hook install'."
+        )
+
+
 def _install_hook(
     hooks_dir: Path,
     name: str,
@@ -549,6 +592,7 @@ def _install_hook(
     hook_path = hooks_dir / name
     if hook_path.exists():
         content = hook_path.read_text(encoding="utf-8")
+        _validate_hook_can_append(hook_path, marker, marker_end)
         if marker in content:
             if marker_end and marker_end in content:
                 start_idx = content.find(marker)
@@ -758,6 +802,16 @@ def install(path: Path = Path(".")) -> str:
         raise RuntimeError(f"No git repository found at or above {path.resolve()}")
 
     hooks_dir = _user_hooks_dir(_hooks_dir(root))
+    _validate_hook_can_append(
+        hooks_dir / "post-commit",
+        _HOOK_MARKER,
+        _HOOK_MARKER_END,
+    )
+    _validate_hook_can_append(
+        hooks_dir / "post-checkout",
+        _CHECKOUT_MARKER,
+        _CHECKOUT_MARKER_END,
+    )
 
     cfg = _load_graphifyrc(root)
     viz_limit = cfg.get("viz_node_limit")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -53,6 +53,68 @@ def test_install_appends_to_existing_hook(tmp_path):
     assert _HOOK_MARKER in content
 
 
+def test_install_rejects_existing_hook_with_terminal_exec(tmp_path):
+    repo = _make_git_repo(tmp_path)
+    marker = repo / "existing-hook-ran"
+    helper = repo / "existing-hook.sh"
+    helper.write_text(
+        f"#!/bin/sh\nprintf ran > {marker}\n",
+        encoding="utf-8",
+    )
+    helper.chmod(0o755)
+    hook = repo / ".git" / "hooks" / "post-commit"
+    original = f"#!/bin/sh\nexec {helper}\n"
+    hook.write_text(original, encoding="utf-8")
+    hook.chmod(0o755)
+
+    with pytest.raises(RuntimeError, match="ends with terminal command"):
+        install(repo)
+
+    assert hook.read_text(encoding="utf-8") == original
+    assert _HOOK_MARKER not in hook.read_text(encoding="utf-8")
+    subprocess.run([hook], cwd=repo, check=True)
+    assert marker.read_text(encoding="utf-8") == "ran"
+
+
+def test_install_rejects_unreachable_existing_graphify_block(tmp_path):
+    repo = _make_git_repo(tmp_path)
+    hook = repo / ".git" / "hooks" / "post-commit"
+    original = (
+        "#!/bin/sh\n"
+        "exec existing-helper\n\n"
+        "# graphify-hook-start\n"
+        "echo unreachable\n"
+        "# graphify-hook-end\n"
+    )
+    hook.write_text(original, encoding="utf-8")
+    hook.chmod(0o755)
+
+    with pytest.raises(RuntimeError, match="ends with terminal command"):
+        install(repo)
+
+    assert hook.read_text(encoding="utf-8") == original
+
+
+def test_install_preflights_both_hooks_before_writing(tmp_path):
+    repo = _make_git_repo(tmp_path)
+    commit_hook = repo / ".git" / "hooks" / "post-commit"
+    checkout_hook = repo / ".git" / "hooks" / "post-checkout"
+    commit_original = "#!/bin/sh\necho commit\n"
+    checkout_original = "#!/bin/sh\nexec checkout-helper\n"
+    commit_hook.write_text(commit_original, encoding="utf-8")
+    checkout_hook.write_text(checkout_original, encoding="utf-8")
+    commit_hook.chmod(0o755)
+    checkout_hook.chmod(0o755)
+
+    with pytest.raises(RuntimeError, match="ends with terminal command"):
+        install(repo)
+
+    assert commit_hook.read_text(encoding="utf-8") == commit_original
+    assert checkout_hook.read_text(encoding="utf-8") == checkout_original
+    assert _HOOK_MARKER not in commit_hook.read_text(encoding="utf-8")
+    assert _CHECKOUT_MARKER not in checkout_hook.read_text(encoding="utf-8")
+
+
 def test_uninstall_removes_hook(tmp_path):
     repo = _make_git_repo(tmp_path)
     install(repo)
@@ -373,6 +435,119 @@ def test_installed_hooks_contain_no_nohup(tmp_path):
         text = (repo / ".git" / "hooks" / name).read_text(encoding="utf-8")
         assert "nohup" not in text, f"installed {name} still references nohup"
         assert "start_new_session=True" in text
+
+
+def test_post_commit_hook_stays_silent_without_existing_graph(tmp_path):
+    """Installing the repository hook alone must not initialize Graphify.
+
+    A repository opts into rebuilds by creating graphify-out/graph.json. Before
+    that file exists, post-commit must exit without output or filesystem writes.
+    """
+    repo = _make_git_repo(tmp_path)
+    (repo / "fixture.py").write_text("value = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "fixture.py"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=Hook Test",
+            "-c",
+            "user.email=hook@example.invalid",
+            "commit",
+            "-m",
+            "fixture",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    install(repo)
+
+    (repo / "fixture.py").write_text("value = 2\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "fixture.py"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=Hook Test",
+            "-c",
+            "user.email=hook@example.invalid",
+            "commit",
+            "-m",
+            "change",
+        ],
+        check=True,
+        capture_output=True,
+        env={**os.environ, "GRAPHIFY_SKIP_HOOK": "1"},
+    )
+
+    result = subprocess.run(
+        [repo / ".git" / "hooks" / "post-commit"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HOME": str(tmp_path / "home")},
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+    assert not (repo / "graphify-out").exists()
+
+
+@pytest.mark.parametrize(
+    ("output_dir", "create_output_dir", "create_default_graph"),
+    [
+        ("graphify-out", False, False),
+        ("graphify-out", True, False),
+        ("custom-graph", True, True),
+    ],
+)
+def test_post_checkout_hook_stays_silent_without_active_graph(
+    tmp_path,
+    output_dir,
+    create_output_dir,
+    create_default_graph,
+):
+    repo = _make_git_repo(tmp_path)
+    install(repo)
+    if create_output_dir:
+        (repo / output_dir).mkdir()
+    if create_default_graph:
+        default_out = repo / "graphify-out"
+        default_out.mkdir(exist_ok=True)
+        (default_out / "graph.json").write_text("{}", encoding="utf-8")
+
+    env = {**os.environ, "HOME": str(tmp_path / "home")}
+    if output_dir != "graphify-out":
+        env["GRAPHIFY_OUT"] = output_dir
+    before = sorted(
+        str(path.relative_to(repo))
+        for path in repo.rglob("*")
+        if ".git" not in path.parts
+    )
+
+    result = subprocess.run(
+        [repo / ".git" / "hooks" / "post-checkout", "old", "new", "1"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    after = sorted(
+        str(path.relative_to(repo))
+        for path in repo.rglob("*")
+        if ".git" not in path.parts
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+    assert before == after
+    assert not (repo / output_dir / "graph.json").exists()
 
 
 # ── #1385: reject Windows-style hooks paths instead of creating a junk dir ───


### PR DESCRIPTION
## Summary
- keep post-commit and post-checkout silent until the active output contains graph.json
- honor GRAPHIFY_OUT in both Git hooks
- reject terminal existing hooks, including old unreachable marker blocks
- preflight both hook files before any installation write

## Reproduction
Graphify 0.8.46 creates graphify-out on the next commit when hooks are installed before a graph exists. It also reports successful appends after terminal exec hooks even though the Graphify block cannot run.

## Verification
- 105 hook tests passed
- 211 hook and installer tests passed
- Ruff passed
- CI-parity full suite passed 5,299 tests with one worktree-path-only failure; that test passes from a non-hidden checkout
- independent hook-protocol review: no findings