### PR TITLE
fix(detect): gate the bare out dir on build-output evidence (#3347)

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -933,11 +933,21 @@ def _has_build_output_markers(d: "Path") -> bool:
                     return True
                 if entry.is_dir():
                     subdirs.append(entry.path)
-        for sub in subdirs[:20]:  # bounded: probe one more level, cheaply
+        # Probe one more level across EVERY subdirectory (a wide TS outDir may
+        # keep its compiled files only under later-sorted module dirs), bounded
+        # by total entries scanned rather than by subdirectory count so a
+        # pathological tree still costs O(1)-ish.
+        budget = 4000
+        for sub in subdirs:
+            if budget <= 0:
+                break
             with os.scandir(sub) as it:
                 for entry in it:
+                    budget -= 1
                     if entry.is_file() and entry.name.lower().endswith(_BUILD_OUTPUT_SUFFIXES):
                         return True
+                    if budget <= 0:
+                        break
     except OSError:
         pass
     return False

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -827,7 +827,7 @@ def _is_regular_file(path: Path) -> bool:
 _SKIP_DIRS = {
     "venv", ".venv",  # "env"/".env"/"*_env" are gated on venv markers below (#2058)
     "node_modules", "__pycache__", ".git",
-    "dist", "build", "target", "out",
+    "dist", "build", "target",  # bare "out" is gated on build-output evidence below (#3347)
     "site-packages", "lib64",
     ".pytest_cache", ".mypy_cache", ".ruff_cache",
     ".tox", ".nox", ".eggs", "*.egg-info",  # nox is tox's successor, same .nox/ venv shape (#1804)
@@ -899,6 +899,50 @@ def _has_coverage_artifacts(d: "Path") -> bool:
     return False
 
 
+# Files only a compiler/bundler writes. Any one of them inside an ``out/``
+# tree is proof the directory is generated output rather than source.
+_BUILD_OUTPUT_SUFFIXES = (
+    ".class", ".jar", ".o", ".obj", ".exe", ".dll", ".pyc",
+    ".js.map", ".css.map", ".d.ts",
+)
+
+
+def _has_build_output_markers(d: "Path") -> bool:
+    """True only when *d* holds evidence a build tool generated it.
+
+    ``out`` is a mainstream SOURCE convention in hexagonal / ports-and-adapters
+    codebases — ``adapter/out/`` and ``port/out/`` hold the entire outbound
+    layer (persistence adapters, entities, outbound ports) — so pruning it by
+    name alone silently drops an architectural layer from the graph: 196 of
+    655 .java files on the #3347 corpus, exit code 0, no warning. Prune only
+    on real generated-output evidence, mirroring the ``env``/``coverage``/
+    ``snapshots`` gating (#1666/#2058/#2339): the IntelliJ ``out/production``
+    layout, a Next.js static-export ``_next/`` tree, or compiled artifacts in
+    the top two directory levels. An ``out`` that cannot be verified is kept —
+    the same keep-on-doubt bias every other gated name has.
+    """
+    try:
+        if (d / "production").is_dir():  # IntelliJ IDEA compile output layout
+            return True
+        if (d / "_next").is_dir():      # `next export` static-site output
+            return True
+        subdirs: list = []
+        with os.scandir(d) as it:
+            for entry in it:
+                if entry.is_file() and entry.name.lower().endswith(_BUILD_OUTPUT_SUFFIXES):
+                    return True
+                if entry.is_dir():
+                    subdirs.append(entry.path)
+        for sub in subdirs[:20]:  # bounded: probe one more level, cheaply
+            with os.scandir(sub) as it:
+                for entry in it:
+                    if entry.is_file() and entry.name.lower().endswith(_BUILD_OUTPUT_SUFFIXES):
+                        return True
+    except OSError:
+        pass
+    return False
+
+
 def _has_venv_markers(d: "Path") -> bool:
     """True only when *d* has actual virtualenv/conda structure on disk.
 
@@ -938,6 +982,14 @@ def _is_noise_dir(part: str, parent: "Path | None" = None) -> bool:
         if parent is None:
             return False  # cannot verify; keep a possibly-real code dir
         return _has_coverage_artifacts(parent / part)
+    if part == "out":
+        # Ambiguous: compiler/bundler output (IntelliJ, `next export`, a TS
+        # outDir) OR the outbound layer of a hexagonal codebase
+        # (adapter/out/, port/out/). Prune only on actual build-output
+        # evidence (#3347).
+        if parent is None:
+            return False  # cannot verify; keep a possibly-real code dir
+        return _has_build_output_markers(parent / part)
     if part == "snapshots":
         # Prune only when it looks like an actual JS/Vitest snapshot dir.
         if parent is None:

--- a/tests/test_out_dir_evidence.py
+++ b/tests/test_out_dir_evidence.py
@@ -81,6 +81,25 @@ def test_compiled_artifacts_one_level_down_prune_out(tmp_path, monkeypatch):
     assert not any("out/lib" in f for f in files), files
 
 
+def test_wide_out_dir_markers_beyond_twenty_subdirs_still_prune(tmp_path, monkeypatch):
+    """A wide outDir whose compiled files sit only under a late-sorted
+    subdirectory is still recognized as build output."""
+    monkeypatch.chdir(tmp_path)
+    for i in range(30):
+        sub = tmp_path / f"out/mod{i:02d}"
+        sub.mkdir(parents=True)
+        (sub / "notes.txt").write_text("no artifacts here\n", encoding="utf-8")
+    late = tmp_path / "out/zz-final"
+    late.mkdir()
+    (late / "index.js.map").write_text("{}", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/index.ts").write_text("export const x = 1;\n", encoding="utf-8")
+
+    files = _scanned(tmp_path)
+    assert any("src/index.ts" in f for f in files), files
+    assert not any("/out/" in f for f in files), files
+
+
 def test_other_skip_dirs_stay_unconditional(tmp_path, monkeypatch):
     """The gate is scoped to `out`: build/, dist/, target/ prune by name."""
     monkeypatch.chdir(tmp_path)

--- a/tests/test_out_dir_evidence.py
+++ b/tests/test_out_dir_evidence.py
@@ -1,0 +1,97 @@
+"""A bare ``out`` directory is pruned only on build-output evidence (#3347).
+
+``out`` was in ``_SKIP_DIRS`` unconditionally, so a hexagonal codebase's
+``adapter/out/`` and ``port/out/`` — the entire outbound layer, 30% of the
+corpus on the reporting repo — vanished from the scan with exit code 0 and no
+warning. It now gets the same evidence gating ``env``/``coverage``/
+``snapshots`` already have (#1666/#2058/#2339): keep on doubt, prune on proof.
+"""
+
+from graphify.detect import detect
+
+
+def _scanned(td):
+    d = detect(td)
+    return sorted(
+        str(f).replace("\\", "/") for cat in d["files"].values() for f in cat
+    )
+
+
+def test_hexagonal_out_layers_are_scanned(tmp_path, monkeypatch):
+    """adapter/out/ and port/out/ holding only source stay in the corpus."""
+    monkeypatch.chdir(tmp_path)
+    ad = tmp_path / "src/main/java/demo/adapter/out/persistence"
+    ad.mkdir(parents=True)
+    (ad / "OrderEntity.java").write_text(
+        "package demo.adapter.out.persistence;\npublic class OrderEntity { }\n",
+        encoding="utf-8")
+    po = tmp_path / "src/main/java/demo/port/out"
+    po.mkdir(parents=True)
+    (po / "OrderRepositoryPort.java").write_text(
+        "package demo.port.out;\npublic interface OrderRepositoryPort { }\n",
+        encoding="utf-8")
+
+    files = _scanned(tmp_path)
+    assert any("adapter/out/persistence/OrderEntity.java" in f for f in files), files
+    assert any("port/out/OrderRepositoryPort.java" in f for f in files), files
+
+
+def test_intellij_out_production_is_pruned(tmp_path, monkeypatch):
+    """out/production/... (IntelliJ compile output) stays out of the corpus."""
+    monkeypatch.chdir(tmp_path)
+    ij = tmp_path / "out/production/demo"
+    ij.mkdir(parents=True)
+    (ij / "Order.class").write_bytes(b"\xca\xfe\xba\xbe")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/Order.java").write_text(
+        "public class Order { }\n", encoding="utf-8")
+
+    files = _scanned(tmp_path)
+    assert any("src/Order.java" in f for f in files), files
+    assert not any("/out/" in f for f in files), files
+
+
+def test_next_export_out_is_pruned(tmp_path, monkeypatch):
+    """A `next export` static-site out/ (marked by _next/) stays out."""
+    monkeypatch.chdir(tmp_path)
+    nx = tmp_path / "out/_next"
+    nx.mkdir(parents=True)
+    (tmp_path / "out/index.html").write_text("<html></html>", encoding="utf-8")
+    (tmp_path / "pages").mkdir()
+    (tmp_path / "pages/index.tsx").write_text(
+        "export default function Home() { return null; }\n", encoding="utf-8")
+
+    files = _scanned(tmp_path)
+    assert any("pages/index.tsx" in f for f in files), files
+    assert not any("out/index.html" in f for f in files), files
+
+
+def test_compiled_artifacts_one_level_down_prune_out(tmp_path, monkeypatch):
+    """A TS outDir shape — compiled .js.map one level inside out/ — is pruned."""
+    monkeypatch.chdir(tmp_path)
+    o = tmp_path / "out/lib"
+    o.mkdir(parents=True)
+    (o / "index.js").write_text("module.exports = {};\n", encoding="utf-8")
+    (o / "index.js.map").write_text("{}", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/index.ts").write_text("export const x = 1;\n", encoding="utf-8")
+
+    files = _scanned(tmp_path)
+    assert any("src/index.ts" in f for f in files), files
+    assert not any("out/lib" in f for f in files), files
+
+
+def test_other_skip_dirs_stay_unconditional(tmp_path, monkeypatch):
+    """The gate is scoped to `out`: build/, dist/, target/ prune by name."""
+    monkeypatch.chdir(tmp_path)
+    for name in ("build", "dist", "target"):
+        d = tmp_path / name
+        d.mkdir()
+        (d / "Thing.java").write_text("public class Thing { }\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/Real.java").write_text("public class Real { }\n", encoding="utf-8")
+
+    files = _scanned(tmp_path)
+    assert any("src/Real.java" in f for f in files), files
+    assert not any(any(f"/{n}/" in f for n in ("build", "dist", "target"))
+                   for f in files), files


### PR DESCRIPTION
Closes #3347.

## The problem

`_SKIP_DIRS` contains the bare name `out`, matched unconditionally — so in a hexagonal / ports-and-adapters codebase, `adapter/out/` and `port/out/` (the entire outbound layer: persistence adapters, entities, outbound ports) are silently dropped from the scan. On the reporting repo that was 196 of 655 `.java` files — 30%, including every `@Entity` class — with exit code 0 and no warning.

`_is_noise_dir` already gates three ambiguous names on corroborating evidence, keeping the directory when it cannot verify: `env`/`.env`/`*_env` on venv markers (#2058), `coverage` on report artifacts (#2339), `snapshots` on `.snap` files (#1666). `out` got none of it.

## The change

`out` becomes the fourth gated name. `_has_build_output_markers` prunes it only on real generated-output evidence:

- the IntelliJ compile layout (`out/production/` subdir);
- a Next.js static export (`out/_next/` subtree);
- compiled artifacts (`.class`, `.jar`, `.o`, `.obj`, `.exe`, `.dll`, `.pyc`, `.js.map`, `.css.map`, `.d.ts`) in the top two directory levels — a bounded `os.scandir` probe, same cost profile as the venv/coverage gates.

An `out` that cannot be verified is **kept** — the same keep-on-doubt bias every other gated name has, and pruned-as-noise dirs stay traceable via `pruned_noise_dirs` (#2058). `build`, `dist` and `target` remain unconditional; the wider question of gating those is #2479's, and this PR deliberately stays on the `out` case where the dropped set is an architectural layer under a mainstream source convention rather than an incidental directory.

## Tests

`tests/test_out_dir_evidence.py` — 5 tests: `adapter/out/` and `port/out/` holding only source stay in the corpus (the issue's shape, and the test that fails 
on the unpatched tree); IntelliJ `out/production/`, a `next export` `out/`, and a TS outDir with `.js.map` one level down are all still pruned; and `build`/`dist`/`target` stay unconditionally pruned. The detect suites are unchanged (584 passed; the two failing hook tests fail identically on clean `v8` on this Windows machine); the full suite matches a fresh same-version `v8` (0.9.56) baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJbLfztSxm2tH5cJwBbe9q
