### PR TITLE
fix(extract): emit a calls self-edge for direct recursion (#3350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: when duplicate nodes merge, the richer (more complete) node is now kept as the survivor and the losers' non-empty fields are folded in, instead of a shorter-id passing mention winning and dropping content (#3372, thanks @abhay-codes07).
 - Fix: a C# generic call site with explicit type arguments — `Get<int>(...)`, unqualified or through `this` — now resolves to the method definition instead of capturing `Get<int>` as the callee and failing to match (#3406, thanks @abhay-codes07).
 - Fix: `this.X = function` / `this.X = () => …` members are now captured in every enclosing-function form (function expressions, arrows, IIFEs, callbacks), not just function declarations (#3408, thanks @abhay-codes07).
+- Fix: direct recursion now produces a `calls` self-edge — a call resolving to its own caller was dropped at extraction, so `factorial` calling `factorial` was absent while an ordinary call to it was present; a local binding or parameter that shadows the definition still yields no edge (#3350, thanks @rebel-JuhwanKim).
 
 ## 0.9.56 (2026-09-07)
 

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -5756,7 +5756,24 @@ def _extract_generic(
                         and not nid_to_sf.get(tgt_nid)
                     ):
                         tgt_nid = None
-                if tgt_nid and tgt_nid != caller_nid:
+                # A call whose callee resolves to the caller itself is direct
+                # recursion, and it was being dropped — `factorial` calling
+                # `factorial` produced no edge while `entry` calling `factorial`
+                # did, so the extracted call structure did not match the source
+                # (#3350). `build_from_json` already keeps a supplied recursive
+                # `calls` self-edge (#2038); only extraction was withholding it.
+                # Guard the one way a name resolving to the caller is not
+                # recursion: a local binding or parameter of the same name
+                # shadows the definition, so the call names that value. Rejecting
+                # it here (rather than clearing tgt_nid) keeps the name out of
+                # the cross-file raw_call queue, which would otherwise bind it to
+                # an unrelated same-named definition elsewhere in the corpus.
+                # The shadow table is populated for Python and JS/TS; elsewhere
+                # it is empty and a self-resolving name can only be recursion.
+                _shadowed_self_call = tgt_nid == caller_nid and callee_name in (
+                    local_bound_names.get(caller_nid, frozenset()) | extra_locals
+                )
+                if tgt_nid and not _shadowed_self_call:
                     pair = (caller_nid, tgt_nid)
                     if pair not in seen_call_pairs:
                         seen_call_pairs.add(pair)

--- a/tests/test_recursive_calls.py
+++ b/tests/test_recursive_calls.py
@@ -1,0 +1,180 @@
+"""Regression tests for direct recursion producing a `calls` self-edge (#3350).
+
+The direct-call path in the tree-sitter engine emitted an edge only when
+`tgt_nid != caller_nid`, so a call whose callee resolved to the caller itself —
+i.e. direct recursion — was dropped. `factorial` calling `factorial` produced
+nothing while `entry` calling `factorial` produced an edge, so the extracted
+call structure did not match the source. `build_from_json` has kept a supplied
+recursive `calls` self-edge since #2038; only extraction was withholding it.
+
+The one case where a name resolving to the caller is *not* recursion is a local
+binding or parameter that shadows the definition, and that stays edge-free.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _calls(result: dict) -> set[tuple[str, str]]:
+    return {
+        (edge["source"], edge["target"])
+        for edge in result["edges"]
+        if edge.get("relation") == "calls"
+    }
+
+
+def test_python_direct_recursion_emits_a_self_edge(tmp_path: Path):
+    from graphify.extract import extract
+
+    source = _write(
+        tmp_path / "repro.py",
+        "def factorial(n):\n"
+        "    return 1 if n < 2 else n * factorial(n - 1)\n"
+        "\n"
+        "def entry(n):\n"
+        "    return factorial(n)\n",
+    )
+
+    result = extract([source], root=tmp_path, cache_root=tmp_path)
+
+    calls = _calls(result)
+    assert ("repro_factorial", "repro_factorial") in calls
+    # The ordinary call must be unaffected.
+    assert ("repro_entry", "repro_factorial") in calls
+
+
+def test_recursive_self_edge_carries_extracted_confidence_and_a_location(tmp_path: Path):
+    from graphify.extract import extract
+
+    source = _write(
+        tmp_path / "walk.py",
+        "def walk(node):\n"
+        "    for child in node:\n"
+        "        walk(child)\n",
+    )
+
+    result = extract([source], root=tmp_path, cache_root=tmp_path)
+
+    self_edges = [
+        edge
+        for edge in result["edges"]
+        if edge.get("relation") == "calls" and edge["source"] == edge["target"]
+    ]
+    assert len(self_edges) == 1
+    assert self_edges[0]["confidence"] == "EXTRACTED"
+    assert self_edges[0]["source_location"] == "L3"
+
+
+def test_repeated_recursive_calls_produce_one_edge(tmp_path: Path):
+    """The pair-dedup guard still applies: two call sites, one edge."""
+    from graphify.extract import extract
+
+    source = _write(
+        tmp_path / "fib.py",
+        "def fib(n):\n"
+        "    if n < 2:\n"
+        "        return n\n"
+        "    return fib(n - 1) + fib(n - 2)\n",
+    )
+
+    result = extract([source], root=tmp_path, cache_root=tmp_path)
+
+    self_edges = [
+        edge
+        for edge in result["edges"]
+        if edge.get("relation") == "calls" and edge["source"] == edge["target"]
+    ]
+    assert len(self_edges) == 1
+
+
+def test_javascript_direct_recursion_emits_a_self_edge(tmp_path: Path):
+    from graphify.extract import extract
+
+    source = _write(
+        tmp_path / "rec.js",
+        "function fact(n) { return n < 2 ? 1 : n * fact(n - 1); }\n"
+        "function main() { return fact(5); }\n",
+    )
+
+    result = extract([source], root=tmp_path, cache_root=tmp_path)
+
+    calls = _calls(result)
+    assert ("rec_fact", "rec_fact") in calls
+    assert ("rec_main", "rec_fact") in calls
+
+
+@pytest.mark.parametrize(
+    "filename,text",
+    [
+        (
+            "shadow.js",
+            "function run() {\n"
+            "  const run = () => 1;\n"
+            "  return run();\n"
+            "}\n",
+        ),
+        (
+            "shadow.py",
+            "def run(run):\n"
+            "    return run()\n",
+        ),
+    ],
+)
+def test_a_shadowed_name_is_not_recursion(tmp_path: Path, filename: str, text: str):
+    """A local binding or parameter of the same name names a value, not the
+    enclosing function, so no self-edge."""
+    from graphify.extract import extract
+
+    source = _write(tmp_path / filename, text)
+
+    result = extract([source], root=tmp_path, cache_root=tmp_path)
+
+    assert not [
+        edge
+        for edge in result["edges"]
+        if edge.get("relation") == "calls" and edge["source"] == edge["target"]
+    ]
+
+
+def test_a_shadowed_self_call_is_not_parked_for_cross_file_resolution(tmp_path: Path):
+    """Rejecting the shadowed call must not hand the name to the corpus-level
+    resolver, which would bind it to an unrelated same-named definition."""
+    from graphify.extract import extract
+
+    shadowing = _write(
+        tmp_path / "app.js",
+        "function run() {\n"
+        "  const run = () => 1;\n"
+        "  return run();\n"
+        "}\n",
+    )
+    elsewhere = _write(tmp_path / "lib.js", "export function run() { return 2; }\n")
+
+    result = extract([shadowing, elsewhere], root=tmp_path, cache_root=tmp_path)
+
+    assert ("app_run", "lib_run") not in _calls(result)
+
+
+def test_a_recursive_edge_survives_graph_construction(tmp_path: Path):
+    """End to end: the extracted self-edge reaches the built graph (#2038)."""
+    from graphify.build import build_from_json
+    from graphify.extract import extract
+
+    source = _write(
+        tmp_path / "repro.py",
+        "def factorial(n):\n"
+        "    return 1 if n < 2 else n * factorial(n - 1)\n",
+    )
+
+    result = extract([source], root=tmp_path, cache_root=tmp_path)
+    graph = build_from_json(result)
+
+    assert graph.has_edge("repro_factorial", "repro_factorial")


### PR DESCRIPTION
Fixes #3350.

## The bug

The direct-call path in `extractors/engine.py` gated the edge on `tgt_nid != caller_nid`, so a call whose callee resolved to the caller itself — direct recursion — produced nothing. The reporter's repro:

```python
def factorial(n):
    return 1 if n < 2 else n * factorial(n - 1)

def entry(n):
    return factorial(n)
```

extracted `entry -> factorial` and dropped `factorial -> factorial`. Both nodes exist; the call in `factorial`'s own body is simply absent, so the extracted call structure does not match the source.

As the report notes, `build_from_json` has preserved a *supplied* recursive `calls` self-edge since #2038 — the graph layer was already ready for this. Only extraction was withholding it.

## The fix

Drop the `!= caller_nid` gate, and guard the one case where a name resolving to the caller is **not** recursion: a local binding or parameter of the same name shadows the definition, so the call names that value.

```js
function run() {
  const run = () => 1;
  return run();   // not recursion
}
```

Two details worth flagging for review:

1. **Rejected at the emit site, not by clearing `tgt_nid`.** Clearing it would fall into the `elif callee_name and not tgt_nid` branch and park the name in the cross-file raw_call queue, where it could bind to an unrelated same-named definition elsewhere in the corpus. There is a test for that (`test_a_shadowed_self_call_is_not_parked_for_cross_file_resolution`).
2. **The shadow tables are only populated for Python and JS/TS** (`_python_local_bound_names` / `_js_local_bound_names`). For other languages the set is empty, which is the correct default: absent a local binding, a bare name resolving to the enclosing function can only be recursion. Verified that JS recursion now links too.

`seen_call_pairs` is untouched, so a function with several recursive call sites still produces one edge.

The three sibling self-edge filters in the same function (`uses_static_prop`, `references_constant`, `uses_<helper>`) are deliberately left alone — those are not calls and a self-reference there is noise, not structure.

## Tests

`tests/test_recursive_calls.py`, 8 cases: the Python repro verbatim (recursive **and** ordinary edge); the self-edge's `EXTRACTED` confidence and `source_location`; two call sites → one edge; JS recursion; the two shadowing forms (JS `const`, Python parameter) emit nothing; a shadowed self-call is not parked for cross-file resolution; and the extracted self-edge survives `build_from_json` end to end.

Both shadowing cases were confirmed to fail with the guard removed, so they are load-bearing rather than decorative.

Full suite: 5493 passed, 3 pre-existing failures unrelated to this change (`test_extract_code_only_cli`, two `test_ollama` backend-detection tests — environment-dependent, failing identically on `v8` without this patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)