### PR TITLE
fix(paths): bound atomic temp filename length on Windows

### DIFF
--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -45,7 +45,7 @@ def _atomic_replace(path: "str | Path", write_fn) -> None:
     # atomic rename) and the replace writes through the link, not over it.
     real = Path(os.path.realpath(str(path)))
     real.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=str(real.parent), prefix=f".{real.name}.", suffix=".tmp")
+    fd, tmp = tempfile.mkstemp(dir=str(real.parent), prefix=".gfy-", suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             write_fn(f)
@@ -79,7 +79,7 @@ def _atomic_replace(path: "str | Path", write_fn) -> None:
             # The temp was chmod'd to match the destination above, so when the
             # destination is read-only the temp is too — and Windows refuses to
             # unlink a read-only file. Clear the bit and retry, or every failed
-            # write leaks a `.graph.json.*.tmp` into the output directory.
+            # write leaks a `.gfy-*.tmp` into the output directory.
             try:
                 os.chmod(tmp, stat.S_IWRITE)
                 os.unlink(tmp)

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -176,3 +176,53 @@ def test_write_json_atomic_ensure_ascii_false_preserves_utf8(tmp_path):
     assert "Wörker 数据" in raw  # raw UTF-8, not \\uXXXX escapes
     assert "\\u" not in raw
     assert json.loads(raw) == {"label": "Wörker 数据"}
+
+
+def test_atomic_replace_temp_name_is_bounded_and_does_not_embed_long_filename(tmp_path, monkeypatch):
+    """Regression #3351: temp filename must not grow with destination filename."""
+    import tempfile
+    from pathlib import Path
+    from graphify.paths import _WINDOWS_MAX_PATH, _atomic_replace
+
+    base = str(tmp_path.resolve())
+    # Sized to be a long name (> 100 chars) while fitting within MAX_PATH
+    remaining = (_WINDOWS_MAX_PATH - 1) - len(base) - 1
+    long_name = "a" * (remaining - 10) + ".md"
+    assert len(long_name) >= 100
+    target = tmp_path / long_name
+
+    intercepted_temps = []
+    real_mkstemp = tempfile.mkstemp
+
+    def tracking_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        intercepted_temps.append(path)
+        return fd, path
+
+    monkeypatch.setattr(tempfile, "mkstemp", tracking_mkstemp)
+    _atomic_replace(target, lambda f: f.write("hello"))
+
+    assert target.exists()
+    assert len(intercepted_temps) == 1
+    temp_path = Path(intercepted_temps[0])
+
+    assert len(temp_path.name) <= 25, f"temp filename was unexpectedly long: {temp_path.name}"
+    assert temp_path.name.startswith(".gfy-")
+    assert temp_path.name.endswith(".tmp")
+    assert "a" * 50 not in temp_path.name, "temp filename embedded the long destination name"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows MAX_PATH test")
+def test_write_text_atomic_succeeds_near_windows_max_path(tmp_path):
+    """Regression #3351: atomic write to a path at Windows MAX_PATH limit must succeed."""
+    from graphify.paths import _WINDOWS_MAX_PATH, write_text_atomic
+
+    base = str(tmp_path.resolve())
+    remaining = (_WINDOWS_MAX_PATH - 1) - len(base) - 1
+    filename = ("x" * (remaining - 4)) + ".txt"
+    target = tmp_path / filename
+    assert len(str(target)) == _WINDOWS_MAX_PATH - 1
+
+    write_text_atomic(target, "content-at-max-path")
+    assert target.read_text(encoding="utf-8") == "content-at-max-path"
+    assert not any(p.name.endswith(".tmp") for p in tmp_path.iterdir())


### PR DESCRIPTION
## Summary

Fixes #3351 by preventing atomic-write temporary filenames from exceeding Windows `MAX_PATH`.

## Problem

`_atomic_replace()` previously generated temporary files using the destination filename as part of the temporary filename:

```python
prefix=f".{real.name}."
```

For long Obsidian and Canvas export filenames, this caused the temporary path to become significantly longer than the already-capped destination path.

As a result, exports could fail on Windows even though the final destination path itself was within the supported `MAX_PATH` limit.

## Fix

Replace the destination-dependent prefix with a fixed, bounded Graphify-specific prefix:

```python
prefix=".gfy-"
```

Temporary files now have a constant-length form such as:

```text
.gfy-XXXXXXXX.tmp
```

The temporary file is still created in the destination's parent directory, so the existing atomic `os.replace()` behavior and same-filesystem guarantees are preserved.

No changes were made to exporter path budgeting or `stem_filename_budget()`.

## Regression Coverage

Added tests covering:

* Temporary filenames remain bounded and do not embed long destination filenames.
* Atomic writes succeed at the Windows `MAX_PATH` boundary.
* Temporary `.tmp` files are cleaned up after successful writes.

Existing Obsidian and Canvas path-length regression tests now pass as well.

## Validation

* `32 passed, 2 skipped` — atomic write / Canvas / path-length test suites
* `93 passed` — exporter and control-character test suites
* `git diff --check` — clean
* `graphify update .` — completed successfully

This keeps the fix localized to the atomic-write implementation while preserving the existing atomicity, symlink handling, permissions, and Windows error-handling behavior.
