### PR TITLE
fix(query): rank same-hop nodes by query relevance before degree under the budget

### DIFF
--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -989,11 +989,25 @@ def _dfs(G: nx.Graph, start_nodes: list[str], depth: int) -> tuple[set[str], lis
     return visited, edges_seen
 
 
-def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_budget: int = 2000, *, seeds: list[str] | None = None) -> str:
+def _subgraph_to_text(
+    G: nx.Graph,
+    nodes: set[str],
+    edges: list[tuple],
+    token_budget: int = 2000,
+    *,
+    seeds: list[str] | None = None,
+    scores: dict[str, float] | None = None,
+) -> str:
     """Render subgraph as text, cutting at token_budget (approx 3 chars/token).
 
     seeds: exact-match nodes rendered first before the degree-sorted expansion,
     so the queried symbol always appears at the top of the output.
+    scores: per-node relevance to the question (the `_score_query` ranking the
+    query path already computed). Within one hop layer, a node that scored
+    against the query renders before a higher-degree node that scored zero, so
+    a tight budget cuts the incidental hub rather than the answer. Nodes absent
+    from the map score 0.0; an empty or missing map leaves the hop/degree order
+    unchanged.
     """
     char_budget = token_budget * 3
     lines = []
@@ -1025,9 +1039,13 @@ def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_bu
                     dist[nb] = hop
                     nxt.append(nb)
         frontier = nxt
+    # Hop distance stays the primary key (#BUG2); query relevance decides
+    # within a layer so a term match outranks an unrelated hub; degree then
+    # str(n) keep the tail deterministic and byte-identical when no score is set.
+    score_of = scores or {}
     ordered = seed_hits + sorted(
         nodes - seed_set,
-        key=lambda n: (dist.get(n, 1 << 30), -G.degree(n), str(n)),
+        key=lambda n: (dist.get(n, 1 << 30), -score_of.get(n, 0.0), -G.degree(n), str(n)),
     )
     for nid in ordered:
         d = G.nodes[nid]
@@ -1253,7 +1271,13 @@ def _query_graph_text(
     # Pass the seeds so the queried symbol renders first and survives truncation
     # (#BUG2): a branch merge had silently dropped this argument, leaving the
     # seed-first ordering as dead code.
-    return header + _subgraph_to_text(traversal_graph, nodes, edges, token_budget, seeds=start_nodes)
+    # `qs.ranked` already holds every node's relevance to the question; hand it
+    # to the renderer so the budget cut is relevance-aware instead of dropping a
+    # term-matching node behind a same-layer hub.
+    scores = {nid: score for score, nid in qs.ranked}
+    return header + _subgraph_to_text(
+        traversal_graph, nodes, edges, token_budget, seeds=start_nodes, scores=scores
+    )
 
 
 def _find_node_tiers(

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1735,3 +1735,65 @@ def test_resolve_single_node_shared_by_get_node_and_get_neighbors():
     nid, err = _resolve_single_node(G, "nonexistent")
     assert nid is None
     assert "No node matching" in err
+
+
+# --- relevance-aware ordering under the budget ---
+
+def _hub_vs_match_graph():
+    """Seed S with two depth-1 neighbors: `RetryTimeout` (degree 1, matches the
+    query term "timeout") and `Logger` (a hub wired to many leaves, matches
+    nothing). Both sit in the same hop layer, so today's (hop, -degree) sort
+    puts the hub first and a tight budget cuts the node that actually answers
+    the question."""
+    G = nx.Graph()
+    G.add_node("s", label="CompanySpacingGate", source_file="gate.py")
+    G.add_node("match", label="RetryTimeout", source_file="retry.py")
+    G.add_node("hub", label="Logger", source_file="log.py")
+    G.add_edge("s", "match", relation="calls", confidence="EXTRACTED")
+    G.add_edge("s", "hub", relation="calls", confidence="EXTRACTED")
+    for i in range(8):
+        G.add_node(f"leaf{i}", label=f"Leaf{i}", source_file="leaf.py")
+        G.add_edge("hub", f"leaf{i}", relation="calls", confidence="EXTRACTED")
+    return G
+
+
+def test_subgraph_to_text_query_match_outranks_hub_in_same_hop_layer():
+    """Within one hop layer, a node that scored against the query must render
+    before a higher-degree node that scored zero, so a tight budget cuts the
+    incidental hub, not the answer."""
+    G = _hub_vs_match_graph()
+    text = _subgraph_to_text(
+        G, set(G.nodes), list(G.edges()), token_budget=40,
+        seeds=["s"], scores={"match": 5.0},
+    )
+    node_lines = [l for l in text.splitlines() if l.startswith("NODE ")]
+    assert "CompanySpacingGate" in node_lines[0], "seed still renders first"
+    assert "RetryTimeout" in node_lines[1], f"query match must beat the hub: {node_lines}"
+
+
+def test_subgraph_to_text_without_scores_keeps_degree_order():
+    """No scores (or all-zero scores) must leave the existing hop/degree
+    ordering byte-identical — the hub still wins its layer."""
+    G = _hub_vs_match_graph()
+    kwargs = dict(token_budget=2000, seeds=["s"])
+    baseline = _subgraph_to_text(G, set(G.nodes), list(G.edges()), **kwargs)
+    node_lines = [l for l in baseline.splitlines() if l.startswith("NODE ")]
+    assert "Logger" in node_lines[1]
+    assert _subgraph_to_text(G, set(G.nodes), list(G.edges()), scores={}, **kwargs) == baseline
+    assert _subgraph_to_text(G, set(G.nodes), list(G.edges()), scores={"match": 0.0}, **kwargs) == baseline
+
+
+def test_query_graph_text_threads_relevance_scores_into_rendering():
+    """End to end: `query` already scores every node against the question;
+    that ranking must reach the renderer so a non-seed node matching a query
+    term survives a tight budget ahead of an unrelated hub."""
+    G = _hub_vs_match_graph()
+    # `TimeoutPolicy` takes the per-term seat for "timeout"; `RetryTimeout`
+    # still matches the term but is NOT a seed — the case this fix is about.
+    G.add_node("policy", label="TimeoutPolicy", source_file="policy.py")
+    G.add_edge("s", "policy", relation="calls", confidence="EXTRACTED")
+    text = _query_graph_text(G, "CompanySpacingGate timeout", mode="bfs", depth=1, token_budget=60)
+    labels = [l.split(" [", 1)[0] for l in text.splitlines() if l.startswith("NODE ")]
+    assert "NODE RetryTimeout" in labels, f"non-seed query match was cut: {labels}"
+    if "NODE Logger" in labels:
+        assert labels.index("NODE RetryTimeout") < labels.index("NODE Logger"), labels


### PR DESCRIPTION
## Summary

`query` already scores every node against the question to pick seeds, then throws that ranking away before rendering. Under a tight `--budget`, the renderer's hop-then-degree order lets an unrelated hub outrank a node that actually matched a query term in the same hop layer — so the hub survives and the answer is cut. This threads the existing ranking into `_subgraph_to_text` as a second sort key. ~30 lines, no new scoring pass, no new flag.

## Problem

`_subgraph_to_text` orders non-seed nodes by `(hop distance, -degree, id)` (#BUG2). Given seed `S` with two depth-1 neighbors — `RetryTimeout` (degree 1, matches the term "timeout") and `Logger` (a hub wired to eight leaves, matches nothing) — the query `"CompanySpacingGate timeout"` at `--budget 60` renders:

```
NODE CompanySpacingGate
NODE TimeoutPolicy        <- per-term seed for "timeout"
NODE Logger               <- hub, zero relevance
... (truncated — RetryTimeout cut)
```

`RetryTimeout` is a genuine match that did not win the single per-term seed seat, so it is neither protected as a seed nor ranked above the hub — the exact node the question is about is the one dropped.

## Fix

- `_subgraph_to_text(..., scores: dict[str, float] | None = None)`: sort key becomes `(hop, -score, -degree, id)`. Hop distance stays primary (the #BUG2 intent is preserved); relevance decides within a layer; degree and id keep the tail deterministic.
- `_query_graph_text` passes `{nid: score for score, nid in qs.ranked}` — the ranking `_score_query` already computed for seed selection.

**Byte-identical** when no non-seed node scored: a missing/empty map or all-zero scores fall through to the previous degree order. Seeds still render first and still survive truncation. `path` / `explain` untouched.

## Tests

- `test_subgraph_to_text_query_match_outranks_hub_in_same_hop_layer` — unit: scored node renders before a higher-degree unscored node in the same layer.
- `test_subgraph_to_text_without_scores_keeps_degree_order` — unit: `scores=None`, `{}`, and all-zero produce identical output to today.
- `test_query_graph_text_threads_relevance_scores_into_rendering` — end to end: a second term-matching node that is *not* the per-term seed survives a tight budget ahead of the hub.

Watched all three fail before the change (the e2e failure reproduces the `['CompanySpacingGate', 'TimeoutPolicy', 'Logger']` output above). `tests/test_serve.py`: 149 passed. Full suite: 5,167 passed; the 14 failures present (`test_ollama_retry_cap.py` missing `openai`, `test_skillgen.py` audit baselines) reproduce identically on pristine `v8` in this environment and are unrelated.

## Relation to existing work

Deliberately narrower than #347 / #1856 (which rework retrieval end to end): this is an ordering-only change inside the existing renderer. Complementary to #1303 (degree-blind seed ties) and the resolved #897 (seed scoring) — those concern *which seeds* are chosen; this concerns *what survives the budget* after seeds are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
