### PR TITLE
fix(docs): repair broken relative links in translated READMEs

### DIFF
--- a/docs/translations/README.ja-JP.md
+++ b/docs/translations/README.ja-JP.md
@@ -208,9 +208,9 @@ graphify query "..." --graph path/to/graph.json
 
 | コーパス | ファイル数 | 削減率 | 出力 |
 |--------|-------|-----------|--------|
-| Karpathy リポジトリ + 論文5本 + 画像4枚 | 52 | **71.5x** | [`worked/karpathy-repos/`](worked/karpathy-repos/) |
-| graphify ソース + Transformer 論文 | 4 | **5.4x** | [`worked/mixed-corpus/`](worked/mixed-corpus/) |
-| httpx（合成 Python ライブラリ） | 6 | ~1x | [`worked/httpx/`](worked/httpx/) |
+| Karpathy リポジトリ + 論文5本 + 画像4枚 | 52 | **71.5x** | [`worked/karpathy-repos/`](../../worked/karpathy-repos/) |
+| graphify ソース + Transformer 論文 | 4 | **5.4x** | [`worked/mixed-corpus/`](../../worked/mixed-corpus/) |
+| httpx（合成 Python ライブラリ） | 6 | ~1x | [`worked/httpx/`](../../worked/httpx/) |
 
 トークン削減はコーパスサイズに応じてスケールします。6 ファイルはいずれにせよコンテキストウィンドウに収まるため、そこでのグラフの価値は圧縮ではなく構造的明瞭さです。52 ファイル（コード + 論文 + 画像）では 71 倍以上が得られます。各 `worked/` フォルダには生の入力ファイルと実際の出力（`GRAPH_REPORT.md`、`graph.json`）があり、自分で実行して数字を検証できます。
 
@@ -233,6 +233,6 @@ NetworkX + Leiden（graspologic） + tree-sitter + vis.js。意味的抽出は C
 
 **抽出バグ** - 入力ファイル、キャッシュエントリ（`graphify-out/cache/`）、何が見逃された/捏造されたかを添えて issue を開いてください。
 
-モジュールの責任と言語の追加方法については [ARCHITECTURE.md](ARCHITECTURE.md) を参照してください。
+モジュールの責任と言語の追加方法については [ARCHITECTURE.md](../../ARCHITECTURE.md) を参照してください。
 
 </details>

--- a/docs/translations/README.ko-KR.md
+++ b/docs/translations/README.ko-KR.md
@@ -248,9 +248,9 @@ graphify query "..." --graph path/to/graph.json
 
 | 코퍼스 | 파일 수 | 축소율 | 결과 |
 |--------|---------|--------|------|
-| Karpathy 리포지토리 + 논문 5편 + 이미지 4장 | 52 | **71.5x** | [`worked/karpathy-repos/`](worked/karpathy-repos/) |
-| graphify 소스 + Transformer 논문 | 4 | **5.4x** | [`worked/mixed-corpus/`](worked/mixed-corpus/) |
-| httpx (합성 Python 라이브러리) | 6 | ~1x | [`worked/httpx/`](worked/httpx/) |
+| Karpathy 리포지토리 + 논문 5편 + 이미지 4장 | 52 | **71.5x** | [`worked/karpathy-repos/`](../../worked/karpathy-repos/) |
+| graphify 소스 + Transformer 논문 | 4 | **5.4x** | [`worked/mixed-corpus/`](../../worked/mixed-corpus/) |
+| httpx (합성 Python 라이브러리) | 6 | ~1x | [`worked/httpx/`](../../worked/httpx/) |
 
 토큰 축소는 코퍼스 크기에 비례하여 확장됩니다. 6개 파일은 어차피 컨텍스트 윈도우에 들어가므로, 그래프의 가치는 압축이 아닌 구조적 명확성에 있습니다. 52개 파일(코드 + 논문 + 이미지)에서는 71배 이상을 달성합니다. 각 `worked/` 폴더에는 원본 입력 파일과 실제 출력(`GRAPH_REPORT.md`, `graph.json`)이 있어 직접 실행하여 수치를 검증할 수 있습니다.
 
@@ -277,6 +277,6 @@ graphify는 그래프 레이어입니다. 그 위에 [Penpax](https://safishamsi
 
 **추출 버그** - 입력 파일, 캐시 엔트리(`graphify-out/cache/`), 그리고 누락되거나 날조된 내용과 함께 이슈를 열어주세요.
 
-모듈 책임과 언어 추가 방법은 [ARCHITECTURE.md](ARCHITECTURE.md)를 참조하세요.
+모듈 책임과 언어 추가 방법은 [ARCHITECTURE.md](../../ARCHITECTURE.md)를 참조하세요.
 
 </details>

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -200,9 +200,9 @@ graphify trae-cn uninstall
 
 | 语料 | 文件数 | 压缩比 | 输出 |
 |------|--------|--------|------|
-| Karpathy 的仓库 + 5 篇论文 + 4 张图片 | 52 | **71.5x** | [`worked/karpathy-repos/`](worked/karpathy-repos/) |
-| graphify 源码 + Transformer 论文 | 4 | **5.4x** | [`worked/mixed-corpus/`](worked/mixed-corpus/) |
-| httpx（合成 Python 库） | 6 | ~1x | [`worked/httpx/`](worked/httpx/) |
+| Karpathy 的仓库 + 5 篇论文 + 4 张图片 | 52 | **71.5x** | [`worked/karpathy-repos/`](../../worked/karpathy-repos/) |
+| graphify 源码 + Transformer 论文 | 4 | **5.4x** | [`worked/mixed-corpus/`](../../worked/mixed-corpus/) |
+| httpx（合成 Python 库） | 6 | ~1x | [`worked/httpx/`](../../worked/httpx/) |
 
 Token 压缩效果会随着语料规模增大而更明显。6 个文件本来就塞得进上下文窗口，所以 graphify 在这种场景里的价值更多是结构清晰度，而不是 token 压缩。到了 52 个文件（代码 + 论文 + 图片）这种规模，就能做到 71x+。每个 `worked/` 目录里都带了原始输入和真实输出（`GRAPH_REPORT.md`、`graph.json`），你可以自己跑一遍核对数字。
 
@@ -221,6 +221,6 @@ NetworkX + Leiden（graspologic）+ tree-sitter + vis.js。语义提取由 Claud
 
 **提取 bug** —— 提 issue 时请附上输入文件、对应的缓存项（`graphify-out/cache/`）以及它漏提取或瞎编了什么。
 
-模块职责和新增语言的方法见 [ARCHITECTURE.md](ARCHITECTURE.md)。
+模块职责和新增语言的方法见 [ARCHITECTURE.md](../../ARCHITECTURE.md)。
 
 </details>


### PR DESCRIPTION
## Summary
- The Japanese, Korean, and Chinese README translations under `docs/translations/` link to `ARCHITECTURE.md` and the `worked/*` example folders using paths copied verbatim from the root README.
- Since these translation files live two directories deeper (`docs/translations/`), those relative links resolve to `docs/translations/ARCHITECTURE.md` and `docs/translations/worked/*`, which don't exist — the links are broken on GitHub.
- Fixed by pointing them back at the repo root with `../../`.

## Test plan
- [x] Verified all 12 affected links (4 per file × 3 files) now resolve to existing files/folders relative to each translation file's location.
- [x] No other files reference these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)