### PR TITLE
fix(detect): prune htmlcov/, coverage.py's HTML report dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 ## 0.9.57 (unreleased)
 
+- Fix: `htmlcov/` — coverage.py's `coverage html` output dir, the Python counterpart of the already-skipped `lcov-report/` — is now pruned as a noise dir. It was reaching `collect_files`, which does not read the `.gitignore` coverage.py writes inside it, so the generated bundle and `status.json` were extracted as source.
 - Fix: an incremental rebuild no longer wipes cross-file project AST nodes — re-extracting one `.csproj`/`.sln` was dropping package/framework nodes of a *referenced* project (whose stub carried the referenced file's `source_file`); the AST-replacement set is now derived from the files actually extracted (#3411, thanks @hopstreax).
 - Fix: when duplicate nodes merge, the richer (more complete) node is now kept as the survivor and the losers' non-empty fields are folded in, instead of a shorter-id passing mention winning and dropping content (#3372, thanks @abhay-codes07).
 - Fix: a C# generic call site with explicit type arguments — `Get<int>(...)`, unqualified or through `this` — now resolves to the method definition instead of capturing `Get<int>` as the callee and failing to match (#3406, thanks @abhay-codes07).

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -836,6 +836,7 @@ _SKIP_DIRS = {
     "lcov-report",                          # Vitest/Istanbul/nyc HTML reports (#870);
                                             # bare "coverage" is gated on report
                                             # artefacts below (#2339)
+    "htmlcov",                              # coverage.py's `coverage html` output dir
     "visual-tests", "visual-test",          # Playwright/visual-regression bundles (#869)
     "__snapshots__",                        # Jest/Vitest snapshot dir (unambiguous)
     "storybook-static",                     # Storybook production build output

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -991,6 +991,59 @@ def test_is_noise_dir_coverage_is_evidence_gated(tmp_path):
     assert detect_mod._is_noise_dir("lcov-report") is True
 
 
+def test_detect_skips_htmlcov_dir(tmp_path):
+    """htmlcov/ is coverage.py's `coverage html` output — the Python counterpart
+    of lcov-report/, and generated the same way.
+
+    It was not in _SKIP_DIRS and the "coverage" gate does not reach it (that gate
+    only fires on a dir literally named ``coverage``), so the tree was walked in
+    full. Modern coverage.py drops a ``.gitignore`` inside htmlcov/ that hides it
+    from detect's ignore pass, but that is incidental cover: it is absent under
+    --no-gitignore, and collect_files does not consult it at all (see
+    test_collect_files_skips_htmlcov_dir).
+    """
+    cov = tmp_path / "htmlcov"
+    cov.mkdir()
+    (cov / "index.html").write_text("<html>coverage report</html>")
+    (cov / "z_1a2b_app_py.html").write_text("<html>file coverage</html>")
+    (cov / "style_cb_9ff733b0.css").write_text("body{}")
+    (tmp_path / "main.py").write_text("def hello(): pass")
+    result = detect(tmp_path)
+    all_files = [f for files in result["files"].values() for f in files]
+    assert not any(f.startswith(str(cov)) for f in all_files)
+    assert any("main.py" in f for f in all_files)
+    assert any(p.rstrip(os.sep).endswith("htmlcov") for p in result["pruned_noise_dirs"])
+
+
+def test_collect_files_skips_htmlcov_dir(tmp_path):
+    """The extract path is where htmlcov actually cost tokens.
+
+    collect_files does not read the ``.gitignore`` coverage.py writes inside
+    htmlcov/, so before this it returned the generated bundle and status file --
+    a minified JS blob and a generated JSON, parsed as if they were source.
+    """
+    from graphify.extract import collect_files
+
+    cov = tmp_path / "htmlcov"
+    cov.mkdir()
+    (cov / ".gitignore").write_text("# Created by coverage.py\n*\n")
+    (cov / "coverage_html_cb_dd2e7eb5.js").write_text("var x=1;")
+    (cov / "status.json") .write_text('{"format":5,"files":{}}')
+    (cov / "index.html").write_text("<html>coverage report</html>")
+    (tmp_path / "app.py").write_text("def f(): pass\n")
+
+    walked = {str(p.relative_to(tmp_path)) for p in collect_files(tmp_path)}
+    assert walked == {"app.py"}, f"htmlcov leaked into extraction: {walked}"
+
+
+def test_is_noise_dir_htmlcov_is_unconditional(tmp_path):
+    """htmlcov needs no evidence gate: unlike "coverage" it is not a plausible
+    package name (no PyPI package, no language convention), only coverage.py's
+    default HTML output dir — same contract as lcov-report."""
+    assert detect_mod._is_noise_dir("htmlcov") is True
+    assert detect_mod._is_noise_dir("htmlcov", tmp_path) is True
+
+
 def test_detect_skips_visual_tests_dir(tmp_path):
     """visual-tests/ bundles and snapshots are noise — must be excluded (#869)."""
     vt = tmp_path / "visual-tests"


### PR DESCRIPTION
## The problem

`htmlcov/` is where `coverage html` writes its report. It is the Python counterpart of `lcov-report/`, which `_SKIP_DIRS` already prunes unconditionally, but `htmlcov` was not in the set.

The `coverage` evidence gate (#2339) does not cover it: that gate fires only on a directory literally named `coverage`, and `_has_coverage_artifacts` is never consulted for `htmlcov`.

Modern coverage.py drops a `.gitignore` (`# Created by coverage.py` / `*`) inside `htmlcov/`, which hides the tree from `detect`'s ignore pass — but that cover is incidental, not a decision:

- it is gone under `--no-gitignore`;
- **`collect_files` never consults it**, so the extract path walked in.

Measured on a fresh `coverage run` + `coverage html` tree at `v8` HEAD (0.9.57):

```python
>>> collect_files(root)   # before
['app.py', 'htmlcov/coverage_html_cb_dd2e7eb5.js', 'htmlcov/status.json', 'test_app.py']
>>> collect_files(root)   # after
['app.py', 'test_app.py']
```

A minified Istanbul-style JS bundle and a generated JSON, parsed and graphed as source. On a real repo the same shape shows up in `detect` under `--no-gitignore` as a pile of generated `.html` files reported as documents and queued for semantic extraction — LLM tokens spent extracting concepts out of a coverage report, and a "pending extraction" backlog number that stops meaning anything.

## The change

One entry, beside `lcov-report`:

```python
    "lcov-report",                          # Vitest/Istanbul/nyc HTML reports (#870);
                                            # bare "coverage" is gated on report
                                            # artefacts below (#2339)
    "htmlcov",                              # coverage.py's `coverage html` output dir
```

**Unconditional, deliberately.** The collision question that gated `coverage` (#2339), `env` (#2058), `snapshots` (#1666) and is being asked of `out` (#3347/#3424) does not arise here: `htmlcov` is not a plausible package or namespace name in any language — no PyPI package claims the name (404), it is not a directory convention anywhere, it is only coverage.py's default output dir. Same contract as `lcov-report`, which the comment right above it already states no package is ever named.

If a maintainer would still rather have it gated, `_has_coverage_artifacts` works on it unchanged (coverage.py writes both `index.html` and `status.json` into `htmlcov/`) — say the word and I will move it behind the gate.

## Tests

Three cases in `tests/test_detect.py`, next to the existing `coverage` ones. All three fail on the unpatched tree:

- `test_detect_skips_htmlcov_dir` — the walk drops the tree and records it in `pruned_noise_dirs` rather than leaving it to the ignore pass;
- `test_collect_files_skips_htmlcov_dir` — the extract path, **with the coverage.py `.gitignore` present**, so it pins the actual leak rather than the incidentally-covered case;
- `test_is_noise_dir_htmlcov_is_unconditional` — the contract, with and without a parent.

Suite: `5495 passed, 14 skipped, 3 failed`. The 3 failures are pre-existing and environmental — `test_ollama.py::test_detect_backend_ollama`, `test_ollama.py::test_detect_backend_none_without_envvars`, `test_extract_code_only_cli.py::test_mixed_repo_without_key_errors_and_points_at_code_only` — all three fail identically on clean `v8` on this machine (a local Ollama is up and a provider key is in the env). The five `tools.skillgen` CI checks pass.

## Prior art / not a duplicate

No open issue or PR mentions `htmlcov`. Related but distinct: #870 (added `lcov-report`), #2339 (gated bare `coverage`), #2479 / #3347 / #3424 (the ambiguous-name gating question for `build`/`out`) — this one is the unambiguous-name case those PRs explicitly leave alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeARDWQjvnPZigoytREuHm
