### PR TITLE
fix(ingest): make memory-doc filenames unique so concurrent saves do not overwrite

### DIFF
--- a/graphify/ingest.py
+++ b/graphify/ingest.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import json
 import re
+import uuid
 import urllib.error
 import urllib.parse
 from datetime import datetime, timezone
@@ -299,7 +300,11 @@ def save_query_result(
 
     now = datetime.now(timezone.utc)
     slug = re.sub(r"[^\w]", "_", question.lower())[:50].strip("_")
-    filename = f"query_{now.strftime('%Y%m%d_%H%M%S')}_{slug}.md"
+    # A second-granularity stamp plus a 50-char slug is not unique: two saves in
+    # the same second whose questions share a prefix resolve to one path, and the
+    # later write_text silently replaces the earlier one (#3301). The short uuid
+    # makes every save its own file; the query_ prefix and .md suffix are kept.
+    filename = f"query_{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}_{slug}.md"
 
     frontmatter_lines = [
         "---",

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -98,3 +98,15 @@ def test_no_outcome_means_no_outcome_section(tmp_path):
 def test_invalid_outcome_rejected(tmp_path):
     with pytest.raises(ValueError):
         save_query_result("q", "a", tmp_path / "memory", outcome="great")
+
+
+def test_concurrent_saves_of_the_same_question_do_not_overwrite(tmp_path):
+    """Regression for #3301: a second-granularity stamp plus a 50-char slug is
+    not unique, so saves in the same second sharing a prefix collapsed into one
+    file and the earlier ones were silently lost."""
+    from concurrent.futures import ThreadPoolExecutor
+    mem = tmp_path / "memory"
+    with ThreadPoolExecutor(max_workers=20) as ex:
+        paths = list(ex.map(lambda _: save_query_result("how does auth work", "a", mem), range(20)))
+    assert len({p.name for p in paths}) == 20
+    assert len(list(mem.glob("*.md"))) == 20


### PR DESCRIPTION
Fixes #3301.

`save_query_result` names memory docs `query_<second>_<slug50>.md` and writes them with a plain `write_text`. Two saves that land in the same second and share the first 50 characters of the question resolve to one path, and the later one silently replaces the earlier. Both calls return normally.

Measured on v0.9.53 (20 concurrent saves): distinct questions keep 20/20, the same question keeps 1/20, and questions differing only after character 50 keep 1/20. The third case is the ordinary one when several agents sweep one subsystem in parallel.

**Change:** add `uuid.uuid4().hex[:8]` to the filename. The `query_` prefix and `.md` suffix are unchanged, so `reflect.load_memory_docs` (`*.md` glob) and the existing tests are unaffected. One regression test added: 20 concurrent saves of one question → 20 files.

The one-file-per-memory layout is what makes unrelated writes safe here; this only closes the filename.