### PR TITLE
Fix: global_remove deletes a shared external node other repos still r…

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -2266,7 +2266,25 @@ def distinct_repo_tags(graph_paths: "list[Path]") -> "list[str]":
 
 
 def prune_repo_from_graph(G: nx.Graph, repo_tag: str) -> int:
-    """Remove all nodes tagged with repo_tag from G in-place. Returns count removed."""
-    to_remove = [n for n, d in G.nodes(data=True) if d.get("repo") == repo_tag]
+    """Remove all nodes tagged with repo_tag from G in-place. Returns count removed.
+
+    A node carrying "ref_repos" (set by global_add when it deduplicates a
+    shared external/library node across repos) is only dropped once every
+    referencing repo has released it; removing repo_tag just shrinks the
+    list. Nodes without "ref_repos" are uniquely owned by their "repo" and
+    removed outright, as before.
+    """
+    to_remove = []
+    for n, d in G.nodes(data=True):
+        ref_repos = d.get("ref_repos")
+        if ref_repos is not None:
+            if repo_tag in ref_repos:
+                remaining = [r for r in ref_repos if r != repo_tag]
+                if remaining:
+                    d["ref_repos"] = remaining
+                else:
+                    to_remove.append(n)
+        elif d.get("repo") == repo_tag:
+            to_remove.append(n)
     G.remove_nodes_from(to_remove)
     return len(to_remove)

--- a/graphify/global_graph.py
+++ b/graphify/global_graph.py
@@ -135,10 +135,27 @@ def global_add(source_path: Path, repo_tag: str) -> dict:
         if not data.get("source_file") and data.get("label") in external_labels:
             remap[node] = external_labels[data["label"]]
 
-    # Compose: add prefixed nodes (except deduplicated externals) into global graph
+    # Compose: add prefixed nodes (except deduplicated externals) into global graph.
+    # A deduplicated external node keeps living under whichever repo_tag first
+    # created it (its "repo" attribute), but other repos can depend on it too.
+    # "ref_repos" tracks every repo currently referencing it so
+    # prune_repo_from_graph can drop one repo's reference without deleting a
+    # node other repos still depend on.
     for node, data in prefixed.nodes(data=True):
         if node not in remap:
+            if not data.get("source_file"):
+                data = dict(data)
+                data["ref_repos"] = [repo_tag]
             G.add_node(node, **data)
+        else:
+            target_data = G.nodes[remap[node]]
+            ref_repos = target_data.get("ref_repos")
+            if ref_repos is None:
+                owner = target_data.get("repo")
+                ref_repos = [owner] if owner else []
+            if repo_tag not in ref_repos:
+                ref_repos.append(repo_tag)
+            target_data["ref_repos"] = ref_repos
     for u, v, data in prefixed.edges(data=True):
         u = remap.get(u, u)
         v = remap.get(v, v)

--- a/tests/test_global_graph.py
+++ b/tests/test_global_graph.py
@@ -368,6 +368,53 @@ def test_global_add_rewires_edges_to_deduplicated_externals(tmp_path):
     assert G.edges["repoB::modb", "repoA::requests"]["relation"] == "imports"
 
 
+def test_global_remove_of_first_owner_keeps_shared_external_node(tmp_path):
+    """Removing the repo that happened to add a shared external node first must
+    not delete it out from under a second repo that still references it."""
+    g1 = tmp_path / "graph1.json"
+    g2 = tmp_path / "graph2.json"
+    GA = _make_graph(
+        [
+            {"id": "moda", "label": "ModA", "source_file": "src/a.py"},
+            {"id": "requests", "label": "requests"},
+        ],
+        [{"source": "moda", "target": "requests", "relation": "imports"}],
+    )
+    GB = _make_graph(
+        [
+            {"id": "modb", "label": "ModB", "source_file": "src/b.py"},
+            {"id": "requests", "label": "requests"},
+        ],
+        [{"source": "modb", "target": "requests", "relation": "imports"}],
+    )
+    _graph_to_json(GA, g1)
+    _graph_to_json(GB, g2)
+
+    global_dir = tmp_path / ".graphify"
+    with patch("graphify.global_graph._GLOBAL_DIR", global_dir), \
+         patch("graphify.global_graph._GLOBAL_GRAPH", global_dir / "global-graph.json"), \
+         patch("graphify.global_graph._GLOBAL_MANIFEST", global_dir / "global-manifest.json"):
+        from graphify.global_graph import global_add, global_remove, _load_global_graph
+        global_add(g1, "repoA")
+        global_add(g2, "repoB")  # dedups onto repoA's "requests" node
+        global_remove("repoA")
+        G = _load_global_graph()
+
+    # repoB's own node is untouched
+    assert "repoB::modb" in G.nodes
+    # the shared external node must survive - repoB still depends on it
+    assert "repoA::requests" in G.nodes
+    assert G.has_edge("repoB::modb", "repoA::requests")
+    # and it only disappears once the last referencing repo is also removed
+    with patch("graphify.global_graph._GLOBAL_DIR", global_dir), \
+         patch("graphify.global_graph._GLOBAL_GRAPH", global_dir / "global-graph.json"), \
+         patch("graphify.global_graph._GLOBAL_MANIFEST", global_dir / "global-manifest.json"):
+        from graphify.global_graph import global_remove, _load_global_graph
+        global_remove("repoB")
+        G2 = _load_global_graph()
+    assert G2.number_of_nodes() == 0
+
+
 def test_global_add_rejects_oversized_source_graph(monkeypatch, tmp_path):
     """#F4: global_add must refuse to read a source graph.json that
     exceeds the size cap, rather than json.loads-ing it into memory."""


### PR DESCRIPTION
`prune_repo_from_graph` removes nodes by matching the `repo` attribute set at creation time. When two repos both reference the same external/library node (e.g. both import `requests`), `global_add`'s dedup step rewires the second repo's edges onto the first repo's existing node — but never updates its ownership. Removing the first repo (`global_remove`) then deletes that node outright, silently dropping the second repo's edges to it too.

This adds a `ref_repos` list to deduplicated external nodes (tracking every repo currently referencing them) and updates `prune_repo_from_graph` to only delete such a node once every referencing repo has released it. Internal per-file nodes are unaffected — they're still removed by `repo` match as before.

Added `test_global_remove_of_first_owner_keeps_shared_external_node` reproducing the exact scenario. Ran the existing `tests/test_global_graph.py` suite before/after: 17/20 to 18/20 passing, same 3 pre-existing failures both times (they need `rapidfuzz`, unrelated to this change).