### PR TITLE
PHP: give `use A\B\C as D` the imported class's identity (#3421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: when duplicate nodes merge, the richer (more complete) node is now kept as the survivor and the losers' non-empty fields are folded in, instead of a shorter-id passing mention winning and dropping content (#3372, thanks @abhay-codes07).
 - Fix: a C# generic call site with explicit type arguments — `Get<int>(...)`, unqualified or through `this` — now resolves to the method definition instead of capturing `Get<int>` as the callee and failing to match (#3406, thanks @abhay-codes07).
 - Fix: `this.X = function` / `this.X = () => …` members are now captured in every enclosing-function form (function expressions, arrows, IIFEs, callbacks), not just function declarations (#3408, thanks @abhay-codes07).
+- Fix: PHP `use A\B\C as D` now gives the import edge the same target as a plain `use A\B\C` — the target was derived from the imported name's last segment, so an aliased import either split the class into a second identity or dangled (103 of 145 dangling endpoints on the reported codebase); aliased group-uses resolve too (#3421, thanks @DmitrySamushchenko).
 
 ## 0.9.56 (2026-09-07)
 

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -728,23 +728,44 @@ def _import_scala(node, source: bytes, file_nid: str, stem: str, edges: list, st
 
 
 def _import_php(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str, scope_stack: list[str] | None = None) -> None:
+    # `use function ns\f as g` / `use const ns\C as D` are symbol imports, not
+    # class imports: _resolve_php_type_references deliberately skips them, so
+    # their alias is absent from its per-file `uses` map and the imported name's
+    # last segment stays the right bare name for the unique-label rewire.
+    is_symbol_import = any(c.type in ("function", "const") for c in node.children)
+    imported = ""
+    alias = ""
+    saw_as = False
     for child in node.children:
-        if child.type in ("qualified_name", "name", "identifier"):
-            raw = _read_text(child, source)
-            module_name = raw.split("\\")[-1].strip()
-            if module_name:
-                tgt_nid = _make_id(module_name)
-                edges.append({
-                    "source": file_nid,
-                    "target": tgt_nid,
-                    "relation": "imports",
-                    "context": "import",
-                    "confidence": "EXTRACTED",
-                    "source_file": str_path,
-                    "source_location": f"L{node.start_point[0] + 1}",
-                    "weight": 1.0,
-                })
-            break
+        if child.type == "as":
+            saw_as = True
+        elif child.type in ("qualified_name", "name", "identifier"):
+            if saw_as:
+                alias = _read_text(child, source)
+                break
+            if not imported:
+                imported = _read_text(child, source)
+    # An alias is a file-local binding, but it is the name this file's own
+    # references use AND the key _resolve_php_type_references files the imported
+    # FQN under, so the edge has to be minted on it for that pass to
+    # canonicalize the target onto the imported class. Taking the last segment
+    # of the *imported* name instead gave `use A\B\C as D` a target no `uses`
+    # entry could match, so the edge either minted a second identity for C or
+    # dangled outright — 103 of 145 dangling endpoints on the reported
+    # codebase (#3421).
+    binding = (alias if alias and not is_symbol_import else imported.split("\\")[-1]).strip()
+    if not binding:
+        return
+    edges.append({
+        "source": file_nid,
+        "target": _make_id(binding),
+        "relation": "imports",
+        "context": "import",
+        "confidence": "EXTRACTED",
+        "source_file": str_path,
+        "source_location": f"L{node.start_point[0] + 1}",
+        "weight": 1.0,
+    })
 
 
 # ── C/C++ function name helpers ───────────────────────────────────────────────

--- a/tests/test_php_type_resolution.py
+++ b/tests/test_php_type_resolution.py
@@ -188,3 +188,142 @@ def test_php_import_resolves_when_target_name_prefixes_sibling_classes(tmp_path:
 
     assert len(imports) == 1
     assert imports[0]["target"] == pivot_id
+
+
+# ── `use A\B\C as D`: the alias must not mint a second identity (#3421) ───────
+
+def _imports_from(result: dict, source_fragment: str) -> list[dict]:
+    return [
+        e for e in result["edges"]
+        if e["relation"] == "imports"
+        and source_fragment in e.get("source", "").lower()
+    ]
+
+
+def test_php_aliased_external_import_shares_target_with_plain_import(tmp_path: Path):
+    """The reported repro: two files importing GuzzleHttp\\Client, one aliased.
+
+    The import edge target was derived from the last segment of the imported
+    name, so the aliased file's edge landed on a bare `client` that nothing else
+    used — `GuzzleHttp\\Client` became two nodes and neither file was reachable
+    from the other's traversal (#3421).
+    """
+    a = _write(
+        tmp_path / "src/A.php",
+        "<?php\nnamespace App;\n"
+        "use GuzzleHttp\\Client;\n"
+        "class A { public function __construct(private Client $c) {} }\n",
+    )
+    b = _write(
+        tmp_path / "src/B.php",
+        "<?php\nnamespace App;\n"
+        "use GuzzleHttp\\Client as HttpClient;\n"
+        "class B { public function __construct(private HttpClient $c) {} }\n",
+    )
+    result = extract([a, b], cache_root=tmp_path)
+
+    plain = _imports_from(result, "src_a")
+    aliased = _imports_from(result, "src_b")
+    assert len(plain) == 1 and len(aliased) == 1
+    assert aliased[0]["target"] == plain[0]["target"], (
+        "an alias is a file-local binding; it must not give the imported class a "
+        "second identity"
+    )
+    tgt = _node_by_id(result, aliased[0]["target"])
+    assert tgt is not None and tgt.get("label") == "GuzzleHttp\\Client"
+    # The bare-name node the alias used to strand is gone entirely.
+    assert _node_by_id(result, "client") is None
+
+
+def test_php_aliased_import_of_internal_class_resolves_to_definition(tmp_path: Path):
+    """An aliased `use` of a class in the same project points at that class's
+    own node, not at a bare-name stub."""
+    user = _write(
+        tmp_path / "src/Models/User.php",
+        "<?php\nnamespace App\\Models;\nclass User {}\n",
+    )
+    b = _write(
+        tmp_path / "src/B.php",
+        "<?php\nnamespace App;\n"
+        "use App\\Models\\User as Member;\n"
+        "class B { public function __construct(private Member $u) {} }\n",
+    )
+    result = extract([user, b], cache_root=tmp_path)
+
+    user_id = _class_defs(result, "User")[0]["id"]
+    aliased = _imports_from(result, "src_b")
+    assert len(aliased) == 1
+    assert aliased[0]["target"] == user_id
+
+
+def test_php_two_aliased_imports_of_same_bare_name_stay_distinct(tmp_path: Path):
+    """The symptom on the reporter's Laravel project: aliasing exists precisely
+    to disambiguate two classes sharing a simple name, and both edges collapsed
+    onto one dangling bare id (`session`, 44 edges)."""
+    session = _write(
+        tmp_path / "src/Models/Session.php",
+        "<?php\nnamespace App\\Models;\nclass Session {}\n",
+    )
+    ctrl = _write(
+        tmp_path / "src/Http/Controller.php",
+        "<?php\nnamespace App\\Http;\n"
+        "use App\\Models\\Session as LocalSession;\n"
+        "use Shopify\\Auth\\Session as ShopifySession;\n"
+        "class Controller { public function run(LocalSession $a, ShopifySession $b) {} }\n",
+    )
+    result = extract([session, ctrl], cache_root=tmp_path)
+
+    node_ids = {n["id"] for n in result["nodes"]}
+    imports = _imports_from(result, "src_http_controller")
+    targets = {e["target"] for e in imports}
+    assert len(targets) == 2, f"the two aliases collapsed onto one target: {targets}"
+    assert not targets - node_ids, f"dangling import endpoint(s): {targets - node_ids}"
+
+    internal_id = _class_defs(result, "Session")[0]["id"]
+    assert internal_id in targets
+    external = (targets - {internal_id}).pop()
+    assert _node_by_id(result, external)["label"] == "Shopify\\Auth\\Session"
+
+
+def test_php_aliased_group_use_resolves(tmp_path: Path):
+    """`use Ns\\{A, Sub\\B as C}` — the alias sits inside a group clause, whose
+    FQN is the group prefix plus the clause's own path."""
+    ctrl = _write(
+        tmp_path / "src/C.php",
+        "<?php\nnamespace App;\n"
+        "use GuzzleHttp\\{Client, Psr7\\Request as Req};\n"
+        "class C { public function go(Client $a, Req $b) {} }\n",
+    )
+    result = extract([ctrl], cache_root=tmp_path)
+
+    labels = {
+        _node_by_id(result, e["target"])["label"]
+        for e in _imports_from(result, "src_c")
+    }
+    assert labels == {"GuzzleHttp\\Client", "GuzzleHttp\\Psr7\\Request"}
+
+
+def test_php_aliased_function_and_const_imports_keep_bare_name(tmp_path: Path):
+    """`use function`/`use const` are symbol imports, not class imports, so
+    their alias is deliberately NOT used: the imported name's last segment stays
+    the bare name the unique-label rewire matches on."""
+    helper = _write(
+        tmp_path / "src/Helpers.php",
+        "<?php\nnamespace App\\Helpers;\nfunction slug(string $s): string { return $s; }\n",
+    )
+    user = _write(
+        tmp_path / "src/U.php",
+        "<?php\nnamespace App;\n"
+        "use function App\\Helpers\\slug as s;\n"
+        "use const App\\Config\\VERSION as V;\n"
+        "class U { public function go() { return s('x'); } }\n",
+    )
+    result = extract([helper, user], cache_root=tmp_path)
+
+    targets = {e["target"] for e in _imports_from(result, "src_u")}
+    assert "version" in targets, f"const import lost its bare name: {targets}"
+    slug_node = next(
+        (n for n in result["nodes"]
+         if n.get("label") == "slug()" and n.get("source_file")), None)
+    assert slug_node is not None
+    assert slug_node["id"] in targets or "slug" in targets


### PR DESCRIPTION
Fixes #3421.

## Root cause

`_import_php` built the import edge target from the last segment of the **imported** name, discarding both the namespace and the alias:

```python
raw = _read_text(child, source)          # "GuzzleHttp\Client"
module_name = raw.split("\\")[-1]        # "Client"
tgt_nid = _make_id(module_name)          # "client"
```

That target is not meant to be final — `_resolve_php_type_references` canonicalizes it. But that pass keys its per-file `uses` map by the **local binding**:

```python
key = (alias or fqn.rsplit("\\", 1)[-1]).strip().lower()
uses.setdefault(key, fqn)
```

So for `use GuzzleHttp\Client as HttpClient` the map is `{"httpclient": "GuzzleHttp\Client"}` while the edge target was `client` — nothing matched, and the canonicalization silently did nothing. The pass even carries a fallback that only makes sense if the target *is* the alias, and which could therefore never fire:

```python
if not label and relation == "imports":
    label = next((alias for alias in uses if _make_id(alias) == tgt), "")
```

A plain `use` worked only because there the binding and the last segment happen to be the same string. The alias is the trigger, exactly as reported.

## Both reported symptoms, verified

Baseline on the issue's repro:

```
nodes: client, guzzlehttp_client, src_a, src_b, ...
src_a --imports--> guzzlehttp_client
src_b --imports--> client              ← one class, two identities
```

Baseline on the ambiguous-name shape (the Laravel symptom):

```php
use App\Models\Session as LocalSession;
use Shopify\Auth\Session as ShopifySession;
use GuzzleHttp\{Client, Psr7\Request as Req};
```
```
src_http_controller --imports--> session   <-- DANGLING
src_http_controller --imports--> session   <-- DANGLING   (both aliases collapsed)
src_http_controller --imports--> request   <-- DANGLING
```

That is the reporter's `session` (44 edges) / `client` (21) / `connection` (5) breakdown: aliasing exists *precisely* to disambiguate two classes with one simple name, and the bare name is the one thing that cannot represent either.

## Fix

Mint the edge on the local binding — the alias when the clause has one, else the imported name's last segment. That is the key the resolver already looks up, so both forms now canonicalize onto the imported class: to its own definition node when internal, to an FQN-labeled stub when external.

After the fix, the same two fixtures:

```
nodes: guzzlehttp_client, src_a, src_b, ...      (no stray `client`)
src_a --imports--> guzzlehttp_client
src_b --imports--> guzzlehttp_client
```
```
src_http_controller --imports--> src_models_session_session
src_http_controller --imports--> shopify_auth_session
src_http_controller --imports--> guzzlehttp_client
src_http_controller --imports--> guzzlehttp_psr7_request
```

Group-use aliases (`use Ns\{A, Sub\B as C}`) travel the same path, since the resolver already composes the group prefix with each clause.

## Deliberately out of scope

`use function ns\f as g` and `use const ns\C as D` keep the old behavior: `_resolve_php_type_references` skips symbol imports by design (`if c.type in ("function", "const"): return  # not a class import`), so their alias is absent from `uses` and switching to it would strand the edge on a one-letter id. The imported name's last segment stays the right bare name for the unique-label rewire. A regression test pins this.

Those two still dangle on both sides of the change (`slug`, `version`) — resolving symbol imports needs a function/const index rather than the class index this pass builds, which is a separate change.

## Tests

Five tests in `tests/test_php_type_resolution.py`; the first four fail on unpatched `extract.py` and pass with the fix, the fifth is the function/const regression guard.

- `test_php_aliased_external_import_shares_target_with_plain_import` — the issue's repro; also asserts the stray `client` node is gone.
- `test_php_aliased_import_of_internal_class_resolves_to_definition`
- `test_php_two_aliased_imports_of_same_bare_name_stay_distinct` — two targets, neither dangling, internal vs external correctly split.
- `test_php_aliased_group_use_resolves`
- `test_php_aliased_function_and_const_imports_keep_bare_name`

Full suite: 5498 passed, 3 pre-existing environment-dependent failures unchanged (`test_extract_code_only_cli`, two `test_ollama` backend-detection tests — all fail on a clean tree here too).

## Note on #3346

The linked TypeScript issue looks like the same shape (identity taken from a name that is not the one the resolver keys on) but a different pass; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)