### PR TITLE
fix(resolution): require owned sources for type-use edges

### DIFF
--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -1094,6 +1094,11 @@ def _apply_symbol_resolution_facts(
         if target_id is None:
             continue
         source_id = use_fact.source_id
+        # Structural walking can omit named-function-local declarations while
+        # materializing callback-local ones. Only actual node ownership decides
+        # whether a type relationship has a represented source declaration.
+        if use_fact.relation in ("inherits", "implements", "references") and source_id not in owned:
+            continue
         if use_fact.relation == "calls" and source_id not in owned:
             source_id = source_file_id.get(file_path)
             if source_id is None:

--- a/tests/test_owned_type_sources.py
+++ b/tests/test_owned_type_sources.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+from graphify.extract import extract
+
+
+def run(tmp_path, sources):
+    paths = []
+    for name, text in sources.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text)
+        paths.append(p)
+    return extract(paths, root=tmp_path, cache_root=tmp_path, parallel=False)
+
+
+def triples(g):
+    return {(e["source"], e["target"], e["relation"]) for e in g["edges"]}
+
+
+def test_callback_local_method_preserved_named_function_local_omitted(tmp_path):
+    g = run(
+        tmp_path,
+        {
+            "base.ts": "export class Base {}\nexport interface Result {}\n",
+            "local.ts": 'import {Base,Result} from "./base.js";\nexport function make() { class Hidden extends Base { method(): Result { return {}; } } return Hidden; }\nit("x", () => { class Visible extends Base { method(): Result { return {}; } } });\n',
+        },
+    )
+    ids = {n["id"] for n in g["nodes"]}
+    edges = triples(g)
+    assert ("local_visible_method", "base_result", "references") in edges
+    assert ("local_visible", "base_base", "inherits") in edges
+    assert not any(e["source"] not in ids for e in g["edges"])
+    assert not any("hidden" in e["source"] for e in g["edges"])
+
+
+def test_same_basename_sources_do_not_suppress_other_callers(tmp_path):
+    g = run(
+        tmp_path,
+        {
+            "base.ts": "export class Base {}\nexport interface Result {}\n",
+            "a/local.ts": 'import {Base,Result} from "../base.js";\nexport function make() { class Shared extends Base { method(): Result { return {}; } } return Shared; }\n',
+            "b/local.ts": 'import {Base,Result} from "../base.js";\nit("x", () => { class Shared extends Base { method(): Result { return {}; } } });\n',
+        },
+    )
+    ids = {n["id"] for n in g["nodes"]}
+    edges = triples(g)
+    assert ("b_local_shared_method", "base_result", "references") in edges
+    assert ("b_local_shared", "base_base", "inherits") in edges
+    assert not any(e["source"] not in ids for e in g["edges"])
+
+
+def test_abstract_method_omissions_do_not_drop_concrete_method(tmp_path):
+    g = run(
+        tmp_path,
+        {
+            "base.ts": "export interface Result {}\n",
+            "local.ts": 'import {Result} from "./base.js";\nexport abstract class Abstract { abstract method(): Result; concrete(): Result { return {}; } }\n',
+        },
+    )
+    ids = {n["id"] for n in g["nodes"]}
+    assert ("local_abstract_concrete", "base_result", "references") in triples(g)
+    assert not any(e["source"] not in ids for e in g["edges"])


### PR DESCRIPTION
A class inside a named function can have no extracted AST node while the symbol resolver still emits its inheritance and member type-reference edges.
Abstract method signatures can produce the same missing-source records.

Require an owned source node before emitting `inherits`, `implements`, or `references` use facts.
This preserves relationships for callback-local classes that the structural extractor does materialize, including their method return types.
It follows the existing ownership boundary for call facts without changing call attribution or adding extraction support for omitted declarations.

The four-file CLI reproduction on upstream `937e59a5476fcb2665d6c4f4b7c0d0a4142011b6` keeps all 12 nodes and changes 24 edges to 22.
Only the two missing-source records disappear; `Visible.method → Result` remains.

[Immutable fixture, raw graphs, exact hashes and CLI receipts](https://github.com/VasuBansal7576/graphify/tree/7ddd8582e94dfc4cfa7a332a3b8ff976e8bf153e).
The images below are offline-rendered raw-graph audit reports, not Graphify viewer screenshots.
Browser capture was unavailable because the browser security policy blocked the local report URL.

| Before | After |
| --- | --- |
| ![Before audit report](https://raw.githubusercontent.com/VasuBansal7576/graphify/7ddd8582e94dfc4cfa7a332a3b8ff976e8bf153e/before.png) | ![After audit report](https://raw.githubusercontent.com/VasuBansal7576/graphify/7ddd8582e94dfc4cfa7a332a3b8ff976e8bf153e/after.png) |

Validation:

- Three new extraction regressions fail before and pass after: named-function versus callback-local classes, same-named classes in sibling same-basename files, and abstract versus concrete methods.
- 108 tests pass across the new regressions, symbol resolution, and JS import resolution.
- Ruff and `git diff --check` pass.
- Required `graphify update . --no-cluster` completed on the sparse development checkout. Optional SQL, DM and Robot parsers were unavailable; the existing Luau fixture reports a syntax warning.
- A separate 22-file OpenClaw preservation control retains all 27 valid relationships lost by an ancestry-based filtering approach. This is bounded evidence, not full-source acceptance.

Duplicate checks included open and closed local-class, abstract-method and missing-source reports.
#2653 concerns nested function materialization; #2040 concerns containment; #1764 concerns synthesized endpoints in other extractors.
#2382 and #3342 concern incremental resolution and external-stub lifecycle paths.
This patch is limited to the shared symbol-use producer ownership check.
