### PR TITLE
fix(hook): bound the soft read/search nudge per session

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ for example `graphify claude install --project` or `graphify codex install --pro
 
 > **Git hooks and uv tool / pipx:** `graphify hook install` embeds the current interpreter path directly into the hook scripts at install time, so the post-commit hook fires correctly even in GUI git clients and CI runners where `~/.local/bin` is not on PATH. If you reinstall or upgrade graphify, re-run `graphify hook install` to refresh the embedded path.
 
-> **Strict mode (Claude Code):** `graphify install --project --strict` makes the assistant actually use the graph. The default install *nudges* it to run `graphify query` before reading files; strict mode *blocks* the first raw source read of a session and redirects it to the graph, then reverts to the nudge (so it fires at most once per session and never gets stuck). Toggle at runtime with `GRAPHIFY_HOOK_STRICT=1`/`0`; the default install is unchanged (soft nudge).
+> **Strict mode (Claude Code):** `graphify install --project --strict` makes the assistant actually use the graph. The default install *nudges* it to run `graphify query` before reading files; strict mode *blocks* the first raw source read of a session and redirects it to the graph, then reverts to the nudge (so it fires at most once per session and never gets stuck). Toggle at runtime with `GRAPHIFY_HOOK_STRICT=1`/`0`; the default install is unchanged (soft nudge). The soft nudge itself is bounded: it is skipped while a recent `graphify query`/`explain`/`path` shows the assistant is already oriented, and it fires at most `GRAPHIFY_HOOK_NUDGE_CAP` times per session (default 5; `0` disables the cap).
 
 <details>
 <summary><b>Pick your platform</b> (20+ assistants, click to expand)</summary>

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -707,6 +707,65 @@ def _query_stamp_fresh() -> bool:
         return False
 
 
+def _nudge_allowed(session_id: str) -> bool:
+    """Whether to emit the soft read/search nudge for this tool call (#3435).
+
+    The nudge is advisory context that used to be re-injected on EVERY qualifying
+    Read/Glob/Grep/Bash call — thousands of times per session, far more tokens
+    than the graph queries it asks for. Two bounds:
+
+    * a fresh query stamp (the agent ran query/explain/path within
+      GRAPHIFY_HOOK_STRICT_TTL) means it is already oriented, so no nudge;
+    * at most GRAPHIFY_HOOK_NUDGE_CAP nudges per session (default 5; 0 or a
+      non-number disables the cap), counted in a per-session marker next to the
+      strict-mode ones. Calls without a session id are not counted.
+
+    Fail-open: any error allows the nudge.
+    """
+    from graphify.paths import out_path, write_text_atomic
+    if _query_stamp_fresh():
+        return False
+    try:
+        cap = int(os.environ.get("GRAPHIFY_HOOK_NUDGE_CAP", "5"))
+    except ValueError:
+        cap = 0
+    if cap <= 0:
+        return True
+    sid = re.sub(r"[^A-Za-z0-9_-]", "_", str(session_id))[:64]
+    if not sid:
+        return True
+    try:
+        d = out_path("cache", "hook_sessions")
+        d.mkdir(parents=True, exist_ok=True)
+        marker = d / f"{sid}.nudges"
+        try:
+            count = int(marker.read_text(encoding="utf-8").strip() or "0")
+        except (OSError, ValueError):
+            count = 0
+        if count >= cap:
+            return False
+        write_text_atomic(marker, str(count + 1))
+        if count == 0:
+            _gc_hook_session_markers(d)
+        return True
+    except Exception:
+        return True
+
+
+def _gc_hook_session_markers(d: "Path") -> None:
+    """Best-effort removal of per-session hook markers older than 24h."""
+    try:
+        cutoff = time.time() - 86400
+        for entry in os.scandir(d):
+            try:
+                if entry.stat().st_mtime < cutoff:
+                    os.unlink(entry.path)
+            except OSError:
+                pass
+    except OSError:
+        pass
+
+
 def _mark_session_denied(session_id: str) -> bool:
     """Atomically claim a one-time strict block for this session. Returns True only
     on the FIRST call for a given session id (O_EXCL create wins once); every later
@@ -721,16 +780,7 @@ def _mark_session_denied(session_id: str) -> bool:
         d.mkdir(parents=True, exist_ok=True)
         fd = os.open(str(d / f"{sid}.denied"), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
         os.close(fd)
-        try:
-            cutoff = time.time() - 86400
-            for entry in os.scandir(d):
-                try:
-                    if entry.stat().st_mtime < cutoff:
-                        os.unlink(entry.path)
-                except OSError:
-                    pass
-        except OSError:
-            pass
+        _gc_hook_session_markers(d)
         return True
     except FileExistsError:
         return False
@@ -866,7 +916,8 @@ def _run_hook_guard(kind: str, strict: bool = False) -> None:
             # grep. Nudge-only, even in strict mode — see the docstring.
             is_grep_tool = not cmd_str and bool(t.get("pattern"))
             is_bash_search = bool(cmd_str) and _bash_invokes_search(cmd_str)
-            if (is_grep_tool or is_bash_search) and out_path("graph.json").is_file():
+            if (is_grep_tool or is_bash_search) and out_path("graph.json").is_file() \
+                    and _nudge_allowed(str(d.get("session_id") or "")):
                 sys.stdout.write(_SEARCH_NUDGE)
         elif kind == "read":
             vals = [str(t.get("file_path") or ""), str(t.get("pattern") or ""), str(t.get("path") or "")]
@@ -937,7 +988,8 @@ def _run_hook_guard(kind: str, strict: bool = False) -> None:
                     and _mark_session_denied(str(d.get("session_id") or "")):
                 sys.stdout.write(_READ_DENY)
                 return
-            sys.stdout.write(_READ_NUDGE)
+            if _nudge_allowed(str(d.get("session_id") or "")):
+                sys.stdout.write(_READ_NUDGE)
     except Exception:
         pass
 

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -203,6 +203,63 @@ def test_search_out_path_error_is_swallowed(tmp_path, monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# soft nudge bounds (#3435): fresh query stamp suppresses, per-session cap
+# --------------------------------------------------------------------------- #
+def _read_payload(sid="s1"):
+    return {"session_id": sid, "tool_name": "Read", "tool_input": {"file_path": "src/app.py"}}
+
+
+def _search_payload(sid="s1"):
+    return {"session_id": sid, "tool_input": {"command": "grep -rn foo ."}}
+
+
+def test_read_nudge_skipped_while_query_stamp_fresh(tmp_path, monkeypatch):
+    import time
+    stamp = tmp_path / "graphify-out" / "cache" / "last_query_stamp"
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.write_text(str(time.time()), encoding="utf-8")
+    assert _invoke("read", _read_payload(), tmp_path, monkeypatch) == ""
+    assert _invoke("search", _search_payload(), tmp_path, monkeypatch) == ""
+
+
+def test_nudges_capped_per_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_HOOK_NUDGE_CAP", "3")
+    outs = [_invoke("read", _read_payload("cap"), tmp_path, monkeypatch) for _ in range(3)]
+    assert all("MANDATORY" in o for o in outs)
+    assert _invoke("read", _read_payload("cap"), tmp_path, monkeypatch) == ""
+    assert _invoke("search", _search_payload("cap"), tmp_path, monkeypatch) == ""
+    # Another session has its own budget.
+    assert "MANDATORY" in _invoke("read", _read_payload("other"), tmp_path, monkeypatch)
+
+
+def test_read_and_search_nudges_share_the_session_budget(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_HOOK_NUDGE_CAP", "2")
+    assert "MANDATORY" in _invoke("search", _search_payload("mix"), tmp_path, monkeypatch)
+    assert "MANDATORY" in _invoke("read", _read_payload("mix"), tmp_path, monkeypatch)
+    assert _invoke("search", _search_payload("mix"), tmp_path, monkeypatch) == ""
+
+
+def test_nudge_cap_default_is_five(tmp_path, monkeypatch):
+    monkeypatch.delenv("GRAPHIFY_HOOK_NUDGE_CAP", raising=False)
+    outs = [_invoke("read", _read_payload("d"), tmp_path, monkeypatch) for _ in range(6)]
+    assert [bool(o) for o in outs] == [True] * 5 + [False]
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "not-a-number"])
+def test_nudge_cap_disabled(value, tmp_path, monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_HOOK_NUDGE_CAP", value)
+    outs = [_invoke("read", _read_payload("nocap"), tmp_path, monkeypatch) for _ in range(8)]
+    assert all("MANDATORY" in o for o in outs)
+
+
+def test_nudges_without_session_id_are_not_counted(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_HOOK_NUDGE_CAP", "1")
+    payload = {"tool_name": "Read", "tool_input": {"file_path": "src/app.py"}}
+    outs = [_invoke("read", payload, tmp_path, monkeypatch) for _ in range(3)]
+    assert all("MANDATORY" in o for o in outs)
+
+
+# --------------------------------------------------------------------------- #
 # gemini: BeforeTool contract (always allow; nudge only when a graph exists)
 # --------------------------------------------------------------------------- #
 def test_gemini_allow_with_nudge(tmp_path, monkeypatch):

--- a/tests/test_hook_strict.py
+++ b/tests/test_hook_strict.py
@@ -86,7 +86,8 @@ def test_fresh_query_stamp_suppresses_deny(tmp_path, monkeypatch):
     stamp.parent.mkdir(parents=True, exist_ok=True)
     stamp.write_text(str(time.time()), encoding="utf-8")
     out = _invoke("read", _read(f), tmp_path, monkeypatch, strict=True)
-    assert not _is_deny(out) and "MANDATORY" in out
+    # Recently oriented: neither the block nor the soft nudge (#3435).
+    assert not _is_deny(out) and out == ""
 
 
 def test_expired_query_stamp_still_denies(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #3435

**Problem:** `_run_hook_guard` writes `_READ_NUDGE` / `_SEARCH_NUDGE` on every qualifying Read/Glob/Grep/Bash call. There is no dedup, no session cap, and the "recently oriented" query stamp only suppresses the opt-in strict deny, so an agent that just ran `graphify query` is told on its very next read that it must run `graphify query`. The issue measured 8,348 injections (~651k tokens) for 339 graphify calls in one project.

**Change** (`graphify/cli.py`):
- `_nudge_allowed(session_id)` gates both soft nudges. It returns `False` while `_query_stamp_fresh()` (the agent ran `query`/`explain`/`path` within `GRAPHIFY_HOOK_STRICT_TTL`) and after `GRAPHIFY_HOOK_NUDGE_CAP` nudges in the same session (default 5; `0` or a non-number disables the cap). The count lives in `graphify-out/cache/hook_sessions/<sid>.nudges`, next to the strict-mode `.denied` markers, and read + search share one budget.
- Calls without a `session_id` are not counted (no key to count on), and the guard keeps its fail-open contract: any error allows the nudge.
- The 24h marker GC that only ran on the strict path is now `_gc_hook_session_markers()` and runs when a new session counter is created too.
- Strict mode is unchanged: the once-per-session deny still fires first; the nudge that follows it is what gets bounded.
- README: one sentence on the new bound next to the strict-mode note.

**Tests:** `tests/test_hook_guard.py` covers stamp suppression (read + search), the per-session cap with independent sessions, the shared read/search budget, the default of 5, the disable values, and uncounted calls without a session id. `tests/test_hook_strict.py::test_fresh_query_stamp_suppresses_deny` now expects no output at all when the stamp is fresh (previously the soft nudge), which is the intended behaviour change.

```
pytest tests/test_hook_guard.py tests/test_hook_strict.py tests/test_hook_guard_token_match.py tests/test_hook_out_of_project_paths.py
154 passed, 4 skipped
ruff check: clean
```

The rest of the suite: 5118 passed locally; the 24 failures are environmental in my checkout (missing optional `openai` / `tree-sitter-hcl`, shallow git history for the skillgen tests, a wheel-build test) and don't touch the hook code.
