### PR TITLE
fix(install): emit a bare hook command for the default install too (#3129)

### DIFF
--- a/graphify/install.py
+++ b/graphify/install.py
@@ -298,14 +298,17 @@ def _print_project_git_add_hint(paths: list[Path]) -> None:
     print()
     print("Project-scoped install. Add to version control:")
     print(f"  git add {' '.join(unique)}")
-def _claude_pretooluse_hooks(strict: bool = False, project: bool = False) -> "list[dict]":
+def _claude_pretooluse_hooks(strict: bool = False) -> "list[dict]":
     """graphify's Claude/Codebuddy PreToolUse hooks, resolved at install time.
 
-    The command invokes `graphify hook-guard <search|read>` via the absolute exe
-    path (`_resolve_graphify_exe`) — or, for a project-scoped install, via the
-    bare `graphify` command, since that config gets committed (#3129). Either
-    form parses under sh, cmd.exe and PowerShell alike — this is the #522 fix,
-    and mirrors the codex hook. Matchers are
+    The command invokes `graphify hook-guard <search|read>` via the bare
+    `graphify` command. `.claude/settings.json` (like `.codebuddy/settings.json`)
+    is always written into the current directory -- there is no separate
+    user-profile destination for it, project-scoped or not -- so it is always a
+    candidate for being committed, and an absolute path resolved from the
+    installing machine would be wrong in every other clone (#3129). This parses
+    under sh, cmd.exe and PowerShell alike -- the #522 fix, mirroring the codex
+    hook. Matchers are
     "Bash|Grep" and "Read|Glob" and the command always contains "graphify", so the
     existing install/uninstall filters find and replace both old bash hooks and
     these. "Grep" is in the search matcher because current Claude Code routes
@@ -316,7 +319,7 @@ def _claude_pretooluse_hooks(strict: bool = False, project: bool = False) -> "li
     first raw read per session (Claude Code only). The ``GRAPHIFY_HOOK_STRICT`` env
     var can force it on or off at runtime without a reinstall.
     """
-    exe = _resolve_graphify_exe(project=project)
+    exe = _resolve_graphify_exe(project=True)
     if " " in exe and not exe.startswith('"'):
         exe = f'"{exe}"'
     read_cmd = f"{exe} hook-guard read" + (" --strict" if strict else "")
@@ -704,13 +707,15 @@ _CLAUDE_MD_MARKER = "## graphify"
 _CODEBUDDY_MD_MARKER = "## graphify"
 _AGENTS_MD_MARKER = "## graphify"
 _GEMINI_MD_MARKER = "## graphify"
-def _gemini_hook(project: bool = False) -> dict:
+def _gemini_hook() -> dict:
     """Gemini CLI BeforeTool hook, resolved to a shell-agnostic `graphify` call.
 
-    A project-scoped install emits the bare command, since .gemini/settings.json
-    is then committed and an installing machine's path is wrong there (#3129).
+    Always emits the bare command: .gemini/settings.json is always written into
+    the current directory (there is no separate user-profile destination for
+    it), so it is always a candidate for being committed, and an installing
+    machine's absolute path would be wrong there (#3129).
     """
-    exe = _resolve_graphify_exe(project=project)
+    exe = _resolve_graphify_exe(project=True)
     if " " in exe and not exe.startswith('"'):
         exe = f'"{exe}"'
     return {
@@ -740,7 +745,7 @@ def gemini_install(project_dir: Path | None = None, *, project: bool = False) ->
 
     # Always re-install the Gemini hook so an older payload (e.g. pre-issue-#580
     # wording) is replaced on upgrade.
-    _install_gemini_hook(project_dir, project=project)
+    _install_gemini_hook(project_dir)
     if project:
         _print_project_git_add_hint([_project_scope_root(skill_dst, project_dir), project_dir / "GEMINI.md", project_dir / ".gemini"])
     print()
@@ -788,7 +793,7 @@ def _write_settings_with_backup(settings_path: Path, settings: dict) -> None:
         backup = settings_path.with_name(settings_path.name + ".graphify-bak")
         shutil.copy2(settings_path, backup)
     settings_path.write_text(output, encoding="utf-8")
-def _install_gemini_hook(project_dir: Path, project: bool = False) -> None:
+def _install_gemini_hook(project_dir: Path) -> None:
     settings_path = project_dir / ".gemini" / "settings.json"
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings = _read_settings_for_merge(settings_path)
@@ -801,7 +806,7 @@ def _install_gemini_hook(project_dir: Path, project: bool = False) -> None:
     hooks["BeforeTool"] = [
         h for h in before_tool if "graphify" not in str(h)
     ]
-    hooks["BeforeTool"].append(_gemini_hook(project=project))
+    hooks["BeforeTool"].append(_gemini_hook())
     _write_settings_with_backup(settings_path, settings)
     print("  .gemini/settings.json  ->  BeforeTool hook registered")
 def _uninstall_gemini_hook(project_dir: Path) -> None:
@@ -1452,18 +1457,23 @@ def _resolve_graphify_exe(project: bool = False) -> str:
                 found = str(candidate)
                 break
     return (found or "graphify").replace("\\", "/")
-def _install_codex_hook(project_dir: Path, project: bool = False) -> None:
+def _install_codex_hook(project_dir: Path) -> None:
     """Add graphify PreToolUse hook to .codex/hooks.json.
 
-    A project-scoped install emits the bare command, since .codex/hooks.json is
-    then committed and an installing machine's path is wrong there (#3129).
+    Always emits the bare command: .codex/hooks.json is always written into
+    the current directory (there is no separate user-profile destination for
+    it, project-scoped or not), so it is always a candidate for being
+    committed, and an installing machine's absolute path would be wrong there
+    (#3129). If a future fix (#2164) gives the non-project install a genuine,
+    non-shared destination, that call site should resolve the exe itself
+    rather than resurrecting this one's project flag.
     """
     hooks_path = project_dir / ".codex" / "hooks.json"
     hooks_path.parent.mkdir(parents=True, exist_ok=True)
 
     existing = _read_settings_for_merge(hooks_path)
 
-    graphify_exe = _resolve_graphify_exe(project=project)
+    graphify_exe = _resolve_graphify_exe(project=True)
     hook_entry = {
         "hooks": {
             "PreToolUse": [
@@ -1505,7 +1515,7 @@ def _uninstall_codex_hook(project_dir: Path) -> None:
     existing["hooks"]["PreToolUse"] = filtered
     hooks_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
     print(f"  .codex/hooks.json  ->  PreToolUse hook removed")
-def _agents_install(project_dir: Path, platform: str, project: bool = False) -> None:
+def _agents_install(project_dir: Path, platform: str) -> None:
     """Write the graphify section to the local AGENTS.md for always-on platforms."""
     target = (project_dir or Path(".")) / "AGENTS.md"
 
@@ -1524,7 +1534,7 @@ def _agents_install(project_dir: Path, platform: str, project: bool = False) -> 
         print(f"graphify section written to {target.resolve()}")
 
     if platform == "codex":
-        _install_codex_hook(project_dir or Path("."), project=project)
+        _install_codex_hook(project_dir or Path("."))
     elif platform == "opencode":
         _install_opencode_plugin(project_dir or Path("."))
     elif platform == "kilo":
@@ -1588,7 +1598,7 @@ def _project_install(platform_name: str, project_dir: Path | None = None, strict
     platform_name = _canonical_platform(platform_name)
     if platform_name in ("claude", "windows"):
         install(platform=platform_name, project=True, project_dir=project_dir)
-        claude_install(project_dir, strict=strict, project=True)
+        claude_install(project_dir, strict=strict)
         _print_project_git_add_hint([project_dir / ".claude", project_dir / "CLAUDE.md"])
     elif platform_name == "gemini":
         gemini_install(project_dir, project=True)
@@ -1600,7 +1610,7 @@ def _project_install(platform_name: str, project_dir: Path | None = None, strict
         _print_project_git_add_hint([project_dir / ".kiro"])
     elif platform_name in ("aider", "amp", "codex", "opencode", "claw", "droid", "trae", "trae-cn", "hermes"):
         skill_dst = _copy_skill_file(platform_name, project=True, project_dir=project_dir)
-        _agents_install(project_dir, platform_name, project=True)
+        _agents_install(project_dir, platform_name)
         hint_paths = [_project_scope_root(skill_dst, project_dir), project_dir / "AGENTS.md"]
         if platform_name == "opencode":
             hint_paths.append(project_dir / ".opencode")
@@ -1741,7 +1751,7 @@ def _kilo_uninstall(project_dir: Path) -> None:
     _agents_uninstall(project_dir or Path("."), platform="kilo")
     removed = _kilo_uninstall_global()
     print("; ".join(removed) if removed else "nothing to remove")
-def claude_install(project_dir: Path | None = None, strict: bool = False, project: bool = False) -> None:
+def claude_install(project_dir: Path | None = None, strict: bool = False) -> None:
     """Write the graphify section to the local CLAUDE.md."""
     target = (project_dir or Path(".")) / "CLAUDE.md"
 
@@ -1761,7 +1771,7 @@ def claude_install(project_dir: Path | None = None, strict: bool = False, projec
 
     # Always re-install the Claude Code PreToolUse hook so an old hook
     # payload (e.g. pre-issue-#580 wording) is replaced on upgrade.
-    _install_claude_hook(project_dir or Path("."), strict=strict, project=project)
+    _install_claude_hook(project_dir or Path("."), strict=strict)
 
     print()
     print("Claude Code will now check the knowledge graph before answering")
@@ -1769,11 +1779,13 @@ def claude_install(project_dir: Path | None = None, strict: bool = False, projec
     if strict:
         print("Strict mode: the first raw file read per session is blocked until")
         print("one `graphify query` runs (toggle with GRAPHIFY_HOOK_STRICT=0).")
-def _install_claude_hook(project_dir: Path, strict: bool = False, project: bool = False) -> None:
+def _install_claude_hook(project_dir: Path, strict: bool = False) -> None:
     """Add graphify PreToolUse hook to .claude/settings.json.
 
-    A project-scoped install emits the bare command, since .claude/settings.json
-    is then committed and an installing machine's path is wrong there (#3129).
+    Always emits the bare command: .claude/settings.json is always written into
+    the current directory (there is no separate user-profile destination for
+    it), so it is always a candidate for being committed, and an installing
+    machine's absolute path would be wrong there (#3129).
     """
     settings_path = project_dir / ".claude" / "settings.json"
     settings_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1788,7 +1800,7 @@ def _install_claude_hook(project_dir: Path, strict: bool = False, project: bool 
         _refuse_to_modify(settings_path)
 
     hooks["PreToolUse"] = [h for h in pre_tool if not (isinstance(h, dict) and h.get("matcher") in ("Glob|Grep", "Bash", "Bash|Grep", "Read|Glob") and "graphify" in str(h))]
-    hooks["PreToolUse"].extend(_claude_pretooluse_hooks(strict=strict, project=project))
+    hooks["PreToolUse"].extend(_claude_pretooluse_hooks(strict=strict))
     _write_settings_with_backup(settings_path, settings)
     _mode = " (strict)" if strict else ""
     print(f"  .claude/settings.json  ->  PreToolUse hooks registered (Bash|Grep search + Read/Glob){_mode}")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -405,6 +405,20 @@ def test_codebuddy_install_writes_hook(tmp_path):
     assert any("graphify" in str(h) for h in hooks)
 
 
+def test_codebuddy_hook_command_is_portable(tmp_path, monkeypatch):
+    """#3129: CodeBuddy has no --project variant at all -- every install writes
+    .codebuddy/settings.json into the cwd, so it is always a commit candidate
+    and the exe must always be bare, never a machine-absolute path."""
+    from graphify.__main__ import codebuddy_install
+    monkeypatch.setattr("shutil.which", lambda _name: r"C:\Users\installer\graphify.EXE")
+    codebuddy_install(tmp_path)
+    commands = _hook_commands((tmp_path / ".codebuddy" / "settings.json").read_text(encoding="utf-8"))
+    assert commands, "codebuddy install registered no hook command"
+    for command in commands:
+        assert command.startswith("graphify "), command
+        assert "installer" not in command, f"installing user's path leaked: {command}"
+
+
 def test_claude_hook_is_shell_agnostic(tmp_path):
     # #522: the installed PreToolUse hooks must be plain exe invocations, not
     # POSIX bash (which fails on Windows cmd.exe/PowerShell).
@@ -1220,17 +1234,29 @@ def test_codex_hook_command_is_a_real_cli_subcommand(tmp_path):
         )
 
 
-# --- #3129: project-scoped installs must not embed a machine-absolute path ----
+# --- #3129: installs must not embed a machine-absolute path into a hook file --
+# committed by definition ----------------------------------------------------
 #
 # `--project` writes hook config that the installer then tells the user to
 # commit ("Add to version control: git add ..."). An exe path resolved from the
 # installing machine is wrong in every other clone, and the drive letter and
 # .EXE casing do not even survive between two Windows checkouts. The committed
 # hook must name `graphify` and let PATH resolve it, the way the git-hook layer
-# already does with `command -v graphify` (hooks.py). The user-profile install
-# is deliberately left alone: it stays on the machine that wrote it, and an
-# absolute path is what makes the hook work where the venv Scripts/ dir is not
-# on PATH (e.g. the VS Code Codex extension on Windows).
+# already does with `command -v graphify` (hooks.py).
+#
+# v0.9.52 (#3149) fixed this for `--project`. The plain (non-`--project`)
+# install was left as a follow-up on the theory that it targets a "user
+# profile" location nobody else maintains, where an absolute path is actually
+# correct (it's what makes the hook work when the venv Scripts/ dir isn't on
+# PATH). That theory doesn't hold for these three hook files specifically:
+# `_install_codex_hook`/`_claude_pretooluse_hooks`/`_gemini_hook` write into
+# `project_dir` -- which defaults to the cwd -- whether or not `--project` was
+# passed. There is no separate user-profile destination for them today, so the
+# file is always a commit candidate and the exe is always resolved bare now,
+# regardless of `--project` (see `test_default_install_hook_command_is_also_portable`
+# below). If a future fix for #2164 gives the plain install a genuine,
+# non-shared destination for these files, that is the point to reintroduce an
+# absolute-path branch for it -- not before.
 
 _PROJECT_HOOK_FILES = {
     "claude": ".claude/settings.json",
@@ -1285,8 +1311,19 @@ def test_project_install_hook_command_is_portable(tmp_path, monkeypatch, platfor
 
 
 @pytest.mark.parametrize("platform", sorted(_PROJECT_HOOK_FILES))
-def test_user_profile_install_still_resolves_absolute_path(tmp_path, monkeypatch, platform):
-    """The non-project install keeps the resolved path (#522/#1987 behaviour)."""
+def test_default_install_hook_command_is_also_portable(tmp_path, monkeypatch, platform):
+    """The plain (non---project) install must be just as portable (#3129).
+
+    `.claude/settings.json`, `.codex/hooks.json` and `.gemini/settings.json` are
+    always written into the current directory -- `--project` never changed
+    *that*, only which exe path got resolved into them. So a plain
+    `graphify <platform> install`, run in a repo the author then commits (the
+    reproduction in #3129), embeds the exact same machine-absolute path
+    `--project` was fixed for in v0.9.52 (#3149). This superseded
+    `test_user_profile_install_still_resolves_absolute_path`, which pinned the
+    old (buggy) behaviour on the incorrect premise that this install targets a
+    location nobody else maintains -- see the module comment above.
+    """
     home = tmp_path / "home"
     project = tmp_path / "project"
     project.mkdir()
@@ -1302,7 +1339,11 @@ def test_user_profile_install_still_resolves_absolute_path(tmp_path, monkeypatch
     commands = _hook_commands((project / _PROJECT_HOOK_FILES[platform]).read_text(encoding="utf-8"))
     assert commands, f"{platform} install registered no hook command"
     for command in commands:
-        assert command.startswith("C:/Users/installer/graphify.EXE "), command
+        assert command.startswith("graphify "), command
+        assert ":" not in command, f"drive letter / absolute path leaked: {command}"
+        assert "\\" not in command, f"backslash path leaked: {command}"
+        assert ".exe" not in command.lower(), f"platform exe casing leaked: {command}"
+        assert "installer" not in command, f"installing user's path leaked: {command}"
 
 
 @pytest.mark.parametrize("platform", sorted(_PROJECT_HOOK_FILES))


### PR DESCRIPTION
## Summary

v0.9.52 (#3149, thanks @davidbhoward for the original analysis) fixed
`graphify install --project`: a committed, shared install now emits a bare,
run-time-resolved `graphify` command instead of pinning an absolute
interpreter path. That PR was deliberately scoped to `--project` only, and
said so explicitly:

> This PR also does not address the non-`--project` half of #3129 ... the
> absolute path is defensible there ... and the case is further entangled
> with #2164 ... Left for a maintainer call rather than silently bundled.

This is the deferred half, offered as the patch mentioned on the issue thread
on 2026-09-01. It only extends #3149's own fix to the case its own scope
section named as open.

## The remaining defect

`_install_codex_hook`, `_claude_pretooluse_hooks` (claude + codebuddy) and
`_gemini_hook` all write into `project_dir`, which defaults to the current
directory -- **whether or not `--project` was passed**. There is no separate
user-profile destination for these specific hook files today; only the flag
that picked which exe path got resolved into them differed. So a plain
`graphify codex install` (no flag) still wrote a machine-absolute path
(e.g. `C:/Users/<user>/.local/bin/graphify.EXE hook-check`) into
`.codex/hooks.json`, and if that gets committed -- which is exactly what the
issue's own reproduction does -- it is wrong on every other machine and in CI.

Checked whether this was codex-specific, per the discussion on the issue: it
is not. `claude_install`, `gemini_install` and `codebuddy_install` all resolve
their hook destination the same way (`project_dir or Path(".")`, no
distinction by scope), so all three shared the identical defect --
`_claude_pretooluse_hooks` is used by both claude and codebuddy, and codebuddy
has no `--project` variant at all, meaning *every* codebuddy install hit this.

## The fix

Small and destination-keyed, not flag-keyed: since these particular hook files
are always written into the current directory regardless of `--project`
today, the exe they embed is now always the bare `graphify` command,
independent of that flag. The `project` parameter #3149 threaded through these
three functions is dropped since it no longer changes the outcome for them;
`_resolve_graphify_exe` itself, and its absolute-path branch, are untouched.

## Why this doesn't preempt #2164

#2164 is about *where* the non-project install writes (cwd vs. a real
user-profile directory). This PR doesn't touch that -- it only changes what
gets embedded in the file at whatever destination is used today, which is
unconditionally the project directory. If #2164 is ever fixed so the
non-project install gets a genuine, non-shared destination, `_resolve_graphify_exe`'s
absolute-path branch (left exactly as-is here) is what that destination should
resolve to -- that's the point to reintroduce a project/non-project
distinction on these three call sites, not before. This PR should need no
rework when that lands; it just stops being the only caller of that branch's
bare-command side.

## The cost this pays, stated plainly

There is a real trade-off here and it deserves naming rather than burying,
because `_resolve_graphify_exe`'s own docstring makes the case against this
change:

> Using an absolute path ensures the hook works in environments where the venv
> `Scripts/` directory is not on PATH (e.g. VS Code Codex extension on Windows).

That is true, and this PR gives it up for these three hook files. On a machine
where `graphify` is not on PATH, a bare command fails where the absolute path
would have worked.

I think #3149 already answered this, and the answer now covers more ground than
it did when written:

> A missing binary and a wrong absolute path both fail the hook; the difference
> is diagnosis. `graphify: command not found` names the problem, whereas a path
> into another developer's home directory gives the reader nothing to work with
> and reads like a deliberate configuration choice. ... This argument applies
> only to the committed case, which is why the user-profile path is left alone.

The last sentence is the hinge. That argument was scoped to "the committed
case" because the non-project install was assumed to have a different,
uncommitted destination. For these three hook files it does not — every
install writes them into the working directory — so *every* case is the
committed case, and #3149's own reasoning extends to all of them.

If you would rather keep the absolute path for the PATH-fragile environments
and accept the churn, the alternative is (2) from the issue thread: stop
writing these files into a tracked location for non-project installs. That is
the larger change and it overlaps #2164, which is presumably why you deferred
it — I have not attempted it here.

## One consequence worth flagging for review

After this change all three call sites pass `_resolve_graphify_exe(project=True)`,
so its absolute-path branch has no live caller. I deliberately did **not**
delete it: #2164 is exactly the change that should revive it, and removing it
now would mean re-deriving the Windows/PATH reasoning later from the git log.
But it does mean the parameter now reads oddly at the call sites — a
non-project install asking for `project=True`. If you take this, a rename
(`bare=True`, or an explicit `_bare_graphify_command()` helper) would say what
is actually meant; I left the signature alone to keep the diff reviewable and
because naming is yours to pick.

## Scope

Matches #3149's own boundary: the trailing-newline and
customized-hook-clobber issues it flagged as deliberately out of scope are
still untouched here.

## This is an offer, not a demand

Per the maintainer's own framing on the issue (partial fix landed, remainder
"left for a maintainer call"), this follows the "(1)" option floated on the
thread -- happy to close this in favor of a different design, or adjust scope,
if a different approach is preferred.

Refs #3129.

## Verification

Re-verified the defect at current `v8` HEAD (`33362d9`, "chore: bump to
0.9.53") before writing any code: `graphify codex install` (no `--project`)
still writes `_resolve_graphify_exe(project=False)`'s absolute result into
`.codex/hooks.json` in the cwd; `claude_install`/`gemini_install`/`codebuddy_install`
all showed the same `project_dir or Path(".")` pattern.

**Red first.** Added/renamed tests in `tests/test_install.py`
(`test_default_install_hook_command_is_also_portable`, parametrized over
claude/codex/gemini, plus `test_codebuddy_hook_command_is_portable`), and
confirmed they fail against unmodified `v8`:

```
python -m pytest tests/test_install.py -k "test_default_install_hook_command_is_also_portable or test_codebuddy_hook_command_is_portable" -v
...
FAILED tests/test_install.py::test_codebuddy_hook_command_is_portable
FAILED tests/test_install.py::test_default_install_hook_command_is_also_portable[claude]
FAILED tests/test_install.py::test_default_install_hook_command_is_also_portable[codex]
FAILED tests/test_install.py::test_default_install_hook_command_is_also_portable[gemini]
4 failed, 97 deselected
```

All four pass after the fix.

**Existing #3149 test conflict, resolved explicitly, not silently.**
`test_user_profile_install_still_resolves_absolute_path` pinned the premise
that the non-project install has a separate, non-shared destination. That
premise doesn't hold for these three writers (see above), so the fix
necessarily changes what that test asserts. Rather than delete or quietly
tweak it, it's replaced by `test_default_install_hook_command_is_also_portable`
with a docstring stating exactly why the old test's premise no longer holds
and cross-referencing this PR, plus a module comment explaining the
supersession for anyone reading the test file later.

**Scoped run:**

```
python -m pytest tests/test_install.py tests/test_settings_merge.py tests/test_install_roundtrip.py -q
171 passed, 3 failed
```

The 3 failures (`test_codex_skill_uses_graphify_with_existing_graph`,
`test_hermes_skill_destination_posix_uses_home`,
`test_skill_roundtrip_at_real_destination[user-hermes]`) are pre-existing and
unrelated (Windows `LOCALAPPDATA`/hermes path handling) -- confirmed present,
identical, on a clean `v8` checkout before this change (170 passed, 3 failed;
the one extra passing test on the fixed branch is the added
`test_codebuddy_hook_command_is_portable`).

**Full suite, both branches, failure sets diffed:**

```
python -m pytest -q   # this branch:   30 failed, 4950 passed, 283 skipped
python -m pytest -q   # clean v8:      30 failed, 4949 passed, 283 skipped
diff <(sort fixed_failures.txt) <(sort baseline_failures.txt)   # empty
```

Identical 30-test failure set on both (symlinks/fifo/unix-socket, hermes/LOCALAPPDATA,
ollama retry-cap, terraform parser, ambient-environment tests unrelated to
install.py) -- zero introduced, zero fixed. Windows-only run; the Ubuntu CI
matrix is exact parity per the README.

**Lint / CI gates:**

```
ruff check graphify/install.py tests/test_install.py   # All checks passed!
python -m tools.skillgen --check                        # check OK: 134 artifact(s) match
python -m tools.skillgen --audit-coverage                # OK
python -m tools.skillgen --schema-singleton              # OK
python -m tools.skillgen --monolith-roundtrip             # OK
python -m tools.skillgen --always-on-roundtrip            # OK
```

(`install.py` is not a skillgen-generated file; ran the gate anyway since it's
a blocking CI job.)
