### PR TITLE
feat(mcp): log every tool read, not just query_graph

### DIFF
--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -2063,7 +2063,53 @@ def _build_server(graph_path: str):
                 return f"Could not generate questions: {exc}"
         raise ValueError(f"Unknown resource: {uri_str}")
 
+    # Per-tool question extraction for the read log: each tool's most
+    # meaningful argument, so a GraphPulse feed card reads like a sentence
+    # instead of "get_node".
+    _LOG_QUESTION_KEYS = {
+        "query_graph": ("question",),
+        "get_node": ("label",),
+        "get_neighbors": ("label",),
+        "get_community": ("community_id",),
+        "god_nodes": ("top_n",),
+        "graph_stats": (),
+        "shortest_path": ("source", "target"),
+        "list_prs": ("repo",),
+        "get_pr_impact": ("pr_number",),
+        "triage_prs": ("repo",),
+    }
+
+    def _log_tool_read(name: str, arguments: dict, result: str, duration_ms: float) -> None:
+        """Record ONE MCP tool call in the graphify query log.
+
+        query_graph already logs itself inside its handler (with mode/depth/
+        budget detail), so it is skipped here to avoid double counting. Every
+        other tool is logged from this single dispatch point, which is why
+        adding a tool later cannot silently reintroduce an invisible read.
+
+        Fail-silent by contract: querylog.log_query never raises, and this
+        wrapper must never turn an observability concern into a tool error.
+        """
+        if name == "query_graph":
+            return
+        try:
+            from graphify import querylog
+            keys = _LOG_QUESTION_KEYS.get(name, ())
+            parts = [str(arguments[k]) for k in keys if arguments.get(k) is not None]
+            question = " -> ".join(parts) if parts else name
+            querylog.log_query(
+                kind=f"mcp_{name}",
+                question=question,
+                corpus=str(active_graph_path),
+                result=result,
+                duration_ms=duration_ms,
+                tool=name,
+            )
+        except Exception:
+            pass
+
     async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+        import time as _time
         arguments = dict(arguments or {})
         project_path = arguments.pop("project_path", None)
         handler = _handlers.get(name)
@@ -2071,7 +2117,10 @@ def _build_server(graph_path: str):
             return [types.TextContent(type="text", text=f"Unknown tool: {name}")]
         try:
             _select_graph(project_path)  # bind G/communities to the target graph
-            return [types.TextContent(type="text", text=handler(arguments))]
+            _t0 = _time.perf_counter()
+            result = handler(arguments)
+            _log_tool_read(name, arguments, result, (_time.perf_counter() - _t0) * 1000)
+            return [types.TextContent(type="text", text=result)]
         except ToolError:
             # A handler-signalled error: propagate so the result is marked
             # isError:true (the mcp 1.x decorator wraps a raised exception into


### PR DESCRIPTION
## Problem

Only `_tool_query_graph` calls `querylog.log_query`. The other nine MCP tools
(`get_node`, `get_neighbors`, `get_community`, `god_nodes`, `graph_stats`,
`shortest_path`, `list_prs`, `get_pr_impact`, `triage_prs`) return data without
leaving a trace.

That makes the query log an unreliable measure of graph usage, and it silently
breaks anything that tails the log. An agent doing the natural MCP flow

```
get_node -> get_neighbors -> shortest_path
```

is working entirely inside the graph while every log-based consumer shows it as
idle. I hit this while wiring the MCP server into a live viewer that tails
`GRAPHIFY_QUERY_LOG`: the agent was busy, the activity feed was empty, and the
log said nothing had happened.

## Change

Log from the single `call_tool` dispatch point instead of adding nine per-handler
calls. This way a tool added later cannot silently reintroduce an invisible read.

- `query_graph` keeps its in-handler call (it records `mode`, `depth`,
  `token_budget`) and is skipped in the wrapper, so nothing is double counted.
- Records carry `kind="mcp_<tool>"`, the tool's most meaningful argument as
  `question`, plus `duration_ms` and `tool=<name>`.
- Fail-silent by contract: `log_query` never raises, and the wrapper swallows
  everything, so observability can never turn into a tool error.

Sample records produced by four previously-silent tools:

```json
{"kind": "mcp_graph_stats",   "question": "graph_stats",   "duration_ms": 1.407}
{"kind": "mcp_god_nodes",     "question": "5",             "duration_ms": 22.133}
{"kind": "mcp_get_node",      "question": "install()",     "duration_ms": 1.15}
{"kind": "mcp_get_neighbors", "question": "install()",     "duration_ms": 1.248}
```

Opt-in behaviour is unchanged: with `GRAPHIFY_QUERY_LOG` unset, `_log_path()`
returns `None` and nothing is written.

## Testing

- Live MCP session over stdio JSON-RPC against a real graph: the four tools above
  each produced exactly one record, all with sane durations.
- `tests/test_serve.py`, `tests/test_serve_http.py`, `tests/test_querylog.py`:
  196 passed.
- `tests/test_mcp_ingest.py`: 29 passed.

Environment: Windows 11, Python 3.12, graphify 0.9.53.

Note for maintainers: six install/uninstall tests fail on Windows on a clean
checkout (POSIX separator assertions plus a gemini path case), unrelated to this
change. Verified by stashing this diff and re-running: identical failures before
and after. Also, `tests/test_dedup*.py` needs `rapidfuzz` present or collection
fails.
