### PR TITLE
fix(watch): preserve qualified file labels in no-cluster updates

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1783,10 +1783,16 @@ def _rebuild_code(
             # Dedupe parallel edges (the clustered path's DiGraph collapses them implicitly);
             # without it, --no-cluster + repeated `update` accumulate duplicates and edge
             # counts diverge across build modes (#1317).
-            from graphify.build import dedupe_edges as _dedupe_edges, dedupe_nodes as _dedupe_nodes
+            from graphify.build import (
+                dedupe_edges as _dedupe_edges,
+                dedupe_nodes as _dedupe_nodes,
+                disambiguate_file_labels_in_nodes as _disamb_labels,
+            )
+            raw_nodes = _dedupe_nodes(result.get("nodes", []))
+            _disamb_labels(raw_nodes)
             candidate_graph_data = {
                 **{k: v for k, v in result.items() if k not in ("edges", "nodes")},
-                "nodes": _dedupe_nodes(result.get("nodes", [])),
+                "nodes": raw_nodes,
                 "links": _dedupe_edges(result.get("edges", [])),
                 # Inherit the existing graph's directed flag (#2342) so
                 # `graphify update --no-cluster` can't silently drop it -

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -635,6 +635,61 @@ def test_rebuild_honors_persisted_no_gitignore(tmp_path):
     assert any(source.endswith("generated/gen.py") for source in sources)
 
 
+def test_no_cluster_rebuild_disambiguates_colliding_file_labels(tmp_path):
+    """The raw update path keeps the same display labels as a fresh extract.
+
+    File nodes with the same basename need directory-qualified labels (#2032),
+    including after an incremental no-cluster rebuild.
+    """
+    import json
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    (corpus / "pkg_a").mkdir(parents=True)
+    (corpus / "pkg_b").mkdir()
+    (corpus / "pkg_a" / "errors.ts").write_text(
+        "export class AlphaError {}\n", encoding="utf-8"
+    )
+    (corpus / "pkg_b" / "errors.ts").write_text(
+        "export class BetaError {}\n", encoding="utf-8"
+    )
+    entry = corpus / "entry.ts"
+    entry.write_text(
+        'import { AlphaError } from "./pkg_a/errors.js";\n'
+        'import { BetaError } from "./pkg_b/errors.js";\n'
+        "export const errors = [AlphaError, BetaError];\n",
+        encoding="utf-8",
+    )
+
+    assert _rebuild_code(corpus, no_cluster=True, acquire_lock=False) is True
+    graph_path = corpus / "graphify-out" / "graph.json"
+    graph = json.loads(graph_path.read_text(encoding="utf-8"))
+    labels = {
+        node["label"]
+        for node in graph["nodes"]
+        if node.get("id") in {"pkg_a_errors", "pkg_b_errors"}
+    }
+    assert labels == {"pkg_a/errors.ts", "pkg_b/errors.ts"}
+
+    entry.write_text(
+        entry.read_text(encoding="utf-8") + "export const count = errors.length;\n",
+        encoding="utf-8",
+    )
+    assert _rebuild_code(
+        corpus,
+        changed_paths=[entry],
+        no_cluster=True,
+        acquire_lock=False,
+    ) is True
+    graph = json.loads(graph_path.read_text(encoding="utf-8"))
+    labels = {
+        node["label"]
+        for node in graph["nodes"]
+        if node.get("id") in {"pkg_a_errors", "pkg_b_errors"}
+    }
+    assert labels == {"pkg_a/errors.ts", "pkg_b/errors.ts"}
+
+
 def test_graphify_root_preserves_absolute_when_user_supplied(tmp_path):
     """When the caller supplies an absolute path, ``.graphify_root`` stores
     that absolute form verbatim — preserving explicit-absolute intent."""


### PR DESCRIPTION
`graphify update --no-cluster` writes same-basename files with ambiguous labels because the raw rebuild skips the file-label disambiguation used by fresh extraction. For example, `pkg_a/errors.ts` and `pkg_b/errors.ts` both become `errors.ts` after rebuilding.

Reuse `disambiguate_file_labels_in_nodes` after deduplicating nodes in the raw watch rebuild. Node IDs and edges remain unchanged. The regression checks both an initial rebuild and an incremental update after editing an importer.

Validation on current `v8` at `937e59a`:
- The new regression fails on the unchanged release with `{'errors.ts'}` instead of the two qualified names.
- All 149 watch tests pass on this branch.
- Ruff and `git diff --check` pass.
- AST-only `graphify update . --no-cluster` completes. Optional SQL, DM, Common Lisp and Robot Framework parsers are absent, and the existing Luau fixture reports a syntax warning.

The earlier CLI reproduction used a 15-file OpenWiki corpus after a rename, deletion and import rewire. Before and after graphs had identical node IDs and edge lists, with 197 nodes and 575 edges; only the two colliding file labels changed. These captures show that earlier comparison at `33362d9` / `ddab7f0`, not the rebased revisions above.

| Before | After |
| --- | --- |
| ![Before: both files labeled errors.ts](https://raw.githubusercontent.com/VasuBansal7576/graphify/d05405fcb689ef68b7f66956edf7f5eb75681903/evidence/graphify-qualified-label-captures/before.png) | ![After: directory-qualified labels](https://raw.githubusercontent.com/VasuBansal7576/graphify/d05405fcb689ef68b7f66956edf7f5eb75681903/evidence/graphify-qualified-label-captures/after.png) |

Checked existing open and closed work for overlap. #2218 handles community-label membership and visualization retention; #3342 handles external dependency retention. This change concerns file-node display labels in the no-cluster rebuild.
