### PR TITLE
Fix Python submodule imports from external source roots

### DIFF
--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -1,7 +1,7 @@
 """resolution — moved verbatim from graphify/extract.py."""
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 from pathlib import Path
 from graphify.extractors.models import LanguageConfig, _JS_CACHE_BYPASS_SUFFIXES, _NamespaceExportFact, _StarExportFact, _SymbolAliasFact, _SymbolDeclarationFact, _SymbolExportFact, _SymbolImportFact, _SymbolResolutionFacts, _SymbolUseFact, _WORKSPACE_PACKAGE_CACHE  # noqa: E402,F401
 from graphify.extractors.base import (  # noqa: F401
@@ -1766,7 +1766,42 @@ def _probe_python_module_candidate(candidate: Path) -> Path | None:
     return None
 
 
-def _resolve_python_module_path(module_name: str, current_path: Path, root: Path, level: int) -> Path | None:
+def _discover_python_source_roots(paths: Sequence[Path], root: Path) -> tuple[Path, ...]:
+    """Discover all non-package source root directories (e.g. `src/`) that contain
+    at least one Python package in `paths` (#2072, #3272)."""
+    try:
+        root_resolved = Path(root).resolve()
+    except OSError:
+        root_resolved = Path(root)
+    source_roots: set[Path] = set()
+    for p in paths:
+        if p.suffix.lower() not in (".py", ".pyi"):
+            continue
+        try:
+            p_res = Path(p).resolve()
+            rel = p_res.relative_to(root_resolved)
+        except (ValueError, OSError):
+            continue
+        parts = rel.parts
+        if len(parts) < 2:
+            continue
+        d = p_res.parent
+        levels = 0
+        while levels < len(parts) - 1 and (d / "__init__.py").is_file():
+            levels += 1
+            d = d.parent
+        if levels > 0 and d != root_resolved:
+            source_roots.add(d)
+    return tuple(sorted(source_roots))
+
+
+def _resolve_python_module_path(
+    module_name: str,
+    current_path: Path,
+    root: Path,
+    level: int,
+    source_roots: Sequence[Path] = (),
+) -> Path | None:
     if level > 0:
         base = current_path.parent
         for _ in range(level - 1):
@@ -1802,6 +1837,18 @@ def _resolve_python_module_path(module_name: str, current_path: Path, root: Path
         cand = _probe_python_module_candidate(anc / rel)
         if cand is not None:
             return cand
+
+    # If the caller is outside the package tree (e.g. tests/ importing from src/,
+    # #3272), probe candidate source roots discovered across the corpus.
+    if source_roots:
+        candidates: list[Path] = []
+        for sroot in source_roots:
+            cand = _probe_python_module_candidate(sroot / rel)
+            if cand is not None:
+                candidates.append(cand)
+        if len(candidates) == 1 or (candidates and all(c == candidates[0] for c in candidates)):
+            return candidates[0]
+
     return None
 
 def _python_top_level_function_bodies(path: Path, root_node, source: bytes) -> list[tuple[str, object]]:
@@ -1833,6 +1880,7 @@ def _collect_python_symbol_resolution_facts(
     if not py_paths:
         return
 
+    source_roots = _discover_python_source_roots(py_paths, root)
     trees: dict[Path, tuple[bytes, object]] = {}
     for path in py_paths:
         parsed = _parse_python_tree(path)
@@ -1848,7 +1896,9 @@ def _collect_python_symbol_resolution_facts(
             if module is None:
                 continue
             level, module_name = module
-            target_path = _resolve_python_module_path(module_name, path, root, level)
+            target_path = _resolve_python_module_path(
+                module_name, path, root, level, source_roots=source_roots
+            )
             if target_path is None:
                 continue
             # #1146: `from pkg import submod` — if the target is a package

--- a/tests/test_src_layout_import_resolution.py
+++ b/tests/test_src_layout_import_resolution.py
@@ -151,3 +151,127 @@ def test_non_python_import_edge_is_not_repointed(tmp_path):
     assert not any(v == "src_pkg_mod" and u == "app_cs" for _, u, v in _import_edges(G)), (
         "non-Python import edge was repointed onto a Python file (#2072 review)"
     )
+
+
+def test_package_submodule_import_from_outside_and_inside_src_layout_resolves(tmp_path):
+    """#3272: `from <pkg> import <submodule>` must resolve to submodule.py and downstream
+    submodule.func() calls whether the importing file is inside or outside the package tree."""
+    (tmp_path / "src" / "towmo" / "core").mkdir(parents=True)
+    (tmp_path / "src" / "towmo" / "domains").mkdir(parents=True)
+    (tmp_path / "tests").mkdir(parents=True)
+
+    (tmp_path / "src" / "towmo" / "__init__.py").write_text("")
+    (tmp_path / "src" / "towmo" / "core" / "__init__.py").write_text("")
+    (tmp_path / "src" / "towmo" / "domains" / "__init__.py").write_text("")
+
+    helper = tmp_path / "src" / "towmo" / "core" / "helper.py"
+    helper.write_text("def do_work(value):\n    return value * 2\n")
+
+    inside = tmp_path / "src" / "towmo" / "domains" / "inside_pkg_form.py"
+    inside.write_text("from towmo.core import helper\n\ndef run():\n    return helper.do_work(21)\n")
+
+    test_file = tmp_path / "tests" / "test_pkg_form.py"
+    test_file.write_text("from towmo.core import helper\n\ndef test_it():\n    assert helper.do_work(21) == 42\n")
+
+    paths = [
+        tmp_path / "src" / "towmo" / "__init__.py",
+        tmp_path / "src" / "towmo" / "core" / "__init__.py",
+        tmp_path / "src" / "towmo" / "domains" / "__init__.py",
+        helper,
+        inside,
+        test_file,
+    ]
+
+    res = extract(paths, root=tmp_path, parallel=False)
+    nodes_by_id = {n["id"]: n for n in res["nodes"]}
+    edges = res["edges"]
+
+    # 1. Verify submodule import edges exist for both inside and outside callers
+    submodule_imports = [
+        (e["source"], e["target"], e.get("context"))
+        for e in edges
+        if e.get("relation") == "imports_from" and e.get("context") == "submodule_import"
+    ]
+    submodule_sources = {src for src, tgt, _ in submodule_imports}
+    assert "src_towmo_domains_inside_pkg_form" in submodule_sources
+    assert "tests_test_pkg_form" in submodule_sources
+
+    # Both must point to helper.py
+    for src, tgt, _ in submodule_imports:
+        assert tgt == "src_towmo_core_helper"
+
+    # 2. Verify calls edges to do_work() exist for both inside and outside callers
+    call_edges = [
+        (e["source"], e["target"])
+        for e in edges
+        if e.get("relation") == "calls"
+    ]
+    call_sources = {src for src, tgt in call_edges}
+    assert "src_towmo_domains_inside_pkg_form_run" in call_sources
+    assert "tests_test_pkg_form_test_it" in call_sources
+
+    for src, tgt in call_edges:
+        assert tgt == "src_towmo_core_helper_do_work"
+
+
+def test_ambiguous_source_roots_fail_closed(tmp_path):
+    """#3272: when two distinct source roots contain conflicting packages with the same
+    name, absolute module resolution from an outside importer must fail closed (return None)
+    rather than arbitrarily binding to one."""
+    (tmp_path / "root1" / "pkg").mkdir(parents=True)
+    (tmp_path / "root2" / "pkg").mkdir(parents=True)
+    (tmp_path / "tests").mkdir(parents=True)
+
+    (tmp_path / "root1" / "pkg" / "__init__.py").write_text("")
+    (tmp_path / "root2" / "pkg" / "__init__.py").write_text("")
+
+    mod1 = tmp_path / "root1" / "pkg" / "mod.py"
+    mod1.write_text("def fn1(): return 1\n")
+    mod2 = tmp_path / "root2" / "pkg" / "mod.py"
+    mod2.write_text("def fn2(): return 2\n")
+
+    test_file = tmp_path / "tests" / "test_ambig.py"
+    test_file.write_text("from pkg import mod\n")
+
+    source_roots = [tmp_path / "root1", tmp_path / "root2"]
+    # Direct function test: conflicting candidate targets across source_roots -> None
+    assert _resolve_python_module_path("pkg.mod", test_file, tmp_path, level=0, source_roots=source_roots) is None
+
+
+def test_multi_source_root_distinct_packages_resolve(tmp_path):
+    """#3272: in a multi-root layout with distinct package names, external callers can
+    resolve modules across all source roots."""
+    (tmp_path / "packages" / "pkg_a" / "src" / "alpha").mkdir(parents=True)
+    (tmp_path / "packages" / "pkg_b" / "src" / "beta").mkdir(parents=True)
+    (tmp_path / "tests").mkdir(parents=True)
+
+    (tmp_path / "packages" / "pkg_a" / "src" / "alpha" / "__init__.py").write_text("")
+    (tmp_path / "packages" / "pkg_b" / "src" / "beta" / "__init__.py").write_text("")
+
+    alpha_mod = tmp_path / "packages" / "pkg_a" / "src" / "alpha" / "service.py"
+    alpha_mod.write_text("def work(): return 1\n")
+
+    test_file = tmp_path / "tests" / "test_cross.py"
+    test_file.write_text("from alpha import service\n\ndef test_fn():\n    return service.work()\n")
+
+    paths = [
+        tmp_path / "packages" / "pkg_a" / "src" / "alpha" / "__init__.py",
+        tmp_path / "packages" / "pkg_b" / "src" / "beta" / "__init__.py",
+        alpha_mod,
+        test_file,
+    ]
+
+    res = extract(paths, root=tmp_path, parallel=False)
+    submodule_imports = [
+        (e["source"], e["target"])
+        for e in res["edges"]
+        if e.get("relation") == "imports_from" and e.get("context") == "submodule_import"
+    ]
+    assert ("tests_test_cross", "packages_pkg_a_src_alpha_service") in submodule_imports
+
+    calls = [
+        (e["source"], e["target"])
+        for e in res["edges"]
+        if e.get("relation") == "calls"
+    ]
+    assert ("tests_test_cross_test_fn", "packages_pkg_a_src_alpha_service_work") in calls


### PR DESCRIPTION
## Summary

Fixes #3272 by correcting Python submodule resolution when imports originate outside the package's source root.

Previously, imports such as:

```python
from towmo.core import helper
```

could fail to resolve `helper.py` when the importing file was outside a `src/`-style package tree, such as a test file under `tests/`.

## Changes

* Added dynamic Python source-root discovery based on `__init__.py` package boundaries.
* Pass discovered source roots into Python module resolution as fallback candidates.
* Preserved the existing resolution order and relative-import behavior.
* Added fail-closed handling for ambiguous matches across multiple source roots.
* Discover source roots once per extraction batch to avoid repeated directory traversal.
* Added regression tests for:

  * Imports from both inside and outside `src/`.
  * Multiple source roots with distinct packages.
  * Ambiguous packages across multiple source roots.

## Validation

* `12 passed` — focused Python resolution tests.
* `19 passed, 442 deselected` — Python-focused suite.
* `339 passed, 4 skipped, 1 failed` — broader extraction/build suite.
* `git diff --check` passes cleanly.

The single broader-suite failure is the existing Windows `MAX_PATH` failure in `test_c_include_out_of_root_target_id_is_deterministic_across_checkout_paths` and is unrelated to this change.
