### PR TITLE
fix(bash): resolve exec-position script paths built from a variable

### DIFF
--- a/graphify/extractors/bash.py
+++ b/graphify/extractors/bash.py
@@ -473,10 +473,25 @@ def extract_bash(path: Path) -> dict:
                                 if tgt_nid:
                                     add_edge(file_nid, tgt_nid, "imports", line,
                                              context="import")
-                elif cmd and cmd not in defined_functions:
-                    raw = cmd if cmd.endswith(".sh") else None
-                    if cmd in _BASH_SCRIPT_RUNNERS and args:
+                elif cmd not in defined_functions:
+                    raw = cmd if (cmd and cmd.endswith(".sh")) else None
+                    if cmd and cmd in _BASH_SCRIPT_RUNNERS and args:
                         raw = literal(args[0])
+                    if raw is None:
+                        # The command name is itself an expansion, e.g.
+                        # `"$script_dir/x.sh" --flag`. `literal()` rejects any
+                        # candidate containing "$", so `cmd` is None and neither
+                        # of the two branches above can see the path. Read the
+                        # node's raw text the way the `source` branch does and
+                        # strip the leading ${VAR}/ segments -- the same
+                        # script-dir assumption already used for `source
+                        # "$DIR/lib/x.sh"` (#2079). `_bash_source_suffix`
+                        # rejects a remainder that still holds an expansion or
+                        # a `..` segment, and the `resolved.is_file()` gate
+                        # below means a wrong script-dir guess emits nothing.
+                        cand = _read_text(cmd_name_node, source).strip().strip("'\"")
+                        if cand.endswith(".sh") and "$" in cand:
+                            raw = _bash_source_suffix(cand) or None
                     if raw and raw.endswith(".sh"):
                         resolved = (path.parent / raw).resolve()
                         if resolved.is_file():

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2614,6 +2614,110 @@ def test_extract_bash_attributes_script_invocation_to_function(tmp_path):
     assert invocation["source"] == deploy["id"]
 
 
+@pytest.mark.parametrize("invocation", [
+    '"$script_dir/helpers.sh"',
+    '"${script_dir}/helpers.sh"',
+    '"$script_dir/helpers.sh" --flag value',
+    '$script_dir/helpers.sh',
+])
+def test_extract_bash_script_invocation_via_variable_built_path(tmp_path, invocation):
+    helpers = tmp_path / "helpers.sh"
+    helpers.write_text("#!/bin/bash\necho helper\n", encoding="utf-8")
+    script = tmp_path / "deploy.sh"
+    script.write_text(
+        "#!/bin/bash\n"
+        'script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+        f"{invocation}\n",
+        encoding="utf-8",
+    )
+
+    result = extract_bash(script)
+    invocations = [
+        edge for edge in result["edges"]
+        if edge.get("relation") == "calls" and edge.get("context") == "script_invocation"
+    ]
+
+    assert invocations == [{
+        "source": _make_id(str(script)) + "__entry",
+        "target": _make_id(str(helpers.resolve())) + "__entry",
+        "relation": "calls",
+        "confidence": "EXTRACTED",
+        "source_file": str(script),
+        "source_location": "L3",
+        "weight": 1.0,
+        "context": "script_invocation",
+        # Transient canonicalization hint (#2243); popped before persist.
+        "target_file": str(helpers.resolve()),
+    }]
+
+
+def test_extract_bash_variable_built_invocation_with_dynamic_stem_emits_no_edge(tmp_path):
+    helpers = tmp_path / "helpers.sh"
+    helpers.write_text("#!/bin/bash\necho helper\n", encoding="utf-8")
+    script = tmp_path / "deploy.sh"
+    script.write_text(
+        "#!/bin/bash\n"
+        'script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+        '"$script_dir/$name.sh"\n',
+        encoding="utf-8",
+    )
+
+    result = extract_bash(script)
+
+    assert not any(edge.get("context") == "script_invocation" for edge in result["edges"])
+
+
+def test_extract_bash_variable_built_invocation_no_on_disk_match_emits_no_edge(tmp_path):
+    script = tmp_path / "deploy.sh"
+    script.write_text(
+        "#!/bin/bash\n"
+        'script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+        '"$script_dir/missing.sh"\n',
+        encoding="utf-8",
+    )
+
+    result = extract_bash(script)
+
+    assert not any(edge.get("context") == "script_invocation" for edge in result["edges"])
+
+
+def test_extract_bash_variable_built_invocation_targets_existing_entrypoint(tmp_path):
+    helpers = tmp_path / "helpers.sh"
+    helpers.write_text("#!/bin/bash\necho helper\n", encoding="utf-8")
+    script = tmp_path / "deploy.sh"
+    script.write_text(
+        "#!/bin/bash\n"
+        'script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+        '"$script_dir/helpers.sh"\n',
+        encoding="utf-8",
+    )
+
+    result = extract([script, helpers], cache_root=tmp_path, parallel=False)
+    node_ids = {node["id"] for node in result["nodes"]}
+    invocation = next(edge for edge in result["edges"] if edge.get("context") == "script_invocation")
+
+    assert invocation["source"] in node_ids
+    assert invocation["target"] in node_ids
+
+
+def test_extract_bash_attributes_variable_built_invocation_to_function(tmp_path):
+    helpers = tmp_path / "helpers.sh"
+    helpers.write_text("#!/bin/bash\necho helper\n", encoding="utf-8")
+    script = tmp_path / "deploy.sh"
+    script.write_text(
+        "#!/bin/bash\n"
+        'script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+        'deploy() { "$script_dir/helpers.sh"; }\n',
+        encoding="utf-8",
+    )
+
+    result = extract_bash(script)
+    deploy = next(node for node in result["nodes"] if node["label"] == "deploy()")
+    invocation = next(edge for edge in result["edges"] if edge.get("context") == "script_invocation")
+
+    assert invocation["source"] == deploy["id"]
+
+
 def test_extract_bash_no_self_loops():
     result = extract_bash(FIXTURES / "sample.sh")
     for e in result["edges"]:


### PR DESCRIPTION
Fixes #3416.

## The problem

`script_invocation` edges (#1756) resolve a path only when it is a bare literal — `./helpers.sh`, or `bash ./helpers.sh`. Both routes into that branch go through `literal()`, which rejects by design any token containing `$`. So the most common way one shell script calls a sibling never produces an edge:

```bash
script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
"$script_dir/helpers.sh" --flag
```

`literal(cmd_name_node)` returns `None`, the `elif cmd and cmd not in defined_functions` guard short-circuits on the `None`, and the branch that would have resolved the path never runs.

On a 206-file shell tree that uses the `script_dir` idiom throughout, `script_invocation` emitted **zero** edges. For that whole style of codebase the feature is effectively dead — and it's a common style, because it's the idiom that makes a script runnable from any working directory.

## The fix

The `source` branch already solved exactly this problem for `source "$DIR/lib/x.sh"` in #2079: strip the leading `${VAR}/` segments with `_bash_source_suffix` and resolve the literal remainder against the sourcing file's own directory, on the grounds that the canonical `script_dir` idiom makes that variable equal to precisely that directory.

This applies the identical treatment to the exec position — read the command-name node's raw text instead of its `literal()`, strip the same way, and fall through to the `resolved.is_file()` gate that was already there.

15 lines, one file, no new helpers, no new dependency, no change to any existing edge.

## Nothing new is fabricated

Every existing guard still applies, and the reuse of `_bash_source_suffix` brings its guards along:

- a remainder that still holds an expansion (`"$dir/$name.sh"`) returns `None` — no edge
- a `..` segment returns `None` (`allow_dotdot=False`, the script-dir-guess default) — no traversal outside the tree
- `resolved.is_file()` still gates emission, so a wrong `script_dir` guess emits nothing rather than a dangling edge

The three existing negative tests pass unchanged: `test_extract_bash_skips_missing_and_shadowed_script_invocations`, `test_extract_bash_skips_dynamic_script_invocation`, and `test_extract_bash_source_via_variable_path_no_match_emits_no_dead_edge`.

The known limitation is inherited, not introduced: the heuristic assumes the leading variable is the script's own directory. When it isn't, an edge appears only if a same-named file happens to sit beside the caller. That is the same assumption #2079 already ships for `source`.

## Tests

Five new tests in `tests/test_extract.py`, placed with and modelled on the existing `script_invocation` block:

| test | asserts |
|---|---|
| `test_extract_bash_script_invocation_via_variable_built_path` | parametrised over `"$script_dir/helpers.sh"`, `"${script_dir}/helpers.sh"`, the same with arguments, and unquoted — full edge dict equality, same shape as `test_extract_bash_emits_script_invocation_calls` |
| `test_extract_bash_variable_built_invocation_with_dynamic_stem_emits_no_edge` | `"$script_dir/$name.sh"` → no edge |
| `test_extract_bash_variable_built_invocation_no_on_disk_match_emits_no_edge` | target absent → no edge |
| `test_extract_bash_variable_built_invocation_targets_existing_entrypoint` | through `extract()`: both endpoints are real nodes, not dangling ids |
| `test_extract_bash_attributes_variable_built_invocation_to_function` | invocation inside a function body is attributed to that function, not the file entrypoint |

All six positive assertions fail on `v8` as it stands and pass with this change; the two negatives pass either way, which is the point.

## Verification

- `pytest tests/test_extract.py -k bash` — 57 passed (was 49; +8 new cases)
- `pytest tests/test_extract.py` — 222 passed, 4 skipped
- full `pytest tests` — 5098 passed, 255 skipped, 25 failed; the identical 25 fail on unmodified `v8` in this environment (terraform, ollama, skillgen — all unrelated to this change), so **no regressions**
- real corpus, 206 shell files: **0 → 16** `script_invocation` edges across 10 distinct file pairs. All 16 hand-checked back to a genuine exec-position invocation of a file that exists. No false positives.

One of the 16 is worth calling out because it looks like it should be wrong and isn't: a test harness does `cp "$repo_root/tests/run_smokes.sh" "$failure_dir/run_smokes.sh"` and then invokes `"$failure_dir/run_smokes.sh"`. `$failure_dir` is a temp directory, not the script's own directory — but the file it runs is a copy of the very sibling the heuristic resolved to, so the structural answer is right for the right reason.
