### PR TITLE
fix(rust): extract trait method declarations (fixes #3366)

### DIFF
--- a/graphify/extractors/rust.py
+++ b/graphify/extractors/rust.py
@@ -182,6 +182,27 @@ def extract_rust(path: Path) -> dict:
                     function_bodies.append((func_nid, body))
             return
 
+        if t == "function_signature_item":
+            # `fn greet(&self) -> String;` — a trait method with no body. This node type
+            # had no branch at all, so a trait's required methods were unreachable: the
+            # only method nodes in a graph came from impl blocks, and a trait with no
+            # implementor in the corpus contributed none. Mirrors function_item, minus
+            # the body walk (there is no body).
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                func_name = _read_text(name_node, source)
+                line = node.start_point[0] + 1
+                if parent_impl_nid:
+                    func_nid = _make_id(parent_impl_nid, func_name)
+                    add_node(func_nid, f".{func_name}()", line)
+                    add_edge(parent_impl_nid, func_nid, "method", line)
+                else:
+                    func_nid = _make_id(stem, func_name)
+                    add_node(func_nid, f"{func_name}()", line)
+                    add_edge(file_nid, func_nid, "contains", line)
+                emit_param_return_refs(node, func_nid, line)
+            return
+
         if t in ("struct_item", "enum_item", "trait_item"):
             name_node = node.child_by_field_name("name")
             if name_node:
@@ -292,6 +313,16 @@ def extract_rust(path: Path) -> dict:
                                             continue
                                         type_node = field.child_by_field_name("type")
                                         _emit_enum_type(type_node, field.start_point[0] + 1)
+                if t == "trait_item":
+                    # The methods a trait declares are its contract, and they were not
+                    # reached: this branch returns below, so nothing walked the body.
+                    # Descend the same way impl_item does, attributing each method to
+                    # the trait node — so `explain <Trait>` can list what an
+                    # implementor must provide.
+                    body = node.child_by_field_name("body")
+                    if body:
+                        for child in body.children:
+                            walk(child, parent_impl_nid=item_nid)
             return
 
         if t == "impl_item":


### PR DESCRIPTION
Fixes #3366.

## The problem

A Rust trait gets a node; the methods it declares do not. Across three real Rust repositories, **504 of 654 trait method declarations (77%) have no node**. A trait is the API contract, so it appears in the graph as a bare name with no operations attached — `explain <Trait>` cannot say what an implementor must provide.

The methods that *do* appear are only there because an `impl` block in the same file happens to define a method of the same name, and they are anchored at the impl, not the declaration.

## Two gaps, both in `extractors/rust.py`

1. **`function_signature_item` had no branch anywhere in the package.** That is the tree-sitter-rust node type for a bodyless `fn greet(&self) -> String;`, so a signature-only method had no extraction path at all.
2. **The `struct_item`/`enum_item`/`trait_item` branch returns before descending**, so nothing walked a trait's body — a method with a *default body* inside a trait was never reached either.

## The change

- Add a `function_signature_item` branch mirroring `function_item`, minus the body walk (there is no body).
- In the `trait_item` case, descend into the trait's body the way `impl_item` already descends into its own, passing the trait node as `parent_impl_nid` so each method gets a `method` edge from the trait.

Both follow the existing shape of the file rather than introducing a new mechanism.

## Before / after

The reproducer from #3366 — a trait with no implementor in the corpus:

```rust
pub trait Lonely {
    fn only_signature(&self) -> u8;
    fn with_default(&self) -> u8 { 42 }
}
```

```
before:  L1 lonely.rs, L2 Lonely
after:   L1 lonely.rs, L2 Lonely, L3 .only_signature(), L4 .with_default()
         + method edges Lonely -> each
```

And where an impl exists, the declaration and the implementation are now distinct nodes (`Greeter::greet` at the trait's line, `Alice::greet` at the impl's), instead of only the latter.

## Measured on a real codebase

A 937-file Rust service:

| | before | after |
|---|---|---|
| trait methods with no node | 70 / 112 (62%) | **0 / 112** |
| nodes | 9,426 | 9,574 |
| edges | 28,638 | 29,177 |

## Tests

Full suite unchanged: **17 failed / 5296 passed / 93 skipped**, identical with and without this commit. The 17 failures are pre-existing on `v8` and all in `test_skillgen.py`; I verified by stashing the change and re-running.

## One note for reviewers verifying locally

The AST cache is keyed on file content, not extractor version, so `graphify-out/cache` has to be removed to observe any extractor change — `--force` re-runs extraction but still serves cached per-file results. That cost me a confusing round of "the fix does nothing" before I spotted it; it may be worth folding the extractor version into the cache key separately.