### PR TITLE
fix(extract): stop cross-project edges from platform imports and shared npm deps (#3237)

### DIFF
--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -491,6 +491,13 @@ def _report_id_collision(nid: str, survivor: dict, losers: list[dict]) -> None:
                     f"dropping '{lose_label}'.",
                     file=sys.stderr,
                 )
+        elif (survivor.get("type") == "module" and loser.get("type") == "module"
+              and _norm(lose_label) == _norm(keep_label)):
+            # Module anchors (#1327) and registry-package refs (#3237) are
+            # shared nodes by design: every file that imports or declares the
+            # same module mints the same id on purpose, so collapsing the
+            # copies loses nothing — not a collision worth warning about.
+            continue
         elif _defines_id(survivor) and not _defines_id(loser):
             continue  # the loser only references the entity the survivor defines
         else:

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -644,6 +644,23 @@ def _import_js(node, source: bytes, file_nid: str, stem: str, edges: list, str_p
                                         })
 
 
+# Package roots that live in the JVM/Android platform or the Kotlin stdlib —
+# never in the scanned repo. An import under these roots must not emit a
+# repo-collidable bare-stem target: the bare id can byte-collide with an
+# unrelated node that collapses to the same _make_id (e.g. `java.util.UUID`
+# hitting a package.json dependency entry for npm's `uuid`), and it can ride
+# build.py's pre-migration alias index onto whichever unrelated same-stem file
+# uniquely claims that stem (`android.graphics.Color` binding to another
+# project's `ui/theme/Color.kt`) — confident cross-project phantom edges in a
+# monorepo (#3237). Retargeting to the "ref" namespace is the same cure
+# _resolve_js_import_target applies to unresolvable JS imports (#1638): the
+# ref id matches no repo node, so build drops the edge as an external import.
+_JVM_PLATFORM_PACKAGE_ROOTS = (
+    "java.", "javax.", "jakarta.", "kotlin.", "kotlinx.",
+    "android.", "androidx.", "dalvik.",
+)
+
+
 def _import_java(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str, scope_stack: list[str] | None = None) -> None:
     def _walk_scoped(n) -> str:
         parts: list[str] = []
@@ -669,7 +686,10 @@ def _import_java(node, source: bytes, file_nid: str, stem: str, edges: list, str
                 path_str.split(".")[-2] if len(path_str.split(".")) > 1 else path_str
             )
             if module_name:
-                tgt_nid = _make_id(module_name)
+                # Platform imports get a non-collidable external target (#3237).
+                tgt_nid = (_make_id("ref", path_str)
+                           if path_str.startswith(_JVM_PLATFORM_PACKAGE_ROOTS)
+                           else _make_id(module_name))
                 edges.append({
                     "source": file_nid,
                     "target": tgt_nid,
@@ -799,10 +819,15 @@ def _import_kotlin(node, source: bytes, file_nid: str, stem: str, edges: list, s
     # Target is the bare last segment for now; _resolve_kotlin_import_targets
     # rewrites it to the real node id via the target_fqn stamped here, once the
     # per-file package index exists. Unresolved targets stay dangling like other
-    # languages' external imports.
+    # languages' external imports — except platform-namespace imports, whose
+    # bare stem must never be collidable in the first place (#3237): the
+    # corpus resolver could not rewrite them anyway (their package is never a
+    # repo package), so they go straight to the external "ref" namespace.
     edges.append({
         "source": file_nid,
-        "target": _make_id(module_name),
+        "target": (_make_id("ref", raw)
+                   if raw.startswith(_JVM_PLATFORM_PACKAGE_ROOTS)
+                   else _make_id(module_name)),
         "relation": "imports",
         "context": "import",
         "confidence": "EXTRACTED",

--- a/graphify/extractors/json_config.py
+++ b/graphify/extractors/json_config.py
@@ -91,11 +91,15 @@ def extract_json(path: Path) -> dict:
         "optionalDependencies", "bundleDependencies", "bundledDependencies",
     })
 
-    def add_node(nid: str, label: str, line: int, file_type: str = "code") -> None:
+    def add_node(nid: str, label: str, line: int, file_type: str = "code",
+                 node_type: str | None = None) -> None:
         if nid and nid not in seen_ids:
             seen_ids.add(nid)
-            nodes.append({"id": nid, "label": label, "file_type": file_type,
-                          "source_file": str_path, "source_location": f"L{line}"})
+            node = {"id": nid, "label": label, "file_type": file_type,
+                    "source_file": str_path, "source_location": f"L{line}"}
+            if node_type:
+                node["type"] = node_type
+            nodes.append(node)
 
     def add_edge(src: str, tgt: str, relation: str, line: int,
                  context: str | None = None) -> None:
@@ -217,9 +221,18 @@ def extract_json(path: Path) -> dict:
                     #    `types` could then be collapsed onto a same-named local
                     #    module by build.py's alias index -- the #1638 failure
                     #    mode reached through a different door.
+                    #
+                    # The ref node models the registry package itself, so it is
+                    # stamped `type="module"` (#3237): several manifests
+                    # declaring the same package share ONE anchor node under the
+                    # #1327 module exemption in _disambiguate_colliding_node_ids
+                    # instead of being salted apart per file, and a JS
+                    # `import ... from "<pkg>"` (which already targets
+                    # _make_id("ref", raw)) lands on it instead of dangling.
                     dep_nid = _make_id("ref", key)
                     if dep_nid:
-                        add_node(dep_nid, key, line, file_type="concept")
+                        add_node(dep_nid, key, line, file_type="concept",
+                                 node_type="module")
                         add_edge(file_nid, dep_nid, "imports", line, context="import")
 
     # Entry: find root document → object

--- a/tests/test_monorepo_import_collisions.py
+++ b/tests/test_monorepo_import_collisions.py
@@ -1,0 +1,259 @@
+"""Cross-project name-collision fixes for monorepos (#3237).
+
+Two mechanisms produced confident (EXTRACTED) edges between unrelated projects
+that merely share a name:
+
+1. JVM/Android platform imports (``import java.util.UUID``,
+   ``import android.graphics.Color``) emitted a bare last-segment target id.
+   That id could byte-collide with an unrelated node that collapses to the
+   same ``_make_id`` (npm's ``uuid`` dependency entry in another project's
+   package.json), or ride build.py's pre-migration alias index onto whichever
+   unrelated same-stem file uniquely claims the stem (another project's
+   ``ui/theme/Color.kt``).
+
+2. package.json dependency entries minted a global bare target node per
+   package name, so two projects that independently install the same npm
+   package were joined through it.
+
+The fix applies the "ref" external namespace (J-4 / #1638 convention) to both
+sites, and models a registry package as a single shared ``type="module"``
+anchor node.
+"""
+
+import json
+
+import pytest
+
+from graphify.build import build
+from graphify.extract import extract
+
+
+def _extract_and_build(td, files):
+    r = extract(files, cache_root=td)
+    G = build([{"nodes": r["nodes"], "edges": r["edges"]}], root=str(td))
+    return r, G
+
+
+def _write(base, rel, text):
+    p = base / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+KOTLIN_PLATFORM_UUID = (
+    "package com.b.service\n\n"
+    "import java.util.UUID\n\n"
+    "class Service {\n"
+    "    fun newId(): String = UUID.randomUUID().toString()\n"
+    "}\n"
+)
+
+PACKAGE_JSON_WITH_UUID = json.dumps(
+    {"name": "proj-a", "version": "1.0.0", "dependencies": {"uuid": "^9.0.0"}}
+)
+
+
+def test_platform_import_does_not_bind_to_npm_dependency_node(tmp_path, monkeypatch):
+    """`import java.util.UUID` must not edge into another project's package.json.
+
+    The Kotlin import's bare target id (`uuid`) used to byte-collide with the
+    npm dependency node minted from an unrelated project's manifest.
+    """
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, "projA/package.json", PACKAGE_JSON_WITH_UUID)
+    _write(tmp_path, "projB/src/Service.kt", KOTLIN_PLATFORM_UUID)
+
+    _, G = _extract_and_build(
+        tmp_path,
+        [tmp_path / "projA/package.json", tmp_path / "projB/src/Service.kt"],
+    )
+
+    kotlin_sourced = {
+        n for n, a in G.nodes(data=True)
+        if str(a.get("source_file", "")).endswith(".kt")
+    }
+    manifest_sourced = {
+        n for n, a in G.nodes(data=True)
+        if str(a.get("source_file", "")).endswith("package.json")
+    }
+    crossing = [
+        (u, v) for u, v in G.edges()
+        if (u in kotlin_sourced and v in manifest_sourced)
+        or (v in kotlin_sourced and u in manifest_sourced)
+    ]
+    assert crossing == [], (
+        f"platform import bound across projects: {crossing}"
+    )
+
+
+def test_platform_import_does_not_ride_alias_onto_unrelated_file(tmp_path, monkeypatch):
+    """`import android.graphics.Color` must not bind to another project's Color.kt.
+
+    The bare `color` target used to ride build.py's pre-migration alias index
+    onto the unrelated file node that uniquely claims the `color` stem.
+    """
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path, "projA/app/Painter.kt",
+        "package com.a.app\n\n"
+        "import android.graphics.Color\n\n"
+        "class Painter {\n"
+        "    fun tint(): Int = Color.parseColor(\"#ff0000\")\n"
+        "}\n",
+    )
+    _write(
+        tmp_path, "projB/ui/theme/Color.kt",
+        "package com.b.theme\n\n"
+        "object Color {\n"
+        "    val Primary: Long = 0xFF6200EE\n"
+        "}\n",
+    )
+
+    _, G = _extract_and_build(
+        tmp_path,
+        [tmp_path / "projA/app/Painter.kt", tmp_path / "projB/ui/theme/Color.kt"],
+    )
+
+    painter_edges = [
+        (u, v, a) for u, v, a in G.edges(data=True)
+        if str(a.get("source_file", "")).endswith("Painter.kt")
+        and a.get("relation") == "imports"
+    ]
+    assert painter_edges == [], (
+        f"platform import survived into the built graph: {painter_edges}"
+    )
+
+
+def test_repo_local_kotlin_import_still_resolves(tmp_path, monkeypatch):
+    """Control: a repo-local FQN import keeps resolving to the real node (#2526)."""
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path, "projA/app/Painter.kt",
+        "package com.a.app\n\n"
+        "import com.b.theme.Color\n\n"
+        "class Painter {\n"
+        "    fun tint(): Long = 1L\n"
+        "}\n",
+    )
+    _write(
+        tmp_path, "projB/ui/theme/Color.kt",
+        "package com.b.theme\n\n"
+        "object Color {\n"
+        "    val Primary: Long = 0xFF6200EE\n"
+        "}\n",
+    )
+
+    _, G = _extract_and_build(
+        tmp_path,
+        [tmp_path / "projA/app/Painter.kt", tmp_path / "projB/ui/theme/Color.kt"],
+    )
+
+    resolved = [
+        (u, v) for u, v, a in G.edges(data=True)
+        if a.get("relation") == "imports"
+        and str(a.get("source_file", "")).endswith("Painter.kt")
+        and any(n.startswith("projb_ui_theme_color") for n in (u, v))
+    ]
+    assert resolved, "repo-local Kotlin import no longer resolves (#2526 regression)"
+
+
+def test_java_platform_import_emits_ref_namespaced_target(tmp_path, monkeypatch):
+    """A .java platform import gets a non-collidable `ref_` target, a repo-shaped
+    one keeps the bare stem for downstream resolution."""
+    monkeypatch.chdir(tmp_path)
+    f = _write(
+        tmp_path, "src/Service.java",
+        "package com.b.service;\n\n"
+        "import java.util.UUID;\n"
+        "import com.b.util.Helper;\n\n"
+        "public class Service {\n"
+        "    public String newId() { return UUID.randomUUID().toString(); }\n"
+        "}\n",
+    )
+    r = extract([f], cache_root=tmp_path)
+    targets = {
+        e["target"] for e in r["edges"] if e.get("relation") == "imports"
+    }
+    assert "uuid" not in targets, "platform import still emits a bare collidable id"
+    assert any(t.startswith("ref_java_util_uuid") for t in targets), targets
+    assert "helper" in targets, "repo-shaped import lost its resolvable bare stem"
+
+
+def test_kotlin_platform_import_emits_ref_namespaced_target(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    f = _write(
+        tmp_path, "src/Service.kt",
+        "package com.b.service\n\n"
+        "import java.util.UUID\n"
+        "import androidx.compose.material3.Typography\n"
+        "import com.b.util.Helper\n\n"
+        "class Service {\n"
+        "    fun newId(): String = UUID.randomUUID().toString()\n"
+        "}\n",
+    )
+    r = extract([f], cache_root=tmp_path)
+    targets = {
+        e["target"] for e in r["edges"] if e.get("relation") == "imports"
+    }
+    assert "uuid" not in targets and "typography" not in targets, targets
+    assert any(t.startswith("ref_java_util_uuid") for t in targets), targets
+    assert any(t.startswith("ref_androidx_compose") for t in targets), targets
+    assert "helper" in targets, "repo-shaped import lost its resolvable bare stem"
+
+
+def test_shared_dependency_joins_manifests_through_one_module_node(tmp_path, monkeypatch):
+    """Two projects installing the same npm package share ONE `type=module` ref
+    node instead of edging one project's declaration into the other's."""
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, "projA/package.json", json.dumps(
+        {"name": "proj-a", "dependencies": {"typescript": "^5.2.4"}}))
+    _write(tmp_path, "projC/package.json", json.dumps(
+        {"name": "proj-c", "dependencies": {"typescript": "6.0.8"}}))
+
+    r, G = _extract_and_build(
+        tmp_path,
+        [tmp_path / "projA/package.json", tmp_path / "projC/package.json"],
+    )
+
+    ref_nodes = [n for n in G.nodes() if n.startswith("ref_typescript")]
+    assert len(ref_nodes) == 1, f"expected one shared registry node, got {ref_nodes}"
+    ref = ref_nodes[0]
+    assert G.nodes[ref].get("type") == "module"
+
+    entry_nodes = {
+        n for n, a in G.nodes(data=True)
+        if a.get("label") == "typescript" and n != ref
+    }
+    # Both manifests' entries reach the shared node...
+    for entry in entry_nodes:
+        assert G.has_edge(entry, ref), f"{entry} not wired to the shared node"
+    # ...and no edge joins the two projects' entries directly.
+    proj_of = {
+        n: str(G.nodes[n].get("source_file", "")).split("/")[0] for n in entry_nodes
+    }
+    direct = [
+        (u, v) for u, v in G.edges()
+        if u in entry_nodes and v in entry_nodes and proj_of[u] != proj_of[v]
+    ]
+    assert direct == [], f"projects still joined directly: {direct}"
+
+
+def test_js_bare_specifier_binds_to_manifest_dependency(tmp_path, monkeypatch):
+    """`import ... from "uuid"` already targets _make_id("ref", "uuid") (#2457);
+    with the dependency node in the same namespace the code→manifest link binds."""
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, "package.json", PACKAGE_JSON_WITH_UUID)
+    _write(tmp_path, "main.ts", 'import { v4 } from "uuid";\nexport const x = v4();\n')
+
+    _, G = _extract_and_build(
+        tmp_path, [tmp_path / "package.json", tmp_path / "main.ts"]
+    )
+
+    bind = [
+        (u, v) for u, v, a in G.edges(data=True)
+        if a.get("relation") == "imports_from"
+        and str(a.get("source_file", "")).endswith("main.ts")
+        and ("ref_uuid" in (u, v))
+    ]
+    assert bind, "TS npm import no longer binds to the manifest dependency node"

--- a/tests/test_monorepo_import_collisions.py
+++ b/tests/test_monorepo_import_collisions.py
@@ -221,20 +221,28 @@ def test_shared_dependency_joins_manifests_through_one_module_node(tmp_path, mon
     ref = ref_nodes[0]
     assert G.nodes[ref].get("type") == "module"
 
-    entry_nodes = {
+    # Both manifests reach the shared node (the dep edge is sourced at the
+    # manifest file since the #1764 self-loop fix)...
+    manifest_files = {
+        n for n, a in G.nodes(data=True)
+        if str(a.get("source_file", "")).endswith("package.json")
+        and a.get("label") == "package.json"
+    }
+    wired = {m for m in manifest_files if G.has_edge(m, ref)}
+    assert wired == manifest_files, (
+        f"manifests not wired to the shared node: {manifest_files - wired}"
+    )
+    # ...and no edge joins the two projects' typescript nodes directly.
+    ts_nodes = {
         n for n, a in G.nodes(data=True)
         if a.get("label") == "typescript" and n != ref
     }
-    # Both manifests' entries reach the shared node...
-    for entry in entry_nodes:
-        assert G.has_edge(entry, ref), f"{entry} not wired to the shared node"
-    # ...and no edge joins the two projects' entries directly.
     proj_of = {
-        n: str(G.nodes[n].get("source_file", "")).split("/")[0] for n in entry_nodes
+        n: str(G.nodes[n].get("source_file", "")).split("/")[0] for n in ts_nodes
     }
     direct = [
         (u, v) for u, v in G.edges()
-        if u in entry_nodes and v in entry_nodes and proj_of[u] != proj_of[v]
+        if u in ts_nodes and v in ts_nodes and proj_of[u] != proj_of[v]
     ]
     assert direct == [], f"projects still joined directly: {direct}"
 

--- a/tests/test_monorepo_import_collisions.py
+++ b/tests/test_monorepo_import_collisions.py
@@ -237,9 +237,25 @@ def test_shared_dependency_joins_manifests_through_one_module_node(tmp_path, mon
         n for n, a in G.nodes(data=True)
         if a.get("label") == "typescript" and n != ref
     }
-    proj_of = {
-        n: str(G.nodes[n].get("source_file", "")).split("/")[0] for n in ts_nodes
-    }
+
+    def _project_of(node_id: str) -> str:
+        # The project is the first path segment of the node's source_file.
+        # Normalize first: source_file can be stored absolute and/or with OS
+        # separators (Windows), and a naive `.split("/")[0]` would then collapse
+        # both projects onto the drive/root and make the check below vacuous.
+        sf = str(G.nodes[node_id].get("source_file", "")).replace("\\", "/")
+        rel = sf
+        base = str(tmp_path).replace("\\", "/").rstrip("/") + "/"
+        if rel.startswith(base):
+            rel = rel[len(base):]
+        return rel.split("/", 1)[0]
+
+    proj_of = {n: _project_of(n) for n in ts_nodes}
+    # Guard against a vacuous pass: the two typescript entries must resolve to
+    # two DISTINCT projects, or the direct-edge assertion proves nothing.
+    assert len(set(proj_of.values())) == 2, (
+        f"expected two distinct projects, got {proj_of}"
+    )
     direct = [
         (u, v) for u, v in G.edges()
         if u in ts_nodes and v in ts_nodes and proj_of[u] != proj_of[v]


### PR DESCRIPTION
Closes #3237 (classes 1 and 2). Rebased onto `v8` (0.9.55).

> **Scope note after the rebase:** 0.9.55's json_config fix independently landed the ref-namespaced dependency id and re-sourced the dep edge at the manifest, which covers part of what this PR originally carried. What remains here is everything that fix does not reach: the JVM/Android platform-import side of class 1, and the shared-anchor model that stops N manifests from being salted apart (and warned about) per file.

## The problem

Two mechanisms produced confident (EXTRACTED) cross-**project** edges between symbols that merely share a name — 20 of the 25 cross-project edges the reporter audited:

1. **JVM/Android platform imports emit a repo-collidable bare-stem target.** `_import_kotlin`/`_import_java` target `_make_id(last_segment)`. For `import java.util.UUID` that byte-collides with any unrelated node collapsing to `uuid`, and even with nothing owning the bare id it can ride build.py's pre-migration alias index (#1504) onto whichever unrelated same-stem file uniquely claims it — `import android.graphics.Color` in project A binds to project B's `ui/theme/Color.kt` file node. Reproduces on 0.9.55 from a four-file corpus.

2. **N manifests declaring the same npm package still fragment.** With 0.9.55's `ref_<pkg>` ids, two package.json files now mint the *same* id from different files, so `_disambiguate_colliding_node_ids` salts them apart per file and dedup prints a "minted by two different files … dropping" WARNING — for a collapse that is exactly the intent (one registry package).

## The change

- **Kotlin and Java imports** whose FQN root is a platform namespace (`java.`, `javax.`, `jakarta.`, `kotlin.`, `kotlinx.`, `android.`, `androidx.`, `dalvik.`) target `_make_id("ref", fqn)` instead of the bare stem — the same cure `_resolve_js_import_target` applies to unresolvable JS imports (#1638). These roots are never repo-local, so the #2526 corpus resolver could not have rewritten them anyway; the ref target matches no repo node and build drops the edge as an external import, the behavior every other external import already has. Repo-shaped imports keep the bare stem and the #2526 repo-local rewrite is untouched (control test).
- **The dependency ref node gains `type="module"`**, modeling the registry package as one shared external anchor — the issue's own suggestion. That puts it under the #1327 module-anchor exemption in `_disambiguate_colliding_node_ids`, so N manifests share ONE node; a matching exemption in dedup's collision reporter silences the "minted by two different files" warning for identical-label module anchors, whose collapse is the intent, not a loss. (`file_type` stays `concept`, its classification since the node was introduced — binding is by id, and both exemptions gate on `type`.)

A side effect worth having: a TS `import { v4 } from "uuid"` (which targets `_make_id("ref", "uuid")` since #2457) lands on the manifest's dependency node instead of dangling, so code links to the manifest that declares the package.

Class 3 (minified-bundle symbol nodes) is a separate detection question and is not touched here; the non-imported `Result`-supertype case in class 1 is the type-stub fragmentation tracked in #3252.

## Tests

`tests/test_monorepo_import_collisions.py` — 7 tests: the UUID byte-collision and the Color alias-ride (built end-to-end from the issue's shapes) no longer cross projects; a repo-local Kotlin FQN import still resolves (#2526 control); Kotlin and Java platform imports emit `ref_`-namespaced targets while repo-shaped imports keep the bare stem; both manifests wire to exactly one shared `type=module` registry node with no direct project-to-project edge; and the TS bare-specifier→manifest bind exists. Against 0.9.55 without this change, 4 of 7 fail (the other three cover the ground 0.9.55's json_config fix already holds, kept as regression guards). Related suites unchanged; the full suite matches a fresh same-version `v8` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJbLfztSxm2tH5cJwBbe9q
