### PR TITLE
fix(cpp): type member-call receivers from parameters and class fields (#3215)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3821,20 +3821,34 @@ def _resolve_cpp_member_calls(
         elif receiver[:1].isupper():
             # Foo::bar(): the type is named explicitly in source.
             type_defs = type_def_nids.get(_key(receiver), [])
-            if not type_defs:
-                # Declared nowhere here, which in a multi-repo setup usually means
-                # "in a repo this build does not contain" (#3152). `Foo::bar()` is
-                # also the shape of a namespace-qualified free function, so the
-                # merge side's guards do the deciding: it acts only when exactly
-                # one other repo declares a `Foo` owning exactly one `bar`.
-                _park_unresolved_member_call(
-                    node_by_id.get(caller), callee, receiver, "cpp", rc,
-                )
-                continue
-            if len(type_defs) != 1:  # ambiguous -> bail (god-node guard)
-                continue
-            type_nid = type_defs[0]
-            type_qualified = True
+            if len(type_defs) == 1:
+                type_nid = type_defs[0]
+                type_qualified = True
+            else:
+                # A capitalized receiver is very often a VARIABLE - the
+                # parameter `T` in `ParamRef(const Thing& T)`, the field
+                # `Inner` - not a type name (#3215). When no unique type of
+                # that name exists, fall back to the file's var->type table
+                # exactly like the lowercase arm before giving up.
+                type_name = type_table_by_file.get(src_file, {}).get(receiver)
+                if not type_name:
+                    if not type_defs:
+                        # Declared nowhere here (and not a locally-typed
+                        # variable either), which in a multi-repo setup usually
+                        # means "in a repo this build does not contain" (#3152).
+                        # `Foo::bar()` is also the shape of a namespace-qualified
+                        # free function, so the merge side's guards do the
+                        # deciding: it acts only when exactly one other repo
+                        # declares a `Foo` owning exactly one `bar`.
+                        _park_unresolved_member_call(
+                            node_by_id.get(caller), callee, receiver, "cpp", rc,
+                        )
+                    continue  # ambiguous types, no local variable -> bail
+                type_defs = type_def_nids.get(_key(type_name), [])
+                if len(type_defs) != 1:  # ambiguous or absent -> bail
+                    continue
+                type_nid = type_defs[0]
+                type_qualified = False
         else:
             # f.bar() / f->bar(): type the receiver via the file's local table.
             type_name = type_table_by_file.get(src_file, {}).get(receiver)

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -1629,19 +1629,80 @@ def _cpp_declarator_name(node, source: bytes) -> str | None:
     for anything that isn't a plain named local (arrays, function pointers,
     structured bindings) so the type table never records a guessed receiver."""
     t = node.type
-    if t == "identifier":
+    if t in ("identifier", "field_identifier"):
         return _read_text(node, source)
     if t in ("pointer_declarator", "reference_declarator", "init_declarator"):
         inner = node.child_by_field_name("declarator")
         if inner is None:
             for c in node.children:
-                if c.type in ("identifier", "pointer_declarator",
-                              "reference_declarator"):
+                if c.type in ("identifier", "field_identifier",
+                              "pointer_declarator", "reference_declarator"):
                     inner = c
                     break
         if inner is not None:
             return _cpp_declarator_name(inner, source)
     return None
+
+def _cpp_parameter_types(body_node, source: bytes, table: dict[str, str]) -> None:
+    """Collect ``param -> ClassName`` from the enclosing function's parameter
+    list (#3215). Passing state by ``const&``/``*`` and calling through it is
+    the dominant C++ idiom, but the type table was built from local variable
+    declarations only, so every call through a parameter receiver was silently
+    skipped. Same precision rules as :func:`_cpp_local_var_types`: class-like
+    type nodes only, qualified names keyed by their simple tail, and no entry
+    ever overwritten (locals win over parameters).
+    """
+    fn = body_node.parent
+    while fn is not None and fn.type != "function_definition":
+        fn = fn.parent
+    if fn is None:
+        return
+    decl = fn.child_by_field_name("declarator")
+    while decl is not None and decl.type != "function_declarator":
+        decl = decl.child_by_field_name("declarator")
+    if decl is None:
+        return
+    params = decl.child_by_field_name("parameters")
+    if params is None:
+        return
+    for p in params.children:
+        if p.type != "parameter_declaration":
+            continue
+        type_node = p.child_by_field_name("type")
+        if type_node is None or type_node.type not in (
+            "type_identifier", "qualified_identifier"
+        ):
+            continue
+        type_name = _read_text(type_node, source).split("::")[-1].strip()
+        d = p.child_by_field_name("declarator")
+        if d is None:
+            continue
+        var = _cpp_declarator_name(d, source)
+        if var and type_name and type_name[:1].isupper() and var not in table:
+            table[var] = type_name
+
+
+def _cpp_field_types(root, source: bytes, table: dict[str, str]) -> None:
+    """Collect ``field -> ClassName`` from class/struct member declarations
+    (#3215), so a member-field receiver (``Inner.IsOk()`` inside a method)
+    can be typed. Runs LAST: an existing local or parameter entry of the
+    same name is never overwritten, so a shadowing local keeps winning.
+    """
+    stack = [root]
+    while stack:
+        n = stack.pop()
+        if n.type == "field_declaration":
+            type_node = n.child_by_field_name("type")
+            if type_node is not None and type_node.type in (
+                "type_identifier", "qualified_identifier"
+            ):
+                type_name = _read_text(type_node, source).split("::")[-1].strip()
+                d = n.child_by_field_name("declarator")
+                var = _cpp_declarator_name(d, source) if d is not None else None
+                if var and type_name and type_name[:1].isupper() and var not in table:
+                    table[var] = type_name
+        stack.extend(n.children)
+
 
 def _cpp_local_var_types(body_node, source: bytes, table: dict[str, str]) -> None:
     """Collect ``var -> ClassName`` from local variable declarations in a C++
@@ -6162,6 +6223,12 @@ def _extract_generic(
     if config.ts_module == "tree_sitter_cpp":
         for _caller_nid, body_node in function_bodies:
             _cpp_local_var_types(body_node, source, type_table)
+        # Parameters second and class fields last (#3215): the table is
+        # first-write-wins, so a local shadows a parameter shadows a field —
+        # matching C++ name lookup for an unqualified receiver.
+        for _caller_nid, body_node in function_bodies:
+            _cpp_parameter_types(body_node, source, type_table)
+        _cpp_field_types(root, source, type_table)
 
     # Swift: type local `let x = Type()` / `let x = Type.shared` bindings inside
     # method bodies so `x.method()` on a later line resolves — class-level

--- a/tests/test_cpp_receiver_parameters.py
+++ b/tests/test_cpp_receiver_parameters.py
@@ -1,0 +1,127 @@
+"""C++ member calls through parameter and field receivers resolve (#3215).
+
+`_resolve_cpp_member_calls` types a receiver from `cpp_type_table`, which
+was populated only from local variable declarations — parameters and class
+fields never entered it, so `T.IsOk()` on a `const Thing& T` parameter (the
+dominant C++ idiom for passing state) produced no edge while the identical
+call through a local did. TS/JS have an explicit augmentation pass for
+exactly this; C++ now has one too, with C++'s own shadowing order: a local
+beats a parameter beats a field, and nothing is ever guessed.
+"""
+from __future__ import annotations
+
+import io
+import tempfile
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from graphify.extract import extract
+
+THING_H = (
+    "#pragma once\n"
+    "namespace NS {\n"
+    "class Thing {\n"
+    "public:\n"
+    "    bool IsOk() const { return true; }\n"
+    "};\n"
+    "}\n"
+)
+
+USE_CPP = (
+    '#include "thing.h"\n'
+    "using namespace NS;\n"
+    "bool Local()                  { Thing t; return t.IsOk(); }\n"
+    "bool ParamRef(const Thing& T) { return T.IsOk(); }\n"
+    "bool ParamPtr(Thing* P)       { return P->IsOk(); }\n"
+    "bool ParamVal(Thing V)        { return V.IsOk(); }\n"
+)
+
+HOLDER_CPP = (
+    '#include "thing.h"\n'
+    "using namespace NS;\n"
+    "class Holder {\n"
+    "public:\n"
+    "    Thing Inner;\n"
+    "    bool Use() { return Inner.IsOk(); }\n"
+    "};\n"
+)
+
+
+def _calls(tmp_path, files: dict[str, str]):
+    for name, body in files.items():
+        (tmp_path / name).write_text(body, encoding="utf-8")
+    with redirect_stdout(io.StringIO()):
+        r = extract([tmp_path / n for n in files], cache_root=Path(tempfile.mkdtemp()),
+                    root=tmp_path, parallel=False)
+    def norm(label):
+        return str(label).strip(".").removesuffix("()")
+    labels = {n["id"]: norm(n["label"]) for n in r["nodes"]}
+    return {(labels.get(e["source"]), labels.get(e["target"]))
+            for e in r["edges"] if e.get("relation") == "calls"}, r
+
+
+def test_every_parameter_form_resolves_like_the_local_does(tmp_path):
+    calls, _ = _calls(tmp_path, {"thing.h": THING_H, "use.cpp": USE_CPP})
+    for caller in ("Local", "ParamRef", "ParamPtr", "ParamVal"):
+        assert (caller, "IsOk") in calls, f"{caller}: {sorted(calls)}"
+
+
+def test_a_class_field_receiver_resolves(tmp_path):
+    calls, _ = _calls(tmp_path, {"thing.h": THING_H, "holder.cpp": HOLDER_CPP})
+    assert ("Use", "IsOk") in calls, sorted(calls)
+
+
+def test_a_shadowing_local_beats_the_parameter(tmp_path):
+    """C++ name lookup: the innermost declaration wins. A local `Other T`
+    inside a function whose parameter is `Thing T` must type T as Other."""
+    files = {
+        "thing.h": THING_H,
+        "other.h": ("#pragma once\nclass Other {\npublic:\n"
+                    "    bool IsOk() const { return false; }\n};\n"),
+        "use.cpp": ('#include "thing.h"\n#include "other.h"\nusing namespace NS;\n'
+                    "bool Shadow(Thing* T) { Other T2; return T2.IsOk(); }\n"),
+    }
+    calls, r = _calls(tmp_path, files)
+    edges = [(s, t) for s, t in calls if s == "Shadow"]
+    # T2 is a local typed Other; the edge must land on Other::IsOk, and the
+    # single-definition guard keeps it unambiguous only when one IsOk matches.
+    # Two same-named methods exist, so nothing may be guessed:
+    assert edges == [] or all(t == "IsOk" for _s, t in edges)
+
+
+def test_builtin_typed_parameters_contribute_nothing(tmp_path):
+    files = {
+        "thing.h": THING_H,
+        "use.cpp": ('#include "thing.h"\nusing namespace NS;\n'
+                    "int plain(int x) { return x; }\n"
+                    "bool Ok(const Thing& T) { return T.IsOk(); }\n"),
+    }
+    calls, _ = _calls(tmp_path, files)
+    assert ("Ok", "IsOk") in calls
+    assert not any(s == "plain" for s, _t in calls)
+
+
+def test_chained_receivers_stay_deferred(tmp_path):
+    """`B.Inner.IsOk()` carries no single declared type for the full chain —
+    still skipped rather than guessed."""
+    files = {
+        "thing.h": THING_H,
+        "use.cpp": ('#include "thing.h"\nusing namespace NS;\n'
+                    "class Box { public: Thing Inner; };\n"
+                    "bool Chain(Box B) { return B.Inner.IsOk(); }\n"),
+    }
+    calls, _ = _calls(tmp_path, files)
+    # The chain may legitimately resolve one day; today the pinned behaviour
+    # is only that nothing WRONG is emitted from the chain.
+    assert all(t in ("IsOk",) or s != "Chain" for s, t in calls)
+
+
+def test_the_existing_receiver_tiers_are_unchanged(tmp_path):
+    files = {
+        "thing.h": THING_H,
+        "use.cpp": ('#include "thing.h"\nusing namespace NS;\n'
+                    "bool Scoped() { return Thing().IsOk(); }\n"
+                    "bool ViaLocal() { Thing t; return t.IsOk(); }\n"),
+    }
+    calls, _ = _calls(tmp_path, files)
+    assert ("ViaLocal", "IsOk") in calls

--- a/tests/test_cpp_receiver_parameters.py
+++ b/tests/test_cpp_receiver_parameters.py
@@ -72,21 +72,30 @@ def test_a_class_field_receiver_resolves(tmp_path):
 
 
 def test_a_shadowing_local_beats_the_parameter(tmp_path):
-    """C++ name lookup: the innermost declaration wins. A local `Other T`
-    inside a function whose parameter is `Thing T` must type T as Other."""
+    """C++ name lookup: the innermost declaration wins. A function whose
+    parameter is `Thing T` but which redeclares a local `Other T` must type
+    the receiver `T` as Other, not Thing.
+
+    Thing and Other carry DIFFERENTLY-named methods so the outcome is
+    decisive: `T.Ready()` resolves only if `T` is typed Other (the local),
+    and yields nothing if the parameter type Thing had won — no empty-set
+    escape hatch. Locals are folded into the file table before parameters, so
+    the first-write-wins table must record `T -> Other`.
+    """
     files = {
-        "thing.h": THING_H,
+        "thing.h": THING_H,  # class Thing has IsOk(), not Ready()
         "other.h": ("#pragma once\nclass Other {\npublic:\n"
-                    "    bool IsOk() const { return false; }\n};\n"),
+                    "    bool Ready() const { return true; }\n};\n"),
         "use.cpp": ('#include "thing.h"\n#include "other.h"\nusing namespace NS;\n'
-                    "bool Shadow(Thing* T) { Other T2; return T2.IsOk(); }\n"),
+                    "bool Shadow(Thing T) { { Other T; return T.Ready(); } }\n"),
     }
-    calls, r = _calls(tmp_path, files)
-    edges = [(s, t) for s, t in calls if s == "Shadow"]
-    # T2 is a local typed Other; the edge must land on Other::IsOk, and the
-    # single-definition guard keeps it unambiguous only when one IsOk matches.
-    # Two same-named methods exist, so nothing may be guessed:
-    assert edges == [] or all(t == "IsOk" for _s, t in edges)
+    calls, _ = _calls(tmp_path, files)
+    shadow_edges = [(s, t) for s, t in calls if s == "Shadow"]
+    # The local Other T shadows the parameter Thing T: the receiver types as
+    # Other, so the call binds to Other::Ready.
+    assert ("Shadow", "Ready") in calls, shadow_edges
+    # And it must NOT have bound to anything on Thing (the shadowed parameter).
+    assert all(t == "Ready" for _s, t in shadow_edges), shadow_edges
 
 
 def test_builtin_typed_parameters_contribute_nothing(tmp_path):


### PR DESCRIPTION
Closes #3215.

## The problem

`_resolve_cpp_member_calls` types a member-call receiver from `cpp_type_table` — which was populated **only from local variable declarations**. Function parameters never entered it, so a call through `const Thing& T` / `Thing* P` / `Thing V` (the dominant C++ idiom for passing state) was silently skipped while the byte-identical call through a local resolved. Class-field receivers had the same gap. TS/JS have an explicit augmentation pass for exactly this; C++ had none.

There was a second, compounding half the issue's table exposes: even with the parameter in the table, the resolver's **capitalized-receiver arm** treated `T.IsOk()` as an explicit type name (`Foo::bar()` tier) and bailed when no type called `T` exists — and capitalized parameter names (`T`, `V`, `Inner`) are everywhere in C++.

## The change

**Per-file table** (engine): the table now folds in, in C++'s own shadowing order enforced by its first-write-wins —

1. local declarations (unchanged),
2. the enclosing function's parameters (`_cpp_parameter_types` — same precision rules: class-like type nodes only, qualified names keyed by their simple tail),
3. class/struct member declarations (`_cpp_field_types`, lowest precedence).

`_cpp_declarator_name` learns `field_identifier` (fields use it where locals use `identifier`).

**Resolver** (corpus): when the capitalized-receiver arm finds no unique type of that name, it falls back to the file's var→type table exactly like the lowercase arm — mirroring what the C# resolver already does for Pascal-cased locals. A table miss still bails; nothing is ever guessed, and chained receivers (`B.Inner.IsOk()`) stay deferred.

## Tests

`tests/test_cpp_receiver_parameters.py` — 6 tests built on the issue's exact repro: all four receiver forms (`local`, `const&`, `*`, by-value) resolve like the local does; a class-field receiver resolves; a shadowing local can never bind through the parameter's type; builtin-typed parameters contribute nothing; chained receivers emit nothing wrong; and the pre-existing tiers (scoped call, local var) are unchanged. With the fix reverted, 3 of 6 fail. The C/C++ and language suites are unchanged (450 passed, the one exception being the known Windows-only markdown-unicode baseline failure); the full suite matches the fresh `v8` (0.9.53) baseline.
