### PR TITLE
Park TS/JS member calls whose receiver type lives in another repo (#3152)

### DIFF
--- a/graphify/cross_repo_calls.py
+++ b/graphify/cross_repo_calls.py
@@ -43,6 +43,9 @@ _LANG_SUFFIXES: dict[str, frozenset[str]] = {
     "csharp": frozenset({".cs"}),
     "java": frozenset({".java"}),
     "swift": frozenset({".swift"}),
+    # TS and JS share one key: a TS class legitimately answers a JS call site, so
+    # splitting them would drop every TS<->JS cross-repo call.
+    "typescript": frozenset({".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"}),
 }
 
 # A declaration owns its members through a `method` edge, except in C++, where an

--- a/graphify/cross_repo_calls.py
+++ b/graphify/cross_repo_calls.py
@@ -44,8 +44,10 @@ _LANG_SUFFIXES: dict[str, frozenset[str]] = {
     "java": frozenset({".java"}),
     "swift": frozenset({".swift"}),
     # TS and JS share one key: a TS class legitimately answers a JS call site, so
-    # splitting them would drop every TS<->JS cross-repo call.
-    "typescript": frozenset({".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"}),
+    # splitting them would drop every TS<->JS cross-repo call. An SFC script block is
+    # TS/JS too, so a class exported from `.vue` answers as well.
+    "typescript": frozenset({".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
+                             ".vue", ".svelte", ".astro"}),
 }
 
 # A declaration owns its members through a `method` edge, except in C++, where an

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3391,8 +3391,8 @@ def _resolve_python_member_calls(
             _emit_call(caller, children[0], rc)
 
 
-# Every suffix the TS/JS extractors claim. The member-call resolver both activates on
-# and parks by this set, so a pure-ESM (`.mjs`) repo is not silently left out.
+# Every suffix the TS/JS extractors claim, so a pure-ESM (`.mjs`) repo still activates
+# the member-call resolver below.
 _JS_TS_SUFFIXES = (".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs")
 
 
@@ -3437,11 +3437,15 @@ def _resolve_typescript_member_calls(
 
     contained = {e.get("target") for e in all_edges if e.get("relation") == "contains"}
 
+    # Only the JS/TS interop family declares a type this receiver can hold (SFC script
+    # blocks included). A same-named class in another language must neither answer nor
+    # hide from the parking branch that nothing local declares the name.
     type_def_nids: dict[str, list[str]] = {}
     node_by_id: dict[str, dict] = {}
     for n in all_nodes:
         node_by_id[n.get("id")] = n
-        if n.get("source_file") and n.get("id") in contained and _is_type_like_definition(n):
+        if (_lang_family(n.get("source_file")) == "jsts"
+                and n.get("id") in contained and _is_type_like_definition(n)):
             type_def_nids.setdefault(_key(n.get("label", "")), []).append(n["id"])
 
     method_index: dict[tuple[str, str], str] = {}
@@ -3508,8 +3512,8 @@ def _resolve_typescript_member_calls(
         if not type_defs:
             # Table-typed only: an uppercase receiver also matches namespace aliases and
             # default imports, and node_modules is unscanned, so those are npm names.
-            # The suffix stands in for the `lang` tag TS raw_calls do not carry.
-            if not type_qualified and str(rc.get("source_file", "")).endswith(_JS_TS_SUFFIXES):
+            # The caller's family stands in for the `lang` tag TS raw_calls do not carry.
+            if not type_qualified and _lang_family(rc.get("source_file")) == "jsts":
                 _park_unresolved_member_call(
                     node_by_id.get(caller), callee, type_name, "typescript", rc,
                 )

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3391,6 +3391,11 @@ def _resolve_python_member_calls(
             _emit_call(caller, children[0], rc)
 
 
+# Every suffix the TS/JS extractors claim. The member-call resolver both activates on
+# and parks by this set, so a pure-ESM (`.mjs`) repo is not silently left out.
+_JS_TS_SUFFIXES = (".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs")
+
+
 def _resolve_typescript_member_calls(
     per_file: list[dict],
     all_nodes: list[dict],
@@ -4551,7 +4556,8 @@ register_language_resolver(
     LanguageResolver("ruby_member_calls", frozenset({".rb", ".rake"}), resolve_ruby_member_calls)
 )
 register_language_resolver(
-    LanguageResolver("typescript_member_calls", frozenset({".ts", ".tsx", ".mts", ".cts", ".js", ".jsx"}), _resolve_typescript_member_calls)
+    LanguageResolver("typescript_member_calls", frozenset(_JS_TS_SUFFIXES),
+                     _resolve_typescript_member_calls)
 )
 # C++ (#1547) and ObjC (#1556) receiver-typed member-call resolution. `.h` is in
 # both suffix sets because it routes to extract_cpp or extract_objc by content; the

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3419,6 +3419,10 @@ def _resolve_typescript_member_calls(
     defined in the caller's own file, a named import of the caller's file, or
     contained in a module the caller's file imports. Otherwise EMIT NOTHING —
     a false call edge is worse than a missing one (the C++ resolver's bar).
+
+    A receiver typed to a class this corpus declares nowhere is parked on the caller
+    for a merged graph to finish (#3152); the gate above never sees it, since it only
+    vets a name that did match locally.
     """
     type_table_by_file: dict[str, dict[str, str]] = {}
     for result in per_file:
@@ -3501,6 +3505,15 @@ def _resolve_typescript_member_calls(
         if type_name in _LANGUAGE_BUILTIN_GLOBALS:
             continue
         type_defs = type_def_nids.get(_key(type_name), [])
+        if not type_defs:
+            # Table-typed only: an uppercase receiver also matches namespace aliases and
+            # default imports, and node_modules is unscanned, so those are npm names.
+            # The suffix stands in for the `lang` tag TS raw_calls do not carry.
+            if not type_qualified and str(rc.get("source_file", "")).endswith(_JS_TS_SUFFIXES):
+                _park_unresolved_member_call(
+                    node_by_id.get(caller), callee, type_name, "typescript", rc,
+                )
+            continue
         if len(type_defs) != 1:
             continue
         type_nid = type_defs[0]

--- a/tests/test_cross_repo_member_calls.py
+++ b/tests/test_cross_repo_member_calls.py
@@ -6,10 +6,10 @@ type already in hand and nothing about it reached `graph.json` — the only arti
 `merge-graphs` and `global add` read. The two-repo graph was missing precisely the
 edges that make it a call graph.
 
-The Java, C++, C# and Swift resolvers now park those calls on the caller node and
-this pass finishes them after the merge. The cases below pin what it must NOT do
-as much as what it must: the single-definition guard, the cross-repo-only scope,
-and the language guard are what keep it from fabricating an edge from a name
+The Java, C++, C#, Swift and TS/JS resolvers now park those calls on the caller
+node and this pass finishes them after the merge. The cases below pin what it must
+NOT do as much as what it must: the single-definition guard, the cross-repo-only
+scope, and the language guard are what keep it from fabricating an edge from a name
 collision.
 """
 from __future__ import annotations
@@ -45,6 +45,7 @@ needs_java = _needs("tree_sitter_java")
 needs_cpp = _needs("tree_sitter_cpp")
 needs_csharp = _needs("tree_sitter_c_sharp")
 needs_swift = _needs("tree_sitter_swift")
+needs_typescript = _needs("tree_sitter_typescript")
 
 
 def _caller(repo: str, parked: list[dict], node_id: str = "app_run",
@@ -173,6 +174,33 @@ def test_a_defines_member_does_not_answer_a_java_call():
         caller=_caller("a", PARKED_GREET),
         declarations=[(_declaration("b", "Greeter"), _method("b"))],
         relation="defines",
+    )
+    assert link_cross_repo_member_calls(G) == 0
+
+
+PARKED_TS = [{"callee": "greet", "receiver_type": "Greeter", "lang": "typescript",
+              "line": "L4"}]
+
+
+@pytest.mark.parametrize("declaring_file", ["src/greeter.ts", "src/greeter.js",
+                                            "src/greeter.mjs", "src/greeter.tsx"])
+def test_a_typescript_call_binds_across_the_whole_js_family(declaring_file: str):
+    # One key for TS and JS: a TS class legitimately answers a JS call site, so
+    # splitting the two would drop every TS<->JS cross-repo call.
+    G = _graph(
+        caller=_caller("a", PARKED_TS, source_file="src/app.ts"),
+        declarations=[(_declaration("b", "Greeter", declaring_file),
+                       _method("b", ".greet()", source_file=declaring_file))],
+    )
+    assert link_cross_repo_member_calls(G) == 1, declaring_file
+    assert _added_calls(G) == {("a::app_run", "b::greeter_greet")}
+
+
+def test_a_typescript_call_does_not_bind_to_a_python_declaration():
+    G = _graph(
+        caller=_caller("a", PARKED_TS, source_file="src/app.ts"),
+        declarations=[(_declaration("b", "Greeter", "greeter.py"),
+                       _method("b", ".greet()", source_file="greeter.py"))],
     )
     assert link_cross_repo_member_calls(G) == 0
 
@@ -363,6 +391,16 @@ def test_a_java_build_parks_the_call_and_the_merge_finishes_it(tmp_path: Path):
                        "}\n"),
         ("src/Greeter.cs", "class Greeter { public void Greet() {} }\n"),
         marks=needs_csharp, id="csharp-field-receiver",
+    ),
+    pytest.param(
+        "typescript", "greet",
+        ("src/app.ts", 'import { Greeter } from "greeter-pkg";\n'
+                       "export class App {\n"
+                       "    constructor(private greeter: Greeter) {}\n"
+                       "    run(): void { this.greeter.greet(); }\n"
+                       "}\n"),
+        ("src/greeter.ts", "export class Greeter {\n    greet(): void {}\n}\n"),
+        marks=needs_typescript, id="typescript-parameter-property",
     ),
     pytest.param(
         "swift", "greet",

--- a/tests/test_ts_receiver_member_calls.py
+++ b/tests/test_ts_receiver_member_calls.py
@@ -166,3 +166,46 @@ def test_a_pure_esm_corpus_still_activates_the_resolver(tmp_path):
                     "export function usesDirect() { return s.doThing(); }\n"),
     })
     assert any("usesDirect" in s and "doThing" in t for s, t in calls)
+
+
+def _parked(r) -> list[dict]:
+    return [entry for n in r["nodes"]
+            if isinstance(n.get("metadata"), dict)
+            for entry in n["metadata"].get("unresolved_calls", [])]
+
+
+def test_an_annotated_type_declared_nowhere_is_parked_for_the_merge(tmp_path):
+    _, r = _calls(tmp_path, {
+        "app.ts": ("import { Greeter } from 'greeter-pkg';\n"
+                   "export class App {\n"
+                   "  constructor(private greeter: Greeter) {}\n"
+                   "  run(): void { this.greeter.greet(); }\n"
+                   "}\n"),
+    })
+    assert _parked(r) == [{"callee": "greet", "receiver_type": "Greeter",
+                           "lang": "typescript", "line": "L4"}]
+
+
+def test_a_namespace_style_receiver_is_not_parked(tmp_path):
+    # An uppercase receiver types the type by spelling alone, which a namespace
+    # alias, a default import or a plain const object satisfies just as well.
+    _, r = _calls(tmp_path, {
+        "app.ts": ("import * as React from 'react';\n"
+                   "const s = new Svc();\n"
+                   "export function render(): void { React.createElement(); }\n"),
+    })
+    assert _parked(r) == []
+
+
+def test_a_type_the_origin_gate_rejected_is_not_parked(tmp_path):
+    # A local declaration exists and the gate refused it, so parking would ask the
+    # merge to accept a remote match on evidence the gate just judged weaker.
+    _, r = _calls(tmp_path, {
+        "fileb.ts": _LOCAL_REPO,
+        "filea.ts": ("import type { Repo } from 'external-pkg';\n"
+                     "export class ReportService {\n"
+                     "  constructor(private repo: Repo) {}\n"
+                     "  run(): void { this.repo.save(); }\n"
+                     "}\n"),
+    })
+    assert _parked(r) == []

--- a/tests/test_ts_receiver_member_calls.py
+++ b/tests/test_ts_receiver_member_calls.py
@@ -155,3 +155,14 @@ def test_same_file_type_still_resolves(tmp_path):
                      "export function runLocal(): void { r.save(); }\n"),
     })
     assert any("runLocal" in s and "save" in t for s, t in calls)
+
+
+def test_a_pure_esm_corpus_still_activates_the_resolver(tmp_path):
+    # `.mjs` and `.cjs` route to extract_js like `.js` does, so a repo that uses
+    # only those must not be the one shape where the resolver never runs.
+    calls, _ = _calls(tmp_path, {
+        "svc.mjs": "export class Svc {\n  doThing() { return 1; }\n}\n",
+        "app.mjs": ('import { Svc } from "./svc.mjs";\nconst s = new Svc();\n'
+                    "export function usesDirect() { return s.doThing(); }\n"),
+    })
+    assert any("usesDirect" in s and "doThing" in t for s, t in calls)

--- a/tests/test_ts_receiver_member_calls.py
+++ b/tests/test_ts_receiver_member_calls.py
@@ -209,3 +209,33 @@ def test_a_type_the_origin_gate_rejected_is_not_parked(tmp_path):
                      "}\n"),
     })
     assert _parked(r) == []
+
+
+def test_a_class_from_another_language_neither_answers_nor_blocks_parking(tmp_path):
+    # The declaration index is corpus-wide, so a same-named PHP class used to make the
+    # receiver look locally declared and the call was dropped instead of parked.
+    _, r = _calls(tmp_path, {
+        "app.ts": ("import { Greeter } from 'greeter-pkg';\n"
+                   "export class App {\n"
+                   "  constructor(private greeter: Greeter) {}\n"
+                   "  run(): void { this.greeter.greet(); }\n"
+                   "}\n"),
+        "Greeter.php": "<?php\nclass Greeter {\n    public function greet(): void {}\n}\n",
+    })
+    assert _parked(r) == [{"callee": "greet", "receiver_type": "Greeter",
+                           "lang": "typescript", "line": "L4"}]
+
+
+def test_a_class_declared_in_an_sfc_script_block_still_answers(tmp_path):
+    # An SFC script block is TS, so its declarations belong to the same interop family
+    # as the caller's and must keep resolving.
+    calls, _ = _calls(tmp_path, {
+        "app.ts": ("import { Greeter } from './Greeter.vue';\n"
+                   "export class App {\n"
+                   "  constructor(private greeter: Greeter) {}\n"
+                   "  run(): void { this.greeter.greet(); }\n"
+                   "}\n"),
+        "Greeter.vue": ("<script lang=\"ts\">\nexport class Greeter {\n"
+                        "  greet(): void {}\n}\n</script>\n"),
+    })
+    assert any("run" in str(s) and "greet" in str(t) for s, t in calls), calls


### PR DESCRIPTION
Closes #3386. Continues #3152 (#3385 did Objective-C).

### What changes

`_resolve_typescript_member_calls` now parks a member call whose receiver type is
declared nowhere in this build, instead of dropping it, and
`link_cross_repo_member_calls` finishes it once the graphs are composed.

Two commits, separable:

1. **`.mjs`/`.cjs` activation.** The resolver claimed `.ts .tsx .mts .cts .js .jsx`, so a
   pure-ESM corpus never ran type-aware member-call resolution at all. The suffix set is
   now one constant the resolver both activates on and parks by. Single-repo bug, has its
   own test that fails without the fix.
2. **The parking.** `metadata.unresolved_calls` on the caller (names only — no node ids,
   which the #1529 remap and repo prefixing both rewrite), plus the `"typescript"` entry
   in `_LANG_SUFFIXES`.

### The two precision calls, and why

**Only table-typed receivers park.** The resolver types a receiver either from the
per-file table (constructor parameter properties, local `new` bindings, bare
`type_identifier` annotations) or from spelling — an initial capital is taken to name the
type. That second arm is satisfied by `import * as React`, by default imports and by
plain const objects, and since `node_modules` is not scanned, most receivers that reach
the zero-declarations point through it are npm names. Parking them would send bare names
to the merge with nothing behind them, so the park is gated on `not type_qualified`.
`test_a_namespace_style_receiver_is_not_parked` pins it.

**One `_LANG_SUFFIXES` key over all eight suffixes.** A TS class legitimately answers a JS
call site, so splitting TS from JS would drop every TS↔JS cross-repo call.
`test_a_typescript_call_binds_across_the_whole_js_family` runs the four representative
suffixes.

The park is gated on a JS/TS suffix rather than a `lang` tag because TS `raw_calls` carry
no tag and this resolver iterates every language's — the same shape the Swift resolver
uses.

### Interaction with the origin gate (#2553)

The gate runs after the single-definition check, so it only ever vets a name that did
match locally; the park sits at the zero-declarations point, strictly upstream and
disjoint. `test_a_type_the_origin_gate_rejected_is_not_parked` builds the gate's own case
(a local `class Repo` plus `import type { Repo } from 'external-pkg'`) and asserts nothing
is parked, so a gate rejection cannot be laundered through the merge.

### Known recall cost

`interface_declaration`, `enum_declaration` and `type_alias_declaration` all carry
`_callable_class`, so a `type Greeter = …` alias in a third repo makes a genuine class
match ambiguous and the merge emits nothing. That fails closed, which is the bar the
existing resolvers set, and narrowing it belongs with whatever decides that a type alias
is not a call target.

### Verification

- `tests/test_cross_repo_member_calls.py` + `tests/test_ts_receiver_member_calls.py`: 38 passed.
- Full suite: 5319 passed, 93 skipped, with `tests/test_ollama_retry_cap.py` deselected —
  its 4 failures reproduce unchanged on `v8` at `c9f9901`.
- `ruff check graphify tests`: clean. Added lines are within 100 code points.
