### PR TITLE
fix(detect): sort os.walk to ensure reproducible symbol IDs (#3407)

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1776,6 +1776,8 @@ def detect(root: Path, *, follow_symlinks: bool | None = None, google_workspace:
         for dirpath, dirnames, filenames in os.walk(
             scan_root, followlinks=follow_symlinks, onerror=_on_walk_error
         ):
+            dirnames.sort()
+            filenames.sort()
             dp = Path(dirpath)
             if follow_symlinks and os.path.islink(dirpath):
                 real = os.path.realpath(dirpath)

--- a/tests/test_detect_sort.py
+++ b/tests/test_detect_sort.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from graphify.detect import detect
+
+
+def test_detect_directory_walk_is_sorted(tmp_path):
+    # Create dirs in reverse-alpha order to ensure os.walk would visit them
+    # non-deterministically without our sorting fix.
+    (tmp_path / "b").mkdir()
+    (tmp_path / "a").mkdir()
+
+    # Files named in reverse order within each dir, for the same reason.
+    (tmp_path / "b" / "z.py").write_text("print('z')")
+    (tmp_path / "b" / "y.py").write_text("print('y')")
+    (tmp_path / "a" / "x.py").write_text("print('x')")
+    (tmp_path / "a" / "w.py").write_text("print('w')")
+
+    result = detect(tmp_path)
+    code_files = result["files"]["code"]
+
+    # Full repo-relative paths should arrive in sorted order:
+    # a/w.py, a/x.py, b/y.py, b/z.py — not filesystem-dependent.
+    relative = [str(Path(f).relative_to(tmp_path)) for f in code_files]
+    assert relative == ["a/w.py", "a/x.py", "b/y.py", "b/z.py"], (
+        f"Files were not detected in sorted order: {relative}"
+    )


### PR DESCRIPTION
The bug:
Cross-platform extractions were not deterministic (yielding different output graphs between macOS and Linux CI) because the fallback ordering relied on `os.walk`, which processes directories in raw filesystem order (unordered).

The fix:
Explicitly sorted `dirnames` and `filenames` in the `os.walk` loop in `graphify/detect.py` to guarantee that discovery is 100% reproducible regardless of the underlying OS or filesystem.

Tests:
`tests/test_detect_sort.py` added to assert on full relative paths to rigorously prove that os.walk is traversing the directories in sorted order. This prevents regression of non-deterministic traversal order.