### PR TITLE
fix(wiki): disclose truncated cross-community relationships

### DIFF
--- a/graphify/wiki.py
+++ b/graphify/wiki.py
@@ -161,9 +161,11 @@ def _community_article(
     if cross:
         for other_label, count in cross[:12]:
             lines.append(f"- {_md_link(other_label, resolver)} ({count} shared connections)")
-        if len(cross) > 12:
+        remaining_cross = len(cross) - 12
+        if remaining_cross > 0:
+            noun = "community" if remaining_cross == 1 else "communities"
             lines.append(
-                f"- *…and {len(cross) - 12} more cross-community relationship(s) not listed*"
+                f"- *…and {remaining_cross} more connected {noun} not listed*"
             )
     else:
         lines.append("- No strong cross-community connections detected")

--- a/graphify/wiki.py
+++ b/graphify/wiki.py
@@ -161,6 +161,10 @@ def _community_article(
     if cross:
         for other_label, count in cross[:12]:
             lines.append(f"- {_md_link(other_label, resolver)} ({count} shared connections)")
+        if len(cross) > 12:
+            lines.append(
+                f"- *…and {len(cross) - 12} more cross-community relationship(s) not listed*"
+            )
     else:
         lines.append("- No strong cross-community connections detected")
     lines.append("")

--- a/tests/test_wiki_truncation_indicator.py
+++ b/tests/test_wiki_truncation_indicator.py
@@ -1,4 +1,4 @@
-"""A god-node article says when a relation group was cut (#3127).
+"""Wiki articles say when a bounded relationship list was cut.
 
 `_god_node_article` caps each relation-type group at 20 entries. The header
 still reported the full degree, but the body silently dropped everything past
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import networkx as nx
 
-from graphify.wiki import _god_node_article
+from graphify.wiki import _community_article, _god_node_article
 
 
 def _star(n_refs: int, n_other: int = 0):
@@ -22,6 +22,34 @@ def _star(n_refs: int, n_other: int = 0):
         G.add_node(f"s{i}", label=f"Share{i}", source_file="src/s.py")
         G.add_edge("hub", f"s{i}", relation="shares_data_with", confidence="EXTRACTED")
     return G
+
+
+def _community_with_cross_links(n_communities: int) -> tuple[nx.Graph, dict[int, str], dict[str, int]]:
+    G = nx.Graph()
+    G.add_node("hub", label="Hub", source_file="src/hub.py")
+    labels = {0: "Core"}
+    node_community = {"hub": 0}
+    for i in range(n_communities):
+        nid = f"external-{i:02d}"
+        cid = i + 1
+        G.add_node(nid, label=f"External {i:02d}", source_file=f"src/external_{i:02d}.py")
+        G.add_edge("hub", nid, relation="references", confidence="EXTRACTED")
+        labels[cid] = f"Community {i:02d}"
+        node_community[nid] = cid
+    return G, labels, node_community
+
+
+def _community_text(n_communities: int) -> str:
+    G, labels, node_community = _community_with_cross_links(n_communities)
+    return _community_article(
+        G,
+        0,
+        ["hub"],
+        "Core",
+        labels,
+        cohesion=None,
+        node_community=node_community,
+    )
 
 
 def test_an_over_cap_group_names_how_much_was_cut():
@@ -43,3 +71,21 @@ def test_a_group_at_or_under_the_cap_has_no_indicator():
     for n in (20, 5):
         text = _god_node_article(_star(n), "hub", labels={})
         assert "not listed" not in text
+
+
+def test_an_over_cap_community_names_how_many_relationships_were_cut():
+    text = _community_text(13)
+    relationships = text.split("## Relationships", 1)[1].split("## Source Files", 1)[0]
+
+    assert relationships.count("shared connections") == 12
+    assert "Community 11" in relationships
+    assert "Community 12" not in relationships
+    assert "and 1 more cross-community relationship(s) not listed" in relationships
+
+
+def test_a_community_at_the_relationship_cap_has_no_indicator():
+    text = _community_text(12)
+    relationships = text.split("## Relationships", 1)[1].split("## Source Files", 1)[0]
+
+    assert relationships.count("shared connections") == 12
+    assert "more cross-community relationship(s)" not in relationships

--- a/tests/test_wiki_truncation_indicator.py
+++ b/tests/test_wiki_truncation_indicator.py
@@ -73,14 +73,20 @@ def test_a_group_at_or_under_the_cap_has_no_indicator():
         assert "not listed" not in text
 
 
-def test_an_over_cap_community_names_how_many_relationships_were_cut():
+def test_an_over_cap_community_names_how_many_connected_communities_were_cut():
     text = _community_text(13)
     relationships = text.split("## Relationships", 1)[1].split("## Source Files", 1)[0]
 
     assert relationships.count("shared connections") == 12
     assert "Community 11" in relationships
     assert "Community 12" not in relationships
-    assert "and 1 more cross-community relationship(s) not listed" in relationships
+    assert "and 1 more connected community not listed" in relationships
+
+
+def test_an_over_cap_community_pluralizes_the_indicator():
+    text = _community_text(14)
+
+    assert "and 2 more connected communities not listed" in text
 
 
 def test_a_community_at_the_relationship_cap_has_no_indicator():
@@ -88,4 +94,4 @@ def test_a_community_at_the_relationship_cap_has_no_indicator():
     relationships = text.split("## Relationships", 1)[1].split("## Source Files", 1)[0]
 
     assert relationships.count("shared connections") == 12
-    assert "more cross-community relationship(s)" not in relationships
+    assert "more connected communit" not in relationships


### PR DESCRIPTION
## Summary

- keep wiki community relationship lists capped at 12, but state the exact omitted count
- cover the first over-cap case and the exactly-at-cap boundary

## Problem

Community wiki articles sort cross-community relationships and display at most 12. When more relationships existed, the renderer silently discarded the rest, so a reader could mistake the visible list for complete.

## Result

Over-cap articles now append an indicator such as:

`- *…and 1 more connected community not listed*`

The existing cap and ordering are unchanged.

## Testing

- `uv run --frozen pytest tests/test_wiki.py tests/test_wiki_truncation_indicator.py -q` (37 passed)
- `uv run --frozen pytest tests/ -q --tb=short` (5,146 passed, 119 skipped)
- `uv run --frozen ruff check .`
- `uv run --frozen python -m tools.skillgen --check`
- `uv run --frozen python -m tools.skillgen --audit-coverage`
- `uv run --frozen python -m tools.skillgen --schema-singleton`
- `uv run --frozen python -m tools.skillgen --monolith-roundtrip`
- `uv run --frozen python -m tools.skillgen --always-on-roundtrip`
