### PR TITLE
fix: spurious json_config edges, and a claude-cli envelope parse failure that discards paid-for chunks

### DIFF
--- a/graphify/extractors/json_config.py
+++ b/graphify/extractors/json_config.py
@@ -161,8 +161,14 @@ def extract_json(path: Path) -> dict:
             if val.type == "object":
                 walk_object(val, key_nid, key, depth + 1, pair_count)
 
-            elif val.type == "array":
-                # For "extends" arrays (tsconfig, eslint): each string element.
+            elif val.type == "array" and key == "extends":
+                # Only a genuine `extends` array (tsconfig 5.0+, eslint) is
+                # inheritance. This branch used to fire for *every* array under
+                # a tracked key, so `compilerOptions.lib: ["dom","esnext"]` and
+                # `exclude: ["node_modules",".next"]` each emitted an `extends`
+                # edge — array membership relabelled as inheritance. The string
+                # branch below already gates on `key == "extends"`; this matches
+                # it. Non-`extends` arrays keep their `contains` edge only.
                 # Prefix with "ref_" so external refs don't collide with real
                 # code/file node IDs that share the same collapsed _make_id (J-4).
                 for item in val.children:
@@ -193,10 +199,28 @@ def extract_json(path: Path) -> dict:
                         add_edge(parent_nid, ref_nid, "references", line)
 
                 elif parent_key in _DEP_KEYS and val_text:
-                    dep_nid = _make_id(key)
+                    # Two defects fixed here, both from the #1764 shape:
+                    #
+                    # 1. The edge ran `key_nid -> dep_nid`, and both nodes carry
+                    #    the *same label* (the dependency name), so every
+                    #    dependency produced a visually self-referential
+                    #    `react --imports--> react` (22 of them on a mid-size
+                    #    Next.js repo). The self-loop guard in
+                    #    test_extract_json_import_and_extends_targets_are_real_nodes
+                    #    compares node ids, and these two ids differ, so the
+                    #    duplicate slipped past it. Sourcing the edge at the
+                    #    manifest yields `package.json --imports--> react`.
+                    #
+                    # 2. `_make_id(key)` minted a *bare* id, skipping the "ref"
+                    #    namespacing every other external reference in this file
+                    #    applies (J-4). A dependency named `utils`, `colors` or
+                    #    `types` could then be collapsed onto a same-named local
+                    #    module by build.py's alias index -- the #1638 failure
+                    #    mode reached through a different door.
+                    dep_nid = _make_id("ref", key)
                     if dep_nid:
                         add_node(dep_nid, key, line, file_type="concept")
-                        add_edge(key_nid, dep_nid, "imports", line, context="import")
+                        add_edge(file_nid, dep_nid, "imports", line, context="import")
 
     # Entry: find root document → object
     doc = root

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -1524,6 +1524,40 @@ def _call_claude(api_key: str, model: str, user_message: str, max_tokens: int = 
     return result
 
 
+def _envelope_after_preamble(stdout: str):
+    """Recover the envelope when `claude -p` prefixes it with a diagnostic line.
+
+    The CLI shares stdout with its own subsystems, so the JSON is not always the
+    first thing on it. An attached MCP server that advertises no tools makes
+    every invocation emit
+
+        Client.listTools() called but server does not advertise tools capability
+        - returning empty list
+
+    ahead of the envelope, and `json.loads` then fails on the whole buffer.
+    Because that failure is raised after the model has already answered, the
+    chunk is discarded with its tokens spent -- on a mid-size corpus a run could
+    burn the whole budget and return nothing, and the error names the JSON
+    rather than the preamble that caused it, so the log points at the wrong
+    thing. Any user with an MCP server configured hits this on every chunk.
+
+    Scans for the first `[`/`{` that begins a valid JSON document. `raw_decode`
+    ignores trailing bytes, so a diagnostic on either side is tolerated, and
+    stdout carrying no JSON at all still returns None for the caller to raise on.
+    """
+    decoder = json.JSONDecoder()
+    for idx, ch in enumerate(stdout):
+        if ch not in "[{":
+            continue
+        try:
+            value, _ = decoder.raw_decode(stdout, idx)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, (dict, list)):
+            return value
+    return None
+
+
 def _claude_cli_envelope(stdout: str) -> dict:
     """Parse the JSON returned by `claude -p --output-format json`.
 
@@ -1536,10 +1570,12 @@ def _claude_cli_envelope(stdout: str) -> dict:
     try:
         envelope = json.loads(stdout)
     except json.JSONDecodeError as exc:
-        raise RuntimeError(
-            f"claude -p produced unparseable JSON envelope: {exc}; "
-            f"first 500 chars of stdout: {stdout[:500]!r}"
-        ) from exc
+        envelope = _envelope_after_preamble(stdout)
+        if envelope is None:
+            raise RuntimeError(
+                f"claude -p produced unparseable JSON envelope: {exc}; "
+                f"first 500 chars of stdout: {stdout[:500]!r}"
+            ) from exc
     if isinstance(envelope, list):
         result_events = [
             e for e in envelope

--- a/tests/test_claude_cli_backend.py
+++ b/tests/test_claude_cli_backend.py
@@ -172,6 +172,43 @@ def test_call_llm_success_still_returns_result_text():
         assert llm._call_llm("dummy", backend="claude-cli") == "a fine label"
 
 
+_MCP_PREAMBLE = (
+    "Client.listTools() called but server does not advertise tools capability "
+    "- returning empty list\n"
+)
+
+
+def test_envelope_survives_a_diagnostic_preamble_on_stdout():
+    """An MCP server that advertises no tools must not kill the whole chunk.
+
+    The CLI writes that notice to stdout ahead of the envelope, so json.loads
+    saw `Client.listTools()...` and raised. The failure lands after the model
+    has answered, so the tokens are already spent and the chunk is dropped --
+    every chunk, for anyone with an MCP server configured.
+    """
+    completed = MagicMock(
+        returncode=0, stdout=_MCP_PREAMBLE + json.dumps(_ENVELOPE), stderr=""
+    )
+    with patch("shutil.which", return_value="/fake/bin/claude"), \
+         patch("subprocess.run", return_value=completed):
+        result = llm._call_claude_cli("dummy", max_tokens=8192)
+    assert [n["label"] for n in result["nodes"]] == ["Foo", "greet"]
+
+
+def test_envelope_survives_preamble_around_array_shaped_stream():
+    """Same, for the >= 2.1 array-of-events shape."""
+    stream = [{"type": "system", "subtype": "init"}, _ENVELOPE]
+    completed = MagicMock(
+        returncode=0,
+        stdout=_MCP_PREAMBLE + json.dumps(stream) + "\ntrailing noise\n",
+        stderr="",
+    )
+    with patch("shutil.which", return_value="/fake/bin/claude"), \
+         patch("subprocess.run", return_value=completed):
+        result = llm._call_claude_cli("dummy", max_tokens=8192)
+    assert [n["label"] for n in result["nodes"]] == ["Foo", "greet"]
+
+
 def test_raises_on_garbage_envelope():
     completed = MagicMock(returncode=0, stdout="not json", stderr="")
     with patch("shutil.which", return_value="/fake/bin/claude"), \

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -3289,6 +3289,65 @@ def test_extract_json_extends_resolved():
     assert extends_edges[0].get("context") == "import"
 
 
+def test_extract_json_dependency_edges_are_not_label_self_loops(tmp_path):
+    """A dependency must not point at another node carrying its own label.
+
+    test_extract_json_import_and_extends_targets_are_real_nodes already forbids
+    self-loops, but it compares node *ids*. The dependency branch minted a
+    second node for the same name under a different id, so every dependency
+    rendered as ``react --imports--> react`` -- a self-loop by label that an
+    id-based guard cannot see.
+    """
+    package_json = tmp_path / "package.json"
+    package_json.write_text(json.dumps({
+        "name": "demo",
+        "dependencies": {"react": "^19.0.0", "next": "^15.0.0"},
+        "devDependencies": {"wrangler": "^4.71.0"},
+    }))
+
+    result = extract_json(package_json)
+    labels = {n["id"]: n["label"] for n in result["nodes"]}
+    offenders = [
+        (labels.get(e["source"]), e["relation"], labels.get(e["target"]))
+        for e in result["edges"]
+        if e["relation"] == "imports"
+        and labels.get(e["source"]) == labels.get(e["target"])
+    ]
+    assert offenders == [], f"label self-loop: {offenders}"
+
+    # The dependency structure #1764 restored is still present.
+    imports = [e for e in result["edges"] if e["relation"] == "imports"]
+    assert {labels.get(e["target"]) for e in imports} == {"react", "next", "wrangler"}
+
+    # External dependency ids stay "ref"-namespaced (J-4), so build.py's alias
+    # index cannot collapse a dep named `utils`/`colors` onto a local module.
+    assert all(e["target"].startswith("ref") for e in imports), [e["target"] for e in imports]
+
+
+def test_extract_json_non_extends_arrays_are_not_inheritance(tmp_path):
+    """Only an ``extends`` array is inheritance.
+
+    ``compilerOptions.lib`` and ``exclude`` are ordinary string lists; emitting
+    ``extends`` for them turns array membership into a supertype relation and
+    manufactures a hub out of a build-output glob.
+    """
+    tsconfig = tmp_path / "tsconfig.json"
+    tsconfig.write_text(json.dumps({
+        "extends": ["./base.json", "./strict.json"],
+        "compilerOptions": {"lib": ["dom", "esnext"]},
+        "exclude": ["node_modules", ".next"],
+    }))
+
+    result = extract_json(tsconfig)
+    labels = {n["id"]: n["label"] for n in result["nodes"]}
+    extends_targets = {
+        labels.get(e["target"]) for e in result["edges"] if e["relation"] == "extends"
+    }
+    assert extends_targets == {"./base.json", "./strict.json"}
+    for not_inheritance in ("dom", "esnext", ".next", "node_modules"):
+        assert not_inheritance not in extends_targets
+
+
 def test_extract_json_import_and_extends_targets_are_real_nodes(tmp_path):
     package_json = tmp_path / "package.json"
     package_json.write_text(json.dumps({


### PR DESCRIPTION
Two independent fixes, one commit each — happy to split them into separate PRs or have you cherry-pick just one.

Found while evaluating graphify on a ~500-file Next.js + Supabase repo. All numbers below are measured on that repo or on the minimal fixtures added here.

---

## 1. `json_config` emits spurious `extends` and self-referential `imports` edges

Two defects in `graphify/extractors/json_config.py`, both in the shape introduced by #1764. That change fixed a real dangling-edge bug by creating the missing target as a `concept` node; these are follow-on consequences of the node it mints, not a reason to revert it.

**a. Every array became `extends`.** The array branch carried the comment "For `extends` arrays (tsconfig, eslint)" but had no key check, so it fired for any array under a tracked key:

```
compilerOptions.lib: ["dom", "esnext"]     ->  lib     --extends--> dom, esnext
exclude: ["node_modules", ".next"]         ->  exclude --extends--> node_modules, .next
```

Array membership is recorded as a supertype relation. On the test repo this also manufactured a false hub: `.next` reached degree 25 and ranked 24th by centrality, built from the tsconfig exclude glob plus 24 misresolved bare `next` imports. The string branch directly below already gates on `key == "extends"`; this makes the array branch match it.

**b. Every dependency became a self-loop.** The dependency edge ran `key_nid -> dep_nid`, and both nodes carry the dependency's own label:

```
react --imports--> react          (22 of these on the test repo)
```

`test_extract_json_import_and_extends_targets_are_real_nodes` already forbids self-loops, but it compares node *ids*, and the minted duplicate has a different id with the same label, so the guard cannot see it. Sourcing the edge at the manifest gives `package.json --imports--> react`.

The old target also used a bare `_make_id(key)`, skipping the `"ref"` namespacing every other external reference in this file applies (J-4). A dependency named `utils`, `colors` or `types` could then be collapsed onto a same-named local module by `build.py`'s alias index — the #1638 failure mode reached through a different door. Now `_make_id("ref", key)`.

**Effect on a 3-file fixture (`package.json` + `tsconfig.json` + one `.ts`):**

| | nodes | edges | spurious |
|---|---|---|---|
| before | 21 | 18 | 7 (39%) |
| after | 17 | 15 | 0 |

---

## 2. `claude-cli` backend dies on a diagnostic preamble, after paying for the answer

`_claude_cli_envelope` did `json.loads(stdout)`. But `claude -p --output-format json` shares stdout with the CLI's own subsystems, so the envelope is not always first on it. An attached MCP server that advertises no tools makes every invocation emit:

```
Client.listTools() called but server does not advertise tools capability - returning empty list
{"is_error":false,"duration_api_ms":472526,...}
```

and the parse fails on the whole buffer.

The failure is raised *after* the model has answered, so the chunk is discarded with its tokens already spent. In my run this burned 149,582 input and 52,162 output tokens on chunk 1 of 3 and returned nothing. The error message names the JSON rather than the preamble that caused it, so the log points at the wrong thing.

Anyone running an MCP server hits this on every chunk, which makes the `claude-cli` backend unusable for a large share of Claude Code users.

`_envelope_after_preamble` scans for the first `[`/`{` that begins a valid JSON document. `raw_decode` ignores trailing bytes, so a diagnostic on either side is tolerated. The fast path is unchanged — clean stdout still parses on the first `json.loads` — and stdout containing no JSON still raises, so `test_raises_on_garbage_envelope` holds.

---

## Tests

Four added, each verified to fail on the unpatched tree and pass with the fix:

- `test_extract_json_dependency_edges_are_not_label_self_loops` — closes the id-vs-label gap the existing self-loop guard leaves open, and asserts dependency targets stay `ref`-namespaced
- `test_extract_json_non_extends_arrays_are_not_inheritance`
- `test_envelope_survives_a_diagnostic_preamble_on_stdout` — uses the real MCP notice
- `test_envelope_survives_preamble_around_array_shaped_stream` — the >= 2.1 array-of-events shape, with trailing noise

**No existing test was modified.**

Full suite on `v8` @ 0.9.53: **13 failures before and after — the identical set** (`test_skillgen`, `test_terraform`, ollama retry-cap, and two others, all pre-existing on a clean checkout). Passing goes 4,925 -> 4,929, which is exactly the four new tests.

---

## Noted, not fixed here: SQL `GRANT`/`REVOKE` produce no edges

Out of scope for this PR — it needs new edge relations, which is your call, not a patch. Reporting it because it is the highest-consequence thing I found.

**Reproduced minimally.** This file yields exactly one edge, `file --contains--> public.secured_fn()`:

```sql
CREATE OR REPLACE FUNCTION public.secured_fn(p_id uuid)
RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
AS $function$
begin
  return p_id;
end
$function$;

REVOKE ALL ON FUNCTION public.secured_fn(uuid) FROM public, anon;
GRANT EXECUTE ON FUNCTION public.secured_fn(uuid) TO authenticated, service_role;
```

Neither the `REVOKE` nor the `GRANT` is represented. On the repo I was testing, 455 grant/revoke statements and 29 `CREATE POLICY` statements produced zero edges between them.

That matters more than ordinary missing coverage, because "is this function reachable by the anonymous role" is a question people ask a codebase graph, and in Supabase/PostgREST projects the answer is enforced in CI. A graph that cannot see `REVOKE` cannot answer it, and silence reads as "no exposure".

**One observation I could not reduce to a minimal case.** On that same repo the graph contains:

```
public.ron_append_message() --reads_from--> anon    [EXTRACTED, confidence 1.0]
```

The only occurrences of `anon` in that migration are `REVOKE ... FROM public, anon` lines — the source restricts the role, and the graph records a dependency on it, at full confidence. My best guess was that `FROM public, anon` in a `REVOKE` is being read as a query's `FROM` clause, but I could not trigger it in a small file (I tried the named `$function$` dollar-quote, upper and lower case, and the exact signature), so I am reporting the observation rather than a diagnosis. Happy to dig further, or to send the migration privately if that is useful.

If you would take a PR that adds `grants_execute` / `revokes_from` relations, I am glad to write it — say the shape you want and I will follow it.
