### PR TITLE
fix(detect): classify Jinja templates as documents (#3427)

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -42,7 +42,7 @@ _MTIME_COARSE_S = 2.0
 _MTIME_SUBSECOND_S = 0.05
 
 CODE_EXTENSIONS = {'.py', '.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs', '.ejs', '.ets', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.cu', '.cuh', '.metal', '.rb', '.rake', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.psm1', '.psd1', '.ex', '.exs', '.m', '.mm', '.ml', '.mli', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.svh', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json', '.tf', '.tfvars', '.hcl', '.dm', '.dme', '.dmi', '.dmm', '.dmf', '.sln', '.slnx', '.csproj', '.fsproj', '.vbproj', '.xaml', '.razor', '.cshtml', '.cls', '.trigger', '.lisp', '.cl', '.lsp', '.asd', '.robot', '.resource'}
-DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.skill', '.txt', '.rst', '.html', '.yaml', '.yml'}
+DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.skill', '.txt', '.rst', '.html', '.yaml', '.yml', '.j2', '.jinja', '.jinja2'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}
 OFFICE_EXTENSIONS = {'.docx', '.xlsx'}

--- a/tests/test_detect_jinja.py
+++ b/tests/test_detect_jinja.py
@@ -1,0 +1,6 @@
+from graphify.detect import DOC_EXTENSIONS
+
+def test_jinja2_extensions_are_documents():
+    assert '.j2' in DOC_EXTENSIONS
+    assert '.jinja' in DOC_EXTENSIONS
+    assert '.jinja2' in DOC_EXTENSIONS


### PR DESCRIPTION
The bug:
Jinja2 templates were completely skipped by Graphify's detection phase because their extensions were not listed in the recognized document extensions. This resulted in the source for generated files being hidden from the graph.

The fix:
Added `.j2`, `.jinja`, and `.jinja2` to the `DOC_EXTENSIONS` set in `graphify/detect.py`.

Tests:
`tests/test_detect_jinja.py` added to verify the newly added Jinja extensions are accurately recognized as documents. This ensures the bug does not regress in future updates.