### PR TITLE
Classify Jinja templates (.j2/.jinja/.jinja2) as documents (#3427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: when duplicate nodes merge, the richer (more complete) node is now kept as the survivor and the losers' non-empty fields are folded in, instead of a shorter-id passing mention winning and dropping content (#3372, thanks @abhay-codes07).
 - Fix: a C# generic call site with explicit type arguments — `Get<int>(...)`, unqualified or through `this` — now resolves to the method definition instead of capturing `Get<int>` as the callee and failing to match (#3406, thanks @abhay-codes07).
 - Fix: `this.X = function` / `this.X = () => …` members are now captured in every enclosing-function form (function expressions, arrows, IIFEs, callbacks), not just function declarations (#3408, thanks @abhay-codes07).
+- Fix: Jinja templates (`.j2`, `.jinja`, `.jinja2`) are now classified as documents instead of being silently unclassified — a codegen repo's graph described only the generated files marked `DO NOT EDIT` and none of the templates they come from; oversized templates are sliced like every other text document (#3427, thanks @AmberProof).
 
 ## 0.9.56 (2026-09-07)
 

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -42,7 +42,16 @@ _MTIME_COARSE_S = 2.0
 _MTIME_SUBSECOND_S = 0.05
 
 CODE_EXTENSIONS = {'.py', '.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs', '.ejs', '.ets', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.cu', '.cuh', '.metal', '.rb', '.rake', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.psm1', '.psd1', '.ex', '.exs', '.m', '.mm', '.ml', '.mli', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.svh', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json', '.tf', '.tfvars', '.hcl', '.dm', '.dme', '.dmi', '.dmm', '.dmf', '.sln', '.slnx', '.csproj', '.fsproj', '.vbproj', '.xaml', '.razor', '.cshtml', '.cls', '.trigger', '.lisp', '.cl', '.lsp', '.asd', '.robot', '.resource'}
-DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.skill', '.txt', '.rst', '.html', '.yaml', '.yml'}
+# Jinja templates are documents, not code: in a codegen repo the template is the
+# only file a developer is allowed to edit (the generated module says DO NOT EDIT
+# and is overwritten every build), so leaving `.j2` unclassified made the graph
+# describe exactly the half that must not be touched (#3427). They are not routed
+# to CODE because a template is not valid source in its target language —
+# `{% for %}` in a .py.j2 is a parse error, not an AST — and the semantic pass
+# reads the prose, generator header and structure that carry the real link.
+# Note the outer suffix is what classifies: `module.py.j2` -> `.j2`.
+DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.skill', '.txt', '.rst', '.html', '.yaml', '.yml',
+                  '.j2', '.jinja', '.jinja2'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}
 OFFICE_EXTENSIONS = {'.docx', '.xlsx'}

--- a/graphify/file_slice.py
+++ b/graphify/file_slice.py
@@ -38,6 +38,7 @@ from pathlib import Path
 _SPLITTABLE_TEXT_SUFFIXES = frozenset({
     ".md", ".mdx", ".markdown", ".txt", ".rst",
     ".qmd", ".skill", ".html", ".yaml", ".yml",
+    ".j2", ".jinja", ".jinja2",
 })
 
 # Document types whose BYTES are not what the model is shown. `llm._file_to_text`

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -49,6 +49,16 @@ def test_classify_skill():
     # #1901: .skill agent files (Markdown with YAML frontmatter) were dropped as unclassified.
     assert classify_file(Path("10_Orchestrator.skill")) == FileType.DOCUMENT
 
+def test_classify_jinja_template():
+    # #3427: .j2/.jinja/.jinja2 were unclassified, so a codegen repo's graph
+    # described only the generated files that must NOT be edited.
+    assert classify_file(Path("templates/module.py.j2")) == FileType.DOCUMENT
+    assert classify_file(Path("templates/base.jinja")) == FileType.DOCUMENT
+    assert classify_file(Path("templates/base.jinja2")) == FileType.DOCUMENT
+    # The outer suffix classifies, whatever the target language underneath.
+    for inner in ("py", "ts", "yaml", "conf", "sql", "tf"):
+        assert classify_file(Path(f"t/app.{inner}.j2")) == FileType.DOCUMENT
+
 def test_classify_pdf():
     assert classify_file(Path("paper.pdf")) == FileType.PAPER
 
@@ -95,6 +105,27 @@ def test_detect_skips_noise_dot_dirs():
             # well-known framework caches are always skipped
             for noise in ("/.next/", "/.nuxt/", "/.turbo/", "/.angular/"):
                 assert noise not in f
+
+
+def test_detect_finds_jinja_templates_beside_generated_code(tmp_path):
+    """The reported shape: a codegen repo where the generated module is graphed
+    and the template it comes from is invisible (#3427)."""
+    (tmp_path / "templates").mkdir()
+    (tmp_path / "templates" / "module.py.j2").write_text(
+        "# generated from module.py.j2 — DO NOT EDIT MANUALLY\n"
+        "class {{ name }}:\n    pass\n"
+    )
+    (tmp_path / "templates" / "config.yaml.jinja2").write_text("name: {{ name }}\n")
+    (tmp_path / "module.py").write_text("class Generated:\n    pass\n")
+
+    result = detect(tmp_path)
+
+    assert str(tmp_path / "module.py") in result["files"]["code"]
+    assert set(result["files"]["document"]) == {
+        str(tmp_path / "templates" / "module.py.j2"),
+        str(tmp_path / "templates" / "config.yaml.jinja2"),
+    }
+    assert result["unclassified"] == []
 
 
 def test_detect_skips_obsidian_vault_metadata_dirs(tmp_path):

--- a/tests/test_oversized_document_slicing.py
+++ b/tests/test_oversized_document_slicing.py
@@ -104,7 +104,7 @@ def test_slices_stay_within_the_cap(tmp_path):
 # End to end through the prompt builder
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("ext", [".qmd", ".html", ".yaml", ".yml", ".skill"])
+@pytest.mark.parametrize("ext", [".qmd", ".html", ".yaml", ".yml", ".skill", ".j2"])
 def test_the_tail_of_a_big_document_reaches_the_prompt(tmp_path, ext):
     """The symptom a user would notice: content past 20k was invisible to the
     semantic pass, so nothing in the tail could ever become a node."""


### PR DESCRIPTION
Fixes #3427.

## Problem

`.j2`, `.jinja` and `.jinja2` are in no classification set, so `classify_file` returns `None` and templates never enter the corpus at all — not as code, not as documents. The reporter had **71 tracked template files, 0 detected, 0 nodes.**

For a codegen repo this inverts what the graph is for. The generated modules are marked `DO NOT EDIT MANUALLY` and are overwritten on every build, yet they are the only half with nodes. An agent asking the graph "where do I change X" is pointed at files that must not be edited, and cannot see the file that must.

## Fix

Option 1 from the issue: `.j2`, `.jinja`, `.jinja2` are added to `DOC_EXTENSIONS`.

**Why DOCUMENT and not CODE.** A template is not valid source in its target language — `{% for %}` in a `.py.j2` is a parse error, not an AST — so routing it to the AST path would produce a tree of `ERROR` nodes rather than structure. The semantic pass reads the prose, the generator header and the layout, which is what carries the template → generated relationship the issue is about.

The outer suffix is what classifies, so the usual `<real-ext>.j2` naming works without a compound-extension special case:

```
templates/module.py.j2      -> DOCUMENT
templates/config.yaml.j2    -> DOCUMENT
templates/nginx.conf.j2     -> DOCUMENT
templates/base.jinja        -> DOCUMENT
templates/base.jinja2       -> DOCUMENT
```

## One required companion change

`file_slice._SPLITTABLE_TEXT_SUFFIXES` gets the same three suffixes. The contract test added for #2900 (`test_every_text_document_type_is_splittable`) pins that list against `DOC_EXTENSIONS` for exactly this reason: a document type that reaches the model but is not splittable is silently truncated at `_FILE_CHAR_CAP` (20,000 chars) with no warning and no partial marker. Templates in codegen repos are routinely larger than that.

## Scope notes

- `--code-only` still skips templates, but now says so explicitly (`skipping N non-code file(s)`) instead of the previous silent zero. That is the existing, intended `--code-only` contract.
- The issue also mentions `build/` being pruned by `_SKIP_DIRS`; the reporter explicitly framed that as not-a-bug, so it is untouched here.
- Sensitivity screening is unchanged in behavior: `templates/credentials.j2` and `templates/secrets.yaml.j2` are still flagged, and `.j2` behaves exactly as `.yaml`/`.txt` already do for every other name.
- `watch._WATCHED_EXTENSIONS` is derived from these sets, so editing a template now triggers a rebuild — which is the point.

## Tests

- `test_classify_jinja_template` — all three suffixes, plus `app.{py,ts,yaml,conf,sql,tf}.j2` to pin that the outer suffix classifies.
- `test_detect_finds_jinja_templates_beside_generated_code` — the reported shape end to end: generated `module.py` in `code`, both templates in `document`, `unclassified` empty.
- `test_an_oversized_document_reaches_the_model_whole` is parametrized over `DOC_EXTENSIONS`, so it now covers the three new suffixes automatically; `.j2` is added to the tail-marker case as well.

Full suite: 5499 passed, 3 pre-existing environment-dependent failures unchanged (`test_extract_code_only_cli`, two `test_ollama` backend-detection tests — all fail on a clean tree here too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)