### PR TITLE
fix(watch): preserve pending semantic update flag

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1846,11 +1846,6 @@ def _rebuild_code(
             except Exception:
                 pass
 
-            # clear stale needs_update flag if present
-            flag = out / "needs_update"
-            if flag.exists():
-                flag.unlink()
-
             if same_graph:
                 print("[graphify watch] No code-graph changes detected (--no-cluster); outputs left untouched.")
             else:
@@ -1894,9 +1889,6 @@ def _rebuild_code(
                     )
                 except Exception:
                     pass
-                flag = out / "needs_update"
-                if flag.exists():
-                    flag.unlink()
                 html_action = _reconcile_graph_html(out, existing_graph_data)
                 if html_action == "rendered":
                     print(
@@ -2085,11 +2077,6 @@ def _rebuild_code(
                     )
             except Exception as cf_err:
                 print(f"[graphify watch] callflow HTML update skipped: {cf_err}")
-
-        # clear stale needs_update flag if present
-        flag = out / "needs_update"
-        if flag.exists():
-            flag.unlink()
 
         if not no_change:
             print(f"[graphify watch] Rebuilt: {G.number_of_nodes()} nodes, "

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -163,6 +163,32 @@ def test_check_update_does_not_clear_flag(tmp_path):
     assert flag.exists()
 
 
+@pytest.mark.parametrize(
+    ("no_cluster", "change_topology"),
+    [(True, False), (False, False), (False, True)],
+    ids=["no-cluster", "unchanged-topology", "clustered-rebuild"],
+)
+def test_code_rebuild_preserves_semantic_update_flag(
+    tmp_path, no_cluster, change_topology
+):
+    """An AST-only rebuild cannot clear pending semantic work (#3294)."""
+    source = tmp_path / "app.py"
+    source.write_text("def before(): pass\n", encoding="utf-8")
+    assert _rebuild_code(
+        tmp_path, no_cluster=no_cluster, acquire_lock=False
+    ) is True
+
+    flag = tmp_path / "graphify-out" / "needs_update"
+    flag.write_text("docs/PRD.md\n", encoding="utf-8")
+    if change_topology:
+        source.write_text("def after(): pass\n", encoding="utf-8")
+
+    assert _rebuild_code(
+        tmp_path, no_cluster=no_cluster, acquire_lock=False
+    ) is True
+    assert flag.read_text(encoding="utf-8") == "docs/PRD.md\n"
+
+
 def test_watch_raises_without_watchdog(tmp_path, monkeypatch):
     import builtins
     real_import = builtins.__import__


### PR DESCRIPTION
Closes #3294.

## Problem

`_rebuild_code()` is an AST-only operation, but each of its three successful exit paths deleted `graphify-out/needs_update`. That flag records pending semantic re-extraction for changed documents, so a later code rebuild could silently mark unrelated document work as complete even though no LLM-backed extraction ran.

## Change

- Stop deleting `needs_update` from the no-cluster, unchanged-topology, and clustered rebuild paths.
- Add a parameterized regression test covering all three paths.
- Preserve the flag contents as well as its existence, so the code-only pass cannot rewrite pending semantic state.

The semantic workflow remains responsible for clearing the flag after it actually resolves the pending work.

## Verification

- Regression test before fix: 3 failed (flag deleted on all paths).
- `uv run --frozen pytest tests/test_watch.py -q --tb=short`: 145 passed, 3 skipped.
- `uv run --frozen pytest tests/ -q --tb=short`: 5302 passed, 11 skipped.
- All five `tools.skillgen` CI guards passed.
- `uv run --frozen ruff check graphify/watch.py tests/test_watch.py` passed.
- `uv run --frozen graphify update .` completed successfully.
