### PR TITLE
PHP: receiver-typed member calls, and park them for cross-repo merges

### DIFF
--- a/graphify/cross_repo_calls.py
+++ b/graphify/cross_repo_calls.py
@@ -42,6 +42,7 @@ _LANG_SUFFIXES: dict[str, frozenset[str]] = {
     "cpp": frozenset({".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".h", ".cu", ".cuh"}),
     "csharp": frozenset({".cs"}),
     "java": frozenset({".java"}),
+    "php": frozenset({".php", ".phtml", ".php3", ".php4", ".php5", ".php7", ".phps"}),
     "swift": frozenset({".swift"}),
 }
 

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4615,6 +4615,9 @@ def _resolve_php_member_calls(
     there, takes the single class declaring that type, and emits the ``calls`` edge to
     its method. Always INFERRED: the type comes from the table, never from the call site
     (``Helper::format()`` is a scoped call and keeps its own path).
+
+    A receiver typed to a class this corpus declares nowhere is parked on the caller for
+    a merged graph to finish (#3152).
     """
     raw = [
         rc
@@ -4660,7 +4663,13 @@ def _resolve_php_member_calls(
         if not type_name or type_name in _LANGUAGE_BUILTIN_GLOBALS or type_name in php_builtins:
             continue
         type_defs = type_def_nids.get(_key(type_name), [])
-        if len(type_defs) != 1:  # ambiguous or absent -> bail (god-node guard)
+        if not type_defs:
+            # Declared nowhere here — usually "in a repo this build does not contain",
+            # so park it for the merge (#3152). The extractor's `lang` tag already says
+            # who is asking, so no suffix sniff is needed.
+            _park_unresolved_member_call(node_by_id.get(caller), callee, type_name, "php", rc)
+            continue
+        if len(type_defs) != 1:  # ambiguous -> bail (god-node guard)
             continue
         target = method_index.get((type_defs[0], _key(callee)))
         if not target or target == caller or (caller, target) in existing_pairs:

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4601,6 +4601,86 @@ def _resolve_csharp_qualified_calls(
         })
 
 
+def _resolve_php_member_calls(
+    per_file: list[dict],
+    all_nodes: list[dict],
+    all_edges: list[dict],
+) -> None:
+    """Resolve PHP member calls (``$greeter->greet()``) through the receiver's type.
+
+    The shared cross-file pass skips member calls, so a call on a typed receiver whose
+    method is declared in another file resolved to nothing. The per-file
+    ``php_type_table`` names the declared type of every property, promoted constructor
+    parameter, typed parameter and ``new`` binding; this pass looks the receiver up
+    there, takes the single class declaring that type, and emits the ``calls`` edge to
+    its method. Always INFERRED: the type comes from the table, never from the call site
+    (``Helper::format()`` is a scoped call and keeps its own path).
+    """
+    raw = [
+        rc
+        for result in per_file
+        for rc in result.get("raw_calls", [])
+        if rc.get("lang") == "php" and rc.get("is_member_call")
+        and rc.get("receiver") and rc.get("callee") and rc.get("caller_nid")
+    ]
+    if not raw:
+        return
+    type_table_by_file: dict[str, dict[str, str]] = {}
+    for result in per_file:
+        tt = result.get("php_type_table")
+        if tt and tt.get("path"):
+            type_table_by_file[tt["path"]] = tt.get("table", {})
+
+    def _key(label: str) -> str:
+        return re.sub(r"[^a-zA-Z0-9]+", "", str(label)).lower()
+
+    # A genuine declaration is the target of a `contains` edge from its file node; a bare
+    # type reference mints a same-label stub that would otherwise make a real name ambiguous.
+    contained = {e.get("target") for e in all_edges if e.get("relation") == "contains"}
+    type_def_nids: dict[str, list[str]] = {}
+    node_by_id: dict[str, dict] = {}
+    for n in all_nodes:
+        node_by_id[n.get("id")] = n
+        if n.get("source_file") and n.get("id") in contained and _is_type_like_definition(n):
+            type_def_nids.setdefault(_key(n.get("label", "")), []).append(n["id"])
+
+    method_index: dict[tuple[str, str], str] = {}
+    for e in all_edges:
+        if e.get("relation") != "method":
+            continue
+        tnode = node_by_id.get(e.get("target"))
+        if tnode is not None:
+            method_index[(e.get("source"), _key(tnode.get("label", "")))] = e["target"]
+
+    php_builtins = _LANGUAGE_BUILTIN_BASE_CLASSES.get("php", frozenset())
+    existing_pairs = {(e.get("source"), e.get("target")) for e in all_edges}
+    for rc in raw:
+        receiver, callee, caller = rc["receiver"], rc["callee"], rc["caller_nid"]
+        type_name = type_table_by_file.get(rc.get("source_file", ""), {}).get(receiver)
+        if not type_name or type_name in _LANGUAGE_BUILTIN_GLOBALS or type_name in php_builtins:
+            continue
+        type_defs = type_def_nids.get(_key(type_name), [])
+        if len(type_defs) != 1:  # ambiguous or absent -> bail (god-node guard)
+            continue
+        target = method_index.get((type_defs[0], _key(callee)))
+        if not target or target == caller or (caller, target) in existing_pairs:
+            continue
+        existing_pairs.add((caller, target))
+        all_edges.append({
+            "source": caller,
+            "target": target,
+            "relation": "calls",
+            "context": "call",
+            "confidence": "INFERRED",
+            # The rubric's discrete INFERRED scale (references/extraction-spec.md):
+            # a single-definition type-table hit is the high-confidence rung.
+            "confidence_score": 0.85,
+            "source_file": rc.get("source_file", ""),
+            "source_location": rc.get("source_location"),
+            "weight": 1.0,
+        })
+
+
 def _resolve_kotlin_qualified_calls(
     per_file: list[dict],
     all_nodes: list[dict],
@@ -4793,6 +4873,15 @@ register_language_resolver(
 register_language_resolver(
     LanguageResolver(
         "csharp_qualified_calls", frozenset({".cs"}), _resolve_csharp_qualified_calls
+    )
+)
+# PHP receiver-typed member-call resolution: `$greeter->greet()` where the method is
+# declared in another file. The shared pass skips member calls, so these had no edge.
+register_language_resolver(
+    LanguageResolver(
+        "php_member_calls",
+        frozenset({".php", ".phtml", ".php3", ".php4", ".php5", ".php7", ".phps"}),
+        _resolve_php_member_calls,
     )
 )
 # C# member-level interface dispatch (#3003): a call through an injected

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4601,6 +4601,11 @@ def _resolve_csharp_qualified_calls(
         })
 
 
+# Every suffix the PHP extractor claims. The member-call resolver both activates on and
+# indexes declarations by this set, so an included `.phtml` class is not left out.
+_PHP_SUFFIXES = (".php", ".phtml", ".php3", ".php4", ".php5", ".php7", ".phps")
+
+
 def _resolve_php_member_calls(
     per_file: list[dict],
     all_nodes: list[dict],
@@ -4639,12 +4644,15 @@ def _resolve_php_member_calls(
 
     # A genuine declaration is the target of a `contains` edge from its file node; a bare
     # type reference mints a same-label stub that would otherwise make a real name ambiguous.
+    # Only PHP files count: the index is corpus-wide, so a same-named Java class would both
+    # answer the receiver and hide that nothing local declares its type.
     contained = {e.get("target") for e in all_edges if e.get("relation") == "contains"}
     type_def_nids: dict[str, list[str]] = {}
     node_by_id: dict[str, dict] = {}
     for n in all_nodes:
         node_by_id[n.get("id")] = n
-        if n.get("source_file") and n.get("id") in contained and _is_type_like_definition(n):
+        if (str(n.get("source_file", "")).endswith(_PHP_SUFFIXES)
+                and n.get("id") in contained and _is_type_like_definition(n)):
             type_def_nids.setdefault(_key(n.get("label", "")), []).append(n["id"])
 
     method_index: dict[tuple[str, str], str] = {}
@@ -4889,7 +4897,7 @@ register_language_resolver(
 register_language_resolver(
     LanguageResolver(
         "php_member_calls",
-        frozenset({".php", ".phtml", ".php3", ".php4", ".php5", ".php7", ".phps"}),
+        frozenset(_PHP_SUFFIXES),
         _resolve_php_member_calls,
     )
 )

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4601,11 +4601,6 @@ def _resolve_csharp_qualified_calls(
         })
 
 
-# Every suffix the PHP extractor claims. The member-call resolver both activates on and
-# indexes declarations by this set, so an included `.phtml` class is not left out.
-_PHP_SUFFIXES = (".php", ".phtml", ".php3", ".php4", ".php5", ".php7", ".phps")
-
-
 def _resolve_php_member_calls(
     per_file: list[dict],
     all_nodes: list[dict],
@@ -4644,14 +4639,14 @@ def _resolve_php_member_calls(
 
     # A genuine declaration is the target of a `contains` edge from its file node; a bare
     # type reference mints a same-label stub that would otherwise make a real name ambiguous.
-    # Only PHP files count: the index is corpus-wide, so a same-named Java class would both
-    # answer the receiver and hide that nothing local declares its type.
+    # Only PHP declarations count: the index is corpus-wide, so a same-named Java class
+    # would both answer the receiver and hide that nothing local declares its type.
     contained = {e.get("target") for e in all_edges if e.get("relation") == "contains"}
     type_def_nids: dict[str, list[str]] = {}
     node_by_id: dict[str, dict] = {}
     for n in all_nodes:
         node_by_id[n.get("id")] = n
-        if (str(n.get("source_file", "")).endswith(_PHP_SUFFIXES)
+        if (_lang_family(n.get("source_file")) == "php"
                 and n.get("id") in contained and _is_type_like_definition(n)):
             type_def_nids.setdefault(_key(n.get("label", "")), []).append(n["id"])
 
@@ -4897,7 +4892,7 @@ register_language_resolver(
 register_language_resolver(
     LanguageResolver(
         "php_member_calls",
-        frozenset(_PHP_SUFFIXES),
+        frozenset({".php", ".phtml", ".php3", ".php4", ".php5", ".php7", ".phps"}),
         _resolve_php_member_calls,
     )
 )

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -664,6 +664,77 @@ def _php_collect_type_refs(node, source: bytes, generic: bool, out: list[tuple[s
             if c.is_named:
                 _php_collect_type_refs(c, source, generic, out)
 
+def _php_declared_type_name(node, source: bytes) -> str | None:
+    """The single class name a PHP type annotation names, or None.
+
+    Only `Greeter` and `?Greeter` qualify: a union, an intersection or a primitive names
+    no one class, and binding a receiver to the first arm of `A|B` would be a guess.
+    """
+    if node is None:
+        return None
+    if node.type == "optional_type":
+        node = next((c for c in node.children if c.is_named), None)
+        if node is None:
+            return None
+    if node.type != "named_type":
+        return None
+    return next((_php_name_text(c, source) for c in node.children
+                 if c.type in ("name", "qualified_name")), None)
+
+
+def _php_variable_text(node, source: bytes) -> str | None:
+    """The bare name a PHP `variable_name` binds: `$greeter` -> `greeter`."""
+    if node is None or node.type != "variable_name":
+        return None
+    return next((_read_text(c, source) for c in node.children if c.type == "name"), None)
+
+
+def _php_first_declared_type(node, source: bytes) -> str | None:
+    """The first single-class type annotation among ``node``'s direct children."""
+    return next((name for name in (_php_declared_type_name(c, source) for c in node.children)
+                 if name), None)
+
+
+def _php_receiver_type_table(root, source: bytes, table: dict[str, str]) -> None:
+    """Collect ``name -> TypeName`` for every PHP receiver whose type is written down.
+
+    Four sources, all needed: a typed property (`private Greeter $g;`), a constructor
+    promotion (`__construct(private Greeter $g)`), a typed parameter, and
+    `$g = new Greeter()`. File-scoped and flat, first binding wins — a parameter
+    shadowing a property in another method must not retype the property's own calls.
+    Children are pushed reversed so the walk yields document order and "first" means
+    first in the file.
+    """
+    stack = [root]
+    while stack:
+        n = stack.pop()
+        t = n.type
+        if t == "property_declaration":
+            type_name = _php_first_declared_type(n, source)
+            for element in n.children if type_name else ():
+                if element.type != "property_element":
+                    continue
+                name = next((_php_variable_text(c, source) for c in element.children
+                             if c.type == "variable_name"), None)
+                if name and name not in table:
+                    table[name] = type_name
+        elif t in ("property_promotion_parameter", "simple_parameter"):
+            type_name = _php_first_declared_type(n, source)
+            name = next((_php_variable_text(c, source) for c in n.children
+                         if c.type == "variable_name"), None)
+            if name and type_name and name not in table:
+                table[name] = type_name
+        elif t == "assignment_expression":
+            right = n.child_by_field_name("right")
+            if right is not None and right.type == "object_creation_expression":
+                name = _php_variable_text(n.child_by_field_name("left"), source)
+                type_name = next((_php_name_text(c, source) for c in right.children
+                                  if c.type in ("name", "qualified_name")), None)
+                if name and type_name and name not in table:
+                    table[name] = type_name
+        stack.extend(reversed(n.children))
+
+
 def _php_method_return_type_node(method_node):
     """Return the named_type/primitive_type node sitting after formal_parameters."""
     saw_params = False
@@ -5649,6 +5720,17 @@ def _extract_generic(
                     name_node = node.child_by_field_name("name")
                     if name_node:
                         callee_name = _read_text(name_node, source)
+                    # `$this->greeter->greet()` types the receiver by the property name,
+                    # `$greeter->greet()` by the variable; a longer chain names neither.
+                    obj = node.child_by_field_name("object")
+                    if obj is not None and obj.type == "variable_name":
+                        member_receiver = _php_variable_text(obj, source)
+                    elif obj is not None and obj.type == "member_access_expression":
+                        inner = obj.child_by_field_name("object")
+                        if inner is not None and inner.type == "variable_name" and (
+                                _php_variable_text(inner, source) == "this"):
+                            member_receiver = _read_text(
+                                obj.child_by_field_name("name"), source)
             elif config.ts_module == "tree_sitter_cpp":
                 # C++: function field, then field_expression/qualified_identifier
                 func_node = node.child_by_field_name(config.call_function_field) if config.call_function_field else None
@@ -5823,9 +5905,14 @@ def _extract_generic(
                 _java_defer = (
                     config.ts_module == "tree_sitter_java" and is_member_call
                 )
+                # PHP never defers: the receiver's type is only ever usable once the
+                # bare callee name misses in this file, which already leaves tgt_nid
+                # None and routes the call to raw_calls.
+                _php_keeps_in_file = config.ts_module == "tree_sitter_php"
                 if _python_defer or _java_defer or _builtin_member_call or (
                     is_member_call
                     and member_receiver
+                    and not _php_keeps_in_file
                     and (
                         member_receiver[:1].isupper()
                         or is_this_field_call
@@ -5921,6 +6008,8 @@ def _extract_generic(
                             receiver_type = (receiver_types or {}).get(member_receiver or "")
                             if receiver_type:
                                 rc_entry["receiver_type"] = receiver_type
+                        if config.ts_module == "tree_sitter_php":
+                            rc_entry["lang"] = "php"
                         # Kotlin fully-qualified call (#2550): the dotted prefix +
                         # lang tag let _resolve_kotlin_qualified_calls claim it.
                         if kotlin_qualified_prefix:
@@ -6356,6 +6445,8 @@ def _extract_generic(
     # a name clash (first-binding-wins in the helper).
     if config.ts_module in ("tree_sitter_javascript", "tree_sitter_typescript"):
         _ts_receiver_type_table(root, source, type_table)
+    if config.ts_module == "tree_sitter_php":
+        _php_receiver_type_table(root, source, type_table)
     if config.ts_module == "tree_sitter_swift":
         if type_table or swift_factory_bindings:
             result["swift_type_table"] = {"path": str_path, "table": type_table}
@@ -6369,6 +6460,8 @@ def _extract_generic(
             result["ts_type_table"] = {"path": str_path, "table": type_table}
         elif config.ts_module == "tree_sitter_cpp":
             result["cpp_type_table"] = {"path": str_path, "table": type_table}
+        elif config.ts_module == "tree_sitter_php":
+            result["php_type_table"] = {"path": str_path, "table": type_table}
     return result
 
 def _python_decorator_name(deco_node, source: bytes) -> str | None:

--- a/tests/test_cross_repo_member_calls.py
+++ b/tests/test_cross_repo_member_calls.py
@@ -6,8 +6,8 @@ type already in hand and nothing about it reached `graph.json` — the only arti
 `merge-graphs` and `global add` read. The two-repo graph was missing precisely the
 edges that make it a call graph.
 
-The Java, C++, C# and Swift resolvers now park those calls on the caller node and
-this pass finishes them after the merge. The cases below pin what it must NOT do
+The Java, C++, C#, Swift and PHP resolvers now park those calls on the caller node
+and this pass finishes them after the merge. The cases below pin what it must NOT do
 as much as what it must: the single-definition guard, the cross-repo-only scope,
 and the language guard are what keep it from fabricating an edge from a name
 collision.
@@ -45,6 +45,7 @@ needs_java = _needs("tree_sitter_java")
 needs_cpp = _needs("tree_sitter_cpp")
 needs_csharp = _needs("tree_sitter_c_sharp")
 needs_swift = _needs("tree_sitter_swift")
+needs_php = _needs("tree_sitter_php")
 
 
 def _caller(repo: str, parked: list[dict], node_id: str = "app_run",
@@ -372,6 +373,14 @@ def test_a_java_build_parks_the_call_and_the_merge_finishes_it(tmp_path: Path):
                           "}\n"),
         ("src/Greeter.swift", "class Greeter { func greet() {} }\n"),
         marks=needs_swift, id="swift-property-receiver",
+    ),
+    pytest.param(
+        "php", "greet",
+        ("src/App.php", "<?php\nclass App {\n    private Greeter $greeter;\n"
+                        "    public function run(): void { $this->greeter->greet(); }\n}\n"),
+        ("src/Greeter.php", "<?php\nclass Greeter {\n"
+                            "    public function greet(): void {}\n}\n"),
+        marks=needs_php, id="php-typed-property",
     ),
 ])
 def test_each_language_parks_the_call_and_the_merge_finishes_it(

--- a/tests/test_php_receiver_member_calls.py
+++ b/tests/test_php_receiver_member_calls.py
@@ -163,3 +163,18 @@ def test_a_static_call_keeps_its_own_path(tmp_path):
                    "    public function run(): void { Helper::format(); }\n}\n",
     })
     assert any(src and "run" in src and tgt == "Helper" for src, tgt in calls), calls
+
+
+def test_a_class_from_another_language_never_answers_a_php_receiver(tmp_path):
+    # The declaration index is corpus-wide, so a same-named Java class would both answer
+    # the receiver and hide that no PHP file declares it — the call belongs to the merge.
+    calls, result = _calls(tmp_path, {
+        "App.php": "<?php\nclass App {\n    private Greeter $greeter;\n"
+                   "    public function run(): void { $this->greeter->greet(); }\n}\n",
+        "Greeter.java": "public class Greeter { public void greet() {} }\n",
+    })
+    assert _greet_edge(calls) is None, calls
+    parked = [(n.get("metadata") or {}).get("unresolved_calls") for n in result["nodes"]
+              if "run" in str(n["label"]) and n.get("metadata")]
+    assert parked == [[{"callee": "greet", "receiver_type": "Greeter",
+                        "lang": "php", "line": "L4"}]], parked

--- a/tests/test_php_receiver_member_calls.py
+++ b/tests/test_php_receiver_member_calls.py
@@ -1,0 +1,165 @@
+"""PHP member calls resolve through the receiver's declared type.
+
+The shared cross-file pass skips member calls, and PHP recorded no receiver at all, so
+`$greeter->greet()` on a receiver whose class lives in another file produced no edge —
+the PHP twin of the Swift gap in #1356. Each case below pins one source of the
+receiver's type, and the negative cases pin what must stay unresolved: an untyped
+parameter, a union type, a longer chain, and an ambiguous class name.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from graphify.extract import extract
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("tree_sitter_php") is None,
+    reason="tree_sitter_php not installed",
+)
+
+GREETER = "<?php\nclass Greeter {\n    public function greet(): void {}\n}\n"
+
+
+def _calls(tmp_path, files: dict[str, str]):
+    for name, body in files.items():
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    result = extract([tmp_path / n for n in files],
+                     cache_root=tmp_path / "graphify-out", parallel=False)
+    label = {n["id"]: n["label"] for n in result["nodes"]}
+    calls = {(label.get(e["source"]), label.get(e["target"])): e
+             for e in result["edges"] if e["relation"] == "calls"}
+    return calls, result
+
+
+def _greet_edge(calls: dict) -> dict | None:
+    return next((e for (src, tgt), e in calls.items()
+                 if src and "run" in src and tgt == ".greet()"), None)
+
+
+def test_a_typed_property_types_the_receiver(tmp_path):
+    calls, _ = _calls(tmp_path, {
+        "Greeter.php": GREETER,
+        "App.php": "<?php\nclass App {\n    private Greeter $greeter;\n"
+                   "    public function run(): void { $this->greeter->greet(); }\n}\n",
+    })
+    edge = _greet_edge(calls)
+    assert edge is not None, calls
+    # The type came from the table, never from the call site: `$greeter` names a
+    # variable, so there is no spelling of this call that would be exact.
+    assert edge["confidence"] == "INFERRED"
+
+
+def test_a_promoted_constructor_parameter_types_the_receiver(tmp_path):
+    # Constructor promotion declares no property, so nothing else in the walk ever
+    # names the receiver's type.
+    calls, _ = _calls(tmp_path, {
+        "Greeter.php": GREETER,
+        "App.php": "<?php\nclass App {\n"
+                   "    public function __construct(private Greeter $greeter) {}\n"
+                   "    public function run(): void { $this->greeter->greet(); }\n}\n",
+    })
+    assert _greet_edge(calls) is not None, calls
+
+
+def test_a_typed_parameter_types_the_receiver(tmp_path):
+    calls, _ = _calls(tmp_path, {
+        "Greeter.php": GREETER,
+        "App.php": "<?php\nclass App {\n"
+                   "    public function run(Greeter $greeter): void { $greeter->greet(); }\n}\n",
+    })
+    assert _greet_edge(calls) is not None, calls
+
+
+def test_a_new_binding_types_an_unannotated_local(tmp_path):
+    calls, _ = _calls(tmp_path, {
+        "Greeter.php": GREETER,
+        "App.php": "<?php\nclass App {\n    public function run(): void {\n"
+                   "        $greeter = new Greeter();\n        $greeter->greet();\n    }\n}\n",
+    })
+    assert _greet_edge(calls) is not None, calls
+
+
+def test_a_nullable_property_type_still_names_one_class(tmp_path):
+    calls, _ = _calls(tmp_path, {
+        "Greeter.php": GREETER,
+        "App.php": "<?php\nclass App {\n    private ?Greeter $greeter = null;\n"
+                   "    public function run(): void { $this->greeter->greet(); }\n}\n",
+    })
+    assert _greet_edge(calls) is not None, calls
+
+
+def test_an_untyped_parameter_resolves_to_nothing(tmp_path):
+    calls, _ = _calls(tmp_path, {
+        "Greeter.php": GREETER,
+        "App.php": "<?php\nclass App {\n"
+                   "    public function run($greeter): void { $greeter->greet(); }\n}\n",
+    })
+    assert _greet_edge(calls) is None, calls
+
+
+def test_a_union_typed_receiver_resolves_to_nothing(tmp_path):
+    # `Greeter|Other` names no one class, and binding the first arm would be a guess.
+    calls, _ = _calls(tmp_path, {
+        "Greeter.php": GREETER,
+        "Other.php": "<?php\nclass Other {\n    public function greet(): void {}\n}\n",
+        "App.php": "<?php\nclass App {\n"
+                   "    public function run(Greeter|Other $greeter): void "
+                   "{ $greeter->greet(); }\n}\n",
+    })
+    assert _greet_edge(calls) is None, calls
+
+
+def test_a_longer_chain_resolves_to_nothing(tmp_path):
+    # `$this->a->b->greet()` types neither `a` nor `b` as the receiver.
+    calls, _ = _calls(tmp_path, {
+        "Greeter.php": GREETER,
+        "App.php": "<?php\nclass App {\n    private Greeter $greeter;\n"
+                   "    public function run(): void { $this->greeter->inner->greet(); }\n}\n",
+    })
+    assert _greet_edge(calls) is None, calls
+
+
+def test_two_classes_of_the_same_name_resolve_to_neither(tmp_path):
+    # The single-definition guard: guessing one of two `Greeter`s is worse than
+    # leaving the call unresolved.
+    calls, _ = _calls(tmp_path, {
+        "a/Greeter.php": GREETER,
+        "b/Greeter.php": GREETER,
+        "App.php": "<?php\nclass App {\n    private Greeter $greeter;\n"
+                   "    public function run(): void { $this->greeter->greet(); }\n}\n",
+    })
+    assert _greet_edge(calls) is None, calls
+
+
+def test_the_first_binding_of_a_name_wins(tmp_path):
+    # The table is flat per file, so a parameter named like a property has to lose:
+    # otherwise `other`'s signature would redirect the property's own calls.
+    calls, result = _calls(tmp_path, {
+        "Greeter.php": GREETER,
+        "Other.php": "<?php\nclass Other {\n    public function greet(): void {}\n}\n",
+        "App.php": "<?php\nclass App {\n    private Greeter $greeter;\n"
+                   "    public function run(): void { $this->greeter->greet(); }\n"
+                   "    public function other(Other $greeter): void { $greeter->greet(); }\n}\n",
+    })
+    source_of = {n["id"]: str(n.get("source_file") or "") for n in result["nodes"]}
+    label_of = {n["id"]: n["label"] for n in result["nodes"]}
+    run_targets = {source_of[e["target"]] for e in result["edges"]
+                   if e["relation"] == "calls"
+                   and "run" in str(label_of.get(e["source"]))
+                   and label_of.get(e["target"]) == ".greet()"}
+    assert len(run_targets) == 1, run_targets
+    assert run_targets.pop().endswith("Greeter.php")
+
+
+def test_a_static_call_keeps_its_own_path(tmp_path):
+    # `Helper::format()` is a scoped call, not a member call, and still binds.
+    calls, _ = _calls(tmp_path, {
+        "Helper.php": "<?php\nclass Helper {\n    public static function format(): void {}\n}\n",
+        "App.php": "<?php\nclass App {\n"
+                   "    public function run(): void { Helper::format(); }\n}\n",
+    })
+    assert any(src and "run" in src and tgt == "Helper" for src, tgt in calls), calls


### PR DESCRIPTION
Fixes #3390. Two cherry-pickable commits: the single-repo resolver, then the park that
lets a merged graph finish what one build cannot.

## Commit 1 — resolve PHP member calls through the receiver's declared type

PHP recorded no receiver on a member call and exported no type table, so
`$greeter->greet()` across files produced no edge. Both halves are added:

- the extractor captures the receiver — the variable for `$greeter->greet()`, the
  property name for `$this->greeter->greet()`;
- a per-file `php_type_table` is exported, and `_resolve_php_member_calls` types the
  receiver from it and emits `calls` to the single class declaring that type.

Table sources, all four needed:

| source | why it cannot be dropped |
| --- | --- |
| typed property | `private Greeter $greeter;` |
| promoted constructor parameter | `__construct(private Greeter $g)` declares no property, so nothing else names the type |
| typed parameter | `function run(Greeter $g)` |
| `new` binding | `$g = new Greeter();` |

Design calls:

1. **Always INFERRED, no EXTRACTED tier.** The sibling resolvers give a
   type-qualified receiver (`Type.staticMethod()`) 1.0/EXTRACTED, but in PHP that
   spelling is `Helper::format()` — a `scoped_call_expression`, which already has its own
   path and is left alone. Every receiver this pass types is a variable, so there is no
   spelling of a member call that names the type exactly.
2. **PHP does not defer.** A call whose bare callee name matches in its own file still
   resolves there, exactly as before; the receiver type is consulted only after that miss,
   which is the only situation where it can add an edge. This keeps in-file behaviour
   byte-identical rather than trading known edges for better-typed ones.
3. **One class name or nothing.** A union or intersection type names no one class, and
   binding the first arm of `Greeter|Other` would be a guess. `?Greeter` does name one.
4. **Receiver depth 1.** `$this->prop->call()` and `$var->call()` are typed;
   `$this->a->b->call()` types neither `a` nor `b` and is left unresolved.
5. **First binding in the file wins**, so a parameter named like a property in another
   method cannot retype the property's own calls. The table walk pushes children reversed
   to yield document order — without that, "first" is DFS order and the wrong binding wins
   (this is what the shadowing test caught).
6. **`confidence_score` is 0.85**, the high-confidence rung of the rubric's discrete
   INFERRED scale in `references/extraction-spec.md`. The sibling member-call resolvers
   still emit the off-rubric 0.8; `test_no_module_hardcodes_an_off_rubric_inferred_score`
   exists to stop new ones, and snapping the pre-existing sites is out of scope here.

## Commit 2 — park what this build cannot answer (#3152)

A receiver typed to a class with **zero** declarations in this corpus is parked on the
caller as a `metadata.unresolved_calls` entry (names only, never node ids — those are
rewritten by the #1529 remap and again by repo prefixing). `> 1` declarations stays
dropped: local ambiguity is not something merging can narrow. The merge pass then binds
the entry when exactly one declaration in another repo answers it.

`_LANG_SUFFIXES["php"]` covers every extension the PHP extractors claim (`.php`, `.phtml`,
`.php3`–`.php7`, `.phps`), so a class declared in a template file still answers.

## Known cost

Class name matching is case-sensitive on both sides. PHP class names are case-insensitive,
so `private greeter $g` binds nothing. Folding case in the merge pass would let the
languages that park alongside PHP bind `greeter` to `Greeter`, which is why the pass keeps
case; a PHP-only fold is a separate change.

## Verification

- `tests/test_php_receiver_member_calls.py` — 11 cases: one per type source (including
  `?Greeter`), the negatives that must stay unresolved (untyped parameter, union type,
  longer chain, two same-named classes), the shadowing case, and one pinning that
  `Helper::format()` keeps its existing path. 6 of the 11 fail on `v8`.
- `tests/test_cross_repo_member_calls.py` — a `php-typed-property` arm in the per-language
  park→merge test.
- Full suite: 5321 passed, 93 skipped, no new failures. `ruff check graphify tests` clean.
