### PR TITLE
Split the JS/TS resolution filter from the AST cache gate

### DIFF
--- a/graphify/extractors/models.py
+++ b/graphify/extractors/models.py
@@ -8,7 +8,8 @@ from dataclasses import dataclass, field
 
 _WORKSPACE_PACKAGE_CACHE: dict[str, dict[str, Path]] = {}
 
-_JS_CACHE_BYPASS_SUFFIXES = {".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts", ".vue", ".svelte"}
+_JS_FAMILY_SUFFIXES = {".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts", ".vue", ".svelte"}
+_JS_CACHE_BYPASS_SUFFIXES = _JS_FAMILY_SUFFIXES
 
 @dataclass
 class LanguageConfig:

--- a/graphify/extractors/models.py
+++ b/graphify/extractors/models.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 
 _WORKSPACE_PACKAGE_CACHE: dict[str, dict[str, Path]] = {}
 
-_JS_FAMILY_SUFFIXES = {".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts", ".vue", ".svelte"}
+_JS_FAMILY_SUFFIXES = frozenset({".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts", ".vue", ".svelte"})
 _JS_CACHE_BYPASS_SUFFIXES = _JS_FAMILY_SUFFIXES
 
 @dataclass

--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Callable
 from pathlib import Path
-from graphify.extractors.models import LanguageConfig, _JS_CACHE_BYPASS_SUFFIXES, _NamespaceExportFact, _StarExportFact, _SymbolAliasFact, _SymbolDeclarationFact, _SymbolExportFact, _SymbolImportFact, _SymbolResolutionFacts, _SymbolUseFact, _WORKSPACE_PACKAGE_CACHE  # noqa: E402,F401
+from graphify.extractors.models import LanguageConfig, _JS_CACHE_BYPASS_SUFFIXES, _JS_FAMILY_SUFFIXES, _NamespaceExportFact, _StarExportFact, _SymbolAliasFact, _SymbolDeclarationFact, _SymbolExportFact, _SymbolImportFact, _SymbolResolutionFacts, _SymbolUseFact, _WORKSPACE_PACKAGE_CACHE  # noqa: E402,F401
 from graphify.extractors.base import (  # noqa: F401
     _LANGUAGE_BUILTIN_GLOBALS,
     _file_stem,
@@ -1491,7 +1491,7 @@ def _ts_walk_class_members(class_node, source: bytes, path: Path, class_nid: str
 def _collect_js_symbol_resolution_facts(paths: list[Path], facts: _SymbolResolutionFacts) -> None:
     js_paths = [
         path for path in paths
-        if path.suffix in _JS_CACHE_BYPASS_SUFFIXES
+        if path.suffix in _JS_FAMILY_SUFFIXES
     ]
     if not js_paths:
         return

--- a/tests/test_js_suffix_constant_split.py
+++ b/tests/test_js_suffix_constant_split.py
@@ -1,0 +1,40 @@
+"""JS/TS resolution filter is a separate constant from the AST cache gate.
+
+`_JS_CACHE_BYPASS_SUFFIXES` used to answer two unrelated questions: whether a
+file skips the AST cache (`extract.py`) and whether it goes through JS/TS
+cross-file symbol resolution (`resolution.py`). Narrowing the set for caching
+reasons therefore dropped INFERRED edges with no error and almost no change in
+node count. `_JS_FAMILY_SUFFIXES` now answers the language question, so the
+cache gate can move independently.
+"""
+from __future__ import annotations
+
+import inspect
+
+from graphify.extractors import models, resolution
+
+
+def test_family_and_cache_sets_agree_today():
+    assert models._JS_FAMILY_SUFFIXES == models._JS_CACHE_BYPASS_SUFFIXES
+
+
+def test_family_set_covers_the_js_ts_extensions():
+    for suffix in (".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts", ".vue", ".svelte"):
+        assert suffix in models._JS_FAMILY_SUFFIXES
+
+
+def test_resolution_filters_on_the_language_set_not_the_cache_gate():
+    src = inspect.getsource(resolution._collect_js_symbol_resolution_facts)
+    assert "_JS_FAMILY_SUFFIXES" in src
+    assert "_JS_CACHE_BYPASS_SUFFIXES" not in src
+
+
+def test_narrowing_the_cache_gate_leaves_resolution_intact(monkeypatch):
+    monkeypatch.setattr(models, "_JS_CACHE_BYPASS_SUFFIXES", frozenset())
+    monkeypatch.setattr(resolution, "_JS_CACHE_BYPASS_SUFFIXES", frozenset())
+
+    facts = resolution._SymbolResolutionFacts()
+    resolution._collect_js_symbol_resolution_facts([], facts)
+
+    assert ".ts" in resolution._JS_FAMILY_SUFFIXES
+    assert ".vue" in resolution._JS_FAMILY_SUFFIXES

--- a/tests/test_js_suffix_constant_split.py
+++ b/tests/test_js_suffix_constant_split.py
@@ -18,6 +18,11 @@ def test_family_and_cache_sets_agree_today():
     assert models._JS_FAMILY_SUFFIXES == models._JS_CACHE_BYPASS_SUFFIXES
 
 
+def test_suffix_sets_are_immutable():
+    assert isinstance(models._JS_FAMILY_SUFFIXES, frozenset)
+    assert isinstance(models._JS_CACHE_BYPASS_SUFFIXES, frozenset)
+
+
 def test_family_set_covers_the_js_ts_extensions():
     for suffix in (".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts", ".vue", ".svelte"):
         assert suffix in models._JS_FAMILY_SUFFIXES


### PR DESCRIPTION
_JS_CACHE_BYPASS_SUFFIXES decided both whether a file skips the AST cache and whether it goes through JS/TS cross-file symbol resolution. Narrowing it for caching reasons silently dropped INFERRED edges.

_JS_FAMILY_SUFFIXES now answers the language question and resolution.py uses it. _JS_CACHE_BYPASS_SUFFIXES stays as an alias so the cache gate and existing imports are unchanged.

Refs #3326