### PR TITLE
Fix Python type reference stubs across imports (#3252)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -6664,18 +6664,17 @@ def extract(
             logging.getLogger(__name__).warning(
                 "Go type-reference resolution failed, skipping: %s", exc
             )
-    _rewire_unique_stub_nodes(all_nodes, all_edges)
-
-    # Add cross-file class-level edges (Python only - uses Python parser internally)
+    # Cross-file Python import resolution and type-reference repointing (#3252)
     py_paths = [p for p in paths if p.suffix == ".py"]
     if py_paths:
         py_results = [r for r, p in zip(per_file, paths) if p.suffix == ".py"]
         try:
-            cross_file_edges = _resolve_cross_file_imports(py_results, py_paths)
+            cross_file_edges = _resolve_cross_file_imports(py_results, py_paths, all_nodes, all_edges)
             all_edges.extend(cross_file_edges)
         except Exception as exc:
             import logging
             logging.getLogger(__name__).warning("Cross-file import resolution failed, skipping: %s", exc)
+    _rewire_unique_stub_nodes(all_nodes, all_edges)
 
     # Cross-file Java import resolution
     java_paths = [p for p in paths if p.suffix == ".java"]

--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -1914,6 +1914,8 @@ def _augment_symbol_resolution_edges(
 def _resolve_cross_file_imports(
     per_file: list[dict],
     paths: list[Path],
+    all_nodes: list[dict] | None = None,
+    all_edges: list[dict] | None = None,
 ) -> list[dict]:
     """
     Two-pass import resolution: turn file-level imports into class-level edges.
@@ -1975,9 +1977,15 @@ def _resolve_cross_file_imports(
     # shares the file (#2652). The edge is anchored at the real reference, not
     # the import line, so `source_location` points at genuine corroboration.
     new_edges: list[dict] = []
+    node_by_id = {node["id"]: node for node in all_nodes if node.get("id")} if all_nodes else {}
+    repointed_from: set[str] = set()
+    TYPE_REPOINT_RELATIONS = frozenset({"references", "inherits", "implements", "extends"})
 
     for file_result, path in zip(per_file, paths):
         str_path = str(path)
+        file_srcs = {n.get("source_file") for n in file_result.get("nodes", []) if n.get("source_file")}
+        file_srcs.add(str_path)
+        file_srcs.add(path.as_posix())
 
         # Map each local symbol (class or function) to its node id, keyed by the
         # bare symbol name. Function labels end in "()"; the file node ends in
@@ -2023,16 +2031,38 @@ def _resolve_cross_file_imports(
             target_fq: str | None = None
             for child in node.children:
                 if child.type == "relative_import":
+                    prefix_text = ""
+                    dotted_text = ""
                     for sub in child.children:
-                        if sub.type == "dotted_name":
-                            bare = _text(sub).split(".")[-1]
-                            candidate = path.parent / f"{bare}.py"
-                            target_fq = _file_stem(candidate)
-                            break
+                        if sub.type == "import_prefix":
+                            prefix_text = _text(sub)
+                        elif sub.type == "dotted_name":
+                            dotted_text = _text(sub)
+                    dots = prefix_text.count(".") if prefix_text else 1
+                    cur_dir = path.parent
+                    for _ in range(dots - 1):
+                        cur_dir = cur_dir.parent
+                    if dotted_text:
+                        candidate = cur_dir.joinpath(*dotted_text.split(".")).with_suffix(".py")
+                    else:
+                        candidate = cur_dir / "__init__.py"
+                    target_fq = _file_stem(candidate)
                     break
                 if child.type == "dotted_name" and target_fq is None:
-                    bare = _text(child).split(".")[-1]
-                    target_fq = bare_to_qualified.get(bare)
+                    dotted_name = _text(child)
+                    dotted_as_path = "/".join(dotted_name.split("."))
+                    if dotted_as_path in stem_to_entities:
+                        target_fq = dotted_as_path
+                    else:
+                        suffix_matches = [
+                            fq for fq in stem_to_entities
+                            if fq.endswith(f"/{dotted_as_path}") or fq.endswith(f"\\{dotted_as_path}")
+                        ]
+                        if len(suffix_matches) == 1:
+                            target_fq = suffix_matches[0]
+                        else:
+                            bare = dotted_name.split(".")[-1]
+                            target_fq = bare_to_qualified.get(bare)
 
             if not target_fq or target_fq not in stem_to_entities:
                 return
@@ -2106,6 +2136,31 @@ def _resolve_cross_file_imports(
                     "source_location": f"L{line}",
                     "weight": 0.8,
                 })
+
+        # Repoint AST type-reference and inheritance edges from sourceless stubs
+        # to the exact imported target definition (#3252).
+        if all_edges and import_targets:
+            for edge in all_edges:
+                if edge.get("source_file") not in file_srcs:
+                    continue
+                if edge.get("relation") not in TYPE_REPOINT_RELATIONS:
+                    continue
+                tgt = edge.get("target")
+                tgt_node = node_by_id.get(tgt)
+                if not tgt_node or tgt_node.get("source_file"):
+                    continue
+                stub_label = tgt_node.get("label", "")
+                resolved_id = import_targets.get(stub_label)
+                if resolved_id and resolved_id != tgt:
+                    edge["target"] = resolved_id
+                    repointed_from.add(tgt)
+
+    if all_nodes is not None and all_edges is not None and repointed_from:
+        still_referenced = {e.get("source") for e in all_edges} | {e.get("target") for e in all_edges}
+        all_nodes[:] = [
+            node for node in all_nodes
+            if node.get("id") not in repointed_from or node.get("id") in still_referenced
+        ]
 
     return new_edges
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -4165,3 +4165,187 @@ def test_extract_genuinely_empty_json_still_failed(tmp_path, monkeypatch):
     p.write_text("{}\n")
     result = _ex.extract([p], cache_root=tmp_path)
     assert [Path(x).name for x in result.get("failed_sources", [])] == ["meta.json"]
+
+
+# ── #3252: Authoritative Python Type Reference and Inheritance Rewiring ────────
+
+def test_3252_exact_import_beats_global_ambiguity(tmp_path):
+    """#3252: When two packages define same-named types, exact import resolution
+    repoints references to the imported canonical definition without ghost stubs."""
+    (tmp_path / "pkg_a").mkdir()
+    (tmp_path / "pkg_b").mkdir()
+    (tmp_path / "pkg_a" / "types.py").write_text("class StateFrame:\n    pass\n", encoding="utf-8")
+    (tmp_path / "pkg_b" / "types.py").write_text("class StateFrame:\n    pass\n", encoding="utf-8")
+    (tmp_path / "consumer_a.py").write_text(
+        "from pkg_a.types import StateFrame\ndef foo_a(x: StateFrame):\n    pass\n", encoding="utf-8"
+    )
+    (tmp_path / "consumer_b.py").write_text(
+        "from pkg_b.types import StateFrame\ndef foo_b(x: StateFrame):\n    pass\n", encoding="utf-8"
+    )
+
+    files = [
+        tmp_path / "pkg_a" / "types.py",
+        tmp_path / "pkg_b" / "types.py",
+        tmp_path / "consumer_a.py",
+        tmp_path / "consumer_b.py",
+    ]
+    res = extract(files, root=tmp_path, cache_root=tmp_path)
+    node_by_id = {n["id"]: n for n in res["nodes"]}
+
+    ref_edges = [e for e in res["edges"] if e.get("relation") == "references"]
+    ref_a = next(e for e in ref_edges if "consumer_a_foo_a" in e["source"])
+    ref_b = next(e for e in ref_edges if "consumer_b_foo_b" in e["source"])
+
+    assert node_by_id[ref_a["target"]]["source_file"] == "pkg_a/types.py"
+    assert node_by_id[ref_b["target"]]["source_file"] == "pkg_b/types.py"
+
+    # All StateFrame nodes in the graph must be source-backed definitions (0 stubs)
+    sf_nodes = [n for n in res["nodes"] if n.get("label") == "StateFrame"]
+    assert len(sf_nodes) == 2
+    assert all(n.get("source_file") for n in sf_nodes)
+
+
+def test_3252_aliased_import_repoints_references(tmp_path):
+    """#3252: Aliased import (`from state import StateFrame as SF`) repoints
+    references to the canonical StateFrame and removes the SF stub."""
+    (tmp_path / "state.py").write_text("class StateFrame:\n    pass\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        "from state import StateFrame as SF\ndef foo(x: SF):\n    pass\n", encoding="utf-8"
+    )
+
+    res = extract([tmp_path / "state.py", tmp_path / "consumer.py"], root=tmp_path, cache_root=tmp_path)
+    node_by_id = {n["id"]: n for n in res["nodes"]}
+
+    ref_edge = next(e for e in res["edges"] if e.get("relation") == "references")
+    assert ref_edge["source"] == "consumer_foo"
+    assert node_by_id[ref_edge["target"]]["label"] == "StateFrame"
+    assert node_by_id[ref_edge["target"]]["source_file"] == "state.py"
+    assert ref_edge["context"] == "parameter_type"
+    assert ref_edge["confidence"] == "EXTRACTED"
+
+    # SF stub removed
+    assert not any(n.get("label") == "SF" for n in res["nodes"])
+
+
+def test_3252_inheritance_repoints_inherits_edge(tmp_path):
+    """#3252: Class inheritance (`class Child(StateFrame):`) repoints the inherits
+    edge to the canonical definition without ghost stubs."""
+    (tmp_path / "state.py").write_text("class StateFrame:\n    pass\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        "from state import StateFrame\nclass Child(StateFrame):\n    pass\n", encoding="utf-8"
+    )
+
+    res = extract([tmp_path / "state.py", tmp_path / "consumer.py"], root=tmp_path, cache_root=tmp_path)
+    node_by_id = {n["id"]: n for n in res["nodes"]}
+
+    inherits_edge = next(e for e in res["edges"] if e.get("relation") == "inherits")
+    assert inherits_edge["source"] == "consumer_child"
+    assert node_by_id[inherits_edge["target"]]["label"] == "StateFrame"
+    assert node_by_id[inherits_edge["target"]]["source_file"] == "state.py"
+
+    # No sourceless StateFrame stubs remain
+    sf_nodes = [n for n in res["nodes"] if n.get("label") == "StateFrame"]
+    assert len(sf_nodes) == 1
+    assert sf_nodes[0].get("source_file") == "state.py"
+
+
+def test_3252_relative_imports(tmp_path):
+    """#3252: Relative imports (`from .types import StateFrame`) repoint accurately."""
+    (tmp_path / "pkg" / "sub").mkdir(parents=True)
+    (tmp_path / "pkg" / "sub" / "types.py").write_text("class StateFrame:\n    pass\n", encoding="utf-8")
+    (tmp_path / "pkg" / "sub" / "consumer.py").write_text(
+        "from .types import StateFrame\ndef foo(x: StateFrame):\n    pass\n", encoding="utf-8"
+    )
+
+    files = [tmp_path / "pkg" / "sub" / "types.py", tmp_path / "pkg" / "sub" / "consumer.py"]
+    res = extract(files, root=tmp_path, cache_root=tmp_path)
+    node_by_id = {n["id"]: n for n in res["nodes"]}
+
+    ref_edge = next(e for e in res["edges"] if e.get("relation") == "references")
+    assert node_by_id[ref_edge["target"]]["source_file"] == "pkg/sub/types.py"
+    assert not any(n.get("label") == "StateFrame" and not n.get("source_file") for n in res["nodes"])
+
+
+def test_3252_unimported_ambiguous_type_remains_unresolved(tmp_path):
+    """#3252: When multiple definitions exist but consumer has no import, Graphify
+    must NOT guess or collapse to an arbitrary definition."""
+    (tmp_path / "pkg_a").mkdir()
+    (tmp_path / "pkg_b").mkdir()
+    (tmp_path / "pkg_a" / "types.py").write_text("class StateFrame:\n    pass\n", encoding="utf-8")
+    (tmp_path / "pkg_b" / "types.py").write_text("class StateFrame:\n    pass\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        "def foo(x: StateFrame):\n    pass\n", encoding="utf-8"
+    )
+
+    files = [
+        tmp_path / "pkg_a" / "types.py",
+        tmp_path / "pkg_b" / "types.py",
+        tmp_path / "consumer.py",
+    ]
+    res = extract(files, root=tmp_path, cache_root=tmp_path)
+    node_by_id = {n["id"]: n for n in res["nodes"]}
+
+    ref_edge = next(e for e in res["edges"] if e.get("relation") == "references")
+    # Stub must NOT have bound to either definition
+    target_node = node_by_id[ref_edge["target"]]
+    assert not target_node.get("source_file")
+
+
+def test_3252_cross_language_same_name_definition(tmp_path):
+    """#3252: Python import resolution resolves only to Python definitions, not
+    same-named TypeScript definitions."""
+    pytest.importorskip("tree_sitter_typescript")
+    (tmp_path / "types.py").write_text("class StateFrame:\n    pass\n", encoding="utf-8")
+    (tmp_path / "types.ts").write_text("export interface StateFrame { id: string; }\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        "from types import StateFrame\ndef foo(x: StateFrame):\n    pass\n", encoding="utf-8"
+    )
+
+    files = [tmp_path / "types.py", tmp_path / "types.ts", tmp_path / "consumer.py"]
+    res = extract(files, root=tmp_path, cache_root=tmp_path)
+    node_by_id = {n["id"]: n for n in res["nodes"]}
+
+    ref_edge = next(e for e in res["edges"] if e.get("relation") == "references")
+    assert node_by_id[ref_edge["target"]]["source_file"] == "types.py"
+
+
+def test_3252_alias_and_inheritance(tmp_path):
+    """#3252: Aliased import in inheritance (`class Child(SF):`) repoints inherits
+    edge to canonical StateFrame and drops the SF stub."""
+    (tmp_path / "state.py").write_text("class StateFrame:\n    pass\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        "from state import StateFrame as SF\nclass Child(SF):\n    pass\n", encoding="utf-8"
+    )
+
+    res = extract([tmp_path / "state.py", tmp_path / "consumer.py"], root=tmp_path, cache_root=tmp_path)
+    node_by_id = {n["id"]: n for n in res["nodes"]}
+
+    inherits_edge = next(e for e in res["edges"] if e.get("relation") == "inherits")
+    assert inherits_edge["source"] == "consumer_child"
+    assert node_by_id[inherits_edge["target"]]["label"] == "StateFrame"
+    assert node_by_id[inherits_edge["target"]]["source_file"] == "state.py"
+    assert not any(n.get("label") == "SF" for n in res["nodes"])
+
+
+def test_3252_metadata_preservation(tmp_path):
+    """#3252: Repointing mutates only edge['target'] while preserving relation,
+    context, confidence, confidence_score, source_file, and source_location."""
+    (tmp_path / "models.py").write_text("class User:\n    pass\n", encoding="utf-8")
+    (tmp_path / "service.py").write_text(
+        "from models import User\ndef get_user(u: User) -> User:\n    pass\n", encoding="utf-8"
+    )
+
+    res = extract([tmp_path / "models.py", tmp_path / "service.py"], root=tmp_path, cache_root=tmp_path)
+    node_by_id = {n["id"]: n for n in res["nodes"]}
+
+    param_ref = next(
+        e for e in res["edges"]
+        if e.get("relation") == "references" and e.get("context") == "parameter_type"
+    )
+    assert param_ref["relation"] == "references"
+    assert param_ref["context"] == "parameter_type"
+    assert param_ref["confidence"] == "EXTRACTED"
+    assert param_ref["source_file"] == "service.py"
+    assert param_ref["source_location"] == "L2"
+    assert node_by_id[param_ref["target"]]["label"] == "User"
+    assert node_by_id[param_ref["target"]]["source_file"] == "models.py"


### PR DESCRIPTION
## Summary

Fixes #3252 by correctly rewiring Python type-reference and inheritance edges from sourceless AST stubs to their exact imported definitions.

Previously, when multiple definitions shared the same type name, Graphify's generic stub rewiring could not disambiguate them. This left per-file sourceless stubs behind even though the Python import resolver already knew the correct target.

## Root Cause

Python type annotations and inheritance expressions can create temporary sourceless stub nodes such as `StateFrame`.

`_rewire_unique_stub_nodes()` relies on global bare-name uniqueness, so when multiple `StateFrame` definitions exist across packages, tests, or languages, it intentionally refuses to guess.

The Python cross-file import resolver, however, already has the exact import context needed to resolve these references. It previously only added inferred `uses` edges and did not update the original AST `references` / `inherits` edges.

As a result, the graph could contain ghost `StateFrame` nodes with AST edges still pointing at them.

## Changes

* Run Python cross-file import resolution before generic stub rewiring.
* Use the existing file-scoped `import_targets` mapping to identify the exact imported definition.
* Repoint sourceless `references`, `inherits`, `implements`, and `extends` edges to the canonical definition.
* Preserve existing edge metadata when repointing.
* Prune sourceless stubs once they no longer have any incident edges.
* Keep generic `_rewire_unique_stub_nodes()` as the fallback for unimported symbols.
* Preserve existing behavior for ambiguous unimported references rather than guessing.

## Covered Cases

Regression tests cover:

* Multiple packages defining the same type
* Aliased imports
* Imported inheritance
* Relative imports
* Ambiguous unimported types
* Python/TypeScript definitions sharing the same name
* Aliased inheritance
* Edge metadata preservation

## Testing

* `uv run pytest tests/test_extract.py -k "3252" -v`
* `uv run pytest tests/test_extract.py -k "3252 or stateframe or rewire or cross_file_import" -v`
* `uv run pytest tests/test_extract.py -v`
* `uv run pytest tests/test_languages.py -v`
* `uv run pytest -q`

The focused and extraction/language test suites pass, with the full suite run as final verification.
