### PR TITLE
perf(global-graph): global_add_many so a batch pays the whole-graph cost once

### DIFF
--- a/graphify/global_graph.py
+++ b/graphify/global_graph.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import json
 import hashlib
 import sys
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 import networkx as nx
@@ -83,89 +84,128 @@ def global_add(source_path: Path, repo_tag: str) -> dict:
     cross_repo_calls.
     Skipped=True means the source graph hasn't changed since last add.
     """
-    from graphify.build import prefix_graph_for_global, prune_repo_from_graph
+    batch = global_add_many([(source_path, repo_tag)])
+    result = dict(batch["results"][0])
+    result["cross_repo_calls"] = batch["cross_repo_calls"]
+    return result
 
-    if not source_path.exists():
-        raise FileNotFoundError(f"graph not found: {source_path}")
+
+def global_add_many(sources: Sequence[tuple[Path, str]]) -> dict:
+    """Add or update several project graphs in one pass over the global graph.
+
+    ``sources`` is an ordered sequence of ``(source_path, repo_tag)`` composed in the given
+    order, so a later unit's external-node dedup sees what earlier ones added -- the graph
+    the same sequence of ``global_add`` calls produces.
+
+    Returns ``{"results": [...], "cross_repo_calls": int}``, one result dict per input in
+    input order with keys repo_tag / nodes_added / nodes_removed / skipped.
+    ``cross_repo_calls`` counts the whole batch: the pass reads the finished graph, so the
+    number does not divide over the units that made it.
+    """
+    from graphify.build import prefix_graph_for_global, prune_repo_from_graph
+    from graphify.security import check_graph_file_size_cap
+
+    # Whatever cannot finish should fail before the first unit is composed, since a batch
+    # that raises halfway leaves the units before it unwritten and their work wasted.
+    tag_sources: dict[str, Path] = {}
+    for source_path, repo_tag in sources:
+        if not source_path.exists():
+            raise FileNotFoundError(f"graph not found: {source_path}")
+        if repo_tag in tag_sources:
+            raise ValueError(
+                f"repo tag '{repo_tag}' names two sources in one batch "
+                f"({tag_sources[repo_tag]} and {source_path}); the second prunes the first. "
+                f"Give one of them a different tag."
+            )
+        tag_sources[repo_tag] = source_path
 
     manifest = _load_manifest()
-    src_hash = _file_hash(source_path)
+    results: list[dict] = []
+    pending: list[tuple[int, Path, str, str]] = []
+    for source_path, repo_tag in sources:
+        src_hash = _file_hash(source_path)
+        existing = manifest["repos"].get(repo_tag, {})
+        existing_path = existing.get("source_path", "")
+        if existing_path and existing_path != str(source_path.resolve()):
+            print(
+                f"[graphify global] warning: repo tag '{repo_tag}' previously pointed to "
+                f"{existing_path!r}, now updating to {str(source_path.resolve())!r}. "
+                f"Use --as <tag> to give it a different name.",
+                file=sys.stderr,
+            )
+        skipped = existing.get("source_hash") == src_hash
+        results.append({"repo_tag": repo_tag, "nodes_added": 0, "nodes_removed": 0,
+                        "skipped": skipped})
+        if not skipped:
+            check_graph_file_size_cap(source_path)
+            pending.append((len(results) - 1, source_path, repo_tag, src_hash))
 
-    existing = manifest["repos"].get(repo_tag, {})
-    existing_path = existing.get("source_path", "")
-    if existing_path and existing_path != str(source_path.resolve()):
-        print(
-            f"[graphify global] warning: repo tag '{repo_tag}' previously pointed to "
-            f"{existing_path!r}, now updating to {str(source_path.resolve())!r}. "
-            f"Use --as <tag> to give it a different name.",
-            file=sys.stderr,
-        )
-    if existing.get("source_hash") == src_hash:
-        return {"repo_tag": repo_tag, "nodes_added": 0, "nodes_removed": 0, "skipped": True,
-                "cross_repo_calls": 0}
+    # Nothing changed: the global graph is never read or rewritten, which keeps a re-run over
+    # an unchanged corpus as cheap as it is for a single unchanged unit.
+    if not pending:
+        return {"results": results, "cross_repo_calls": 0}
 
-    # Load source graph
-    from graphify.security import check_graph_file_size_cap
-    check_graph_file_size_cap(source_path)
-    data = json.loads(source_path.read_text(encoding="utf-8"))
-    if "links" not in data and "edges" in data:
-        data = dict(data, links=data["edges"])
-    try:
-        src_G = _jg.node_link_graph(data, edges="links")
-    except TypeError:
-        src_G = _jg.node_link_graph(data)
-
-    # Prefix IDs for cross-project isolation
-    prefixed = prefix_graph_for_global(src_G, repo_tag)
-
-    # Load global graph and prune stale nodes for this repo
     G = _load_global_graph()
-    removed = prune_repo_from_graph(G, repo_tag)
+    for index, source_path, repo_tag, src_hash in pending:
+        data = json.loads(source_path.read_text(encoding="utf-8"))
+        if "links" not in data and "edges" in data:
+            data = dict(data, links=data["edges"])
+        try:
+            src_G = _jg.node_link_graph(data, edges="links")
+        except TypeError:
+            src_G = _jg.node_link_graph(data)
 
-    # Merge external-library nodes (no source_file) by label to avoid duplication
-    external_labels = {
-        d.get("label", ""): n
-        for n, d in G.nodes(data=True)
-        if not d.get("source_file") and d.get("label")
-    }
-    # Map each deduplicated external onto the existing global node so that
-    # edges incident to it can be rewired instead of dropped.
-    remap = {}
-    for node, data in prefixed.nodes(data=True):
-        if not data.get("source_file") and data.get("label") in external_labels:
-            remap[node] = external_labels[data["label"]]
+        # Prefix IDs for cross-project isolation, then drop this repo's stale nodes
+        prefixed = prefix_graph_for_global(src_G, repo_tag)
+        removed = prune_repo_from_graph(G, repo_tag)
 
-    # Compose: add prefixed nodes (except deduplicated externals) into global graph
-    for node, data in prefixed.nodes(data=True):
-        if node not in remap:
-            G.add_node(node, **data)
-    for u, v, data in prefixed.edges(data=True):
-        u = remap.get(u, u)
-        v = remap.get(v, v)
-        if u != v:  # don't introduce self-loops via remapping
-            G.add_edge(u, v, **data)
+        # Merge external-library nodes (no source_file) by label to avoid duplication.
+        # Read off the current G, so a unit can merge onto a stub an earlier unit in the
+        # batch composed; collecting these once up front would compose a different graph.
+        external_labels = {
+            d.get("label", ""): n
+            for n, d in G.nodes(data=True)
+            if not d.get("source_file") and d.get("label")
+        }
+        # Map each deduplicated external onto the existing global node so that
+        # edges incident to it can be rewired instead of dropped.
+        remap = {}
+        for node, node_data in prefixed.nodes(data=True):
+            if not node_data.get("source_file") and node_data.get("label") in external_labels:
+                remap[node] = external_labels[node_data["label"]]
 
-    added = prefixed.number_of_nodes() - len(remap)
+        # Compose: add prefixed nodes (except deduplicated externals) into global graph
+        for node, node_data in prefixed.nodes(data=True):
+            if node not in remap:
+                G.add_node(node, **node_data)
+        for u, v, edge_data in prefixed.edges(data=True):
+            u = remap.get(u, u)
+            v = remap.get(v, v)
+            if u != v:  # don't introduce self-loops via remapping
+                G.add_edge(u, v, **edge_data)
+
+        added = prefixed.number_of_nodes() - len(remap)
+        results[index]["nodes_added"] = added
+        results[index]["nodes_removed"] = removed
+        manifest["repos"][repo_tag] = {
+            "added_at": datetime.now(timezone.utc).isoformat(),
+            "source_path": str(source_path.resolve()),
+            "node_count": added,
+            "edge_count": prefixed.number_of_edges(),
+            "source_hash": src_hash,
+        }
+
     # A member call parked on a caller node (#3152) may be answered by a repo
     # already in the global graph, or by this one for a repo added earlier. The
-    # pass recomputes its own output, so adding repos one at a time lands where a
-    # single merge-graphs of the same inputs would.
+    # pass recomputes its own output, so one run over the composed batch lands
+    # where a run per unit -- or a single merge-graphs of the same inputs -- would.
     from graphify.cross_repo_calls import link_cross_repo_member_calls
 
     cross_repo_calls = link_cross_repo_member_calls(G)
     _save_global_graph(G)
-
-    manifest["repos"][repo_tag] = {
-        "added_at": datetime.now(timezone.utc).isoformat(),
-        "source_path": str(source_path.resolve()),
-        "node_count": added,
-        "edge_count": prefixed.number_of_edges(),
-        "source_hash": src_hash,
-    }
     _save_manifest(manifest)
 
-    return {"repo_tag": repo_tag, "nodes_added": added, "nodes_removed": removed,
-            "skipped": False, "cross_repo_calls": cross_repo_calls}
+    return {"results": results, "cross_repo_calls": cross_repo_calls}
 
 
 def global_remove(repo_tag: str) -> int:

--- a/tests/test_global_graph.py
+++ b/tests/test_global_graph.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import pytest
 import networkx as nx
+from contextlib import contextmanager
 from unittest.mock import patch
 
 
@@ -33,6 +34,67 @@ def _graph_to_json(G, path):
     except TypeError:
         data = jg.node_link_data(G)
     path.write_text(json.dumps(data), encoding="utf-8")
+
+
+@contextmanager
+def _global_store(global_dir):
+    """Point graphify.global_graph at ``global_dir`` instead of the user's home."""
+    with patch("graphify.global_graph._GLOBAL_DIR", global_dir), \
+         patch("graphify.global_graph._GLOBAL_GRAPH", global_dir / "global-graph.json"), \
+         patch("graphify.global_graph._GLOBAL_MANIFEST", global_dir / "global-manifest.json"):
+        yield global_dir / "global-graph.json", global_dir / "global-manifest.json"
+
+
+def _write_batch_units(tmp_path):
+    """Three unit graphs: repoA parks a member call repoB answers, plus a shared stub.
+
+    repoC contributes a second copy of the `logging` stub so the external-label dedup has
+    something to do on a unit that is not the first one composed.
+    """
+    units = {}
+    units["repoA"] = _make_graph(
+        [{"id": "app", "label": ".run()", "source_file": "src/App.java",
+          "metadata": {"unresolved_calls": [
+              {"lang": "java", "receiver_type": "Greeter", "callee": "greet", "line": 7}]}},
+         {"id": "logging", "label": "logging"}],
+        [{"source": "app", "target": "logging", "relation": "imports"}],
+    )
+    units["repoB"] = _make_graph(
+        [{"id": "greeter", "label": "Greeter", "source_file": "src/Greeter.java",
+          "_callable_class": True},
+         {"id": "greet", "label": ".greet()", "source_file": "src/Greeter.java"}],
+        [{"source": "greeter", "target": "greet", "relation": "method"}],
+    )
+    units["repoC"] = _make_graph(
+        [{"id": "worker", "label": "Worker", "source_file": "src/worker.py"},
+         {"id": "logging", "label": "logging"}],
+        [{"source": "worker", "target": "logging", "relation": "imports"}],
+    )
+    sources = []
+    for tag, G in units.items():
+        path = tmp_path / tag / "graph.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _graph_to_json(G, path)
+        sources.append((path, tag))
+    return sources
+
+
+def _read_store(graph_path, manifest_path):
+    """Return the stored graph and manifest in a form two runs can be compared by."""
+    from networkx.readwrite import json_graph as jg
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    if "links" not in data and "edges" in data:
+        data = dict(data, links=data["edges"])
+    try:
+        G = jg.node_link_graph(data, edges="links")
+    except TypeError:
+        G = jg.node_link_graph(data)
+    nodes = {n: dict(d) for n, d in G.nodes(data=True)}
+    edges = {frozenset((u, v)): dict(d) for u, v, d in G.edges(data=True)}
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    for entry in manifest["repos"].values():
+        entry.pop("added_at", None)
+    return nodes, edges, manifest
 
 
 # ── build.py helpers ──────────────────────────────────────────────────────────
@@ -385,3 +447,166 @@ def test_global_add_rejects_oversized_source_graph(monkeypatch, tmp_path):
         from graphify.global_graph import global_add
         with pytest.raises(ValueError, match="exceeds"):
             global_add(src_graph, "repoA")
+
+
+# ── global_add_many ───────────────────────────────────────────────────────────
+
+def test_global_add_many_matches_one_add_per_unit(tmp_path):
+    """The acceptance criterion for the batch path: same inputs, same artifact.
+
+    Sequential adds round-trip the global graph through JSON between every two units and
+    run the cross-repo pass after each; the batch does neither. Nodes, node attributes,
+    edges, edge attributes and the manifest all have to come out the same anyway.
+    """
+    from graphify.global_graph import global_add, global_add_many
+
+    seq_sources = _write_batch_units(tmp_path / "seq")
+    with _global_store(tmp_path / "seq-store") as (graph_path, manifest_path):
+        for source_path, repo_tag in seq_sources:
+            global_add(source_path, repo_tag)
+        sequential = _read_store(graph_path, manifest_path)
+
+    batch_sources = _write_batch_units(tmp_path / "batch")
+    with _global_store(tmp_path / "batch-store") as (graph_path, manifest_path):
+        global_add_many(batch_sources)
+        batched = _read_store(graph_path, manifest_path)
+
+    # The manifest records each source's absolute path, which differs by design here.
+    for _, _, manifest in (sequential, batched):
+        for entry in manifest["repos"].values():
+            entry.pop("source_path", None)
+    assert batched[0] == sequential[0]
+    assert batched[1] == sequential[1]
+    assert batched[2] == sequential[2]
+    # The fixture exists to exercise the pass, so a run that resolves nothing proves nothing.
+    assert any(d.get("_cross_repo_call") for d in batched[1].values()), batched[1]
+
+
+def test_global_add_many_reports_per_unit_and_batch_level_counts(tmp_path):
+    from graphify.global_graph import global_add_many
+
+    sources = _write_batch_units(tmp_path)
+    with _global_store(tmp_path / "store"):
+        batch = global_add_many(sources)
+
+    assert [r["repo_tag"] for r in batch["results"]] == ["repoA", "repoB", "repoC"]
+    assert all(r["skipped"] is False for r in batch["results"])
+    assert all(r["nodes_added"] > 0 for r in batch["results"])
+    assert batch["cross_repo_calls"] == 1
+    # A per-unit number would have to attribute the pass's output to one of the two repos
+    # that produced it, so the count stays at the batch level.
+    assert all("cross_repo_calls" not in r for r in batch["results"])
+
+
+def test_global_add_many_dedups_a_later_units_external_against_an_earlier_one(tmp_path):
+    """A stub of the same label composed by an earlier unit in the same batch has to be
+    the one a later unit's edges attach to, exactly as when the two units arrive as two
+    separate adds."""
+    from graphify.global_graph import _load_global_graph, global_add_many
+
+    sources = _write_batch_units(tmp_path)
+    with _global_store(tmp_path / "store"):
+        global_add_many(sources)
+        G = _load_global_graph()
+
+    assert "repoC::logging" not in G.nodes
+    assert G.has_edge("repoC::worker", "repoA::logging")
+
+
+def test_global_add_many_keeps_a_skipped_unit_in_position(tmp_path):
+    from graphify.global_graph import _load_global_graph, global_add_many
+
+    sources = _write_batch_units(tmp_path)
+    with _global_store(tmp_path / "store"):
+        global_add_many(sources[:1])
+        before = {frozenset(e) for e in _load_global_graph().edges()}
+        batch = global_add_many(sources)
+        after = {frozenset(e) for e in _load_global_graph().edges()}
+
+    assert [r["skipped"] for r in batch["results"]] == [True, False, False]
+    assert batch["results"][0]["nodes_added"] == 0
+    assert batch["results"][0]["nodes_removed"] == 0
+    # A skipped unit must not be pruned and re-composed: its edges survive untouched.
+    assert before <= after
+
+
+def test_global_add_many_runs_the_cross_repo_pass_once(tmp_path):
+    from graphify.global_graph import global_add_many
+
+    sources = _write_batch_units(tmp_path)
+    with _global_store(tmp_path / "store"):
+        with patch("graphify.cross_repo_calls.link_cross_repo_member_calls",
+                   return_value=7) as spy:
+            batch = global_add_many(sources)
+
+    assert spy.call_count == 1
+    assert batch["cross_repo_calls"] == 7
+
+
+def test_global_add_many_leaves_the_store_untouched_when_nothing_changed(tmp_path):
+    """An unchanged batch must not read or rewrite the global graph. Loading it to discover
+    there is nothing to do costs a full deserialize plus a full write of the same bytes."""
+    from graphify.global_graph import global_add_many
+
+    sources = _write_batch_units(tmp_path)
+    with _global_store(tmp_path / "store") as (graph_path, _):
+        global_add_many(sources)
+        before = graph_path.stat().st_mtime_ns
+        with patch("graphify.global_graph._load_global_graph") as load:
+            batch = global_add_many(sources)
+
+    assert load.call_count == 0
+    assert graph_path.stat().st_mtime_ns == before
+    assert [r["skipped"] for r in batch["results"]] == [True, True, True]
+    assert batch["cross_repo_calls"] == 0
+
+
+def test_global_add_many_rejects_one_tag_naming_two_sources(tmp_path):
+    """Two sources under one tag would have the second prune the first, so the batch
+    reports a graph half of which is missing. Refuse the input instead."""
+    from graphify.global_graph import global_add_many
+
+    sources = _write_batch_units(tmp_path)
+    clashing = [sources[0], (sources[1][0], sources[0][1])]
+    with _global_store(tmp_path / "store") as (graph_path, _):
+        with pytest.raises(ValueError, match="two sources in one batch"):
+            global_add_many(clashing)
+    assert not graph_path.exists()
+
+
+def test_global_add_many_reports_a_missing_source_the_way_one_add_does(tmp_path):
+    """Hashing the source would raise on its own, with the OS message for a missing file.
+    The batch is still the caller's own input, so it gets `global_add`'s wording."""
+    from graphify.global_graph import global_add_many
+
+    sources = _write_batch_units(tmp_path)
+    with _global_store(tmp_path / "store") as (graph_path, manifest_path):
+        with patch("graphify.build.prefix_graph_for_global") as compose:
+            with pytest.raises(FileNotFoundError, match="graph not found"):
+                global_add_many([*sources, (tmp_path / "absent" / "graph.json", "repoD")])
+
+    assert compose.call_count == 0
+    assert not graph_path.exists()
+    assert not manifest_path.exists()
+
+
+def test_global_add_many_checks_every_size_cap_before_composing_any(monkeypatch, tmp_path):
+    """The batch writes only at the end, so a unit rejected late throws away every unit
+    composed before it. The cap is a stat, so it can be paid for the whole batch up front."""
+    from graphify.global_graph import global_add_many
+
+    sources = _write_batch_units(tmp_path)
+    oversized = tmp_path / "repoD" / "graph.json"
+    oversized.parent.mkdir(parents=True, exist_ok=True)
+    _graph_to_json(_make_graph([{"id": "d", "label": "D" * 4096, "source_file": "d.py"}]),
+                   oversized)
+    cap = max(p.stat().st_size for p, _ in sources) + 1
+    assert oversized.stat().st_size > cap
+    monkeypatch.setattr("graphify.security._MAX_GRAPH_FILE_BYTES", cap)
+
+    with _global_store(tmp_path / "store"):
+        with patch("graphify.build.prefix_graph_for_global") as compose:
+            with pytest.raises(ValueError, match="exceeds"):
+                global_add_many([*sources, (oversized, "repoD")])
+
+    assert compose.call_count == 0

--- a/tests/test_global_graph.py
+++ b/tests/test_global_graph.py
@@ -513,6 +513,39 @@ def test_global_add_many_dedups_a_later_units_external_against_an_earlier_one(tm
     assert G.has_edge("repoC::worker", "repoA::logging")
 
 
+def test_global_add_many_re_adding_a_repo_keeps_its_own_stub_in_the_graph(tmp_path):
+    """The external-label index has to be read after the prune, not before it.
+
+    A stub the previous revision owned is deleted by the prune. An index built ahead of
+    the prune still names it, the unit's own stub is then treated as a duplicate of it and
+    never composed, and rewiring an edge onto the missing id has add_edge invent an
+    attribute-less node in its place.
+    """
+    from graphify.global_graph import _load_global_graph, global_add_many
+
+    sources = _write_batch_units(tmp_path)
+    repo_a_path = sources[0][0]
+    with _global_store(tmp_path / "store"):
+        global_add_many(sources[:1])
+        # A second revision of repoA, still importing `logging`, and different enough
+        # that the source hash cannot skip it.
+        _graph_to_json(
+            _make_graph(
+                [{"id": "app", "label": ".run()", "source_file": "src/App.java"},
+                 {"id": "extra", "label": ".boot()", "source_file": "src/Boot.java"},
+                 {"id": "logging", "label": "logging"}],
+                [{"source": "app", "target": "logging", "relation": "imports"}],
+            ),
+            repo_a_path,
+        )
+        global_add_many(sources[:1])
+        G = _load_global_graph()
+
+    assert G.has_edge("repoA::app", "repoA::logging")
+    ghosts = [n for n, d in G.nodes(data=True) if not d.get("repo")]
+    assert not ghosts, f"nodes with no repo attribute: {ghosts}"
+
+
 def test_global_add_many_keeps_a_skipped_unit_in_position(tmp_path):
     from graphify.global_graph import _load_global_graph, global_add_many
 


### PR DESCRIPTION
Fixes #3433

## Summary

Registering K project graphs with `global add` costs O(K²) work, because each call does three
whole-graph operations — `_load_global_graph`, `link_cross_repo_member_calls`,
`_save_global_graph` — on a graph that grows with every unit. The K-th call pays for the K−1
units already in there.

Only the composition of a unit needs the graph in the state that unit arrives at. The read, the
cross-repo pass and the write depend on the batch as a whole, so a batch API can pay them once.

## Measured

Synthetic units, 1501 nodes / ~2500 edges each, fixed size, K varied. Wall clock, and
`tracemalloc` peak (Python allocations, not RSS):

| K | `global_add` ×K | `global_add_many` | speedup | seq peak MB | batch peak MB | final nodes |
|--:|--:|--:|--:|--:|--:|--:|
| 1 | 0.14 s | 0.12 s | 1.2× | 6.8 | 5.9 | 1 501 |
| 5 | 1.67 s | 0.66 s | 2.5× | 27.8 | 23.5 | 7 501 |
| 10 | 6.05 s | 1.33 s | 4.6× | 54.4 | 36.7 | 15 001 |
| 20 | 22.67 s | 2.86 s | 7.9× | 90.5 | 63.5 | 30 001 |
| 40 | 89.52 s | 5.89 s | 15.2× | 184.5 | 117.7 | 60 001 |

Sequential time roughly quadruples when K doubles (22.67 → 89.52); the batch roughly doubles
(2.86 → 5.89). That is the point of the change: a quadratic term becomes linear. The speedup at a
given K is therefore about K/2, not K — the early units are cheap because the graph is still
small.

Not a from-scratch-only effect. Adding 20 units to a store that already holds 20:

| | wall clock | peak MB |
|--|--:|--:|
| `global_add` ×20 | 64.81 s | 183.4 |
| `global_add_many` | 4.92 s | 123.6 |

Peak memory does not go up — it measured lower in both scenarios. I am reporting that as an
observation rather than a claim about the mechanism; the reason to take this change is the time.

## API

```python
def global_add_many(sources: Sequence[tuple[Path, str]]) -> dict:
    """-> {"results": [{repo_tag, nodes_added, nodes_removed, skipped}, ...],
           "cross_repo_calls": int}"""
```

One result per input, in input order, including skipped units. `cross_repo_calls` sits at the
batch level: the pass reads the finished graph, so the number does not divide over the units that
produced it.

`global_add` now delegates with a batch of one. Its signature, its return keys and its callers are
unchanged, and there is one composition implementation instead of two that have to be kept in
step.

## What had to stay in the loop

- **Prune.** Still per unit, before that unit is composed. It only removes that repo's nodes.
- **The external-label dedup.** Still read off the graph *as it stands when the unit arrives*, so
  a later unit's stub merges onto one an earlier unit in the batch composed. Hoisting it changes
  the graph — the equivalence test below fails if you do.
- **The path-change warning.** Still one per unit.

The cross-repo pass is the one thing that moves out: it drops its own previous output and
recomputes from the parked entries, which is what already makes K sequential adds agree with a
single `merge-graphs` (`global_graph.py` comment, `cross_repo_calls.link_cross_repo_member_calls`
docstring).

## Batch-specific behaviour, all tested

- **An unchanged batch never reads the graph.** Discovering there is nothing to do would otherwise
  cost a full deserialize plus a full rewrite of identical bytes — a regression on the most common
  re-run.
- **Missing source, oversized source, and one tag naming two sources are all rejected before the
  first unit is composed.** The batch writes only at the end, so a unit rejected late discards
  every unit composed before it. The duplicate tag is a new error: the second source would prune
  the first, and the batch would report having added both.
- A missing source raises `FileNotFoundError("graph not found: ...")`, the same wording
  `global_add` used, rather than the OS message hashing it would produce.

## Tradeoff to be aware of

Sequential adds checkpoint: unit 20 of 42 failing leaves units 1–19 durably registered, and a
re-run skips them by hash. A batch is all-or-nothing — it writes nothing on failure, so nothing is
half-merged, but nothing is banked either. Callers that want checkpointing can batch in chunks.

## Tests

`tests/test_global_graph.py`, nine added, no existing assertion changed (29 passed, was 20):

- `test_global_add_many_matches_one_add_per_unit` — the acceptance criterion. Three units, one of
  which parks a member call another answers, plus a stub two units share. Sequential and batch are
  compared on node set, every node attribute, edge set, every edge attribute, and the manifest
  (minus `added_at`). It also asserts the pass actually resolved something, so a fixture that
  stopped exercising it cannot pass silently.
- `test_global_add_many_dedups_a_later_units_external_against_an_earlier_one` — fails if the dedup
  is hoisted out of the loop.
- `test_global_add_many_runs_the_cross_repo_pass_once` — spy, `call_count == 1`.
- `test_global_add_many_keeps_a_skipped_unit_in_position` — a hash-skipped unit keeps its slot in
  `results` and is not pruned and re-composed.
- `test_global_add_many_leaves_the_store_untouched_when_nothing_changed` — `_load_global_graph`
  not called, file mtime unchanged.
- `test_global_add_many_rejects_one_tag_naming_two_sources`,
  `test_global_add_many_reports_a_missing_source_the_way_one_add_does`,
  `test_global_add_many_checks_every_size_cap_before_composing_any` — each asserts
  `prefix_graph_for_global` was never called, and each fails if the corresponding check is moved
  into the compose loop.
- `test_global_add_many_reports_per_unit_and_batch_level_counts` — return shape.

Full suite: 5360 passed, 94 skipped. `tests/test_ts_import_type_arguments.py::test_ts_normalizer_scales_linearly_on_large_files`
fails identically on unmodified `v8` in a full run and passes in isolation — a machine-dependent
`process_time` ratio, unrelated. `ruff check` clean.

No timing assertion is added to the suite. The numbers above come from a standalone script; a
wall-clock ratio in CI is the kind of test that fails on a loaded runner.

## Not in this PR

- **CLI.** `graphify global add` still takes one source. Extending it to several positional
  sources (with `--as` valid only for exactly one) is a small follow-up; callers can use the
  Python API meanwhile.
- **The external-stub dedup semantics.** Unchanged here on purpose — equivalence with the
  sequential path is what this PR is verified against, so it has to keep whatever that path does.
  #3414 / #3415 argue that dedup is wrong and remove it. If #3415 lands first, this PR gets
  simpler: composition becomes order-independent, the per-unit dedup rebuild goes away, and
  `test_global_add_many_dedups_a_later_units_external_against_an_earlier_one` should be dropped
  rather than reversed. If this one lands first, #3415 needs to touch `global_add_many` too. Happy
  to rebase in whichever order you prefer.
