### PR TITLE
test(labeling): don't assert batch completion order

### DIFF
--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -6,6 +6,7 @@ malformed replies, and the no-backend fallback.
 import json
 import re
 import sys
+import threading
 from pathlib import Path
 
 import networkx as nx
@@ -263,6 +264,12 @@ def _wide_graph(n_communities: int):
 
 def test_label_communities_batches_when_over_batch_size(monkeypatch):
     G, communities = _wide_graph(250)
+    # `label_communities` fans the batches out across a ThreadPoolExecutor and
+    # collects them with `as_completed`, so the fake is called from several
+    # threads and finishing order is not dispatch order — the 50-community
+    # batch is the smallest and usually lands before the second 100. Guard the
+    # list rather than relying on `list.append` being atomic under the GIL.
+    calls_lock = threading.Lock()
     calls = []
 
     def fake_call(prompt, *, backend, max_tokens=200):
@@ -271,14 +278,16 @@ def test_label_communities_batches_when_over_batch_size(monkeypatch):
         # key collided with the placeholder sentinel and echoed keys were dropped.
         cids = [int(m.group(1)) for m in
                 (re.match(r"^(\d+): ", line) for line in prompt.splitlines()) if m]
-        calls.append(len(cids))
+        with calls_lock:
+            calls.append(len(cids))
         return "{" + ", ".join(f'"{c}": "Cluster {c}"' for c in cids) + "}"
 
     monkeypatch.setattr("graphify.llm._call_llm", fake_call)
     labels = label_communities(G, communities, backend="gemini", batch_size=100)
 
-    # 250 communities / 100 per batch -> 3 batches (100, 100, 50)
-    assert calls == [100, 100, 50]
+    # 250 communities / 100 per batch -> 3 batches (100, 100, 50), in whatever
+    # order they complete.
+    assert sorted(calls) == [50, 100, 100]
     # And every community got a real name, none left as a placeholder.
     assert all(name.startswith("Cluster ") for name in labels.values()), \
         f"some communities still have placeholders: {[k for k, v in labels.items() if not v.startswith('Cluster ')][:5]}"


### PR DESCRIPTION
`test_label_communities_batches_when_over_batch_size` fails about **75% of the time** — 9 of 12 runs on a clean `v8` checkout here, in isolation, with no other test involved.

```
assert [100, 50, 100] == [100, 100, 50]
E   At index 1 diff: 50 != 100
```

`label_communities` fans its batches out across a `ThreadPoolExecutor` and collects them with `as_completed`, so the mocked `_call_llm` runs on several threads and completion order is not dispatch order. The 50-community batch is the smallest and usually finishes before the second 100.

The batching itself is correct on every run: 250 communities at `batch_size=100` always produces 100/100/50. Only the recorded order varies — which the test never intended to pin, going by its own comment, "250 communities / 100 per batch -> 3 batches (100, 100, 50)".

## Change

Assert on the sorted sizes rather than the sequence:

```python
assert sorted(calls) == [50, 100, 100]
```

and guard the shared list with a `threading.Lock` instead of relying on `list.append` being atomic under the GIL. That second part isn't fixing an observed failure — CPython makes it safe today — but the test appends from a thread pool and shouldn't depend on that.

## Verification

- Before: 9/12 runs fail, isolated
- After: 0/20 runs fail, isolated; 0/20 for the whole of `tests/test_labeling.py`
- Full suite goes from 14 failures to 13 on this machine, and the one that disappears is this test. The other 13 are environmental here (terraform grammar, ollama, wheel payload, markdown frontmatter) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
