### PR TITLE
fix(python): resolve ambiguous absolute imports by proximity, not first-writer

### DIFF
--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -2143,6 +2143,42 @@ def _augment_symbol_resolution_edges(
     _collect_python_symbol_resolution_facts(paths, root, facts)
     _apply_symbol_resolution_facts(paths, nodes, edges, root, facts)
 
+
+def _nearest_stem(candidates, importer_stem: str) -> str | None:
+    """Pick the candidate module sharing the longest leading path with the importer.
+
+    Two files with the same basename in different packages (``service/app/config.py``
+    and ``service-sonos/app/config.py``) are both plausible targets for an absolute
+    ``from app.config import Settings``. Python itself resolves this by sys.path,
+    which is rooted at the importing file's own package, so the candidate sharing
+    the most leading directory segments with the importer is the right one.
+
+    A tie means the import is genuinely ambiguous: return None and emit no edge.
+    The previous behaviour fell through to a bare-stem index whose first writer
+    won, which silently bound every importer in one package to a same-named class
+    in another - a phantom cross-package edge scoring 0.95 INFERRED.
+    """
+    candidates = list(candidates)
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+    imp_dirs = importer_stem.split("/")[:-1]
+    scored = []
+    for fq in candidates:
+        segs = fq.split("/")[:-1]
+        shared = 0
+        for a, b in zip(imp_dirs, segs):
+            if a != b:
+                break
+            shared += 1
+        scored.append((shared, fq))
+    scored.sort(key=lambda x: (-x[0], x[1]))
+    if scored[0][0] == scored[1][0]:
+        return None
+    return scored[0][1]
+
+
 def _resolve_cross_file_imports(
     per_file: list[dict],
     paths: list[Path],
@@ -2176,9 +2212,11 @@ def _resolve_cross_file_imports(
     # Keyed by directory-qualified stem (e.g. "auth_models") to avoid collisions
     # when multiple files share the same filename in different directories.
     # A secondary bare-stem index handles absolute imports where only the module
-    # name is known — first writer wins when names collide (inherently ambiguous).
+    # name is known. It keeps EVERY qualified stem per bare stem, so a basename
+    # shared across packages is disambiguated by proximity to the importer
+    # (_nearest_stem) rather than resolved first-writer-wins.
     stem_to_entities: dict[str, dict[str, str]] = {}
-    bare_to_qualified: dict[str, str] = {}
+    bare_to_candidates: dict[str, set[str]] = {}
     for file_result in per_file:
         for node in file_result.get("nodes", []):
             src = node.get("source_file", "")
@@ -2200,8 +2238,7 @@ def _resolve_cross_file_imports(
                 and node.get("file_type") != "rationale"
             ):
                 stem_to_entities.setdefault(fq_stem, {})[label] = nid
-                if src_path.stem not in bare_to_qualified:
-                    bare_to_qualified[src_path.stem] = fq_stem
+                bare_to_candidates.setdefault(src_path.stem, set()).add(fq_stem)
 
     # Pass 2: for each file, find `from .X import A, B, C`, then attribute the
     # `uses` edge to the specific local symbol (class OR function) whose body
@@ -2252,6 +2289,8 @@ def _resolve_cross_file_imports(
         def _text(n) -> str:
             return source[n.start_byte:n.end_byte].decode("utf-8", errors="replace")
 
+        importer_stem = _file_stem(path)
+
         def resolve_import(node) -> None:
             # Find the module name - handles both absolute and relative imports.
             # Relative: `from .models import X` → relative_import → dotted_name
@@ -2292,9 +2331,15 @@ def _resolve_cross_file_imports(
                         ]
                         if len(suffix_matches) == 1:
                             target_fq = suffix_matches[0]
+                        elif suffix_matches:
+                            # Several packages expose this module path; pick the
+                            # one nearest the importer, or none on a tie.
+                            target_fq = _nearest_stem(suffix_matches, importer_stem)
                         else:
                             bare = dotted_name.split(".")[-1]
-                            target_fq = bare_to_qualified.get(bare)
+                            target_fq = _nearest_stem(
+                                bare_to_candidates.get(bare, ()), importer_stem
+                            )
 
             if not target_fq or target_fq not in stem_to_entities:
                 return

--- a/tests/test_phantom_cross_package_import.py
+++ b/tests/test_phantom_cross_package_import.py
@@ -1,0 +1,128 @@
+"""A Python absolute import must not bind to a same-named module in a sibling package.
+
+Two services in one repo commonly ship their own package under the same name
+(``service/app/config.py`` and ``service-sonos/app/config.py``), each defining a
+class with the same label. Both then contain the byte-identical line
+``from app.config import Settings``.
+
+``_resolve_cross_file_imports`` resolved the module path in three steps: exact
+directory-qualified stem, then a unique suffix match, then a bare-stem index.
+The bare-stem index kept only the first file written for a given basename, so
+when the first two steps could not disambiguate, *every* importer of that module
+name repo-wide bound to whichever package happened to be extracted first — an
+``uses`` edge at INFERRED/0.95 pointing into a package the file never imported.
+
+The symptom is a phantom bridge: the two services share no import, no call and
+no field, yet the mis-bound class became the graph's highest-betweenness node
+precisely because a false edge spans communities that nothing else connects.
+
+The fix resolves an ambiguous module path by proximity — the candidate sharing
+the longest leading path with the importing file, which is what Python's own
+sys.path resolution amounts to — and emits nothing on a genuine tie rather than
+guessing.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify.extract import extract
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _edges(files: list[Path], base: Path) -> set[tuple[str, str, str]]:
+    r = extract(files, cache_root=base, parallel=False)
+    return {(e["source"], e["target"], e["relation"]) for e in r["edges"]}
+
+
+def _two_services(tmp_path: Path) -> list[Path]:
+    """Two packages, each with `app/config.py` defining `Settings`."""
+    _write(tmp_path / "svc_a/app/config.py", "class Settings:\n    league = 'college'\n")
+    _write(tmp_path / "svc_a/app/main.py",
+           "from app.config import Settings\n\n"
+           "class App:\n"
+           "    def build(self):\n"
+           "        return Settings()\n")
+    _write(tmp_path / "svc_b/app/config.py", "class Settings:\n    port = 8002\n")
+    _write(tmp_path / "svc_b/app/main.py",
+           "from app.config import Settings\n\n"
+           "class SonosApp:\n"
+           "    def build(self):\n"
+           "        return Settings()\n")
+    return sorted(tmp_path.rglob("*.py"))
+
+
+def test_ambiguous_absolute_import_does_not_cross_packages(tmp_path: Path) -> None:
+    edges = _edges(_two_services(tmp_path), tmp_path)
+    crossing = [
+        (s, t, r) for s, t, r in edges
+        if (s.startswith("svc_a") and t.startswith("svc_b"))
+        or (s.startswith("svc_b") and t.startswith("svc_a"))
+    ]
+    assert not crossing, crossing
+
+
+def test_ambiguous_absolute_import_resolves_within_its_own_package(tmp_path: Path) -> None:
+    # Dropping the phantom is not enough: each importer must still reach the
+    # `Settings` in its OWN package.
+    edges = _edges(_two_services(tmp_path), tmp_path)
+    for pkg in ("svc_a", "svc_b"):
+        own = [
+            (s, t, r) for s, t, r in edges
+            if s.startswith(pkg) and t.startswith(f"{pkg}_app_config_settings")
+        ]
+        assert own, f"{pkg} has no edge to its own Settings: {sorted(edges)}"
+
+
+def test_importer_in_a_sibling_directory_still_resolves(tmp_path: Path) -> None:
+    # The importing file need not sit beside the target: `svc_a/tests/` is one
+    # level off `svc_a/app/`, and must still prefer svc_a over svc_b.
+    _write(tmp_path / "svc_a/app/config.py", "class Settings:\n    league = 'college'\n")
+    _write(tmp_path / "svc_b/app/config.py", "class Settings:\n    port = 8002\n")
+    _write(tmp_path / "svc_a/tests/test_config.py",
+           "from app.config import Settings\n\n"
+           "class TestConfig:\n"
+           "    def test_defaults(self):\n"
+           "        assert Settings().league == 'college'\n")
+    edges = _edges(sorted(tmp_path.rglob("*.py")), tmp_path)
+    assert not [e for e in edges if e[0].startswith("svc_a_tests") and e[1].startswith("svc_b")]
+
+
+def test_unambiguous_absolute_import_is_unaffected(tmp_path: Path) -> None:
+    # Only one `app/config.py` in the repo — the existing single-suffix-match
+    # path must keep resolving it.
+    _write(tmp_path / "svc_a/app/config.py", "class Settings:\n    league = 'college'\n")
+    _write(tmp_path / "svc_a/app/main.py",
+           "from app.config import Settings\n\n"
+           "class App:\n"
+           "    def build(self):\n"
+           "        return Settings()\n")
+    edges = _edges(sorted(tmp_path.rglob("*.py")), tmp_path)
+    assert [
+        (s, t, r) for s, t, r in edges
+        if s.startswith("svc_a_app_main") and t == "svc_a_app_config_settings"
+    ], sorted(edges)
+
+
+def test_nearest_stem_prefers_the_closest_candidate() -> None:
+    from graphify.extractors.resolution import _nearest_stem
+
+    candidates = ["svc_a/app/config", "svc_b/app/config"]
+    assert _nearest_stem(candidates, "svc_b/app/main") == "svc_b/app/config"
+    assert _nearest_stem(candidates, "svc_a/tests/test_config") == "svc_a/app/config"
+
+
+def test_nearest_stem_refuses_to_guess_on_a_tie() -> None:
+    from graphify.extractors.resolution import _nearest_stem
+
+    # Neither candidate shares any leading segment with the importer: the import
+    # is genuinely ambiguous and must produce no edge at all.
+    candidates = ["svc_a/app/config", "svc_b/app/config"]
+    assert _nearest_stem(candidates, "tools/script") is None
+    # A lone candidate is never a tie.
+    assert _nearest_stem(["svc_a/app/config"], "tools/script") == "svc_a/app/config"
+    assert _nearest_stem([], "tools/script") is None


### PR DESCRIPTION
## The bug

`_resolve_cross_file_imports` resolves an absolute `from app.config import Settings` in three steps: exact directory-qualified stem, unique suffix match, then a bare-stem index. That last index keeps only the first file written for a given basename — its own comment says *"first writer wins when names collide (inherently ambiguous)"*.

So when the first two steps can't disambiguate, **every importer of that module name repo-wide binds to whichever package happened to be extracted first.**

I hit this on a repo where two services each ship their own `app/` package and each define `Settings`:

```
service/app/main.py:7        from app.config import Settings, get_settings
service-sonos/app/main.py:8  from app.config import Settings, get_settings
```

Byte-identical import lines resolving to different files. The result was `uses` edges at INFERRED/0.95 from one service's `create_app()` and tests into the *other* service's class. The two services share no import, no call, and no field — `grep -r service-sonos service/` returns nothing — yet the mis-bound `Settings` became the graph's **highest-betweenness node**, because a false edge spanning communities that nothing else connects is structurally the most valuable kind. It was the top "surprising connection" and the top suggested question in `GRAPH_REPORT.md`.

The bug needs two collisions at once — a shared module basename **and** a shared class label inside it — which is why it surfaces as one confidently wrong class rather than broad noise. `from app.state import BoardState` mis-resolves to the other package's `state`, finds no `BoardState`, and drops silently.

Note it also needs enough of a corpus to defeat the earlier resolution steps: on a cut-down tree containing only the two services, `v8` resolves everything correctly and no phantom appears. Which package wins (and so the direction and exact count of the false edges) depends on extraction order.

## The fix

Resolve an ambiguous module path by proximity: the candidate sharing the longest leading path with the importing file, which is what Python's own `sys.path` resolution amounts to. On a genuine tie, emit nothing rather than guess.

Unambiguous single-suffix-match imports take the same path as before. `bare_to_qualified` became write-only once `_nearest_stem` replaced its only read, so it's removed and its stale comment updated.

## Effect on the reporting repo

Full 101-file corpus, `cache_root` at the repo root, `parallel=False`, 981 nodes both ways:

| | before | after |
|---|---|---|
| cross-service edges | 5 | **0** |
| correct intra-service edges added | — | **14** |
| `calls` edges lost | — | **0** |

The 14 additions are the same importers finally reaching their own package's `Settings`, `NowState` and `Now`. On the built graph this dropped the mis-bound class's betweenness from 0.048 to 0.034, and that service re-clustered from five fragments into one coherent community.

## Verification

- `tests/test_phantom_cross_package_import.py` — 6 tests, red before / green after. Covers the phantom, that each importer still reaches its *own* target (dropping everything would be over-correction), an importer in a sibling directory, the unambiguous case, and `_nearest_stem` directly including tie and empty input.
- Full suite: **5366 passed**. The 16 failures reproduce on pristine `v8` (`test_ollama_retry_cap`, `test_skillgen`) except `test_ts_normalizer_scales_linearly_on_large_files`, a wall-clock assertion that passes 3/3 in isolation and flakes under full-suite load. `_nearest_stem` is only reachable from the Python resolver.
- `ruff check` clean; `pyright` 43 errors before and after.