### PR TITLE
fix(python): resolve src-layout imports when the scan root is a symlink (closes #3446)

### DIFF
--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -1998,6 +1998,31 @@ def _probe_python_module_candidate(candidate: Path) -> Path | None:
     return None
 
 
+def _resolved_or_self(path: Path) -> Path:
+    """`path` with symlinks resolved, or unchanged when it cannot be resolved.
+
+    A broken symlink or an unreadable parent must never abort import resolution.
+    """
+    try:
+        return path.resolve()
+    except OSError:
+        return path
+
+
+def _is_within(candidate: Path, local_root: Path, root_key: Path) -> bool:
+    """True when `candidate` lies inside the scan root, in either spelling."""
+    try:
+        candidate.relative_to(local_root)
+        return True
+    except ValueError:
+        pass
+    try:
+        _resolved_or_self(candidate).relative_to(root_key)
+        return True
+    except ValueError:
+        return False
+
+
 def _resolve_python_module_path(module_name: str, current_path: Path, root: Path, level: int) -> Path | None:
     if level > 0:
         base = current_path.parent
@@ -2013,16 +2038,28 @@ def _resolve_python_module_path(module_name: str, current_path: Path, root: Path
     # src/pkg/mod.py whether the scan root is the repo or src/ (#2072). Mirrors
     # the upward walk already used for Lua (_resolve_lua_import_target, #1075).
     rel = module_name.replace(".", "/")
-    hit = _probe_python_module_candidate(root / rel)
+    # extract() resolves `root`, but the caller's paths keep whatever spelling they
+    # were collected with. When the corpus is reached through a symlink (macOS
+    # /tmp -> /private/tmp, a symlinked workspace, a bind mount in CI) the two
+    # disagree, `anc.relative_to(root)` raises on the very first ancestor, the walk
+    # breaks, and a src-layout import silently resolves to nothing — the same corpus
+    # reached by its real path produces strictly more edges at an identical node
+    # count. Re-derive the root as the CALLER spelled it and probe with that, so
+    # every path this function returns matches the ids built elsewhere.
+    root_key = _resolved_or_self(root)
+    local_root = root
+    for anc in current_path.parents:
+        if _resolved_or_self(anc) == root_key:
+            local_root = anc
+            break
+    hit = _probe_python_module_candidate(local_root / rel)
     if hit is not None:
         return hit
     for anc in current_path.parents:
-        try:
-            anc.relative_to(root)
-        except ValueError:
+        if _resolved_or_self(anc) != root_key and not _is_within(anc, local_root, root_key):
             break  # left the scan root; stop walking up
-        if anc == root:
-            continue  # already probed root/rel above
+        if anc == local_root or _resolved_or_self(anc) == root_key:
+            continue  # already probed local_root/rel above
         # Only probe sys.path-root candidates — dirs that are NOT themselves part
         # of a package. Probing a package dir would resolve an absolute
         # `from helpers import x` to a sibling in the current package (Python-2

--- a/tests/test_symlinked_scan_root.py
+++ b/tests/test_symlinked_scan_root.py
@@ -1,0 +1,100 @@
+"""Reaching the scan root through a symlink must not change the graph.
+
+macOS `/tmp` is a symlink to `/private/tmp`, and symlinked workspace dirs, symlinked
+homes and bind/overlay mounts in CI are all common. Extracting the same files through
+the symlink and through the real path used to produce different graphs: the same node
+count, but fewer edges — the `calls` edges for constructor calls on classes imported
+package-root-relative (src-layout, `from app.config import Settings` where the package
+lives at `svc/app/`) were dropped, leaving only a generic `uses` edge.
+
+Node IDs are clean and repo-relative in both runs, so the usual "absolute path leaked
+into the IDs" symptom is absent — the IDs look right while edges are silently missing,
+which reads downstream as genuine dead code rather than as a bug.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+
+import pytest
+
+from pathlib import Path
+
+from graphify.extract import collect_files, extract
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _corpus(root: Path) -> None:
+    """A src-layout service: package root is `svc/`, imports are written from it."""
+    _write(root / "svc/app/__init__.py", "")
+    _write(root / "svc/app/config.py", "class Settings:\n    port = 8000\n")
+    _write(root / "svc/app/main.py",
+           "def create_app(settings):\n    return {'settings': settings}\n")
+    _write(root / "svc/app/consumer.py",
+           "from app.config import Settings\n\n\n"
+           "def build():\n    return Settings()\n")
+    _write(root / "svc/tests/test_api.py",
+           "from app.config import Settings\n"
+           "from app.main import create_app\n\n\n"
+           "def make():\n    return create_app(settings=Settings())\n")
+
+
+def _extract_via(root: Path) -> dict:
+    # The two spellings name ONE physical directory, so they also share one
+    # graphify-out/ cache. Clear it between runs: otherwise the second extraction
+    # replays entries the first one keyed under the other spelling, and the test
+    # measures cache reuse instead of resolution.
+    shutil.rmtree(root / "graphify-out", ignore_errors=True)
+    files = sorted(f for f in collect_files(root) if f.suffix == ".py")
+    return extract(files, cache_root=root, parallel=False)
+
+
+def _summary(result: dict) -> tuple[int, set[tuple[str, str, str]]]:
+    edges = {(str(e["source"]), str(e["target"]), e["relation"]) for e in result["edges"]}
+    return len(result["nodes"]), edges
+
+
+@pytest.fixture()
+def linked_root(tmp_path: Path) -> tuple[Path, Path]:
+    """(real_root, symlinked_root) pointing at one identical corpus."""
+    real = tmp_path / "real"
+    _corpus(real)
+    link = tmp_path / "link"
+    try:
+        os.symlink(real, link, target_is_directory=True)
+    except (OSError, NotImplementedError):  # Windows without developer mode
+        pytest.skip("symlink creation not permitted on this platform")
+    return real, link
+
+
+def test_symlinked_scan_root_yields_the_same_graph(linked_root) -> None:
+    real, link = linked_root
+    real_nodes, real_edges = _summary(_extract_via(real))
+    link_nodes, link_edges = _summary(_extract_via(link))
+
+    assert link_nodes == real_nodes, "node counts already differ"
+    missing = {(s.split("svc_")[-1], t.split("svc_")[-1], r) for s, t, r in real_edges - link_edges}
+    assert not missing, f"edges lost when the scan root is a symlink: {sorted(missing)}"
+    assert link_edges == real_edges
+
+
+def test_symlinked_scan_root_keeps_constructor_calls(linked_root) -> None:
+    # The concrete symptom: `Settings()` in a src-layout importer.
+    _, link = linked_root
+    edges = _summary(_extract_via(link))[1]
+    for caller in ("svc_app_consumer_build", "svc_tests_test_api_make"):
+        rels = {r for s, t, r in edges if s == caller and t == "svc_app_config_settings"}
+        assert "calls" in rels, f"{caller} lost its `calls` edge to Settings (got {rels or 'nothing'})"
+
+
+def test_symlinked_scan_root_keeps_repo_relative_ids(linked_root) -> None:
+    # Guard the fix's shape: resolving the root must not push absolute paths into IDs.
+    _, link = linked_root
+    ids = {n["id"] for n in _extract_via(link)["nodes"]}
+    assert "svc_app_config_settings" in ids, sorted(ids)
+    assert not any(i.startswith(("private_", "tmp_", "var_", "users_")) for i in ids), sorted(ids)


### PR DESCRIPTION
Fixes #3446.

## The bug

`extract()` resolves `root`, but the caller's paths keep whatever spelling they were collected with — and `collect_files(symlinked_root)` returns symlinked paths. `_resolve_python_module_path` then compares a resolved root against an unresolved `current_path`:

```python
for anc in current_path.parents:
    try:
        anc.relative_to(root)      # resolved root vs symlinked ancestor
    except ValueError:
        break                      # -> bails on the FIRST ancestor
```

The upward walk breaks immediately and the absolute import resolves to nothing.

## The symptom

Identical files, one corpus, two spellings of the same directory:

| scan root | nodes | edges |
|---|---|---|
| `/private/tmp/ctor` (real path) | 11 | **20** |
| `/tmp/ctor` (symlink, macOS) | 11 | **15** |

The node count is unchanged and node ids stay clean and repo-relative in **both** runs, so the familiar "absolute paths leaked into the ids" symptom never shows up. What disappears are the `calls` edges for constructor calls on classes imported package-root-relative (`from app.config import Settings`, package at `svc/app/`) — only a generic `uses` edge survives, and the callee reads downstream as genuine dead code.

An import spelled from the scan root (`from svc.app.config import Settings`) keeps its `calls` edge either way, so the symlink and the src-layout spelling have to combine to trigger it.

macOS `/tmp` → `/private/tmp` is the easiest way to hit this, but a symlinked workspace or home directory and bind/overlay mounts in CI qualify too — and CI is exactly where a silently-smaller graph goes unnoticed.

## The fix

Re-derive the scan root **as the caller spelled it**: walk up from the importing file to the ancestor whose resolved form matches `root`, then probe with that. Every path the function returns then keeps one spelling, consistent with the ids built elsewhere. Containment accepts either spelling.

## What I deliberately did not do

Normalizing `extract()`'s inputs (`paths = [p.resolve() for p in paths]`) also fixes it, and was my first attempt. It breaks `test_rebuild_code_incremental_rename_preserves_symlink_source_path` plus the Kotlin object-literal and JS import-resolution suites — preserving the caller's path spelling in `source_file` is existing contract. So the fix stays inside the comparison rather than rewriting the inputs.

## Verification

- `tests/test_symlinked_scan_root.py` — 3 tests, red before / green after. The symlink is created inside pytest's `tmp_path`, so this is symlinks generally, not a macOS `/tmp` quirk, and it skips cleanly where symlink creation is not permitted. One test guards the fix's shape by asserting ids stay repo-relative.
- Full suite: **5374 passed**, 5 failed — `test_ollama_retry_cap` (4) and `test_ts_normalizer_scales_linearly_on_large_files` (a wall-clock assertion that passes in isolation), all of which fail on pristine `v8` too. No new failures.
- `test_watch.py`, `test_kotlin_object_literal.py`, `test_js_import_resolution.py`, `test_python_import_resolution.py`, `test_src_layout_import_resolution.py`, `test_symbol_resolution.py`, `test_skillgen.py`: 333 passed.
- `ruff check` clean; `pyright` 43 errors before and after.

## Note on the test itself

Both spellings name one physical directory, so they also share one `graphify-out/` cache. The test clears it between runs — otherwise the second extraction replays entries the first keyed under the other spelling, and you end up measuring cache reuse instead of resolution. That shared-cache interaction may be worth a look separately; it is not touched here.

Independent of #3445 (both branch from `v8`); the two do not overlap.