### PR TITLE
fix(llm): repair near-valid JSON replies before dropping the chunk

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -1119,6 +1119,96 @@ def _json_fragment_candidates(text: str) -> "Iterator[str]":
             yield blob
 
 
+# --- Repair pass for near-valid replies -------------------------------------
+# One stray token in an otherwise clean reply currently loses the whole chunk.
+# Measured with a local gemma4:26b extractor: a 15 KB response carrying one
+# bare string where an object member belonged (`{"x", "id": ...`) fell through
+# every candidate above to a single inner node object and scored zero, with
+# 35 nodes recoverable. This runs ONLY after the strict parse and the
+# candidate ladder have both failed to find a fragment with content, so any
+# reply that parses today is untouched. Two stages:
+#   1. drop a bare string token sitting where an object member belongs and
+#      retry the strict parse over the same fence/brace ladder -- the exact
+#      defect measured, recovered losslessly;
+#   2. json_repair over the pruned text, then the raw text, each also through
+#      the candidate ladder -- the general net. Optional: without the package
+#      stage 1 still runs.
+# A stage counts only if it yields a dict carrying a fragment key with at least
+# one node/edge/hyperedge after sanitising. Truncated replies (finish_reason
+# == "length") are still bisected by the caller, so repairing them changes
+# nothing there. Recovery is logged to stderr so a run that leans on repair is
+# visible in the extraction log.
+try:
+    import json_repair as _json_repair
+except ImportError:  # pragma: no cover - optional dependency
+    _json_repair = None
+
+_STRAY_MEMBER_RE = re.compile(r'([{,])\s*"[^"\\]*"\s*,(?=\s*"[^"\\]*"\s*:)')
+
+
+def _item_has_substance(kind: str, item) -> bool:
+    """True for a node with an id, an edge with both ends, a hyperedge with members.
+
+    json_repair closes whatever it is handed, so a half-generated reply such as
+    `{"nodes": [{"id":` comes back as `{"nodes": [{"id": ""}]}` -- a fragment
+    that is not empty but carries nothing. Counting it as recovered would turn a
+    hollow response into one phantom node, so only well-formed items count.
+    """
+    if not isinstance(item, dict):
+        return False
+    if kind == "nodes":
+        return bool(item.get("id"))
+    if kind == "edges":
+        return bool(item.get("source")) and bool(item.get("target"))
+    return any(item.get(k) for k in ("members", "node_ids"))
+
+
+def _fragment_with_content(parsed) -> dict | None:
+    """Sanitised fragment if `parsed` carries a fragment key with real content, else None."""
+    if not isinstance(parsed, dict) or not any(k in parsed for k in _FRAGMENT_KEYS):
+        return None
+    cand = _sanitize_fragment(parsed)
+    if any(_item_has_substance(k, it) for k in _FRAGMENT_KEYS for it in (cand.get(k) or [])):
+        return cand
+    return None
+
+
+def _repair_llm_json(text: str) -> dict | None:
+    """Recover a fragment from a reply that strict parsing and candidate scanning both rejected."""
+    result: dict | None = None
+    stage = ""
+    pruned, n = _STRAY_MEMBER_RE.subn(r"\1", text)
+    if n:
+        # Same fence/brace ladder strict parsing uses, run over the pruned text.
+        for candidate in (pruned, *_json_fragment_candidates(pruned)):
+            try:
+                result = _fragment_with_content(json.loads(candidate))
+            except json.JSONDecodeError:
+                continue
+            if result is not None:
+                stage = f"stray-member prune ({n} token{'s' if n != 1 else ''})"
+                break
+    if result is None and _json_repair is not None:
+        # Pruned text first: json_repair on the raw stray token swallows a node id.
+        for candidate in (pruned, *_json_fragment_candidates(pruned), text, *_json_fragment_candidates(text)):
+            try:
+                repaired = _json_repair.loads(candidate)
+            except Exception:  # noqa: BLE001 - repair is best-effort
+                continue
+            result = _fragment_with_content(repaired)
+            if result is not None:
+                stage = "json_repair"
+                break
+    if result is None:
+        return None
+    print(
+        f"[graphify] LLM JSON repaired via {stage}: "
+        f"{len(result.get('nodes', []))} nodes / {len(result.get('edges', []))} edges recovered",
+        file=sys.stderr,
+    )
+    return result
+
+
 def _parse_llm_json(raw: str) -> dict:
     """Strip optional markdown fences and parse JSON. Returns empty fragment on failure.
 
@@ -1182,6 +1272,12 @@ def _parse_llm_json(raw: str) -> dict:
                 empty_fragment = cand
         elif fallback is None:
             fallback = parsed
+
+    # Repair before settling for a weaker tier; see _repair_llm_json above.
+    # Only reached when nothing above carried content.
+    repaired = _repair_llm_json(stripped)
+    if repaired is not None:
+        return repaired
 
     # A genuinely empty extraction is still a valid answer, and still reads as
     # hollow downstream, so it outranks an object that is not a fragment at all.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "networkx>=3.4",
     "numpy>=1.21",
     "rapidfuzz>=3.0",
+    "json-repair>=0.30",
     "tomli>=2.0.1; python_version < '3.11'",
     "tree-sitter>=0.23.0,<0.26",
     "tree-sitter-python>=0.23,<0.26",

--- a/tests/test_llm_parser.py
+++ b/tests/test_llm_parser.py
@@ -153,3 +153,68 @@ def test_no_model_flag_when_env_var_unset(mock_run, _which, monkeypatch):
     llm._call_claude_cli("payload")
     argv = mock_run.call_args.args[0]
     assert "--model" not in argv
+
+
+# ---------- _parse_llm_json: repair pass for near-valid replies ----------
+
+
+def test_stray_member_token_is_pruned_and_fragment_recovered(monkeypatch, capsys):
+    """A single bare string sitting where an object member belongs
+    (`{"stray", "id": ...`) makes every candidate in the ladder fail
+    strict parsing; the brace scanner then settles on the first inner
+    object that happens to parse and the fragment scores zero. Stage 1
+    of the repair pass drops the stray token and re-runs the same
+    ladder, so the whole chunk comes back with its ids intact. It must
+    not depend on the optional json_repair package."""
+    monkeypatch.setattr(llm, "_json_repair", None)
+    raw = (
+        "```json\n"
+        '{"nodes": [{"stray", "id": "a", "label": "A"}, {"id": "b", "label": "B"}],'
+        ' "edges": [{"source": "a", "target": "b", "relation": "uses"}]}\n'
+        "```"
+    )
+    result = llm._parse_llm_json(raw)
+    assert [n["id"] for n in result["nodes"]] == ["a", "b"]
+    assert len(result["edges"]) == 1
+    assert "repaired via stray-member prune (1 token)" in capsys.readouterr().err
+
+
+def test_clean_reply_never_reaches_repair():
+    """The repair pass runs only after the strict parse and the candidate
+    ladder both fail to find a fragment with content, so a reply that
+    parses today is byte-for-byte untouched."""
+    raw = '{"nodes": [{"id": "a", "label": "A"}], "edges": []}'
+    with patch.object(llm, "_repair_llm_json") as repair:
+        result = llm._parse_llm_json(raw)
+    repair.assert_not_called()
+    assert [n["id"] for n in result["nodes"]] == ["a"]
+
+
+def test_prose_reply_is_still_empty_after_repair():
+    """Repair recovers structure that was nearly there; it must not
+    conjure a fragment out of a reply that has none, which would mask
+    a hollow response instead of surfacing it."""
+    result = llm._parse_llm_json("I could not find any entities in this file.")
+    assert not result.get("nodes")
+    assert not result.get("edges")
+
+
+def test_json_repair_stage_recovers_single_quoted_reply(capsys):
+    """Stage 2 is the general net for defects the stray-member prune does
+    not cover, here a reply written with single quotes. Skipped when the
+    optional package is absent, since stage 1 does not fire on this input."""
+    pytest.importorskip("json_repair")
+    raw = "{'nodes': [{'id': 'a', 'label': 'A'}, {'id': 'b', 'label': 'B'}], 'edges': []}"
+    result = llm._parse_llm_json(raw)
+    assert [n["id"] for n in result["nodes"]] == ["a", "b"]
+    assert "repaired via json_repair" in capsys.readouterr().err
+
+
+def test_half_generated_reply_stays_empty_after_repair():
+    """json_repair closes whatever it is handed, so `{"nodes": [{"id":` would
+    come back as one node with an empty id. That is a hollow response wearing
+    a fragment, and the openai-compat backend relies on it staying hollow so
+    the chunk is retried rather than recorded as extracted."""
+    pytest.importorskip("json_repair")
+    result = llm._parse_llm_json('{"nodes": [{"id":')
+    assert not result.get("nodes")


### PR DESCRIPTION
## Problem

One stray token in an otherwise clean reply loses the whole chunk. Measured with a local `gemma4:26b` extractor over Ollama (openai-compat backend): a 15 KB response carrying one bare string where an object member belonged (`{"x", "id": ...`) failed the strict parse, then every fence/brace candidate in `_json_fragment_candidates`, and finally settled on a single inner node object that happened to parse. The chunk scored 0 nodes with 35 recoverable. Across a 4-chunk sample of four local models, 3 of 16 chunks were lost this way while the same chunks parsed cleanly under a cloud model.

## Change

`_parse_llm_json` gains a repair pass that runs **only after** the strict parse and the candidate ladder have both failed to find a fragment with content, so any reply that parses today is byte-for-byte untouched:

1. **Stray-member prune.** Drop a bare string sitting where an object member belongs (`{"x", "id": ...` or `, "x", "id": ...`) and re-run the same fence/brace ladder with the strict parser. Lossless for the measured defect, no new dependency.
2. **`json_repair`.** Over the pruned text, then the raw text, each also through the candidate ladder. This is the general net. The import is guarded so stage 1 still runs without the package; `json-repair` is added to `dependencies` (pure Python, no transitive deps), and it is a one-line move to an optional extra if you would rather not add a hard dependency.

A stage only counts if the sanitised fragment carries a node with an id, an edge with both ends, or a hyperedge with members. That guard matters: `json_repair` closes whatever it is handed, so a half-generated `{"nodes": [{"id":` would otherwise come back as one phantom node and stop reading as hollow. `test_call_openai_compat_labels_unparseable_json_hollow` caught exactly that during development and now passes.

Truncated replies (`finish_reason == "length"`) are still bisected by the caller, so repairing them changes nothing on that path. Recovery is logged to stderr (`[graphify] LLM JSON repaired via <stage>: N nodes / M edges recovered`) so a run that leans on repair is visible in the extraction log.

## Measured

Same 4 chunks, pristine vs patched parser, replies replayed from disk:

| model | chunks parsed before | after | recovered |
|---|---|---|---|
| gemma4:26b | 3/4 | 4/4 | 35 nodes / 2 edges (stray-member prune, 1 token) |
| llama3.1:8b | 3/4 | 4/4 | truncated reply, still bisected by the caller |
| qwen2.5-coder:7b | 4/4 | 4/4 | unchanged |
| custom role model | 3/4 | 4/4 | truncated reply, still bisected by the caller |

The 13 chunks that parsed before produce identical output after.

## Tests

Five tests appended to `tests/test_llm_parser.py`: stray token pruned and ids recovered without `json_repair`; a clean reply never reaches the repair pass; prose stays empty; single-quoted reply recovered by stage 2 (skipped if the package is absent); half-generated reply stays empty. `tests/test_llm_parser.py`, `test_llm_backends.py`, `test_llm_parser_reasoning.py`, `test_hollow_chunks_arm_shrink_guard.py`: 135 passed.
