### PR TITLE
fix: resolve named re-exports through imported bindings

### DIFF
--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -935,6 +935,7 @@ def _apply_symbol_resolution_facts(
                     changed = True
 
     named_exports_by_file: dict[Path, dict[str, tuple[Path, str]]] = {}
+    export_origins: dict[tuple[Path, str], set[tuple[Path, str]]] = {}
     star_exports_by_file: dict[Path, list[Path]] = {}
 
     for star_fact in facts.star_exports:
@@ -996,7 +997,14 @@ def _apply_symbol_resolution_facts(
             if origin is None and (file_path, export_fact.local_name) in symbol_nodes:
                 origin = (file_path, export_fact.local_name)
         if origin is None:
+            # An explicit export remains evidence even when extraction did not
+            # materialize its binding. Do not mistake it for an absent export.
+            if export_fact.local_name is not None:
+                export_origins.setdefault((file_path, export_fact.exported_name), set()).add(
+                    (file_path, export_fact.local_name)
+                )
             continue
+        export_origins.setdefault((file_path, export_fact.exported_name), set()).add(origin)
         named_exports_by_file.setdefault(file_path, {})[export_fact.exported_name] = origin
         if origin[0] != file_path:
             source_id = source_file_id.get(file_path)
@@ -1031,6 +1039,65 @@ def _apply_symbol_resolution_facts(
             if resolved in symbol_nodes:
                 return resolved
         return key
+
+    def exported_candidates(
+        key: tuple[Path, str], seen: frozenset[tuple[Path, str]]
+    ) -> set[tuple[Path, str]]:
+        # Preserve explicitly exported origins even without owned declarations.
+        # Missing extraction must not turn an ambiguous export into a unique one.
+        if key in seen:
+            return set()
+        seen = seen | {key}
+        origins = export_origins.get(key)
+        if origins is None:
+            candidates: set[tuple[Path, str]] = set()
+            for path in star_exports_by_file.get(key[0], []):
+                candidates.update(exported_candidates((path, key[1]), seen))
+            return candidates
+        candidates = set()
+        for origin in origins:
+            if origin == key:
+                candidates.add(origin)
+            else:
+                candidates.update(exported_candidates(origin, seen) or {origin})
+        return candidates
+
+    # The structural extractor names the immediate barrel's symbol. Resolve
+    # that exact authored export site through the shared import/export facts,
+    # including `import {x}; export {x}` bridges with no local declaration.
+    export_sites: dict[tuple[Path, str, Path], list[_SymbolExportFact]] = {}
+    for export_fact in facts.exports:
+        if export_fact.target_path is not None and export_fact.target_name is not None:
+            site = (
+                export_fact.file_path.resolve(),
+                f"L{export_fact.line}",
+                export_fact.target_path.resolve(),
+            )
+            export_sites.setdefault(site, []).append(export_fact)
+    node_sources = {node["id"]: node["source_file"] for node in nodes if node.get("id") and node.get("source_file")}
+    owned_ids = {node.get("id") for node in nodes}
+    for edge in edges:
+        if edge.get("relation") != "re_exports" or edge.get("target") in owned_ids:
+            continue
+        target_file = edge.get("target_file")
+        source_path = _js_source_path(str(edge.get("source_file", "")), root)
+        if not target_file or source_path is None:
+            continue
+        target_path = Path(target_file)
+        site = (source_path, str(edge.get("source_location", "")), target_path.resolve())
+        for export_fact in export_sites.get(site, []):
+            expected = _make_id(_file_stem(target_path), export_fact.target_name)
+            if edge.get("target") != expected:
+                continue
+            candidates = exported_candidates(
+                (export_fact.target_path.resolve(), export_fact.target_name), frozenset()
+            )
+            if len(candidates) == 1:
+                target_id = symbol_nodes.get(next(iter(candidates)))
+                if target_id in owned_ids:
+                    edge["target"] = target_id
+                    edge["target_file"] = node_sources[target_id]
+            break
 
     for import_fact in facts.imports:
         source_id = source_file_id.get(import_fact.file_path.resolve())
@@ -1222,8 +1289,13 @@ def _js_exported_declaration_names(node, source: bytes) -> list[str]:
     if declaration is None:
         return names
 
-    if declaration.type == "lexical_declaration":
-        names.extend(alias for alias, _target in _js_lexical_aliases(declaration, source))
+    if declaration.type in ("lexical_declaration", "variable_declaration"):
+        for declarator in declaration.named_children:
+            if declarator.type != "variable_declarator":
+                continue
+            name_node = declarator.child_by_field_name("name")
+            if name_node is not None and name_node.type == "identifier":
+                names.append(_read_text(name_node, source))
         return names
 
     if declaration.type in (

--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -1042,25 +1042,31 @@ def _apply_symbol_resolution_facts(
 
     def exported_candidates(
         key: tuple[Path, str], seen: frozenset[tuple[Path, str]]
-    ) -> set[tuple[Path, str]]:
-        # Preserve explicitly exported origins even without owned declarations.
-        # Missing extraction must not turn an ambiguous export into a unique one.
+    ) -> tuple[set[tuple[Path, str]], bool]:
+        # Distinguish a cycle cutoff from an absent export. A cycle contributes
+        # no origin; a named export of an unrepresented binding remains unknown.
         if key in seen:
-            return set()
+            return set(), True
         seen = seen | {key}
         origins = export_origins.get(key)
+        candidates: set[tuple[Path, str]] = set()
+        cyclic = False
         if origins is None:
-            candidates: set[tuple[Path, str]] = set()
             for path in star_exports_by_file.get(key[0], []):
-                candidates.update(exported_candidates((path, key[1]), seen))
-            return candidates
-        candidates = set()
+                branch, branch_cyclic = exported_candidates((path, key[1]), seen)
+                candidates.update(branch)
+                cyclic |= branch_cyclic
+            return candidates, cyclic
         for origin in origins:
             if origin == key:
                 candidates.add(origin)
             else:
-                candidates.update(exported_candidates(origin, seen) or {origin})
-        return candidates
+                branch, branch_cyclic = exported_candidates(origin, seen)
+                candidates.update(branch)
+                cyclic |= branch_cyclic
+                if not branch and not branch_cyclic:
+                    candidates.add(origin)
+        return candidates, cyclic
 
     # The structural extractor names the immediate barrel's symbol. Resolve
     # that exact authored export site through the shared import/export facts,
@@ -1074,7 +1080,6 @@ def _apply_symbol_resolution_facts(
                 export_fact.target_path.resolve(),
             )
             export_sites.setdefault(site, []).append(export_fact)
-    node_sources = {node["id"]: node["source_file"] for node in nodes if node.get("id") and node.get("source_file")}
     owned_ids = {node.get("id") for node in nodes}
     for edge in edges:
         if edge.get("relation") != "re_exports" or edge.get("target") in owned_ids:
@@ -1089,14 +1094,15 @@ def _apply_symbol_resolution_facts(
             expected = _make_id(_file_stem(target_path), export_fact.target_name)
             if edge.get("target") != expected:
                 continue
-            candidates = exported_candidates(
+            candidates, _ = exported_candidates(
                 (export_fact.target_path.resolve(), export_fact.target_name), frozenset()
             )
             if len(candidates) == 1:
-                target_id = symbol_nodes.get(next(iter(candidates)))
+                origin = next(iter(candidates))
+                target_id = symbol_nodes.get(origin)
                 if target_id in owned_ids:
                     edge["target"] = target_id
-                    edge["target_file"] = node_sources[target_id]
+                    edge["target_file"] = str(path_by_resolved.get(origin[0], origin[0]))
             break
 
     for import_fact in facts.imports:
@@ -1290,12 +1296,17 @@ def _js_exported_declaration_names(node, source: bytes) -> list[str]:
         return names
 
     if declaration.type in ("lexical_declaration", "variable_declaration"):
+        # Preserve legacy aggregate-pattern facts for identifier-valued lexical
+        # declarations; individual destructured bindings are a separate feature.
+        names.extend(alias for alias, _target in _js_lexical_aliases(declaration, source))
         for declarator in declaration.named_children:
             if declarator.type != "variable_declarator":
                 continue
             name_node = declarator.child_by_field_name("name")
             if name_node is not None and name_node.type == "identifier":
-                names.append(_read_text(name_node, source))
+                name = _read_text(name_node, source)
+                if name not in names:
+                    names.append(name)
         return names
 
     if declaration.type in (

--- a/tests/test_forwarding_review_findings.py
+++ b/tests/test_forwarding_review_findings.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+from graphify.extract import extract
+
+
+def graph_for(root, files):
+    for name, text in files.items():
+        (root / name).write_text(text)
+    return extract([root / name for name in files], root=root, cache_root=root, parallel=False)
+
+
+def test_star_cycle_with_real_definition_does_not_mask_unique_origin(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "base.ts": "export const x=1;",
+            "a.ts": 'export * from "./b.js"; export * from "./base.js";',
+            "b.ts": 'export {x} from "./a.js";',
+            "api.ts": 'export {x} from "./a.js";',
+        },
+    )
+    edges = [
+        e
+        for e in g["edges"]
+        if e["source"] == "api" and e["relation"] == "re_exports" and e["context"] == "re-export"
+    ]
+    assert {e["target"] for e in edges} == {"base_x"}
+
+
+def test_sourceless_owned_node_is_not_an_export_definition(tmp_path):
+    from graphify.extractors.resolution import _apply_symbol_resolution_facts
+    from graphify.extractors.models import _SymbolResolutionFacts, _SymbolExportFact
+    from graphify.extractors.base import _make_id, _file_stem
+
+    base = tmp_path / "base.ts"
+    api = tmp_path / "api.ts"
+    nodes = [{"id": "orphan", "label": "x"}]
+    edge = {
+        "source": _make_id(str(api)),
+        "target": _make_id(_file_stem(base), "x"),
+        "relation": "re_exports",
+        "context": "re-export",
+        "source_file": str(api),
+        "source_location": "L1",
+        "target_file": str(base),
+    }
+    facts = _SymbolResolutionFacts()
+    facts.exports.extend(
+        [
+            _SymbolExportFact(base, "x", 1, local_name="x"),
+            _SymbolExportFact(api, "x", 1, target_path=base, target_name="x"),
+        ]
+    )
+    _apply_symbol_resolution_facts([base, api], nodes, [edge], tmp_path, facts)
+    assert edge["target"] != "orphan"
+    assert edge["target_file"] == str(base)
+
+
+def test_legacy_aggregate_pattern_facts_and_nodes_are_preserved(tmp_path):
+    from graphify.extractors.resolution import (
+        _parse_js_tree,
+        _walk_js_tree,
+        _js_exported_declaration_names,
+    )
+
+    for name, pattern, value in [("object", "{x}", "{x:1}"), ("array", "[x]", "[1]")]:
+        root = tmp_path / name
+        root.mkdir()
+        g = graph_for(
+            root,
+            {
+                "decl.ts": f"const holder={value}; export const {pattern}=holder;",
+                "consumer.ts": 'import {x} from "./decl.js";',
+            },
+        )
+        source, tree = _parse_js_tree(root / "decl.ts")
+        assert [
+            _js_exported_declaration_names(n, source)
+            for n in _walk_js_tree(tree)
+            if n.type == "export_statement"
+        ] == [[pattern]]
+        assert any(n["id"] == "decl_x" and n["label"] == pattern for n in g["nodes"])
+
+
+def test_identifier_alias_fact_and_binding_are_preserved(tmp_path):
+    from graphify.extractors.resolution import (
+        _parse_js_tree,
+        _walk_js_tree,
+        _js_exported_declaration_names,
+    )
+
+    g = graph_for(
+        tmp_path,
+        {
+            "decl.ts": "const original=1; export const alias=original;",
+            "consumer.ts": 'import {alias} from "./decl.js";',
+        },
+    )
+    source, tree = _parse_js_tree(tmp_path / "decl.ts")
+    assert [
+        _js_exported_declaration_names(n, source)
+        for n in _walk_js_tree(tree)
+        if n.type == "export_statement"
+    ] == [["alias"]]
+    assert any(
+        e["source"] == "consumer" and e["target"] == "decl_alias" and e["relation"] == "imports"
+        for e in g["edges"]
+    )
+
+
+def test_longer_export_cycle_with_definition_remains_resolvable(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "base.ts": "export const x=1;",
+            "a.ts": 'export * from "./b.js"; export * from "./base.js";',
+            "b.ts": 'export {x} from "./c.js";',
+            "c.ts": 'export {x} from "./a.js";',
+            "api.ts": 'export {x} from "./a.js";',
+        },
+    )
+    edges = [
+        e
+        for e in g["edges"]
+        if e["source"] == "api" and e["relation"] == "re_exports" and e["context"] == "re-export"
+    ]
+    assert {e["target"] for e in edges} == {"base_x"}

--- a/tests/test_imported_export_forwarding.py
+++ b/tests/test_imported_export_forwarding.py
@@ -1,0 +1,231 @@
+from graphify.extract import extract
+
+
+def test_imported_then_exported_binding_has_owned_target(tmp_path):
+    files = {
+        "base.ts": "export const VALUE=1;",
+        "bridge.ts": 'import {VALUE} from "./base.js"; export {VALUE};',
+        "api.ts": 'export {VALUE} from "./bridge.js";',
+    }
+    paths = []
+    for name, text in files.items():
+        p = tmp_path / name
+        p.write_text(text)
+        paths.append(p)
+    graph = extract(paths, root=tmp_path, cache_root=tmp_path, parallel=False)
+    ids = {n["id"] for n in graph["nodes"]}
+    exports = [e for e in graph["edges"] if e["relation"] == "re_exports" and e["source"] == "api"]
+    assert exports
+    assert all(e["target"] in ids for e in exports), exports
+    assert any(e["target"] == "base_value" for e in exports)
+
+
+def graph_for(tmp_path, files):
+    paths = []
+    for name, text in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text)
+        paths.append(p)
+    return extract(paths, root=tmp_path, cache_root=tmp_path, parallel=False)
+
+
+def symbol_exports(graph, source):
+    return [
+        e
+        for e in graph["edges"]
+        if e["relation"] == "re_exports" and e["context"] == "re-export" and e["source"] == source
+    ]
+
+
+def test_renamed_import_and_export_keep_original_definition(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "base.ts": "export const VALUE=1;",
+            "bridge.ts": 'import {VALUE as local} from "./base.js"; export {local as publicValue};',
+            "second.ts": 'export {publicValue as renamed} from "./bridge.js";',
+            "api.ts": 'export {renamed as finalValue} from "./second.js";',
+        },
+    )
+    assert {e["target"] for e in symbol_exports(g, "api")} == {"base_value"}
+    assert {e["target"] for e in symbol_exports(g, "second")} == {"base_value"}
+
+
+def test_same_line_exports_resolve_each_explicit_binding(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "left.ts": "export const x=1;",
+            "right.ts": "export const x=2;",
+            "bridge.ts": 'import {x as a} from "./left.js"; import {x as b} from "./right.js"; export {a,b};',
+            "api.ts": 'export {a,b} from "./bridge.js";',
+        },
+    )
+    assert {e["target"] for e in symbol_exports(g, "api")} == {"left_x", "right_x"}
+
+
+def test_imported_but_not_exported_name_stays_unresolved(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "base.ts": "export const VALUE=1;",
+            "bridge.ts": 'import {VALUE} from "./base.js"; export const other=2;',
+            "api.ts": 'export {VALUE} from "./bridge.js";',
+        },
+    )
+    assert {e["target"] for e in symbol_exports(g, "api")} == {"bridge_value"}
+
+
+def test_existing_local_declaration_remains_owned(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "base.ts": "export const VALUE=1;",
+            "bridge.ts": 'import {VALUE as imported} from "./base.js"; export const VALUE=2;',
+            "api.ts": 'export {VALUE} from "./bridge.js";',
+        },
+    )
+    assert {e["target"] for e in symbol_exports(g, "api")} == {"bridge_value"}
+
+
+def test_type_only_forwarding_preserves_edge_metadata(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "base.ts": "export interface Shape {x:number;}",
+            "bridge.ts": 'import type {Shape} from "./base.js"; export type {Shape};',
+            "api.ts": 'export type {Shape} from "./bridge.js";',
+        },
+    )
+    edges = symbol_exports(g, "api")
+    assert {e["target"] for e in edges} == {"base_shape"}
+    assert all(
+        e.get("type_only") is True and e["source_file"] == "api.ts" and e["source_location"] == "L1"
+        for e in edges
+    )
+
+
+def test_export_cycle_does_not_invent_definition(tmp_path):
+    g = graph_for(
+        tmp_path, {"a.ts": 'export {VALUE} from "./b.js";', "b.ts": 'export {VALUE} from "./a.js";'}
+    )
+    ids = {n["id"] for n in g["nodes"]}
+    assert all(e["target"] not in ids for e in symbol_exports(g, "a") + symbol_exports(g, "b"))
+
+
+def test_conflicting_named_exports_do_not_choose_last_definition(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "left.ts": "export const x=1;",
+            "right.ts": "export const x=2;",
+            "bridge.ts": 'export {x} from "./left.js"; export {x} from "./right.js";',
+            "api.ts": 'export {x} from "./bridge.js";',
+        },
+    )
+    assert {e["target"] for e in symbol_exports(g, "bridge")} == {"left_x", "right_x"}
+    assert {e["target"] for e in symbol_exports(g, "api")} == {"bridge_x"}
+
+
+def test_conflicting_star_exports_do_not_choose_first_definition(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "left.ts": "export const x=1;",
+            "right.ts": "export const x=2;",
+            "bridge.ts": 'export * from "./left.js"; export * from "./right.js";',
+            "api.ts": 'export {x} from "./bridge.js";',
+        },
+    )
+    assert {e["target"] for e in symbol_exports(g, "api")} == {"bridge_x"}
+
+
+def test_unrepresented_explicit_star_export_blocks_false_unique_target(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "left.ts": "export const x=1;",
+            "right.ts": "const {x}=getValues(); export {x};",
+            "bridge.ts": 'export * from "./left.js"; export * from "./right.js";',
+            "api.ts": 'export {x} from "./bridge.js";',
+        },
+    )
+    assert {e["target"] for e in symbol_exports(g, "api")} == {"bridge_x"}
+
+
+def test_star_branch_without_export_does_not_block_unique_target(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "left.ts": "export const x=1;",
+            "right.ts": "export const other=2;",
+            "bridge.ts": 'export * from "./left.js"; export * from "./right.js";',
+            "api.ts": 'export {x} from "./bridge.js";',
+        },
+    )
+    assert {e["target"] for e in symbol_exports(g, "api")} == {"left_x"}
+
+
+def test_explicit_named_export_overrides_star_ambiguity(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "left.ts": "export const x=1;",
+            "right.ts": "export const x=2;",
+            "bridge.ts": 'export * from "./left.js"; export * from "./right.js"; export {x} from "./left.js";',
+            "api.ts": 'export {x} from "./bridge.js";',
+        },
+    )
+    assert {e["target"] for e in symbol_exports(g, "api")} == {"left_x"}
+
+
+def test_private_name_in_star_branch_is_not_an_export(tmp_path):
+    g = graph_for(
+        tmp_path,
+        {
+            "left.ts": "export const x=1;",
+            "right.ts": "const x=2; export const other=3;",
+            "bridge.ts": 'export * from "./left.js"; export * from "./right.js";',
+            "api.ts": 'export {x} from "./bridge.js";',
+        },
+    )
+    assert {e["target"] for e in symbol_exports(g, "api")} == {"left_x"}
+
+
+def test_repointed_target_file_tracks_definition_and_preserves_source_site(tmp_path, monkeypatch):
+    from pathlib import Path
+    import graphify.extractors.resolution as resolution
+
+    original = resolution._apply_symbol_resolution_facts
+    observed = []
+
+    def tracked(paths, nodes, edges, root, facts):
+        def authored():
+            return next(
+                e
+                for e in edges
+                if e.get("relation") == "re_exports"
+                and e.get("context") == "re-export"
+                and Path(e["source_file"]).name == "api.ts"
+            )
+
+        before = dict(authored())
+        original(paths, nodes, edges, root, facts)
+        observed.append((before, dict(authored())))
+
+    monkeypatch.setattr(resolution, "_apply_symbol_resolution_facts", tracked)
+    graph_for(
+        tmp_path,
+        {
+            "base.ts": "export const VALUE=1;",
+            "bridge.ts": 'import {VALUE} from "./base.js"; export {VALUE};',
+            "api.ts": 'export {VALUE} from "./bridge.js";',
+        },
+    )
+    before, after = observed[0]
+    assert Path(before["target_file"]).resolve() == (tmp_path / "bridge.ts").resolve()
+    assert Path(after["target_file"]).resolve() == (tmp_path / "base.ts").resolve()
+    assert {k: v for k, v in before.items() if k not in {"target", "target_file"}} == {
+        k: v for k, v in after.items() if k not in {"target", "target_file"}
+    }


### PR DESCRIPTION
`api.ts` re-exporting a binding from `bridge.ts` currently points at a nonexistent bridge-local symbol when the bridge imports that binding and then exports it.
For `base.ts: export const VALUE = 1`, `bridge.ts: import { VALUE } from './base.js'; export { VALUE }`, and `api.ts: export { VALUE } from './bridge.js'`, the raw graph contains `api -> bridge_value` even though only `base_value` exists.

Resolve that exact named-export site through explicit export origins and rewrite it only when one origin has an owned declaration.
Keep unresolved explicit origins in the candidate set, so unsupported extraction cannot hide ambiguity.
Branches without that export contribute nothing; explicit named exports override star branches.
Record simple identifier export declarations so exported constants can be distinguished from private symbols.

The existing edge and source location are preserved.
Its transient `target_file` follows the defining source for ID disambiguation and is removed before graph persistence.
No destructured-binding implementation or edge deletion is added.

Validation:

- 19 regression tests cover forwarding, renamed bindings, same-line exports, private symbols, type-only metadata, cycles, named/star ambiguity, unsupported explicit origins, named-over-star precedence, and transient provenance.
- 124 tests passed across the new tests and existing symbol/JS import resolution suites; configured Ruff checks and `git diff --check` passed.
- Actual CLI before/after runs retain 4 nodes and 7 edges, changing missing targets from 1 to 0. [Raw before graph](https://github.com/VasuBansal7576/graphify/blob/fba6245f7d2f2066ef1cd5c3eb75efdcc9f2bcc9/before.json), [raw after graph](https://github.com/VasuBansal7576/graphify/blob/fba6245f7d2f2066ef1cd5c3eb75efdcc9f2bcc9/after.json), [source and hash receipt](https://github.com/VasuBansal7576/graphify/tree/fba6245f7d2f2066ef1cd5c3eb75efdcc9f2bcc9).
- The required AST-only `graphify update . --no-cluster` completed. Optional SQL/DM/Robot grammars were unavailable, and the existing Luau fixture emitted a syntax warning.

![Offline audit of actual raw graphs, not a Graphify viewer screenshot](https://raw.githubusercontent.com/VasuBansal7576/graphify/fba6245f7d2f2066ef1cd5c3eb75efdcc9f2bcc9/raw-graph-audit.png)


Review follow-up at `0a1f06be8b482505a1c7399686b50a9ddff11457` fixes valid-cycle reachability, restores baseline aggregate-pattern declaration facts, and derives transient target-file provenance from the resolved origin.
Five added controls cover short/long cycles, source-less nodes, aggregate-pattern compatibility, and identifier aliases.
The linked raw evidence and offline visual remain the original `08dd8c1` proof; no new viewer capture is claimed.
