### PR TITLE
fix(extract): emit imports edge for bare Lua require() statements (#3320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 ## 0.9.56 (unreleased)
 
+- Fix: a bare `require("mod")` statement in Lua (the common Neovim/LazyVim `init.lua` idiom, with no `local x =` assignment) now emits an `imports` edge like the assigned form — previously only `variable_declaration` requires were dispatched, so side-effect requires produced no edge and Neovim configs graphed with almost no structure (#3320, thanks @artbylmz).
 - Fix: Rust trait method declarations (signature-only, and default-bodied) are now extracted as nodes — trait bodies were never walked, so both were silently dropped; a trait-declared method stays a distinct node from its impl definition (#3366, thanks @santoshpy).
 - Fix: the atomic-write temp filename is now bounded, so exporting to a path near the Windows MAX_PATH / 255-char component limit no longer fails with a temp-file `FileNotFoundError` (#3351, thanks @hopstreax).
 - Fix: when graphify's git hook decides to skip (no graph, rebase/merge/worktree, `GRAPHIFY_SKIP_HOOK`), it no longer terminates the whole hook — the block runs in a subshell so chained hooks and later steps still execute (#2986, thanks @abhay-codes07).

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1047,7 +1047,18 @@ _PHP_CONFIG = LanguageConfig(
 
 
 def _import_lua(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str, scope_stack: list[str] | None = None) -> None:
-    """Extract require('module') from Lua variable_declaration nodes."""
+    """Extract require('module') from Lua require imports.
+
+    Fires on a `variable_declaration` (`local x = require("mod")`) and on a bare
+    `function_call` statement (`require("mod")` with no assignment, the common
+    Neovim/LazyVim idiom — #3320). For the bare form the callee is checked so a
+    same-named helper (`myrequire(...)`) or a string literal that merely contains
+    `require(...)` (e.g. `print("require(x)")`) does not mint a false import edge.
+    """
+    if node.type == "function_call":
+        name_node = node.child_by_field_name("name")
+        if name_node is None or _read_text(name_node, source) != "require":
+            return
     text = _read_text(node, source)
     import re
     m = re.search(r"""require\s*[\('"]\s*['"]?([^'")\s]+)""", text)
@@ -1074,7 +1085,14 @@ _LUA_CONFIG = LanguageConfig(
     ts_language_fn="language",
     class_types=frozenset(),
     function_types=frozenset({"function_declaration"}),
-    import_types=frozenset({"variable_declaration"}),
+    # A bare `require("mod")` statement (the common Neovim/LazyVim idiom) parses
+    # as a top-level `function_call`, not a `variable_declaration`, so it must be
+    # dispatched to _import_lua too — otherwise side-effect requires produce no
+    # `imports` edge (#3320). The assigned form (`local x = require(...)`) is a
+    # `variable_declaration`; the engine returns after handling an import node, so
+    # its nested `function_call` is never re-visited and no duplicate edge is
+    # emitted. Call edges come from the separate walk_calls pass, unaffected.
+    import_types=frozenset({"variable_declaration", "function_call"}),
     call_types=frozenset({"function_call"}),
     call_function_field="name",
     call_accessor_node_types=frozenset({"method_index_expression"}),

--- a/tests/test_lua_import_resolution.py
+++ b/tests/test_lua_import_resolution.py
@@ -1,0 +1,76 @@
+"""Lua `require(...)` import resolution.
+
+A bare `require("mod")` statement with no assignment — the common Neovim/LazyVim
+config idiom (`require("config.lazy")` in `init.lua`) — must resolve to an
+`imports` edge just like the assigned `local x = require("mod")` form (#3320).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify.extract import extract
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _import_edges(result: dict) -> list[dict]:
+    return [e for e in result["edges"] if e["relation"] == "imports"]
+
+
+def test_bare_require_statement_emits_import_edge(tmp_path: Path):
+    source = _write(tmp_path / "init.lua", 'require("config.lazy")\n')
+    target = _write(tmp_path / "config.lazy.lua", "-- lazy config\n")
+
+    result = extract([source, target], cache_root=tmp_path)
+
+    imports = _import_edges(result)
+    assert len(imports) == 1
+    assert imports[0]["source"] == "init"
+    assert imports[0]["target"] == "config_lazy"
+
+
+def test_multiple_bare_requires_each_emit_an_edge(tmp_path: Path):
+    source = _write(
+        tmp_path / "init.lua",
+        'require("config.lazy")\nrequire("config.options")\n',
+    )
+    _write(tmp_path / "config.lazy.lua", "-- lazy\n")
+    _write(tmp_path / "config.options.lua", "-- options\n")
+
+    result = extract([source, tmp_path / "config.lazy.lua", tmp_path / "config.options.lua"], cache_root=tmp_path)
+
+    targets = sorted(e["target"] for e in _import_edges(result))
+    assert targets == ["config_lazy", "config_options"]
+
+
+def test_similarly_named_call_does_not_emit_import(tmp_path: Path):
+    """A helper whose name merely ends in ``require`` (or a string literal that
+    contains ``require(...)``) must not be mistaken for a real ``require`` import."""
+    source = _write(
+        tmp_path / "init.lua",
+        'myrequire("config.lazy")\nprint("require(\\"config.lazy\\")")\n',
+    )
+    _write(tmp_path / "config.lazy.lua", "-- lazy config\n")
+
+    result = extract([source, tmp_path / "config.lazy.lua"], cache_root=tmp_path)
+
+    assert _import_edges(result) == []
+
+
+def test_assigned_require_still_emits_exactly_one_edge(tmp_path: Path):
+    """Guard against a duplicate edge: the assigned form is a
+    ``variable_declaration`` whose nested ``function_call`` must not be
+    re-dispatched to the import handler."""
+    source = _write(tmp_path / "init.lua", 'local ok = require("config.lazy")\n')
+    _write(tmp_path / "config.lazy.lua", "-- lazy config\n")
+
+    result = extract([source, tmp_path / "config.lazy.lua"], cache_root=tmp_path)
+
+    imports = _import_edges(result)
+    assert len(imports) == 1
+    assert imports[0]["source"] == "init"
+    assert imports[0]["target"] == "config_lazy"


### PR DESCRIPTION
## Why

`graphify.extract._import_lua` only extracted an `imports` edge when a `require(...)` call appeared inside a `variable_declaration` (`local x = require("mod")`). The far more common Neovim/LazyVim idiom — a **bare** `require("mod")` statement with no assignment — produced **no edge at all**:

```lua
-- init.lua
require("config.lazy")
require("config.options")
require("config.keymaps")
```

A bare `require(...)` parses as a top-level `function_call`, which was not in `_LUA_CONFIG.import_types`, so the import handler never fired. Result: real Neovim configs graphed with almost no structure (e.g. a 14-file config produced 13 nodes but only 2 `contains` edges, zero imports).

## What changed

- Add `function_call` to `_LUA_CONFIG.import_types` so bare `require(...)` statements are dispatched to `_import_lua` (`graphify/extract.py`).
- Guard the new path in `_import_lua`: for a `function_call` node it only proceeds when the callee is the `require` global (AST `name` field), so `myrequire(...)`, a `require`-containing string literal (`print("require(x)")`), or a method call (`obj:require(...)`) do **not** mint a false import edge.
- The assigned form (`local x = require(...)`) is unchanged: it is a `variable_declaration`, and the engine returns after handling an import node, so its nested `function_call` is never re-dispatched — **no duplicate edge**.
- Call edges come from the separate `walk_calls` pass and are unaffected. The change is scoped to `_LUA_CONFIG` (Lua/`.luau`/`.toc` only).

## Why it's safe

Structure extraction in Lua only walks classes (none), `function_declaration` (a statement, never an expression argument), and imports — none of which live inside a `function_call`'s arguments. Verified empirically that base vs. branch output is byte-identical for `print(require("x"))`, `require("lazy").setup({})`, and callback-argument cases; the **only** behavioral difference is the intended bare-`require` import edge.

- `ruff check .` — clean
- `python -m tools.skillgen --check` — OK (no generated skill files touched)
- Full suite: **5479 passed, 14 skipped, 0 failed** (baseline v8 was 5475 passed, 0 failed; +4 new Lua tests)

## Test verification (RED → GREEN)

New test file `tests/test_lua_import_resolution.py`.

**RED** — on unmodified `v8` (fix reverted), the bare-require tests fail:

```
FAILED tests/test_lua_import_resolution.py::test_bare_require_statement_emits_import_edge
FAILED tests/test_lua_import_resolution.py::test_multiple_bare_requires_each_emit_an_edge
2 failed, 1 passed
```

**GREEN** — with the fix:

```
tests/test_lua_import_resolution.py ....                                 [100%]
4 passed in 0.29s
```

The `test_similarly_named_call_does_not_emit_import` and `test_assigned_require_still_emits_exactly_one_edge` cases lock in the no-false-positive and no-duplicate guarantees.

Fixes #3320
