### PR TITLE
fix(ts): ignore non-runtime dynamic import text

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import textwrap
+import warnings
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
@@ -1366,7 +1367,7 @@ def extract_js(path: Path) -> dict:
     return result
 
 
-def _js_runtime_import_starts(path: Path, source: bytes) -> set[int]:
+def _js_runtime_import_starts(path: Path, source: bytes) -> set[int] | None:
     """Return byte offsets of parsed runtime ``import(...)`` calls.
 
     The rescue needs module-scope calls, not a second lexical parser. Parsing
@@ -1374,6 +1375,8 @@ def _js_runtime_import_starts(path: Path, source: bytes) -> set[int]:
     and template text. TypeScript import types are excluded by their enclosing
     type-only AST nodes because that grammar can represent ``typeof import('…')``
     as a call even though it is not runtime code.
+    Returns ``None`` when the validator cannot initialize or parse, so the
+    caller can preserve the pre-filter rescue behavior with a visible warning.
     """
     try:
         from tree_sitter import Language, Parser
@@ -1392,7 +1395,7 @@ def _js_runtime_import_starts(path: Path, source: bytes) -> set[int]:
         language = Language(getattr(module, language_name)())
         tree = Parser(language).parse(source)
     except Exception:
-        return set()
+        return None
 
     starts: set[int] = set()
 
@@ -1487,12 +1490,26 @@ def _rescue_js_dynamic_imports(path: Path, result: dict) -> None:
         if not matches:
             return
         runtime_import_starts = _js_runtime_import_starts(path, source_bytes)
+        parser_failed = runtime_import_starts is None
+        if parser_failed:
+            warnings.warn(
+                f"tree-sitter could not validate dynamic import candidates in {path}; "
+                "falling back to the guarded lexical rescue, which may include "
+                "text in comments or strings",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            runtime_import_starts = set()
         # `(?<!\w)` so `fooimport('x')` and `_import('x')` do not match. The
         # backtick alternative mirrors _dynamic_import_js's template-string
         # handling: a literal `import(`./x`)` resolves, `${`-substituted ones
         # are excluded (no `$` in the class) as statically unresolvable.
         for m in matches:
-            if m.start() not in runtime_import_starts:
+            if parser_failed:
+                line_start = source_bytes.rfind(b"\n", 0, m.start()) + 1
+                if b"//" in source_bytes[line_start:m.start()]:
+                    continue
+            elif m.start() not in runtime_import_starts:
                 continue
             raw_bytes = m.group(1) or m.group(2) or m.group(3)
             raw = raw_bytes.decode("utf-8", errors="replace") if raw_bytes else ""

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1366,6 +1366,53 @@ def extract_js(path: Path) -> dict:
     return result
 
 
+def _js_runtime_import_starts(path: Path, source: bytes) -> set[int]:
+    """Return byte offsets of parsed runtime ``import(...)`` calls.
+
+    The rescue needs module-scope calls, not a second lexical parser. Parsing
+    the same source lets tree-sitter distinguish comments, strings, regexes,
+    and template text. TypeScript import types are excluded by their enclosing
+    type-only AST nodes because that grammar can represent ``typeof import('…')``
+    as a call even though it is not runtime code.
+    """
+    try:
+        from tree_sitter import Language, Parser
+
+        suffix = path.suffix.lower()
+        if suffix == ".tsx":
+            module_name = "tree_sitter_typescript"
+            language_name = "language_tsx"
+        elif suffix in (".ts", ".mts", ".cts"):
+            module_name = "tree_sitter_typescript"
+            language_name = "language_typescript"
+        else:
+            module_name = "tree_sitter_javascript"
+            language_name = "language"
+        module = importlib.import_module(module_name)
+        language = Language(getattr(module, language_name)())
+        tree = Parser(language).parse(source)
+    except Exception:
+        return set()
+
+    starts: set[int] = set()
+
+    non_runtime_ancestors = {
+        "ERROR", "type_alias_declaration", "interface_declaration",
+        "type_annotation", "type_arguments", "type_parameter",
+    }
+    pending = [(tree.root_node, frozenset())]
+    while pending:
+        node, ancestors = pending.pop()
+        if node.type == "call_expression":
+            function = node.child_by_field_name("function")
+            if (function is not None and function.type == "import"
+                    and not ancestors.intersection(non_runtime_ancestors)):
+                starts.add(node.start_byte)
+        child_ancestors = ancestors | {node.type}
+        pending.extend((child, child_ancestors) for child in node.children)
+    return starts
+
+
 def _rescue_js_dynamic_imports(path: Path, result: dict) -> None:
     """Recover ``import('…')`` edges the AST pass does not emit for plain JS/TS.
 
@@ -1388,12 +1435,14 @@ def _rescue_js_dynamic_imports(path: Path, result: dict) -> None:
     written inside one, and that is a different fact from "this file depends on
     that module" — the only one file-level traversal can use (#2584).
 
-    Regex false positives in comments/strings are the precedented trade of
-    the Svelte/Vue rescues; a ``//``-prefix guard covers the common case.
+    The AST filter is safer than a raw regex search: comment and string text can
+    contain ``import('…')`` verbatim without making a dependency. Template
+    interpolation is parsed as code, so ```${import('./x')}``` remains live.
     """
     try:
         import re as _re
-        src = path.read_text(encoding="utf-8", errors="replace")
+        source_bytes = path.read_bytes()
+        src = source_bytes.decode("utf-8", errors="replace")
         if "import(" not in src:  # cheap bail — most files have none
             return
         existing_ids = {n["id"] for n in result.get("nodes", [])}
@@ -1431,20 +1480,24 @@ def _rescue_js_dynamic_imports(path: Path, result: dict) -> None:
                         deferred_files.add(str(Path(tf).resolve()))
                     except OSError:
                         deferred_files.add(str(tf))
+        matches = list(_re.finditer(
+            rb"(?<!\w)import\(\s*(?:'([^'\r\n]+)'|\"([^\"\r\n]+)\"|`([^`$\r\n]+)`)\s*\)",
+            source_bytes,
+        ))
+        if not matches:
+            return
+        runtime_import_starts = _js_runtime_import_starts(path, source_bytes)
         # `(?<!\w)` so `fooimport('x')` and `_import('x')` do not match. The
         # backtick alternative mirrors _dynamic_import_js's template-string
         # handling: a literal `import(`./x`)` resolves, `${`-substituted ones
         # are excluded (no `$` in the class) as statically unresolvable.
-        for m in _re.finditer(
-            r"""(?<!\w)import\(\s*(?:'([^'\n]+)'|"([^"\n]+)"|`([^`$\n]+)`)\s*\)""",
-            src,
-        ):
-            raw = m.group(1) or m.group(2) or m.group(3)
+        for m in matches:
+            if m.start() not in runtime_import_starts:
+                continue
+            raw_bytes = m.group(1) or m.group(2) or m.group(3)
+            raw = raw_bytes.decode("utf-8", errors="replace") if raw_bytes else ""
             if not raw:
                 continue
-            line_start = src.rfind("\n", 0, m.start()) + 1
-            if "//" in src[line_start:m.start()]:
-                continue  # line-commented-out import
             resolution = _resolve_rescued_specifier(path, raw, aliases, base_url)
             if resolution is None:
                 continue

--- a/tests/test_js_dynamic_imports.py
+++ b/tests/test_js_dynamic_imports.py
@@ -20,7 +20,15 @@ import networkx as nx
 import pytest
 
 from graphify.affected import DEFAULT_AFFECTED_RELATIONS, affected_nodes
-from graphify.extract import _file_node_id, extract, extract_js
+import graphify.extract as extract_module
+from graphify.extract import (
+    _TS_CONFIG,
+    _extract_generic,
+    _file_node_id,
+    _rescue_js_dynamic_imports,
+    extract,
+    extract_js,
+)
 
 
 def _write(path: Path, text: str) -> Path:
@@ -296,6 +304,26 @@ def test_dynamic_import_text_in_regex_is_not_matched(tmp_path: Path):
     result = extract_js(importer)
 
     assert not any(edge["relation"] == "dynamic_import" for edge in result["edges"])
+
+
+def test_parser_failure_falls_back_with_warning(tmp_path: Path, monkeypatch):
+    _write(tmp_path / "src/dep.ts", "export const dep = 1\n")
+    importer = _write(tmp_path / "src/boot.ts", "export const dep = await import('./dep')\n")
+
+    result = _extract_generic(importer, _TS_CONFIG)
+    original_import = extract_module.importlib.import_module
+
+    def fail_typescript_grammar(name, *args, **kwargs):
+        if name == "tree_sitter_typescript":
+            raise ImportError("simulated parser initialization failure")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(extract_module.importlib, "import_module", fail_typescript_grammar)
+
+    with pytest.warns(RuntimeWarning, match="could not validate dynamic import"):
+        _rescue_js_dynamic_imports(importer, result)
+
+    assert any(edge["relation"] == "dynamic_import" for edge in result["edges"])
 
 
 def test_nested_named_function_calls_resolve(tmp_path: Path):

--- a/tests/test_js_dynamic_imports.py
+++ b/tests/test_js_dynamic_imports.py
@@ -17,9 +17,10 @@ import json
 from pathlib import Path
 
 import networkx as nx
+import pytest
 
 from graphify.affected import DEFAULT_AFFECTED_RELATIONS, affected_nodes
-from graphify.extract import _file_node_id, extract
+from graphify.extract import _file_node_id, extract, extract_js
 
 
 def _write(path: Path, text: str) -> Path:
@@ -213,6 +214,31 @@ def test_template_literal_specifier_without_substitution(tmp_path: Path):
     assert _edges_to(result, "src/dep.ts")
 
 
+def test_runtime_import_in_template_interpolation_survives_rescue(tmp_path: Path):
+    _write(tmp_path / "src/dep.ts", "export const dep = 1\n")
+    importer = _write(
+        tmp_path / "src/boot.ts",
+        "export const message = `${import('./dep')}`\n",
+    )
+
+    result = extract([tmp_path / "src/dep.ts", importer], root=tmp_path)
+
+    assert _edges_to(result, "src/dep.ts")
+
+
+def test_type_import_in_generic_call_is_not_rescued_as_runtime(tmp_path: Path):
+    _write(tmp_path / "src/dep.ts", "export const dep = 1\n")
+    importer = _write(
+        tmp_path / "src/boot.ts",
+        "declare function load<T>(): void\n"
+        "load<typeof import('./dep')>()\n",
+    )
+
+    result = extract([tmp_path / "src/dep.ts", importer], root=tmp_path)
+
+    assert not _edges_to(result, "src/dep.ts")
+
+
 def test_identifier_ending_in_import_is_not_matched(tmp_path: Path):
     """`fooimport('./x')` is a call to `fooimport`, not a dynamic import."""
     _write(tmp_path / "src/x.ts", "export const x = 1\n")
@@ -238,6 +264,38 @@ def test_line_commented_dynamic_import_is_not_matched(tmp_path: Path):
     result = extract([tmp_path / "src/x.ts", importer], root=tmp_path)
 
     assert not _edges_to(result, "src/x.ts")
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    [
+        "/* import('./x') */\nexport const r = 1\n",
+        'const text = "import(\'./x\')"\nexport const r = 1\n',
+        "const text = `import('./x')`\nexport const r = 1\n",
+    ],
+    ids=["block-comment", "string", "template"],
+)
+def test_dynamic_import_text_in_comments_and_strings_is_not_matched(
+    tmp_path: Path, source_text: str
+):
+    """Only executable ``import()`` syntax should create a dependency edge."""
+    _write(tmp_path / "src/x.ts", "export const x = 1\n")
+    importer = _write(tmp_path / "src/caller.ts", source_text)
+
+    result = extract([tmp_path / "src/x.ts", importer], root=tmp_path)
+
+    assert not _edges_to(result, "src/x.ts")
+
+
+def test_dynamic_import_text_in_regex_is_not_matched(tmp_path: Path):
+    importer = _write(
+        tmp_path / "src/caller.ts",
+        "const pattern = /import('x')/\nexport const r = 1\n",
+    )
+
+    result = extract_js(importer)
+
+    assert not any(edge["relation"] == "dynamic_import" for edge in result["edges"])
 
 
 def test_nested_named_function_calls_resolve(tmp_path: Path):


### PR DESCRIPTION
The JavaScript dynamic import rescue matcher treated import-like text inside comments, strings, template text, regex literals, and TypeScript type contexts as executable dynamic imports.
That produced dependency edges for code that never runs.

The rescue path now reparses candidate files with tree-sitter and keeps only runtime import call nodes.
The byte matcher remains lazy, computes one source-offset set per file, and uses iterative traversal.

| Before: [captured CLI output](https://raw.githubusercontent.com/VasuBansal7576/graphify/f382c14f9becd1cdad0e0a5681fc112ace4fdd5f/docs/evidence/dynamic-import-filter/before.png) | After: [captured CLI output](https://raw.githubusercontent.com/VasuBansal7576/graphify/f382c14f9becd1cdad0e0a5681fc112ace4fdd5f/docs/evidence/dynamic-import-filter/after.png) |
| --- | --- |
| ![Before dynamic import edges](https://raw.githubusercontent.com/VasuBansal7576/graphify/f382c14f9becd1cdad0e0a5681fc112ace4fdd5f/docs/evidence/dynamic-import-filter/before.png) | ![After dynamic import edges](https://raw.githubusercontent.com/VasuBansal7576/graphify/f382c14f9becd1cdad0e0a5681fc112ace4fdd5f/docs/evidence/dynamic-import-filter/after.png) |
| Base `33362d9`: false and real dynamic edges, 6 nodes and 5 edges. | Candidate `b31cc43`: real dynamic edge only, 6 nodes and 4 edges. The after screenshot is captured on this head; the follow-up also preserves valid edges when parser validation fails. |

Verification on candidate `b31cc43`:

- `tests/test_js_dynamic_imports.py`: 19 passed.
- Focused related checks across the dynamic-import, import-resolution, and extraction tests: 284 passed, 4 skipped.
- Ruff and `git diff --check` pass.
- Unicode-prefix and same-line URL-string smoke check reports only the real dynamic edge.
- Parser initialization failure regression preserves a valid rescue edge and emits a `RuntimeWarning` describing the degraded fallback.

When tree-sitter cannot validate candidates, the implementation preserves the prior guarded lexical rescue so valid edges are retained and surfaces the precision tradeoff explicitly in a warning; normal parser-success runs continue to filter non-runtime text.

The full suite was not rerun after the follow-up.
An earlier broader run before this follow-up reported 5,175 passed, 92 skipped, and 12 environment or pre-existing failures involving Unix socket permissions, an unavailable OpenAI dependency, and blocked DNS.

The portable fixture and reproduction command are pinned in the separate [evidence commit](https://github.com/VasuBansal7576/graphify/tree/f382c14f9becd1cdad0e0a5681fc112ace4fdd5f/docs/evidence/dynamic-import-filter).
