### PR TITLE
docs(skills): record the merge and agent failure modes seen in the field

### DIFF
--- a/graphify/skills/agents/references/extraction-spec.md
+++ b/graphify/skills/agents/references/extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/graphify/skills/agents/references/update.md
+++ b/graphify/skills/agents/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/amp/references/extraction-spec.md
+++ b/graphify/skills/amp/references/extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/graphify/skills/amp/references/update.md
+++ b/graphify/skills/amp/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/claude/references/extraction-spec.md
+++ b/graphify/skills/claude/references/extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/graphify/skills/claude/references/update.md
+++ b/graphify/skills/claude/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/claw/references/extraction-spec.md
+++ b/graphify/skills/claw/references/extraction-spec.md
@@ -29,3 +29,23 @@ Output exactly this JSON (no other text):
 
 source_file RULE: set source_file to the FILE_LIST path for that file VERBATIM (absolute, no shortening to basename, no re-relativizing, no separator change). Keeps full build and --update on one base so build_merge's replace matches instead of duplicating.
 ```
+
+
+---
+
+## Chunking and agent reliability
+
+**Pack chunks by BYTES, not file count.** ~250 KB for markup, **~110 KB for
+prose** — documentation is much denser in extractable concepts than markup.
+Packing by count handed one agent ~1 MB and killed it at a session limit twice.
+Split an oversized file by line range; node ids are deterministic from the label,
+so a concept straddling a boundary merges rather than duplicating.
+
+**Tell every agent to write its JSON early, then refine it.** Across three waves,
+**ten** agents reported `failed` on a rate limit having already written a
+complete, valid chunk. ⚠️ Never treat a `failed` status as meaning no output —
+list the chunk files and validate them before re-running anything.
+
+**Validate hyperedge members, not just edge endpoints.** An agent will name a
+member id it never emitted as a node; that only surfaces later as a dangling
+hyperedge in the merged graph.

--- a/graphify/skills/claw/references/update.md
+++ b/graphify/skills/claw/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/codex/references/extraction-spec.md
+++ b/graphify/skills/codex/references/extraction-spec.md
@@ -29,3 +29,23 @@ Output exactly this JSON (no other text):
 
 source_file RULE: set source_file to the FILE_LIST path for that file VERBATIM (absolute, no shortening to basename, no re-relativizing, no separator change). Keeps full build and --update on one base so build_merge's replace matches instead of duplicating.
 ```
+
+
+---
+
+## Chunking and agent reliability
+
+**Pack chunks by BYTES, not file count.** ~250 KB for markup, **~110 KB for
+prose** — documentation is much denser in extractable concepts than markup.
+Packing by count handed one agent ~1 MB and killed it at a session limit twice.
+Split an oversized file by line range; node ids are deterministic from the label,
+so a concept straddling a boundary merges rather than duplicating.
+
+**Tell every agent to write its JSON early, then refine it.** Across three waves,
+**ten** agents reported `failed` on a rate limit having already written a
+complete, valid chunk. ⚠️ Never treat a `failed` status as meaning no output —
+list the chunk files and validate them before re-running anything.
+
+**Validate hyperedge members, not just edge endpoints.** An agent will name a
+member id it never emitted as a node; that only surfaces later as a dangling
+hyperedge in the merged graph.

--- a/graphify/skills/codex/references/update.md
+++ b/graphify/skills/codex/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/copilot/references/extraction-spec.md
+++ b/graphify/skills/copilot/references/extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/graphify/skills/copilot/references/update.md
+++ b/graphify/skills/copilot/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/droid/references/extraction-spec.md
+++ b/graphify/skills/droid/references/extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/graphify/skills/droid/references/update.md
+++ b/graphify/skills/droid/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/kilo/references/extraction-spec.md
+++ b/graphify/skills/kilo/references/extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/graphify/skills/kilo/references/update.md
+++ b/graphify/skills/kilo/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/kiro/references/extraction-spec.md
+++ b/graphify/skills/kiro/references/extraction-spec.md
@@ -29,3 +29,23 @@ Output exactly this JSON (no other text):
 
 source_file RULE: set source_file to the FILE_LIST path for that file VERBATIM (absolute, no shortening to basename, no re-relativizing, no separator change). Keeps full build and --update on one base so build_merge's replace matches instead of duplicating.
 ```
+
+
+---
+
+## Chunking and agent reliability
+
+**Pack chunks by BYTES, not file count.** ~250 KB for markup, **~110 KB for
+prose** — documentation is much denser in extractable concepts than markup.
+Packing by count handed one agent ~1 MB and killed it at a session limit twice.
+Split an oversized file by line range; node ids are deterministic from the label,
+so a concept straddling a boundary merges rather than duplicating.
+
+**Tell every agent to write its JSON early, then refine it.** Across three waves,
+**ten** agents reported `failed` on a rate limit having already written a
+complete, valid chunk. ⚠️ Never treat a `failed` status as meaning no output —
+list the chunk files and validate them before re-running anything.
+
+**Validate hyperedge members, not just edge endpoints.** An agent will name a
+member id it never emitted as a node; that only surfaces later as a dangling
+hyperedge in the merged graph.

--- a/graphify/skills/kiro/references/update.md
+++ b/graphify/skills/kiro/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/opencode/references/extraction-spec.md
+++ b/graphify/skills/opencode/references/extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/graphify/skills/opencode/references/update.md
+++ b/graphify/skills/opencode/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/pi/references/extraction-spec.md
+++ b/graphify/skills/pi/references/extraction-spec.md
@@ -29,3 +29,23 @@ Output exactly this JSON (no other text):
 
 source_file RULE: set source_file to the FILE_LIST path for that file VERBATIM (absolute, no shortening to basename, no re-relativizing, no separator change). Keeps full build and --update on one base so build_merge's replace matches instead of duplicating.
 ```
+
+
+---
+
+## Chunking and agent reliability
+
+**Pack chunks by BYTES, not file count.** ~250 KB for markup, **~110 KB for
+prose** — documentation is much denser in extractable concepts than markup.
+Packing by count handed one agent ~1 MB and killed it at a session limit twice.
+Split an oversized file by line range; node ids are deterministic from the label,
+so a concept straddling a boundary merges rather than duplicating.
+
+**Tell every agent to write its JSON early, then refine it.** Across three waves,
+**ten** agents reported `failed` on a rate limit having already written a
+complete, valid chunk. ⚠️ Never treat a `failed` status as meaning no output —
+list the chunk files and validate them before re-running anything.
+
+**Validate hyperedge members, not just edge endpoints.** An agent will name a
+member id it never emitted as a node; that only surfaces later as a dangling
+hyperedge in the merged graph.

--- a/graphify/skills/pi/references/update.md
+++ b/graphify/skills/pi/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/trae/references/extraction-spec.md
+++ b/graphify/skills/trae/references/extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/graphify/skills/trae/references/update.md
+++ b/graphify/skills/trae/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/vscode/references/extraction-spec.md
+++ b/graphify/skills/vscode/references/extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/graphify/skills/vscode/references/update.md
+++ b/graphify/skills/vscode/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/graphify/skills/windows/references/extraction-spec.md
+++ b/graphify/skills/windows/references/extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/graphify/skills/windows/references/update.md
+++ b/graphify/skills/windows/references/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__agents__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__agents__references__extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__agents__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__agents__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__amp__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__amp__references__extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__amp__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__amp__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__claude__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__claude__references__extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__claude__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claude__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__claw__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__claw__references__extraction-spec.md
@@ -29,3 +29,23 @@ Output exactly this JSON (no other text):
 
 source_file RULE: set source_file to the FILE_LIST path for that file VERBATIM (absolute, no shortening to basename, no re-relativizing, no separator change). Keeps full build and --update on one base so build_merge's replace matches instead of duplicating.
 ```
+
+
+---
+
+## Chunking and agent reliability
+
+**Pack chunks by BYTES, not file count.** ~250 KB for markup, **~110 KB for
+prose** — documentation is much denser in extractable concepts than markup.
+Packing by count handed one agent ~1 MB and killed it at a session limit twice.
+Split an oversized file by line range; node ids are deterministic from the label,
+so a concept straddling a boundary merges rather than duplicating.
+
+**Tell every agent to write its JSON early, then refine it.** Across three waves,
+**ten** agents reported `failed` on a rate limit having already written a
+complete, valid chunk. ⚠️ Never treat a `failed` status as meaning no output —
+list the chunk files and validate them before re-running anything.
+
+**Validate hyperedge members, not just edge endpoints.** An agent will name a
+member id it never emitted as a node; that only surfaces later as a dangling
+hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__claw__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__claw__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__codex__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__codex__references__extraction-spec.md
@@ -29,3 +29,23 @@ Output exactly this JSON (no other text):
 
 source_file RULE: set source_file to the FILE_LIST path for that file VERBATIM (absolute, no shortening to basename, no re-relativizing, no separator change). Keeps full build and --update on one base so build_merge's replace matches instead of duplicating.
 ```
+
+
+---
+
+## Chunking and agent reliability
+
+**Pack chunks by BYTES, not file count.** ~250 KB for markup, **~110 KB for
+prose** — documentation is much denser in extractable concepts than markup.
+Packing by count handed one agent ~1 MB and killed it at a session limit twice.
+Split an oversized file by line range; node ids are deterministic from the label,
+so a concept straddling a boundary merges rather than duplicating.
+
+**Tell every agent to write its JSON early, then refine it.** Across three waves,
+**ten** agents reported `failed` on a rate limit having already written a
+complete, valid chunk. ⚠️ Never treat a `failed` status as meaning no output —
+list the chunk files and validate them before re-running anything.
+
+**Validate hyperedge members, not just edge endpoints.** An agent will name a
+member id it never emitted as a node; that only surfaces later as a dangling
+hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__codex__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__codex__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__copilot__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__copilot__references__extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__copilot__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__copilot__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__droid__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__droid__references__extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__droid__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__droid__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__kilo__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__kilo__references__extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__kilo__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kilo__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__kiro__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__kiro__references__extraction-spec.md
@@ -29,3 +29,23 @@ Output exactly this JSON (no other text):
 
 source_file RULE: set source_file to the FILE_LIST path for that file VERBATIM (absolute, no shortening to basename, no re-relativizing, no separator change). Keeps full build and --update on one base so build_merge's replace matches instead of duplicating.
 ```
+
+
+---
+
+## Chunking and agent reliability
+
+**Pack chunks by BYTES, not file count.** ~250 KB for markup, **~110 KB for
+prose** — documentation is much denser in extractable concepts than markup.
+Packing by count handed one agent ~1 MB and killed it at a session limit twice.
+Split an oversized file by line range; node ids are deterministic from the label,
+so a concept straddling a boundary merges rather than duplicating.
+
+**Tell every agent to write its JSON early, then refine it.** Across three waves,
+**ten** agents reported `failed` on a rate limit having already written a
+complete, valid chunk. ⚠️ Never treat a `failed` status as meaning no output —
+list the chunk files and validate them before re-running anything.
+
+**Validate hyperedge members, not just edge endpoints.** An agent will name a
+member id it never emitted as a node; that only surfaces later as a dangling
+hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__kiro__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__kiro__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__opencode__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__opencode__references__extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__opencode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__opencode__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__pi__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__pi__references__extraction-spec.md
@@ -29,3 +29,23 @@ Output exactly this JSON (no other text):
 
 source_file RULE: set source_file to the FILE_LIST path for that file VERBATIM (absolute, no shortening to basename, no re-relativizing, no separator change). Keeps full build and --update on one base so build_merge's replace matches instead of duplicating.
 ```
+
+
+---
+
+## Chunking and agent reliability
+
+**Pack chunks by BYTES, not file count.** ~250 KB for markup, **~110 KB for
+prose** — documentation is much denser in extractable concepts than markup.
+Packing by count handed one agent ~1 MB and killed it at a session limit twice.
+Split an oversized file by line range; node ids are deterministic from the label,
+so a concept straddling a boundary merges rather than duplicating.
+
+**Tell every agent to write its JSON early, then refine it.** Across three waves,
+**ten** agents reported `failed` on a rate limit having already written a
+complete, valid chunk. ⚠️ Never treat a `failed` status as meaning no output —
+list the chunk files and validate them before re-running anything.
+
+**Validate hyperedge members, not just edge endpoints.** An agent will name a
+member id it never emitted as a node; that only surfaces later as a dangling
+hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__pi__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__pi__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__trae__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__trae__references__extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__trae__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__trae__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__vscode__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__vscode__references__extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__vscode__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__vscode__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/expected/graphify__skills__windows__references__extraction-spec.md
+++ b/tools/skillgen/expected/graphify__skills__windows__references__extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/tools/skillgen/expected/graphify__skills__windows__references__update.md
+++ b/tools/skillgen/expected/graphify__skills__windows__references__update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.

--- a/tools/skillgen/fragments/references/shared/extraction-spec-compact.md
+++ b/tools/skillgen/fragments/references/shared/extraction-spec-compact.md
@@ -29,3 +29,23 @@ Output exactly this JSON (no other text):
 
 source_file RULE: set source_file to the FILE_LIST path for that file VERBATIM (absolute, no shortening to basename, no re-relativizing, no separator change). Keeps full build and --update on one base so build_merge's replace matches instead of duplicating.
 ```
+
+
+---
+
+## Chunking and agent reliability
+
+**Pack chunks by BYTES, not file count.** ~250 KB for markup, **~110 KB for
+prose** — documentation is much denser in extractable concepts than markup.
+Packing by count handed one agent ~1 MB and killed it at a session limit twice.
+Split an oversized file by line range; node ids are deterministic from the label,
+so a concept straddling a boundary merges rather than duplicating.
+
+**Tell every agent to write its JSON early, then refine it.** Across three waves,
+**ten** agents reported `failed` on a rate limit having already written a
+complete, valid chunk. ⚠️ Never treat a `failed` status as meaning no output —
+list the chunk files and validate them before re-running anything.
+
+**Validate hyperedge members, not just edge endpoints.** An agent will name a
+member id it never emitted as a node; that only surfaces later as a dangling
+hyperedge in the merged graph.

--- a/tools/skillgen/fragments/references/shared/extraction-spec.md
+++ b/tools/skillgen/fragments/references/shared/extraction-spec.md
@@ -68,3 +68,50 @@ source_file RULE (every node, edge, and hyperedge): set source_file to the path 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
 ```
+
+---
+
+## ⚠️ Chunking and agent-reliability lessons (from a ~106-file, ~4000-node repo)
+
+### Pack chunks by BYTES, never by file count
+
+Packing by count handed one agent ~1 MB and killed it at a session limit —
+twice, before the cause was spotted.
+
+- **~250 KB** is a workable ceiling for markup (HTML, code).
+- **~110 KB for prose.** Documentation is far denser in extractable concepts than
+  markup is, and a 346 KB document is 3–4 chunks, not one.
+
+A single file larger than the ceiling is split by **line range** (`Read` with
+`offset`/`limit`), not skipped. Because node ids are deterministic from the
+label, a concept that straddles a chunk boundary **merges instead of
+duplicating** — measured at 8 dedupes across 1483 nodes, so the cost of
+splitting is negligible.
+
+### Tell every agent to write its JSON EARLY, then refine it
+
+Instruct it explicitly:
+
+> write a first valid JSON file to disk EARLY (after a rough extraction), then
+> keep refining and re-writing it. A partial-but-valid file on disk is far better
+> than a perfect one you never manage to write.
+
+### ⚠️ The completion notification lies — check the disk
+
+Across three waves, **ten** agents reported `failed` on a rate limit having
+already written a complete, valid chunk. Every one of them would have been re-run
+for nothing on the strength of the status alone.
+
+**Never treat a `failed` status as meaning no output.** List the chunk files and
+validate them before deciding what to re-run:
+
+```python
+ids = {n['id'] for n in d.get('nodes', [])}
+dangling = sum(1 for e in d.get('edges', [])
+               if e['source'] not in ids or e['target'] not in ids)
+bad_types = {n.get('file_type') for n in d['nodes']} - VALID_FILE_TYPES
+```
+
+⚠️ Validate **hyperedge members too**, not just edge endpoints — an agent will
+name a member id it never emitted as a node, and that only surfaces later as a
+dangling hyperedge in the merged graph.

--- a/tools/skillgen/fragments/references/shared/update.md
+++ b/tools/skillgen/fragments/references/shared/update.md
@@ -208,3 +208,81 @@ graphify cluster-only .
 ```
 
 `graphify cluster-only .` is **self-contained**: it re-clusters, names communities, and regenerates `GRAPH_REPORT.md`, `graph.json`, and `graph.html` from the existing graph. **Do not re-run Steps 5–9** — they read intermediate files (`.graphify_extract.json`, `.graphify_detect.json`, `.graphify_analysis.json`) that a prior build's cleanup (Step 9) already deleted, so they raise `FileNotFoundError` (#1392). When it finishes, present the refreshed `GRAPH_REPORT.md` summary as usual.
+
+---
+
+## ⚠️ Failure modes seen in the field (read before merging)
+
+Each of these cost a real debugging round on a large repo (~4000 nodes, ~106
+files). They are not hypothetical, and none of them errors — every one fails
+silently and leaves a plausible-looking graph.
+
+### 1. `prune_sources` does not do what it reads like
+
+Two separate traps, and they compound:
+
+- It matches paths **exactly as the graph stores them**, which is *relative*.
+  Passing an absolute path prunes nothing, silently, and you end up with the old
+  and new nodes for that file side by side.
+- `build_merge` prunes **after** inserting. So naming a source you are
+  simultaneously re-adding deletes the **new** nodes too, and you are left with
+  neither.
+
+**What works:** strip that source's nodes and edges from `graph.json` by hand
+first, then merge with **no** `prune_sources` at all.
+
+```python
+drop = {n['id'] for n in g['nodes'] if str(n.get('source_file')) in FULL_REEXTRACT}
+g['nodes'] = [n for n in g['nodes'] if n['id'] not in drop]
+g['links'] = [l for l in g['links']
+              if l['source'] not in drop and l['target'] not in drop]
+```
+
+⚠️ Only prune a source you re-extracted in **FULL**. A partially re-extracted
+file (say you only re-read the changed section of a large doc) must **not** be
+pruned, or everything you did not re-read disappears.
+
+### 2. Hyperedges live in TWO places and the merge overwrites them
+
+`graph.json` carries `hyperedges` at top level **and** under `graph`. Filter only
+one copy and `build_merge` keeps just the incoming batch — 36 vanished this way
+in one run, with no error and no warning.
+
+**Reconstruct them explicitly after every merge**, combining the previous graph's
+with the new batch (new wins on id clash), then assert every member id exists.
+
+### 3. Keep that assertion — it finds pre-existing damage
+
+The first time it ran it surfaced four hyperedges that had been dangling in the
+graph *already*: extraction agents can name a member id they never emit as a
+node, and nothing validates that at write time.
+
+⚠️ The instinct is to blame the change you just made. Check the previous
+`graph.json` before concluding that — in that case they had been broken for a
+whole wave.
+
+**Repair rather than discard:** drop the phantom member when **3 or more real
+members remain** (the grouping is still true); only drop the hyperedge when too
+few survive.
+
+### 4. AST output paths do not match the graph's
+
+`extract()` returns `source_file` as an **absolute path with the platform
+separator** (`C:\repo\tests\foo.spec.js`), while the graph stores **relative,
+forward-slash** paths. Merging raw creates a duplicate source for every file —
+the ghost-node shape.
+
+Normalise `source_file` on **nodes, edges and hyperedges** before merging, then
+assert the final graph contains zero absolute or backslash paths.
+
+### 5. Prefer a targeted update to a full one
+
+Check how much actually changed before planning chunks. In one run `detect_incremental`
+reported 14 changed files (~970 KB), but `git diff` showed **326 lines across 5
+files** — and two of the flagged files had *zero* diff, changed only in metadata.
+Three agents on the changed material beat ten re-deriving untouched prose.
+
+**State the trade-off when you do this:** a partially re-extracted file is not
+pruned, so nodes for *edited* lines keep their earlier phrasing. Additions land;
+rewrites may lag. That is usually the right trade, but it should be a decision,
+not an accident.


### PR DESCRIPTION
Five behaviours cost real debugging time running `--update` against a ~4000-node, ~106-file graph. None of them errors — each fails silently and leaves a plausible-looking graph, which is what makes them expensive to find.

- **`prune_sources` does not do what it reads like.** It matches paths *as the graph stores them* (relative), so an absolute path prunes nothing; and `build_merge` prunes **after** inserting, so naming a source you are simultaneously re-adding deletes the new nodes too. Stripping the source by hand and merging with no `prune_sources` is what works.
- **Hyperedges live in two places.** `graph.json` carries them at top level *and* under `graph`; filtering one copy makes the merge keep only the incoming batch — 36 disappeared in one run with no error and no warning.
- **Asserting hyperedge members exist finds pre-existing damage.** Extraction agents name member ids they never emit as nodes, and nothing validates that at write time. Repairing (drop the phantom member when 3+ real ones remain) preserves the grouping.
- **`extract()` returns absolute, platform-separator `source_file` values** while the graph stores relative forward-slash ones, so merging raw AST creates a duplicate source per file.
- **Chunk by bytes, not file count** (~250 KB markup, ~110 KB prose), and tell agents to write their JSON early — ten agents across three waves reported `failed` having already written a valid chunk, so the completion status is not a reliable signal of output.

Docs only, no behaviour change.

### Where it was applied

The fragment sources, not the generated skill files:

```
tools/skillgen/fragments/references/shared/update.md
tools/skillgen/fragments/references/shared/extraction-spec.md
tools/skillgen/fragments/references/shared/extraction-spec-compact.md
```

The compact variant gets a deliberately shortened version — it exists to be compact.

Regenerated with `python -m tools.skillgen` and `--bless`, so the change is 3 fragments + 28 generated artifacts + 28 `expected/` snapshots. `pytest tests/test_skillgen.py` passes 65/65.

### A note on verification

Developed on Windows, where **29 tests fail on a clean `v8` checkout** for environment reasons (`os.mkfifo`, `socket.AF_UNIX`, symlink privilege, `charmap` codec, WSL `/bin/bash`). I confirmed those are pre-existing by stashing the change and re-running, so I verified against the targeted `tests/test_skillgen.py` suite rather than claiming a clean full run.

Happy to soften the specific numbers to qualitative statements if you would rather the docs not carry another project's telemetry.
