### PR TITLE
fix(report): wrap labels in code spans so identifiers don't trip markdown linters (#3147)

### DIFF
--- a/graphify/report.py
+++ b/graphify/report.py
@@ -192,7 +192,7 @@ def generate(
                 safe = _safe_community_name(label)
                 lines.append(f"- [[_COMMUNITY_{safe}|{label}]]")
             else:
-                lines.append(f"- {label}")
+                lines.append(f"- `{label}`")
 
     lines += [
         "",
@@ -250,11 +250,11 @@ def generate(
     if hyperedges:
         lines += ["", "## Hyperedges (group relationships)"]
         for h in hyperedges:
-            node_labels = ", ".join(h.get("nodes", []))
+            node_labels = ", ".join(f"`{n}`" for n in h.get("nodes", []))
             conf = h.get("confidence", "INFERRED")
             cscore = h.get("confidence_score")
             conf_tag = f"{conf} {cscore:.2f}" if cscore is not None else conf
-            lines.append(f"- **{h.get('label', h.get('id', ''))}** — {node_labels} [{conf_tag}]")
+            lines.append(f"- **`{h.get('label', h.get('id', ''))}`** — {node_labels} [{conf_tag}]")
 
     lines += ["", f"## Communities ({len(communities)} total, {thin_count_summary} thin omitted)"]
     for cid, nodes in communities.items():
@@ -270,9 +270,9 @@ def generate(
         suffix = f" (+{len(real_nodes)-8} more)" if len(real_nodes) > 8 else ""
         lines += [
             "",
-            f"### Community {cid} - \"{label}\"",
+            f"### Community {cid} - \"`{label}`\"",
             f"Cohesion: {score:.2f}",
-            f"Nodes ({len(real_nodes)}): {', '.join(display)}{suffix}",
+            f"Nodes ({len(real_nodes)}): {', '.join(f'`{d}`' for d in display)}{suffix}",
         ]
 
     ambiguous = [(u, v, d) for u, v, d in G.edges(data=True) if d.get("confidence") == "AMBIGUOUS"]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import networkx as nx
 from graphify.build import build_from_json
 from graphify.cluster import cluster, score_all
 from graphify.analyze import god_nodes, surprising_connections
@@ -169,7 +170,8 @@ def test_report_hubs_are_plain_text_by_default():
     report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project", min_community_size=1)
     assert "## Community Hubs (Navigation)" in report
     assert "[[_COMMUNITY_" not in report, "must not emit dangling Obsidian wikilinks by default (#1712)"
-    assert any(f"- Widget {cid}" in report for cid in communities)
+    # #3147: labels are wrapped in a code span like every other label in the file.
+    assert any(f"- `Widget {cid}`" in report for cid in communities)
 
 
 def test_report_hubs_use_wikilinks_when_obsidian():
@@ -178,3 +180,70 @@ def test_report_hubs_use_wikilinks_when_obsidian():
     labels = {cid: f"Widget {cid}" for cid in communities}
     report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project", min_community_size=1, obsidian=True)
     assert "[[_COMMUNITY_" in report
+
+
+# --- #3147: snake_case labels must render inside code spans -------------------
+#
+# God Nodes, Ambiguous Edges, Import Cycles and the isolated-node list already
+# wrap labels in backticks; these four sites didn't, so a corpus with
+# snake_case identifiers produced raw intraword underscores outside any code
+# span, which markdown linters flag as unbalanced emphasis.
+
+def _snake_case_inputs():
+    G = nx.Graph()
+    G.add_node("n1", label="_scan_redirects", file_type="code", source_file="a.py")
+    G.add_node("n2", label="my_var_name", file_type="code", source_file="a.py")
+    G.add_edge("n1", "n2", relation="calls", confidence="EXTRACTED")
+    G.graph["hyperedges"] = [
+        {"id": "he_snake", "label": "flow_builder", "nodes": ["_scan_redirects", "my_var_name"],
+         "confidence": "EXTRACTED"},
+    ]
+    communities = {0: ["n1", "n2"]}
+    cohesion = {0: 0.5}
+    detection = {"total_files": 1, "total_words": 10}
+    tokens = {"input": 0, "output": 0}
+    return G, communities, cohesion, detection, tokens
+
+
+def test_community_hub_label_is_code_wrapped():
+    G, communities, cohesion, detection, tokens = _snake_case_inputs()
+    labels = {0: "my_var_name"}
+    report = generate(G, communities, cohesion, labels, [], [], detection, tokens,
+                      "./project", min_community_size=1)
+    assert "- `my_var_name`" in report
+
+
+def test_hyperedge_label_and_node_labels_are_code_wrapped():
+    G, communities, cohesion, detection, tokens = _snake_case_inputs()
+    labels = {0: "my_var_name"}
+    report = generate(G, communities, cohesion, labels, [], [], detection, tokens,
+                      "./project", min_community_size=1)
+    assert "## Hyperedges" in report
+    assert "**`flow_builder`**" in report
+    assert "`_scan_redirects`" in report
+    assert "`my_var_name`" in report
+
+
+def test_hyperedge_falls_back_to_id_when_unlabeled():
+    G, communities, cohesion, detection, tokens = _snake_case_inputs()
+    G.graph["hyperedges"][0].pop("label")
+    labels = {0: "my_var_name"}
+    report = generate(G, communities, cohesion, labels, [], [], detection, tokens,
+                      "./project", min_community_size=1)
+    assert "**`he_snake`**" in report
+
+
+def test_community_heading_wraps_label_in_code_span():
+    G, communities, cohesion, detection, tokens = _snake_case_inputs()
+    labels = {0: "my_var_name"}
+    report = generate(G, communities, cohesion, labels, [], [], detection, tokens,
+                      "./project", min_community_size=1)
+    assert '### Community 0 - "`my_var_name`"' in report
+
+
+def test_community_node_list_wraps_each_label_in_code_span():
+    G, communities, cohesion, detection, tokens = _snake_case_inputs()
+    labels = {0: "my_var_name"}
+    report = generate(G, communities, cohesion, labels, [], [], detection, tokens,
+                      "./project", min_community_size=1)
+    assert "Nodes (2): `_scan_redirects`, `my_var_name`" in report


### PR DESCRIPTION
## What

`graphify/report.py` emits node/community/hyperedge labels as bare text at
four sites in `GRAPH_REPORT.md`, even though every other section in the same
file (God Nodes, Ambiguous Edges, Import Cycles, the isolated-node list)
already wraps labels in backticks. When a corpus has snake_case identifiers
(`_scan_redirects`, `my_var_name`), the generated report contains raw
intraword underscores outside any code span. Markdown linters flag those as
unbalanced emphasis — on the exact identifier text a reader needs in order to
look the node up. This is visible today in the repo's own tracked worked
example, `worked/httpx/GRAPH_REPORT.md`:

```
### Community 5 - "Community 5"
Cohesion: 0.28
Nodes (3): build_url_with_params(), flatten_queryparams(), primitive_value_to_str()
```

Closes #3147.

## The fix

Wrapped labels in backticks at the four remaining sites, matching the
God-Nodes/Ambiguous-Edges precedent already in the file:

1. **Community Hubs (Navigation)**, non-Obsidian branch — the community label.
2. **Hyperedges** — the hyperedge's own label/id (bolded), and each node label
   in its member list (wrapped per-item and joined, not one span around the
   whole comma-joined string).
3. **Community heading** (`### Community N - "label"`) — the label, nested
   inside the existing quotes.
4. **Communities node list** (`Nodes (N): ...`) — each label wrapped
   individually before joining.

Nothing else changed — no refactor, no touching of the sites that already
wrap.

## Judgment calls

- **Community heading (site 3).** Backticks inside a markdown heading are
  legal and render as code; the alternative the issue raises is
  backslash-escaping the underscore instead. I went with backticks because
  it's the convention already used everywhere else in this file, and
  backslash-escaping would be a second, inconsistent escaping style. I
  grepped the codebase (including `wiki.py` and the Obsidian/HTML exporters)
  for anything that parses `### Community ...` back out of the generated
  report — nothing does. `tests/test_report_gap_thresholds.py` only regexes
  the `"### Community "` prefix to count sections, which is unaffected by
  what follows it. Happy to switch to escaping if a maintainer prefers it for
  heading readability.
- **Hyperedges (site 2).** Nested the label's backticks inside the existing
  bold (`**\`label\`**`) rather than replacing bold with code — this is also
  needed for the id-fallback case (`h.get('label', h.get('id', ''))`), since
  hyperedge ids are frequently snake_case themselves. The node list is
  wrapped per-label and then joined, not wrapped as a single span around the
  whole string, so linters don't see one giant token.
- **Labels containing a backtick.** None of the existing wrapped sites in
  this file (God Nodes, Ambiguous Edges, isolated nodes) escape an embedded
  backtick either, so this fix doesn't invent new escaping machinery for that
  case — it matches the existing house style and has the same limitation.
- **`worked/httpx/GRAPH_REPORT.md`.** This tracked example still shows the
  old, unwrapped output. I checked `.github/workflows/` and found no job that
  regenerates or diffs the `worked/` examples (the `skillgen-check` job only
  validates generated skill files under `graphify/`; `release-graph.yml`
  builds a fresh self-graph, not the `worked/` fixtures). So I left it
  untouched rather than regenerating an artifact nothing checks.

## Verification

Wrote the regression tests first and confirmed they failed against a pristine
`origin/v8` checkout (`33362d9`):

```
uv run --frozen pytest tests/test_report.py -q
# 6 failed, 15 passed
```

(One of the six was an existing test, `test_report_hubs_are_plain_text_by_default`,
whose assertion had to be updated in place — it pinned the exact pre-fix
unwrapped hub-label string.)

After applying the fix, the same file is green:

```
uv run --frozen pytest tests/test_report.py -q
# 21 passed
```

Scoped suite:

```
uv run --frozen pytest tests/test_report.py tests/test_report_gap_thresholds.py -q
# 25 passed
```

Full suite, fix branch vs. a pristine `origin/v8` checkout (Windows machine;
pre-existing failures are symlink-privilege, cp1252-console and missing
optional-dependency tests unrelated to this change):

```
fix branch:     17 failed, 5255 passed, 43 skipped
pristine v8:    17 failed, 5250 passed, 43 skipped
```

`diff` of the two `FAILED` line sets (sorted) is empty — the same 17 tests
fail on both, byte-for-byte. Zero introduced, zero fixed. The 5-test gap in
the passed count is exactly the 5 new tests this PR adds.

Lint:

```
uv run --frozen ruff check graphify/report.py    # All checks passed!
uv run --frozen ruff check tests/test_report.py  # All checks passed!
uv run --frozen python -m tools.skillgen --check # check OK: 134 artifact(s) match
```
