### PR TITLE
fix(hook-guard): honour the orientation stamp in the soft search/read nudges

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -867,6 +867,13 @@ def _run_hook_guard(kind: str, strict: bool = False) -> None:
             is_grep_tool = not cmd_str and bool(t.get("pattern"))
             is_bash_search = bool(cmd_str) and _bash_invokes_search(cmd_str)
             if (is_grep_tool or is_bash_search) and out_path("graph.json").is_file():
+                # The nudge says "only grep after graphify has oriented you".
+                # Honour that: query/explain/path stamp cache/last_query_stamp
+                # (the same stamp the strict read deny consults), and while it
+                # is fresh the agent IS oriented, so repeating the identical
+                # demand on every subsequent search adds nothing.
+                if _query_stamp_fresh():
+                    return
                 sys.stdout.write(_SEARCH_NUDGE)
         elif kind == "read":
             vals = [str(t.get("file_path") or ""), str(t.get("pattern") or ""), str(t.get("path") or "")]
@@ -936,6 +943,12 @@ def _run_hook_guard(kind: str, strict: bool = False) -> None:
                     and _target_is_indexed(fp, root) \
                     and _mark_session_denied(str(d.get("session_id") or "")):
                 sys.stdout.write(_READ_DENY)
+                return
+            # Same contract as the search nudge: a fresh orientation stamp
+            # means the agent already did what the nudge asks for. The stale
+            # nudge above is deliberately NOT gated — "the graph lags this
+            # file" is new information regardless of orientation.
+            if _query_stamp_fresh():
                 return
             sys.stdout.write(_READ_NUDGE)
     except Exception:

--- a/tests/test_hook_guard_oriented.py
+++ b/tests/test_hook_guard_oriented.py
@@ -1,0 +1,92 @@
+"""A fresh orientation stamp silences the soft search/read nudges.
+
+Both nudges promise "only grep/read raw files after graphify has oriented you",
+and `graphify query|explain|path` records that orientation in
+cache/last_query_stamp — but until now only the strict read *deny* consulted the
+stamp, so an agent that obeyed the nudge kept receiving the identical MANDATORY
+demand on every subsequent search or read. While the stamp is fresh
+(GRAPHIFY_HOOK_STRICT_TTL, default 1800s) the agent IS oriented and the guard
+has nothing new to say. The stale-graph nudge is different information (the
+graph lags the file) and keeps firing regardless.
+"""
+import io
+import json
+import os
+import sys
+import time
+
+import pytest
+
+from graphify import __main__ as m
+
+
+def _invoke(kind, payload, tmp_path, monkeypatch, *, stamp_age=None, graph_age=None):
+    monkeypatch.setattr("graphify.paths.GRAPHIFY_OUT", "graphify-out")
+    monkeypatch.setattr("graphify.paths.GRAPHIFY_OUT_NAME", "graphify-out")
+    monkeypatch.chdir(tmp_path)
+    out = tmp_path / "graphify-out"
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "graph.json").write_text("{}", encoding="utf-8")
+    if graph_age is not None:
+        t = time.time() - graph_age
+        os.utime(out / "graph.json", (t, t))
+    if stamp_age is not None:
+        stamp = out / "cache" / "last_query_stamp"
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.write_text(str(time.time()), encoding="utf-8")
+        t = time.time() - stamp_age
+        os.utime(stamp, (t, t))
+
+    class _Stdin:
+        def __init__(self, b):
+            self.buffer = io.BytesIO(b)
+
+    monkeypatch.setattr(sys, "stdin", _Stdin(json.dumps(payload).encode("utf-8")))
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    m._run_hook_guard(kind)
+    return buf.getvalue()
+
+
+_SEARCHES = [
+    {"tool_name": "Bash", "tool_input": {"command": "grep -rn foo src/"}},
+    {"tool_name": "Grep", "tool_input": {"pattern": "foo", "glob": "*.py"}},
+]
+
+
+@pytest.mark.parametrize("payload", _SEARCHES)
+def test_fresh_stamp_silences_search_nudge(payload, tmp_path, monkeypatch):
+    assert _invoke("search", payload, tmp_path, monkeypatch, stamp_age=10).strip() == ""
+
+
+@pytest.mark.parametrize("payload", _SEARCHES)
+def test_expired_stamp_still_nudges_search(payload, tmp_path, monkeypatch):
+    out = _invoke("search", payload, tmp_path, monkeypatch, stamp_age=4000)
+    assert "graphify query" in out
+
+
+def test_no_stamp_still_nudges_search(tmp_path, monkeypatch):
+    out = _invoke("search", {"tool_input": {"command": "grep x"}}, tmp_path, monkeypatch)
+    assert "graphify query" in out
+
+
+def test_fresh_stamp_silences_read_nudge(tmp_path, monkeypatch):
+    (tmp_path / "app.py").write_text("x = 1", encoding="utf-8")
+    payload = {"tool_name": "Read", "tool_input": {"file_path": "app.py"}}
+    # graph.json is written after app.py, so the graph is fresh for the file
+    assert _invoke("read", payload, tmp_path, monkeypatch, stamp_age=10).strip() == ""
+
+
+def test_no_stamp_still_nudges_read(tmp_path, monkeypatch):
+    (tmp_path / "app.py").write_text("x = 1", encoding="utf-8")
+    payload = {"tool_name": "Read", "tool_input": {"file_path": "app.py"}}
+    assert "MANDATORY" in _invoke("read", payload, tmp_path, monkeypatch)
+
+
+def test_fresh_stamp_keeps_stale_graph_read_nudge(tmp_path, monkeypatch):
+    (tmp_path / "app.py").write_text("x = 2", encoding="utf-8")
+    payload = {"tool_name": "Read", "tool_input": {"file_path": "app.py"}}
+    # graph older than the file: the stale nudge carries new information
+    # (the graph lags this file) and is not silenced by orientation
+    out = _invoke("read", payload, tmp_path, monkeypatch, stamp_age=10, graph_age=60)
+    assert "STALE" in out


### PR DESCRIPTION
## Problem

`hook-guard search` and the soft branch of `hook-guard read` both tell the agent *"Only grep / read raw files after graphify has oriented you"*. `graphify query|explain|path` records exactly that orientation in `graphify-out/cache/last_query_stamp` (`_touch_query_stamp`), but only the **strict read deny** consults it (`_query_stamp_fresh()`).

So an agent that does what the nudge asks — runs `graphify query` first — still gets the identical `MANDATORY: … You MUST run graphify query …` context injected on every subsequent Grep call, every Bash grep/rg/find, and every Read of a source file, seconds after the query. In a session that touched a handful of files I counted the same ~200-byte demand six times. A demand that repeats after being satisfied is noise the agent learns to ignore, which works against the nudge's purpose.

Observed on 0.9.45; the `search` branch on `v8` (0.9.53) is unchanged apart from #3121's token matching.

## Fix

Both soft nudges now return silently while the stamp is fresh (same `_query_stamp_fresh()` / `GRAPHIFY_HOOK_STRICT_TTL` the strict deny already uses, default 1800s):

- `search`: check the stamp before writing `_SEARCH_NUDGE`.
- `read`: check the stamp before writing `_READ_NUDGE`, *after* the stale check — `_READ_NUDGE_STALE` is deliberately **not** gated, because "the graph lags this file" is new information regardless of orientation.

No stamp, or an expired stamp → behaviour is exactly as before. Fail-open is preserved (`_query_stamp_fresh` swallows every error and returns `False`).

## Tests

`tests/test_hook_guard_oriented.py` (direct-call harness, same shape as `test_hook_guard.py`):

- fresh stamp silences the search nudge for both payload shapes (Bash `command`, Grep `pattern`+`glob`)
- expired stamp / no stamp still nudge (search and read)
- fresh stamp silences the soft read nudge
- fresh stamp does **not** silence the stale-graph read nudge

Ran `test_hook_guard*.py`, `test_hook_strict.py`, `test_read_hook.py`, `test_search_hook.py`, `test_hook_out_of_project_paths.py`, `test_gemini_hook.py`: all pass except 8 subprocess-based cases in `test_read_hook.py` that fail identically on the untouched `v8` checkout on this Windows machine (`stdout` is `None`), so they are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsNkeutdBkLpHwnXv5nYf7
