### PR TITLE
Gate `out` in _SKIP_DIRS on build evidence (#3347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: when duplicate nodes merge, the richer (more complete) node is now kept as the survivor and the losers' non-empty fields are folded in, instead of a shorter-id passing mention winning and dropping content (#3372, thanks @abhay-codes07).
 - Fix: a C# generic call site with explicit type arguments — `Get<int>(...)`, unqualified or through `this` — now resolves to the method definition instead of capturing `Get<int>` as the callee and failing to match (#3406, thanks @abhay-codes07).
 - Fix: `this.X = function` / `this.X = () => …` members are now captured in every enclosing-function form (function expressions, arrows, IIFEs, callbacks), not just function declarations (#3408, thanks @abhay-codes07).
+- Fix: an `out/` directory is now pruned only on build evidence (compiled artifacts inside, or a build file beside it), like `env`/`coverage`/`snapshots` already are — a hexagonal codebase's `adapter/out/` and `port/out/` were silently dropped by name alone; the Obsidian vault link index goes through the same gate (#3347, thanks @Muneeb7860).
 
 ## 0.9.56 (2026-09-07)
 

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -827,7 +827,7 @@ def _is_regular_file(path: Path) -> bool:
 _SKIP_DIRS = {
     "venv", ".venv",  # "env"/".env"/"*_env" are gated on venv markers below (#2058)
     "node_modules", "__pycache__", ".git",
-    "dist", "build", "target", "out",
+    "dist", "build", "target",  # bare "out" is gated on build evidence below (#3347)
     "site-packages", "lib64",
     ".pytest_cache", ".mypy_cache", ".ruff_cache",
     ".tox", ".nox", ".eggs", "*.egg-info",  # nox is tox's successor, same .nox/ venv shape (#1804)
@@ -899,6 +899,119 @@ def _has_coverage_artifacts(d: "Path") -> bool:
     return False
 
 
+# Suffixes only a compiler/bundler writes. Any one of them inside a directory
+# named `out` is proof it holds build output: JVM (.class/.jar/.war/.ear),
+# native (.o/.obj/.a/.lib/.so/.dylib/.dll/.exe/.pdb), wasm, Python bytecode,
+# .NET packages, and the sourcemap/tsbuildinfo pair a tsc `outDir: "out"` leaves
+# behind (the common JS/TS reason `out` is on this list at all).
+_BUILD_OUTPUT_ARTIFACT_SUFFIXES = frozenset({
+    ".class", ".jar", ".war", ".ear",
+    ".o", ".obj", ".a", ".lib", ".so", ".dylib", ".dll", ".exe", ".pdb",
+    ".wasm", ".pyc", ".pyd", ".nupkg", ".map", ".tsbuildinfo",
+})
+
+# Build files that conventionally emit into a sibling `out/`: IntelliJ and javac
+# for the JVM ones, tsc/bundlers for the JS ones, MSBuild for .NET. A build
+# manifest beside the directory is the second kind of proof — an `out/` next to
+# `pom.xml` is IDEA's output dir, while `adapter/out/` deep inside a source tree
+# has no build file anywhere near it.
+_BUILD_MANIFEST_FILES = frozenset({
+    "pom.xml", "build.gradle", "build.gradle.kts",
+    "settings.gradle", "settings.gradle.kts", "build.xml",
+    "Makefile", "makefile", "GNUmakefile", "CMakeLists.txt",
+    "tsconfig.json", "jsconfig.json", "package.json",
+    "webpack.config.js", "rollup.config.js", "gulpfile.js",
+})
+_BUILD_MANIFEST_SUFFIXES = frozenset({".csproj", ".vbproj", ".fsproj", ".sln"})
+
+# Budget for the artifact probe: a build output tree is wide and deep, and the
+# probe runs during the os.walk descent, so it must not turn a scan into a full
+# second traversal. The entry budget is the real bound; the depth limit only
+# stops a pathological tree. Depth has to clear a JVM layout — IntelliJ writes
+# out/production/<module>/<package path>/App.class, so the first .class file sits
+# several levels down — hence 8 rather than a token 2 or 3.
+_BUILD_OUTPUT_PROBE_ENTRIES = 400
+_BUILD_OUTPUT_PROBE_DEPTH = 8
+
+
+def _has_build_output_artifacts(d: "Path") -> bool:
+    """True when *d* holds files only a compiler or bundler writes.
+
+    Bounded walk: at most ``_BUILD_OUTPUT_PROBE_ENTRIES`` entries over
+    ``_BUILD_OUTPUT_PROBE_DEPTH`` levels, depth-first so a deeply nested
+    artifact is reached before the budget is spent on breadth. Generated trees
+    announce themselves within a few entries of a leaf, so the cap costs recall
+    only in contrived cases and keeps the probe from doubling a scan's cost.
+    """
+    seen = 0
+    stack: list[tuple[Path, int]] = [(d, 0)]
+    while stack:
+        current, depth = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                for entry in it:
+                    seen += 1
+                    if seen > _BUILD_OUTPUT_PROBE_ENTRIES:
+                        return False
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            if depth + 1 < _BUILD_OUTPUT_PROBE_DEPTH:
+                                stack.append((Path(entry.path), depth + 1))
+                            continue
+                    except OSError:
+                        continue
+                    if Path(entry.name).suffix.lower() in _BUILD_OUTPUT_ARTIFACT_SUFFIXES:
+                        return True
+                    # `.d.ts` is a declaration file tsc emits; `Path.suffix` only
+                    # sees `.ts`, which is ordinary source.
+                    if entry.name.lower().endswith(".d.ts"):
+                        return True
+        except OSError:
+            continue
+    return False
+
+
+def _has_sibling_build_manifest(parent: "Path") -> bool:
+    """True when *parent* holds a build file that emits into a sibling ``out/``."""
+    try:
+        with os.scandir(parent) as it:
+            for entry in it:
+                try:
+                    if entry.is_dir(follow_symlinks=False):
+                        continue
+                except OSError:
+                    continue
+                if entry.name in _BUILD_MANIFEST_FILES:
+                    return True
+                if Path(entry.name).suffix.lower() in _BUILD_MANIFEST_SUFFIXES:
+                    return True
+    except OSError:
+        pass
+    return False
+
+
+def _is_build_output_dir(parent: "Path", name: str) -> bool:
+    """Is ``parent/name`` (a directory named ``out``) generated build output?
+
+    ``out`` was pruned by name alone, which is right for IntelliJ's and tsc's
+    output dir and wrong for a hexagonal / ports-and-adapters codebase, where
+    ``adapter/out/`` and ``port/out/`` hold the entire outbound layer —
+    persistence adapters, JPA entities, outbound port interfaces. In the repo
+    that surfaced this, that was 196 of 655 ``.java`` files, every ``@Entity``
+    among them, dropped with exit code 0 and no warning; the surviving graph
+    looked coherent while every path from application code to the database was
+    gone (#3347, same mechanism as #2479).
+
+    So require evidence, like ``env``/``coverage``/``snapshots`` already do, and
+    keep the directory when it cannot be confirmed. Evidence is either compiled
+    artifacts inside it, or a build file beside it.
+    """
+    return (
+        _has_build_output_artifacts(parent / name)
+        or _has_sibling_build_manifest(parent)
+    )
+
+
 def _has_venv_markers(d: "Path") -> bool:
     """True only when *d* has actual virtualenv/conda structure on disk.
 
@@ -938,6 +1051,13 @@ def _is_noise_dir(part: str, parent: "Path | None" = None) -> bool:
         if parent is None:
             return False  # cannot verify; keep a possibly-real code dir
         return _has_coverage_artifacts(parent / part)
+    if part == "out":
+        # Ambiguous: a build output dir OR the outbound layer of a hexagonal
+        # codebase (adapter/out/, port/out/). Prune only on build evidence —
+        # compiled artifacts inside, or a build file beside it (#3347).
+        if parent is None:
+            return False  # cannot verify; keep a possibly-real code dir
+        return _is_build_output_dir(parent, part)
     if part == "snapshots":
         # Prune only when it looks like an actual JS/Vitest snapshot dir.
         if parent is None:

--- a/graphify/extractors/markdown.py
+++ b/graphify/extractors/markdown.py
@@ -129,15 +129,19 @@ def _build_link_index(root: Path) -> "dict[str, list[tuple[int, str, Path]]]":
     """Index every linkable document under *root* by NFC-normalized basename.
 
     Each entry maps basename -> [(depth, root-relative posix path, absolute
-    path)]. Directories in detect._SKIP_DIRS and dot-directories are pruned —
-    the same corpus boundary the scanner draws, and Obsidian itself does not
-    index dot-folders.
+    path)]. Noise directories and dot-directories are pruned — the same corpus
+    boundary the scanner draws, and Obsidian itself does not index dot-folders.
+
+    Pruning goes through _is_noise_dir (not the raw _SKIP_DIRS set) so the
+    evidence-gated names — env/coverage/snapshots/out — are judged here exactly
+    as the scanner judges them, instead of being pruned on their name alone.
     """
-    from graphify.detect import _SKIP_DIRS
+    from graphify.detect import _is_noise_dir
     index: dict[str, list[tuple[int, str, Path]]] = {}
     for dirpath, dirnames, filenames in os.walk(root):
+        dp = Path(dirpath)
         dirnames[:] = sorted(
-            d for d in dirnames if not d.startswith(".") and d not in _SKIP_DIRS
+            d for d in dirnames if not d.startswith(".") and not _is_noise_dir(d, dp)
         )
         for fname in filenames:
             if Path(fname).suffix.lower() not in _MD_LINKABLE_EXTS:

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -991,6 +991,93 @@ def test_is_noise_dir_coverage_is_evidence_gated(tmp_path):
     assert detect_mod._is_noise_dir("lcov-report") is True
 
 
+def test_is_noise_dir_out_is_evidence_gated(tmp_path):
+    """`out` is ambiguous: a build dir OR the outbound layer of a hexagonal
+    codebase. Prune on evidence only; keep it when unverifiable (#3347)."""
+    # Hexagonal Java: adapter/out/ holds sources, no artifacts, no build file.
+    adapter = tmp_path / "src" / "main" / "java" / "com" / "acme" / "adapter"
+    (adapter / "out").mkdir(parents=True)
+    (adapter / "out" / "OrderEntity.java").write_text("class OrderEntity {}")
+    assert detect_mod._is_noise_dir("out", adapter) is False
+
+    # A Go package literally named out is source too.
+    (tmp_path / "internal" / "out").mkdir(parents=True)
+    (tmp_path / "internal" / "out" / "handler.go").write_text("package out")
+    assert detect_mod._is_noise_dir("out", tmp_path / "internal") is False
+
+    # Unverifiable (no parent) keeps a possibly-real code dir.
+    assert detect_mod._is_noise_dir("out") is False
+
+
+def test_is_noise_dir_out_pruned_on_build_evidence(tmp_path):
+    """The two evidence kinds: compiled artifacts inside, or a build manifest
+    beside it (#3347)."""
+    # tsc: emitted .js/.d.ts/.js.map inside out/.
+    tsc = tmp_path / "tsc"
+    (tsc / "out").mkdir(parents=True)
+    (tsc / "out" / "index.js").write_text("exports.a=1;")
+    (tsc / "out" / "index.d.ts").write_text("export declare const a: number;")
+    (tsc / "out" / "index.js.map").write_text("{}")
+    assert detect_mod._is_noise_dir("out", tsc) is True
+
+    # IntelliJ: artifacts are nested a few levels down, not at the top.
+    idea = tmp_path / "idea"
+    deep = idea / "out" / "production" / "classes" / "com" / "acme"
+    deep.mkdir(parents=True)
+    (deep / "App.class").write_text("x")
+    assert detect_mod._is_noise_dir("out", idea) is True
+
+    # A build manifest beside out/ is enough on its own.
+    gradle = tmp_path / "gradle"
+    (gradle / "out").mkdir(parents=True)
+    (gradle / "out" / "notes.txt").write_text("hi")
+    (gradle / "build.gradle.kts").write_text("plugins {}")
+    assert detect_mod._is_noise_dir("out", gradle) is True
+
+
+def test_detect_keeps_hexagonal_outbound_layer(tmp_path):
+    """End to end: the outbound layer of a ports-and-adapters repo must be
+    scanned, not silently dropped (#3347)."""
+    (tmp_path / "pom.xml").write_text("<project/>")
+    base = tmp_path / "src" / "main" / "java" / "com" / "acme"
+    for rel, body in (
+        ("adapter/in/OrderController.java", "class OrderController {}"),
+        ("adapter/out/OrderEntity.java", "class OrderEntity {}"),
+        ("adapter/out/PaymentEntity.java", "class PaymentEntity {}"),
+        ("port/out/OrderRepository.java", "interface OrderRepository {}"),
+    ):
+        p = base / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+
+    result = detect(tmp_path)
+    scanned = {Path(p).name for p in result["files"]["code"]}
+    assert {"OrderEntity.java", "PaymentEntity.java", "OrderRepository.java"} <= scanned, (
+        "adapter/out/ and port/out/ are source, not build output (#3347)"
+    )
+    assert result["pruned_noise_dirs"] == []
+
+
+def test_detect_still_prunes_build_out_dir(tmp_path):
+    """The regression guard for the other direction: a real tsc/IntelliJ out/
+    stays pruned (#3347)."""
+    (tmp_path / "package.json").write_text("{}")
+    (tmp_path / "tsconfig.json").write_text("{}")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "index.ts").write_text("export const a = 1;")
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "index.js").write_text("exports.a=1;")
+    (out / "index.d.ts").write_text("export declare const a: number;")
+    (out / "GENERATED.md").write_text("# generated")
+
+    result = detect(tmp_path)
+    assert any(p.rstrip("/").endswith("out") for p in result["pruned_noise_dirs"])
+    names = {Path(p).name for p in result["files"]["code"] + result["files"]["document"]}
+    assert "index.ts" in names
+    assert not {"index.js", "index.d.ts", "GENERATED.md"} & names
+
+
 def test_detect_skips_visual_tests_dir(tmp_path):
     """visual-tests/ bundles and snapshots are noise — must be excluded (#869)."""
     vt = tmp_path / "visual-tests"

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -2981,6 +2981,44 @@ def test_markdown_wikilink_sibling_still_wins(tmp_path):
         f"sibling must shadow the vault-wide match, got {targets}")
 
 
+def test_markdown_wikilink_fallback_respects_evidence_gated_dirs(tmp_path):
+    """The vault index prunes through _is_noise_dir, not the raw _SKIP_DIRS set,
+    so an evidence-gated name is judged the same way the scanner judges it: a
+    generated out/ is skipped, a hexagonal out/ full of notes is indexed (#3347)."""
+    vault = tmp_path / "vault"
+    (vault / "log").mkdir(parents=True)
+    # Generated: artifacts inside prove it is build output, so its copy of the
+    # note must not win the bare-name lookup.
+    (vault / "out").mkdir()
+    (vault / "out" / "hub.md").write_text("# Generated copy\n")
+    (vault / "out" / "bundle.js.map").write_text("{}")
+    (vault / "docs").mkdir()
+    (vault / "docs" / "hub.md").write_text("# Real hub\n")
+    (vault / "log" / "entry.md").write_text("See [[hub]].\n")
+    _, refs, page_id = _vault_extract(
+        vault, [vault / "docs" / "hub.md", vault / "log" / "entry.md"])
+    entry_id = page_id(vault / "log" / "entry.md")
+    targets = {e["target"] for e in refs if e["source"] == entry_id}
+    assert targets == {page_id(vault / "docs" / "hub.md")}, (
+        f"a generated out/ must stay out of the vault index, got {targets}")
+
+    from graphify.extractors.markdown import _MD_LINK_INDEX_CACHE
+    _MD_LINK_INDEX_CACHE.clear()
+
+    # Source: no artifacts, no build file beside it — an outbound-layer doc is
+    # part of the corpus and must be reachable.
+    hexa = tmp_path / "hexa"
+    (hexa / "adapter" / "out").mkdir(parents=True)
+    (hexa / "adapter" / "out" / "persistence.md").write_text("# Persistence\n")
+    (hexa / "notes.md").write_text("See [[persistence]].\n")
+    _, refs, page_id = _vault_extract(
+        hexa, [hexa / "adapter" / "out" / "persistence.md", hexa / "notes.md"])
+    targets = {e["target"] for e in refs
+               if e["source"] == page_id(hexa / "notes.md")}
+    assert targets == {page_id(hexa / "adapter" / "out" / "persistence.md")}, (
+        f"a source out/ must be indexed, got {targets}")
+
+
 def test_markdown_inline_link_keeps_relative_semantics(tmp_path):
     """Inline [text](missing.md) links get no vault fallback: a missing
     relative target stays dangling exactly as before."""


### PR DESCRIPTION
Fixes #3347.

## Problem

`"out"` is a bare string in `detect._SKIP_DIRS`, so `_is_noise_dir` prunes it on its name alone. In a hexagonal / ports-and-adapters codebase that name is the *outbound* layer:

```
src/main/java/com/acme/
├── adapter/in/     ← scanned
├── adapter/out/    ← dropped (JPA entities, HTTP clients)
└── port/out/       ← dropped (repository ports)
```

The reporter lost 196 of 655 `.java` files this way — exit code 0, no warning, no mention in `pruned_noise_dirs` that anything meaningful had gone.

## Fix

`out` is ambiguous in exactly the way `env`, `coverage` and `snapshots` already are, so it gets the same established treatment: **prune only on evidence; keep the directory when the evidence is absent or cannot be verified.**

Evidence is either of:

- **compiled artifacts inside** — `.class`, `.o`, `.js.map`, `.d.ts`, … located by a depth-first probe bounded to 400 entries over 8 levels. Depth 8 is deliberate: IntelliJ writes `out/production/<module>/<package path>/App.class`, so the first `.class` sits several levels down. The entry budget is the real bound, so the probe cannot turn a scan into a second full traversal.
- **a build manifest beside it** — `pom.xml`, `build.gradle[.kts]`, `tsconfig.json`, `*.csproj`, `Makefile`, `webpack.config.js`, … which is sufficient on its own.

`_is_noise_dir("out")` with no parent returns `False`: unverifiable keeps a possibly-real code dir, matching the `env`/`coverage` contract.

## One related change

`_build_link_index` in `graphify/extractors/markdown.py` filtered on the raw `_SKIP_DIRS` set rather than `_is_noise_dir`, even though its docstring claims it draws "the same corpus boundary the scanner draws". Left alone, the vault index would disagree with the scanner on every evidence-gated name — indexing a *generated* `out/README.md` as a wikilink target while the scanner pruned it. It now goes through the gate.

## Tests

- `test_is_noise_dir_out_is_evidence_gated` — hexagonal Java `adapter/out/`, a Go package named `out`, and the no-parent call all keep the dir.
- `test_is_noise_dir_out_pruned_on_build_evidence` — tsc `out/` (emitted `.js`/`.d.ts`/`.js.map`), IntelliJ `out/production/classes/com/acme/App.class` (nested), and `out/` beside a `build.gradle.kts` all prune.
- `test_detect_keeps_hexagonal_outbound_layer` — end to end: `OrderEntity`, `PaymentEntity`, `OrderRepository` are scanned and `pruned_noise_dirs` is empty.
- `test_detect_still_prunes_build_out_dir` — the other direction: a real tsc `out/` stays pruned and its emitted files stay out of the corpus.
- `test_markdown_wikilink_fallback_respects_evidence_gated_dirs` — a generated `out/` stays out of the vault index; a source `out/` is indexed.

Full suite: 5498 passed, 3 pre-existing environment-dependent failures unchanged (`test_extract_code_only_cli`, two `test_ollama` backend-detection tests — all fail on a clean tree here too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)