### PR TITLE
fix(csharp): resolve unqualified generic call sites, Get<int>(...) (#3406)

### DIFF
--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -2775,6 +2775,20 @@ def _has_multiline_error(root) -> bool:
     return False
 
 
+def _csharp_bare_call_name(name_node, source: bytes) -> str:
+    """The callee identifier of a C# call-site name node.
+
+    A plain `identifier` reads as-is; a `generic_name` (`Get<int>`) reads its
+    identifier child so the type-argument list never leaks into the callee
+    name (#3406). Falls back to raw text for anything else.
+    """
+    if name_node.type == "generic_name":
+        for child in name_node.children:
+            if child.type == "identifier":
+                return _read_text(child, source)
+    return _read_text(name_node, source)
+
+
 def _read_csharp_type_name(node, source: bytes) -> tuple[str, bool, str] | None:
     """Resolve a C# type name, whether it was qualified, and its qualifier prefix."""
     if node is None:
@@ -5362,7 +5376,11 @@ def _extract_generic(
                     mname = fn_node.child_by_field_name("name")
                     recv = fn_node.child_by_field_name("expression")
                     if mname is not None:
-                        callee_name = _read_text(mname, source)
+                        # `recv.Get<int>(...)`: the name field is a
+                        # generic_name; its raw text carries the type-argument
+                        # list, which is not part of the method's identity
+                        # (#3406) — read the bare identifier instead.
+                        callee_name = _csharp_bare_call_name(mname, source)
                         is_member_call = True
                         if recv is not None and recv.type == "identifier":
                             member_receiver = _read_text(recv, source)
@@ -5388,6 +5406,13 @@ def _extract_generic(
                                 member_receiver = _read_text(fname, source)
                 elif fn_node is not None and fn_node.type == "identifier":
                     callee_name = _read_text(fn_node, source)
+                elif fn_node is not None and fn_node.type == "generic_name":
+                    # Unqualified generic call `Get<int>(...)` / `Make<T>()`:
+                    # without this arm the raw-text fallback captured
+                    # `Get<int>` verbatim, so the call never matched the
+                    # `.Get()` member and the edge was silently dropped —
+                    # while the non-generic spelling resolved fine (#3406).
+                    callee_name = _csharp_bare_call_name(fn_node, source)
                 else:
                     # Fallback: original name-field / first-named-child scan.
                     name_node = node.child_by_field_name("name")

--- a/tests/test_csharp_generic_callsites.py
+++ b/tests/test_csharp_generic_callsites.py
@@ -1,0 +1,76 @@
+"""Unqualified generic C# calls keep their calls edge (#3406).
+
+`Get<int>("port")` parses with a `generic_name` function node; the invocation
+handler had arms for `member_access_expression` and `identifier` only, so the
+raw-text fallback captured `Get<int>` verbatim and the call never matched the
+`.Get()` member — while the non-generic spelling of the same call resolved.
+`this.Get<int>(...)` failed the same way through the member arm, whose name
+field is the same `generic_name`.
+"""
+
+from graphify.extract import extract
+
+SETTINGS_CS = (
+    "namespace Demo\n{\n    public class Settings\n    {\n"
+    "        public T Get<T>(string key) { return default(T); }\n"
+    "        public string GetRaw(string key) { return key; }\n    }\n}\n"
+)
+
+READER_CS = (
+    "namespace Demo\n{\n    public class Reader : Settings\n    {\n"
+    "        public int A() { return Get<int>(\"port\"); }\n"
+    "        public int B() { return this.Get<int>(\"port\"); }\n"
+    "        public string C() { return GetRaw(\"host\"); }\n"
+    "        public string D() { return this.GetRaw(\"host\"); }\n    }\n}\n"
+)
+
+LOCAL_CS = (
+    "namespace Demo\n{\n    public class Local\n    {\n"
+    "        public T Make<T>() { return default(T); }\n"
+    "        public int E() { return Make<int>(); }\n    }\n}\n"
+)
+
+
+def _calls(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "Settings.cs").write_text(SETTINGS_CS, encoding="utf-8")
+    (tmp_path / "Reader.cs").write_text(READER_CS, encoding="utf-8")
+    (tmp_path / "Local.cs").write_text(LOCAL_CS, encoding="utf-8")
+    r = extract(sorted(tmp_path.glob("*.cs")), cache_root=tmp_path)
+    return {(e["source"], e["target"]) for e in r["edges"]
+            if e["relation"] == "calls"}
+
+
+def _has(calls, src_frag, tgt_frag):
+    return any(src_frag in s and tgt_frag in t for s, t in calls)
+
+
+def test_unqualified_generic_call_resolves_to_base_member(tmp_path, monkeypatch):
+    """The issue's case 1: `Get<int>("port")` with the target on the base class."""
+    calls = _calls(tmp_path, monkeypatch)
+    assert _has(calls, "reader_a", "settings_get"), sorted(calls)
+
+
+def test_this_qualified_generic_call_resolves(tmp_path, monkeypatch):
+    """Case 2: `this.Get<int>("port")` — the member arm's generic_name name."""
+    calls = _calls(tmp_path, monkeypatch)
+    assert _has(calls, "reader_b", "settings_get"), sorted(calls)
+
+
+def test_same_class_generic_call_resolves(tmp_path, monkeypatch):
+    """Case 5: `Make<int>()` with the target on the same class."""
+    calls = _calls(tmp_path, monkeypatch)
+    assert _has(calls, "local_e", "local_make"), sorted(calls)
+
+
+def test_generic_call_never_targets_the_bracketed_text(tmp_path, monkeypatch):
+    """The old failure shape: no target derived from `Get<int>` raw text."""
+    calls = _calls(tmp_path, monkeypatch)
+    assert not any("<" in t for _, t in calls), sorted(calls)
+
+
+def test_non_generic_controls_unchanged(tmp_path, monkeypatch):
+    """Cases 3 and 4 resolved before the fix and must keep resolving."""
+    calls = _calls(tmp_path, monkeypatch)
+    assert _has(calls, "reader_c", "settings_getraw"), sorted(calls)
+    assert _has(calls, "reader_d", "settings_getraw"), sorted(calls)


### PR DESCRIPTION
Closes #3406.

## The problem

A C# call with an explicit type argument and no receiver never got a `calls` edge — `Get<int>("port")`, `this.Get<int>("port")`, `Make<int>()` all dropped it while the non-generic spellings resolved, exactly as the issue's 5-case table shows (reproduced verbatim on 0.9.56).

The invocation handler has arms for a `member_access_expression` function node and an `identifier` one. `Get<int>(...)` parses as a **`generic_name`**, so it fell to the raw-text fallback and the callee was captured as `Get<int>` — brackets and all — which can never match the `.Get()` member node. `this.Get<int>(...)` failed one arm earlier: the member branch read the `name` field's raw text, and that field is the same `generic_name`.

## The change

A small helper, `_csharp_bare_call_name`, reads the identifier child of a `generic_name` (and passes a plain `identifier` through untouched). The member arm uses it for the name field, and the unqualified path gains a `generic_name` arm beside the `identifier` one. The type-argument list is not part of the method's identity, so the callee is the bare name — after that, same-class and base-class resolution work exactly as they do for the non-generic controls. The #2911 `generic_arg` reference emission reads the type-argument list off the same nodes and is untouched.

## Tests

`tests/test_csharp_generic_callsites.py` — 5 tests on the issue's exact 3-file repro: the unqualified base-class call, the `this.`-qualified call, and the same-class call all resolve; no target ever derives from the bracketed raw text; and the two non-generic controls keep resolving. With the fix reverted, 3 of 5 fail (the controls rightly keep passing). The C# suites are unchanged (174 passed); the full suite matches a fresh same-version `v8` (0.9.56) baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJbLfztSxm2tH5cJwBbe9q
