### PR TITLE
fix(extract): remove quadratic scan in TS import-type normalization (#3359)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import textwrap
+from bisect import bisect_right
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
@@ -1360,6 +1361,58 @@ def _ts_type_argument_ranges(root: Any, *, call_only: bool) -> list[tuple[int, i
     return ranges
 
 
+# Sorted type-argument ranges prepared for lookup: (starts, spans, prefix_max_end).
+# See _ts_build_range_index.
+_TsRangeIndex = "tuple[list[int], list[tuple[int, int]], list[int]]"
+
+
+def _ts_ranges_containing(
+    ranges: "_TsRangeIndex", offset: int
+) -> "list[tuple[int, int]]":
+    """Return the ranges in ``ranges`` that contain ``offset``.
+
+    Scanning the full range list for every match made
+    :func:`_normalize_ts_import_types` O(matches x ranges); on a large monorepo
+    file with thousands of generic calls and thousands of ``import(...)`` types
+    that quadratic blowup pinned a worker at 100% CPU with no output and no file
+    I/O, so extraction never finished (#3359).
+
+    Every range containing ``offset`` must start at or before it, so binary-search
+    to the last such start and walk left. A range that ends before ``offset`` is
+    not itself a hit but must not stop the walk -- a closed sibling can sit inside
+    an enclosing range that does contain ``offset``. The index's running maximum of
+    ends (``prefix_max_end``) gives the correct stop: once no range at or before
+    this position reaches past ``offset``, none of the remaining ones can.
+    """
+    starts, spans, prefix_max_end = ranges
+    hits: list[tuple[int, int]] = []
+    index = bisect_right(starts, offset) - 1
+    while index >= 0 and prefix_max_end[index] > offset:
+        start, end = spans[index]
+        if end > offset:
+            hits.append((start, end))
+        index -= 1
+    hits.reverse()
+    return hits
+
+
+def _ts_build_range_index(root: Any, *, call_only: bool) -> "_TsRangeIndex":
+    """Index :func:`_ts_type_argument_ranges` for :func:`_ts_ranges_containing`.
+
+    Returns the ranges sorted by start, split into a bare ``starts`` list for
+    :func:`bisect_right`, plus a prefix-maximum of ``end`` values so a lookup can
+    tell when no earlier range can still reach a given offset.
+    """
+    spans = sorted(_ts_type_argument_ranges(root, call_only=call_only))
+    starts = [start for start, _ in spans]
+    prefix_max_end: list[int] = []
+    running = -1
+    for _, end in spans:
+        running = max(running, end)
+        prefix_max_end.append(running)
+    return starts, spans, prefix_max_end
+
+
 def _ts_error_nodes(root: Any) -> list[Any]:
     """Return parser error nodes without depending on a grammar's error name."""
     errors: list[Any] = []
@@ -1450,10 +1503,10 @@ def _normalize_ts_import_types(source: bytes, *, tsx: bool = False) -> bytes | N
     # its syntax is parseable as written. This includes the grammar's deliberate
     # comparison-vs-generic ambiguity (`a < b, import("...") > (d)`); retaining
     # that source is essential because it is a runtime expression, not a type.
-    original_type_ranges = _ts_type_argument_ranges(original_root, call_only=False)
+    original_type_ranges = _ts_build_range_index(original_root, call_only=False)
     matches = [
         match for match in matches
-        if not any(start <= match.start() < end for start, end in original_type_ranges)
+        if not _ts_ranges_containing(original_type_ranges, match.start())
     ]
     if not matches:
         return None
@@ -1475,19 +1528,18 @@ def _normalize_ts_import_types(source: bytes, *, tsx: bool = False) -> bytes | N
     # type annotations already parse ``import(...)`` correctly and should keep
     # their native AST shape. A range from an outer call's type_arguments also
     # covers nested generic arguments.
-    type_argument_ranges = _ts_type_argument_ranges(root, call_only=True)
+    type_argument_ranges = _ts_build_range_index(root, call_only=True)
     errors = _ts_error_nodes(original_root)
 
-    if not type_argument_ranges:
+    # `type_argument_ranges` is an index tuple, so test the spans it holds --
+    # the tuple itself is always truthy.
+    if not type_argument_ranges[1]:
         return None
 
     norm = bytearray(source)
     changed = False
     for match in matches:
-        containing_ranges = [
-            candidate for candidate in type_argument_ranges
-            if candidate[0] <= match.start() < candidate[1]
-        ]
+        containing_ranges = _ts_ranges_containing(type_argument_ranges, match.start())
         if containing_ranges and any(
             _ts_mask_candidate_is_malformed(original_root, candidate, errors)
             for candidate in containing_ranges

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1362,13 +1362,14 @@ def _ts_type_argument_ranges(root: Any, *, call_only: bool) -> list[tuple[int, i
 
 
 # Sorted type-argument ranges prepared for lookup: (starts, spans, prefix_max_end).
-# See _ts_build_range_index.
-_TsRangeIndex = "tuple[list[int], list[tuple[int, int]], list[int]]"
+# See _ts_build_range_index. A real alias, not a string: quoting the right-hand
+# side would make this a `str` value, which type checkers reject as a type.
+_TsRangeIndex = tuple[list[int], list[tuple[int, int]], list[int]]
 
 
 def _ts_ranges_containing(
-    ranges: "_TsRangeIndex", offset: int
-) -> "list[tuple[int, int]]":
+    ranges: _TsRangeIndex, offset: int
+) -> list[tuple[int, int]]:
     """Return the ranges in ``ranges`` that contain ``offset``.
 
     Scanning the full range list for every match made
@@ -1396,7 +1397,7 @@ def _ts_ranges_containing(
     return hits
 
 
-def _ts_build_range_index(root: Any, *, call_only: bool) -> "_TsRangeIndex":
+def _ts_build_range_index(root: Any, *, call_only: bool) -> _TsRangeIndex:
     """Index :func:`_ts_type_argument_ranges` for :func:`_ts_ranges_containing`.
 
     Returns the ranges sorted by start, split into a bare ``starts`` list for

--- a/tests/test_ts_import_type_arguments.py
+++ b/tests/test_ts_import_type_arguments.py
@@ -285,3 +285,41 @@ def test_ts_normalizer_does_not_mask_import_text_in_literals_or_comments():
     assert b'import(\\\"./text\\\")' in normalized
     assert b'import("./comment")' in normalized
     assert b'import("./types")' not in normalized
+
+
+def test_ts_normalizer_scales_linearly_on_large_files():
+    """#3359: the match/type-argument-range filters must not be O(matches x ranges).
+
+    A large monorepo file mixes thousands of generic calls (each a
+    ``type_arguments`` range) with thousands of ``import(...)`` types. Filtering
+    each match by scanning every range made extraction quadratic, so `extract`
+    spun at 100% CPU in the regex/scan path and never finished.
+
+    Assert on scaling, not wall-clock, so the test is not machine-dependent:
+    doubling the input must not roughly quadruple the time.
+    """
+    import time
+
+    def build(n: int) -> bytes:
+        lines = []
+        for i in range(n):
+            lines.append(f"const a{i} = fn<Foo{i}, Bar{i}>(x);")
+            lines.append(f"type T{i} = import('./m{i}').Thing;")
+        return "\n".join(lines).encode()
+
+    def timed(n: int) -> float:
+        source = build(n)
+        start = time.perf_counter()
+        _normalize_ts_import_types(source)
+        return time.perf_counter() - start
+
+    timed(200)  # warm the grammar/parser import off the measured path
+    small = min(timed(1000) for _ in range(3))
+    large = min(timed(2000) for _ in range(3))
+
+    # Linear work doubles (~2x). Quadratic work quadruples (~4x). A generous
+    # 3x ceiling separates the two without being flaky under load.
+    assert large < small * 3, (
+        f"scaling looks super-linear: {small:.4f}s -> {large:.4f}s "
+        f"({large / small:.1f}x for 2x input)"
+    )


### PR DESCRIPTION
Fixes #3359.

## Root cause

Not a linearity-unsafe regex. Every `re.sub`/pattern in the extract path is linear — I benchmarked `textwrap.shorten`, `_TS_IMPORT_CALL_RE`, `_VUE_SCRIPT_RE` and the JS rescue patterns and none backtrack. The `_sre` frames in the reporter's `sample` output are the innermost frames of a quadratic **caller**.

`_normalize_ts_import_types` (the #3154 TypeScript `import(...)` normalizer) filters each regex match against every tree-sitter `type_arguments` byte range with a nested linear scan, in both passes:

```python
matches = [m for m in matches
           if not any(start <= m.start() < end for start, end in original_type_ranges)]
```

That is **O(matches × ranges)**, and `m.start()` is re-evaluated inside `any()` for every range — hence `re.Match.start` dominating profiles and `sample` appearing to indict a regex.

Both counts scale with file size in TypeScript that mixes generic calls (`fn<A, B>(x)` → one `type_arguments` range each) with `import(...)` types — the shape of generated and barrel modules in a large monorepo.

Measured on the filter alone:

| file | `import()` sites | before | after |
|---|---|---|---|
| 0.8 MB | 10,000 | ~21 s | 0.003 s |
| 2.1 MB | 25,000 | ~2.6 min | 0.008 s |
| 4.2 MB | 50,000 | ~11.8 min | 0.019 s |

This accounts for every symptom in the report:

- **100% CPU with no open files** — all work is in-memory after the read.
- **Freeze point shifts with the file set** — content-triggered by a few large generated files, not by file count. Explains why `packages/` hangs while other top-level dirs and a 60-file repo finish.
- **`--max-workers 1` stalls *earlier*** (500/2469 vs ~2400/2470) — one worker reaches the pathological file sooner instead of ten racing past it first.
- **`--no-dedup`, 0.9.53 and 0.9.54 all reproduce** — the code is in the extract path and unchanged across those releases.

## Fix

Replace both scans with a binary search over start-sorted ranges plus a prefix-maximum of `end` values, so a lookup touches nesting depth instead of every range.

Type-argument ranges nest but never partially overlap, so the prefix maximum is a correct stop condition. The subtle part: a **closed inner sibling** must not terminate the leftward walk — a naive running-max break gets this wrong and silently drops enclosing ranges.

Normalization output is unchanged: byte-length and line-count preserving, identical masking decisions, and the runtime-vs-type disambiguation from 6baa5e0 still holds.

Also restores the emptiness guard in the second pass — the range list is now an index tuple, which is always truthy, so it checks the spans it holds rather than the container.

## Verification

- **500,000-case differential test** of the new lookup against the old predicate, including non-nested random ranges: zero mismatches.
- `_normalize_ts_import_types` scaling is now ~2× per doubling (was ~4×), linear out to 32k imports.
- Invariants re-checked: byte length, line count, TSX path, comparison-vs-generic ambiguity, comment/string literals untouched.
- New regression test asserts on **scaling** (2× input must not ~4× the time) rather than wall-clock, so it is not machine-dependent. It fails at ~3.4× before this change and passes after.

### Full-suite note

A whole-suite comparison against unmodified `c9f9901` shows 53 vs 61 failures, but the delta is environment flakiness on Windows, not this change:

- The diff lists 13 "new" failures **and 5 that disappeared** — a change confined to the TS normalizer cannot fix unrelated install tests.
- Every failure is in `serve_http` / `install*` / `hooks` / `watch`. None is in `extract`, `resolution`, or any TypeScript path, and no failing test references `_normalize_ts_import_types`, `_ts_ranges_containing`, `_ts_build_range_index`, or `_ts_type_argument_ranges`.
- The install tests are order- and state-dependent: the **same baseline code** produced 8 failures on one run then 3, 3, 3 on the next three, with no edits at all.
- Run head-to-head three times each on the same files, baseline and this branch are identical: 3 failed / 155 passed on every run.
- The 6 install/upgrade tests flagged as regressions all pass on this branch in isolation.
