### PR TITLE
Fix Python nested function call resolution

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2161,6 +2161,75 @@ def _scan_js_nested_function_declarations(
             )
 
 
+def _scan_python_nested_function_declarations(
+    container_node, parent_nid: str, *, source: bytes, config,
+    add_node, add_edge, callable_def_nids: set | None,
+    local_bound_names: dict | None, function_bodies: list,
+    scope_parents: dict[str, str] | None = None,
+    lexical_nids_by_scope: dict[str, dict[str, str]] | None = None,
+) -> None:
+    """Emit a node + `contains` edge for every function lexically nested inside
+    *container_node*, scoped under *parent_nid*, track its body, and record lexical
+    scope hierarchy so calls resolve to local definitions instead of falling through
+    to corpus-wide resolution (#3405).
+
+    Recurses through Python statements (including blocks, if/while/for/try/with),
+    unwrapping `decorated_definition` when it wraps a `function_definition`.
+    """
+    if container_node is None:
+        return
+    for child in container_node.children:
+        target = child
+        if target.type == "decorated_definition":
+            inner = target.child_by_field_name("definition")
+            if inner is not None:
+                target = inner
+        if target.type == "function_definition":
+            name_node = target.child_by_field_name(config.name_field)
+            if name_node is None:
+                for c in target.children:
+                    if c.type in config.name_fallback_child_types:
+                        name_node = c
+                        break
+            func_name = _read_text(name_node, source) if name_node else None
+            if func_name and normalize_id(func_name):
+                line = target.start_point[0] + 1
+                nested_nid = _make_id(parent_nid, func_name)
+                add_node(nested_nid, f"{func_name}()", line)
+                add_edge(parent_nid, nested_nid, "contains", line)
+                if callable_def_nids is not None:
+                    callable_def_nids.add(nested_nid)
+                if local_bound_names is not None:
+                    local_bound_names[nested_nid] = _python_local_bound_names(target, source)
+                if scope_parents is not None:
+                    scope_parents[nested_nid] = parent_nid
+                if lexical_nids_by_scope is not None:
+                    lexical_nids_by_scope.setdefault(parent_nid, {})[func_name] = nested_nid
+                    lexical_nids_by_scope.setdefault(nested_nid, {})[func_name] = nested_nid
+                nested_body = _find_body(target, config)
+                if nested_body:
+                    function_bodies.append((nested_nid, nested_body))
+                    _scan_python_nested_function_declarations(
+                        nested_body, nested_nid, source=source, config=config,
+                        add_node=add_node, add_edge=add_edge,
+                        callable_def_nids=callable_def_nids,
+                        local_bound_names=local_bound_names,
+                        function_bodies=function_bodies,
+                        scope_parents=scope_parents,
+                        lexical_nids_by_scope=lexical_nids_by_scope,
+                    )
+        else:
+            _scan_python_nested_function_declarations(
+                child, parent_nid, source=source, config=config,
+                add_node=add_node, add_edge=add_edge,
+                callable_def_nids=callable_def_nids,
+                local_bound_names=local_bound_names,
+                function_bodies=function_bodies,
+                scope_parents=scope_parents,
+                lexical_nids_by_scope=lexical_nids_by_scope,
+            )
+
+
 def _js_topmost_closures(node, out: list) -> None:
     """Collect the TOPMOST closure nodes (arrow / function expressions) under
     ``node``, without descending into a found closure — its nested closures
@@ -3031,6 +3100,10 @@ def _extract_generic(
     # guard skips any call-argument identifier in the enclosing function's set,
     # so a param/local that shadows a module function name yields no edge.
     local_bound_names: dict[str, set[str]] = {}
+    # Python nested-function lexical scope tracking (#3405): maps child_nid -> parent_scope_nid
+    scope_parents: dict[str, str] = {}
+    # maps scope_nid -> {bare_func_name -> nested_func_nid}
+    lexical_nids_by_scope: dict[str, dict[str, str]] = {}
     # JS/TS only (#2568): per-BODY locals for sibling closures tracked under a
     # single const nid by the #2552 branch (`const h = wrapper(cb1, cb2)`).
     # Keyed by id(body) — like receiver_types_by_body — and fed to the per-body
@@ -4733,6 +4806,16 @@ def _extract_generic(
                         local_bound_names=local_bound_names,
                         function_bodies=function_bodies,
                     )
+                if config.ts_module == "tree_sitter_python":
+                    _scan_python_nested_function_declarations(
+                        body, func_nid, source=source, config=config,
+                        add_node=add_node, add_edge=add_edge,
+                        callable_def_nids=callable_def_nids,
+                        local_bound_names=local_bound_names,
+                        function_bodies=function_bodies,
+                        scope_parents=scope_parents,
+                        lexical_nids_by_scope=lexical_nids_by_scope,
+                    )
                 if config.ts_module == "tree_sitter_kotlin":
                     # #2347: Kotlin anonymous objects (`object : Foo { … }`,
                     # node type `object_literal`). The function branch never
@@ -4967,8 +5050,14 @@ def _extract_generic(
             continue
         raw = n["label"]
         normalised = raw.strip("()").lstrip(".")
-        label_to_nid[normalised] = n["id"]
-        label_to_nid_ci[normalised.lower()] = n["id"]
+        # For languages with lexical nesting (Python), nested functions should not overwrite
+        # module-level definitions in the module/file-level label_to_nid map (#3405).
+        if n["id"] not in scope_parents:
+            label_to_nid[normalised] = n["id"]
+            label_to_nid_ci[normalised.lower()] = n["id"]
+        else:
+            label_to_nid.setdefault(normalised, n["id"])
+            label_to_nid_ci.setdefault(normalised.lower(), n["id"])
 
     seen_call_pairs: set[tuple[str, str]] = set()
     seen_indirect_pairs: set[tuple[str, str]] = set()  # Python indirect_call dedup
@@ -5662,7 +5751,18 @@ def _extract_generic(
                 ):
                     tgt_nid = None
                 else:
-                    tgt_nid = label_to_nid.get(callee_name)
+                    if config.ts_module == "tree_sitter_python" and not is_member_call:
+                        curr_scope = caller_nid
+                        tgt_nid = None
+                        while curr_scope:
+                            if curr_scope in lexical_nids_by_scope and callee_name in lexical_nids_by_scope[curr_scope]:
+                                tgt_nid = lexical_nids_by_scope[curr_scope][callee_name]
+                                break
+                            curr_scope = scope_parents.get(curr_scope)
+                        if not tgt_nid:
+                            tgt_nid = label_to_nid.get(callee_name)
+                    else:
+                        tgt_nid = label_to_nid.get(callee_name)
                     # A qualified `new A.B.Foo()` whose bare name matches only a
                     # sourceless stub in this file would bind the call to the stub
                     # and never reach _resolve_csharp_qualified_calls, the one pass
@@ -5673,7 +5773,7 @@ def _extract_generic(
                         and not nid_to_sf.get(tgt_nid)
                     ):
                         tgt_nid = None
-                if tgt_nid and tgt_nid != caller_nid:
+                if tgt_nid:
                     pair = (caller_nid, tgt_nid)
                     if pair not in seen_call_pairs:
                         seen_call_pairs.add(pair)
@@ -5689,53 +5789,61 @@ def _extract_generic(
                             "weight": 1.0,
                         })
                 elif callee_name and not tgt_nid:
-                    # Callee not in this file — save for cross-file resolution in extract()
-                    rc_entry = {
-                        "caller_nid": caller_nid,
-                        "callee": callee_name,
-                        "is_member_call": is_member_call,
-                        "source_file": str_path,
-                        "source_location": f"L{node.start_point[0] + 1}",
-                        "receiver": swift_receiver or member_receiver,
-                    }
-                    # Ruby: attach the receiver's inferred type from the method's
-                    # local `var = Const.new` bindings, when unambiguously known.
-                    if member_receiver and config.ts_module == "tree_sitter_ruby":
-                        rc_entry["receiver_type"] = ruby_var_types.get(
-                            caller_nid, {}
-                        ).get(member_receiver)
-                    # Tag the C++ raw_call's language so the cross-file C++ resolver
-                    # claims it unambiguously: a `.h` file routes to extract_cpp or
-                    # extract_objc by content, and both resolvers see `.h` in their
-                    # suffix sets, so a source_file suffix alone can't separate them.
-                    if config.ts_module == "tree_sitter_cpp":
-                        rc_entry["lang"] = "cpp"
-                    # C#: tag the raw_call so _resolve_csharp_member_calls claims
-                    # it, and stamp the receiver's type from the method's SCOPED
-                    # bindings by the call's byte offset (#1609, per-method since
-                    # #2299, position-aware since #2472). `this.field.M()` is
-                    # covered too: member_receiver is the bare field name, and
-                    # class fields/properties are the base scope.
-                    if config.ts_module == "tree_sitter_c_sharp":
-                        rc_entry["lang"] = "csharp"
-                        if csharp_qualified_prefix:
-                            rc_entry["qualified_prefix"] = csharp_qualified_prefix
-                        receiver_type = _csharp_scoped_receiver_type(
-                            receiver_types, member_receiver, node.start_byte
-                        )
-                        if receiver_type:
-                            rc_entry["receiver_type"] = receiver_type
-                    if config.ts_module == "tree_sitter_java":
-                        rc_entry["lang"] = "java"
-                        receiver_type = (receiver_types or {}).get(member_receiver or "")
-                        if receiver_type:
-                            rc_entry["receiver_type"] = receiver_type
-                    # Kotlin fully-qualified call (#2550): the dotted prefix +
-                    # lang tag let _resolve_kotlin_qualified_calls claim it.
-                    if kotlin_qualified_prefix:
-                        rc_entry["lang"] = "kotlin"
-                        rc_entry["qualified_prefix"] = kotlin_qualified_prefix
-                    raw_calls.append(rc_entry)
+                    # In Python, if an unqualified call names a local non-callable variable or parameter,
+                    # do NOT append it to raw_calls (#3405 Part 3/4).
+                    is_py_local_data = (
+                        config.ts_module == "tree_sitter_python"
+                        and not is_member_call
+                        and callee_name in (local_bound_names.get(caller_nid, frozenset()) | extra_locals)
+                    )
+                    if not is_py_local_data:
+                        # Callee not in this file — save for cross-file resolution in extract()
+                        rc_entry = {
+                            "caller_nid": caller_nid,
+                            "callee": callee_name,
+                            "is_member_call": is_member_call,
+                            "source_file": str_path,
+                            "source_location": f"L{node.start_point[0] + 1}",
+                            "receiver": swift_receiver or member_receiver,
+                        }
+                        # Ruby: attach the receiver's inferred type from the method's
+                        # local `var = Const.new` bindings, when unambiguously known.
+                        if member_receiver and config.ts_module == "tree_sitter_ruby":
+                            rc_entry["receiver_type"] = ruby_var_types.get(
+                                caller_nid, {}
+                            ).get(member_receiver)
+                        # Tag the C++ raw_call's language so the cross-file C++ resolver
+                        # claims it unambiguously: a `.h` file routes to extract_cpp or
+                        # extract_objc by content, and both resolvers see `.h` in their
+                        # suffix sets, so a source_file suffix alone can't separate them.
+                        if config.ts_module == "tree_sitter_cpp":
+                            rc_entry["lang"] = "cpp"
+                        # C#: tag the raw_call so _resolve_csharp_member_calls claims
+                        # it, and stamp the receiver's type from the method's SCOPED
+                        # bindings by the call's byte offset (#1609, per-method since
+                        # #2299, position-aware since #2472). `this.field.M()` is
+                        # covered too: member_receiver is the bare field name, and
+                        # class fields/properties are the base scope.
+                        if config.ts_module == "tree_sitter_c_sharp":
+                            rc_entry["lang"] = "csharp"
+                            if csharp_qualified_prefix:
+                                rc_entry["qualified_prefix"] = csharp_qualified_prefix
+                            receiver_type = _csharp_scoped_receiver_type(
+                                receiver_types, member_receiver, node.start_byte
+                            )
+                            if receiver_type:
+                                rc_entry["receiver_type"] = receiver_type
+                        if config.ts_module == "tree_sitter_java":
+                            rc_entry["lang"] = "java"
+                            receiver_type = (receiver_types or {}).get(member_receiver or "")
+                            if receiver_type:
+                                rc_entry["receiver_type"] = receiver_type
+                        # Kotlin fully-qualified call (#2550): the dotted prefix +
+                        # lang tag let _resolve_kotlin_qualified_calls claim it.
+                        if kotlin_qualified_prefix:
+                            rc_entry["lang"] = "kotlin"
+                            rc_entry["qualified_prefix"] = kotlin_qualified_prefix
+                        raw_calls.append(rc_entry)
 
             # Indirect dispatch: a function passed BY NAME as a call argument
             # (executor.submit(fn), Thread(target=fn), map(fn, xs)) is a real dependency

--- a/tests/test_issue_3405_python_resolution.py
+++ b/tests/test_issue_3405_python_resolution.py
@@ -1,0 +1,289 @@
+"""Tests for issue #3405: Python nested-function extraction + lexical-scope-aware local call resolution."""
+import pytest
+from pathlib import Path
+
+from graphify.extract import extract
+
+
+def test_python_nested_function_node_and_contains(tmp_path: Path):
+    """Test 1 — Nested node + contains
+
+    def outer():
+        def inner():
+            pass
+    """
+    f = tmp_path / "test_nested.py"
+    f.write_text(
+        "def outer():\n"
+        "    def inner():\n"
+        "        pass\n"
+    )
+    result = extract([f], root=tmp_path)
+    by_label = {n["label"]: n for n in result["nodes"]}
+
+    assert "outer()" in by_label
+    assert "inner()" in by_label
+
+    outer_id = by_label["outer()"]["id"]
+    inner_id = by_label["inner()"]["id"]
+
+    assert inner_id == f"{outer_id}_inner"
+    assert by_label["inner()"].get("type") in (None, "function")
+
+    edges = [(e["source"], e["target"], e["relation"]) for e in result["edges"]]
+    assert (outer_id, inner_id, "contains") in edges
+
+
+def test_python_outer_calls_nested_function(tmp_path: Path):
+    """Test 2 — Outer calls nested function
+
+    def outer():
+        def inner():
+            pass
+        inner()
+    """
+    f = tmp_path / "test_call.py"
+    f.write_text(
+        "def outer():\n"
+        "    def inner():\n"
+        "        pass\n"
+        "    inner()\n"
+    )
+    result = extract([f], root=tmp_path)
+    by_label = {n["label"]: n for n in result["nodes"]}
+
+    outer_id = by_label["outer()"]["id"]
+    inner_id = by_label["inner()"]["id"]
+
+    call_edges = [
+        e for e in result["edges"]
+        if e["source"] == outer_id and e["target"] == inner_id and e["relation"] == "calls"
+    ]
+    assert len(call_edges) == 1
+    edge = call_edges[0]
+    assert edge["confidence"] == "EXTRACTED"
+    assert edge["weight"] == 1.0
+
+    # Ensure this call does not fall through to raw_calls (unresolved cross-file)
+    raw_calls = result.get("raw_calls", [])
+    for rc in raw_calls:
+        assert rc.get("callee") != "inner"
+
+
+def test_python_nested_function_shadows_module_function(tmp_path: Path):
+    """Test 3 — Nested function shadows module function
+
+    def walk():
+        pass
+
+    def trace():
+        def walk():
+            pass
+        walk()
+    """
+    f = tmp_path / "test_shadow.py"
+    f.write_text(
+        "def walk():\n"
+        "    pass\n"
+        "\n"
+        "def trace():\n"
+        "    def walk():\n"
+        "        pass\n"
+        "    walk()\n"
+    )
+    result = extract([f], root=tmp_path)
+    trace_nodes = [n for n in result["nodes"] if n["label"] == "trace()"]
+    assert len(trace_nodes) == 1
+    trace_id = trace_nodes[0]["id"]
+
+    # Locate the nested walk vs module walk
+    walk_nodes = [n for n in result["nodes"] if n["label"] == "walk()"]
+    assert len(walk_nodes) == 2
+
+    nested_walk = next(n for n in walk_nodes if n["id"].startswith(trace_id))
+    module_walk = next(n for n in walk_nodes if not n["id"].startswith(trace_id))
+
+    calls = [
+        (e["source"], e["target"], e["relation"], e["confidence"], e["weight"])
+        for e in result["edges"]
+        if e["relation"] == "calls"
+    ]
+
+    # trace must call nested_walk, NOT module_walk!
+    assert (trace_id, nested_walk["id"], "calls", "EXTRACTED", 1.0) in calls
+    assert (trace_id, module_walk["id"], "calls", "EXTRACTED", 1.0) not in calls
+
+    # Ensure no raw_calls for walk
+    raw_calls = result.get("raw_calls", [])
+    for rc in raw_calls:
+        if rc.get("caller_nid") == trace_id:
+            assert rc.get("callee") != "walk"
+
+
+def test_python_nested_sibling_call(tmp_path: Path):
+    """Test 4 — Nested sibling call
+
+    def outer():
+        def helper():
+            pass
+        def worker():
+            helper()
+        worker()
+    """
+    f = tmp_path / "test_sibling.py"
+    f.write_text(
+        "def outer():\n"
+        "    def helper():\n"
+        "        pass\n"
+        "    def worker():\n"
+        "        helper()\n"
+        "    worker()\n"
+    )
+    result = extract([f], root=tmp_path)
+    by_label = {n["label"]: n for n in result["nodes"]}
+
+    outer_id = by_label["outer()"]["id"]
+    helper_id = by_label["helper()"]["id"]
+    worker_id = by_label["worker()"]["id"]
+
+    calls = [
+        (e["source"], e["target"], e["relation"], e["confidence"], e["weight"])
+        for e in result["edges"]
+        if e["relation"] == "calls"
+    ]
+
+    assert (worker_id, helper_id, "calls", "EXTRACTED", 1.0) in calls
+    assert (outer_id, worker_id, "calls", "EXTRACTED", 1.0) in calls
+
+
+def test_python_nested_recursion(tmp_path: Path):
+    """Test 5 — Nested recursion
+
+    def outer():
+        def walk(n):
+            if n:
+                walk(n - 1)
+        walk(10)
+    """
+    f = tmp_path / "test_recursion.py"
+    f.write_text(
+        "def outer():\n"
+        "    def walk(n):\n"
+        "        if n:\n"
+        "            walk(n - 1)\n"
+        "    walk(10)\n"
+    )
+    result = extract([f], root=tmp_path)
+    by_label = {n["label"]: n for n in result["nodes"]}
+
+    outer_id = by_label["outer()"]["id"]
+    walk_id = by_label["walk()"]["id"]
+
+    calls = [
+        (e["source"], e["target"], e["relation"], e["confidence"], e["weight"])
+        for e in result["edges"]
+        if e["relation"] == "calls"
+    ]
+
+    assert (walk_id, walk_id, "calls", "EXTRACTED", 1.0) in calls
+    assert (outer_id, walk_id, "calls", "EXTRACTED", 1.0) in calls
+
+
+def test_python_async_nested_function(tmp_path: Path):
+    """Test 6 — Async nested function
+
+    async def outer():
+        async def fetch():
+            pass
+        await fetch()
+    """
+    f = tmp_path / "test_async.py"
+    f.write_text(
+        "async def outer():\n"
+        "    async def fetch():\n"
+        "        pass\n"
+        "    await fetch()\n"
+    )
+    result = extract([f], root=tmp_path)
+    by_label = {n["label"]: n for n in result["nodes"]}
+
+    assert "fetch()" in by_label
+    outer_id = by_label["outer()"]["id"]
+    fetch_id = by_label["fetch()"]["id"]
+
+    edges = [(e["source"], e["target"], e["relation"]) for e in result["edges"]]
+    assert (outer_id, fetch_id, "contains") in edges
+
+    calls = [
+        (e["source"], e["target"], e["relation"], e["confidence"], e["weight"])
+        for e in result["edges"]
+        if e["relation"] == "calls"
+    ]
+    assert (outer_id, fetch_id, "calls", "EXTRACTED", 1.0) in calls
+
+
+def test_python_deep_nesting(tmp_path: Path):
+    """Test 7 — Deep nesting
+
+    def outer():
+        def middle():
+            def inner():
+                pass
+            inner()
+        middle()
+    """
+    f = tmp_path / "test_deep.py"
+    f.write_text(
+        "def outer():\n"
+        "    def middle():\n"
+        "        def inner():\n"
+        "            pass\n"
+        "        inner()\n"
+        "    middle()\n"
+    )
+    result = extract([f], root=tmp_path)
+    by_label = {n["label"]: n for n in result["nodes"]}
+
+    outer_id = by_label["outer()"]["id"]
+    middle_id = by_label["middle()"]["id"]
+    inner_id = by_label["inner()"]["id"]
+
+    assert middle_id == f"{outer_id}_middle"
+    assert inner_id == f"{middle_id}_inner"
+
+    edges = [(e["source"], e["target"], e["relation"]) for e in result["edges"]]
+    assert (outer_id, middle_id, "contains") in edges
+    assert (middle_id, inner_id, "contains") in edges
+
+    calls = [
+        (e["source"], e["target"], e["relation"], e["confidence"], e["weight"])
+        for e in result["edges"]
+        if e["relation"] == "calls"
+    ]
+    assert (middle_id, inner_id, "calls", "EXTRACTED", 1.0) in calls
+    assert (outer_id, middle_id, "calls", "EXTRACTED", 1.0) in calls
+
+
+def test_python_local_non_callable_suppression(tmp_path: Path):
+    """Test 8 — Local non-callable binding does not become cross-file raw_call
+
+    def outer():
+        f = 123
+        f()
+    """
+    f = tmp_path / "test_local_data.py"
+    f.write_text(
+        "def outer():\n"
+        "    f = 123\n"
+        "    f()\n"
+    )
+    result = extract([f], root=tmp_path)
+    by_label = {n["label"]: n for n in result["nodes"]}
+    outer_id = by_label["outer()"]["id"]
+
+    # f is a local int variable, not a known callable.
+    # It must NOT be added to raw_calls!
+    raw_calls = result.get("raw_calls", [])
+    for rc in raw_calls:
+        if rc.get("caller_nid") == outer_id:
+            assert rc.get("callee") != "f"


### PR DESCRIPTION
## Summary

Fixes Python nested-function extraction and lexical call resolution for issue #3405.

### Changes

- Extract nested Python functions as proper Graphify function nodes.
- Add `contains` edges between parent and nested functions.
- Resolve unqualified calls using lexical scope.
- Correctly handle nested-function shadowing of module-level functions.
- Support nested sibling calls, recursion, async nested functions, and deeper nesting.
- Prevent local non-callable variables from being incorrectly emitted as unresolved calls.

### Tests

Added coverage for:

- Nested function extraction and node IDs
- Parent → nested `contains` relationships
- Outer → nested function calls
- Lexical shadowing
- Nested sibling calls
- Recursive nested functions
- Async nested functions
- Deeply nested functions
- Local non-callable suppression

Existing Python, confidence-rubric, and JavaScript nested-function tests also pass.

Issue: #3405