### PR TITLE
Fix: recover SQL CREATE POLICY statements as nodes (#3401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: when duplicate nodes merge, the richer (more complete) node is now kept as the survivor and the losers' non-empty fields are folded in, instead of a shorter-id passing mention winning and dropping content (#3372, thanks @abhay-codes07).
 - Fix: a C# generic call site with explicit type arguments — `Get<int>(...)`, unqualified or through `this` — now resolves to the method definition instead of capturing `Get<int>` as the callee and failing to match (#3406, thanks @abhay-codes07).
 - Fix: `this.X = function` / `this.X = () => …` members are now captured in every enclosing-function form (function expressions, arrows, IIFEs, callbacks), not just function declarations (#3408, thanks @abhay-codes07).
+- Fix: SQL `CREATE POLICY` statements now become nodes attached to the table they guard, so `graphify affected "<table>"` reaches the row-level-security policies on it; `--postgres` also reads `pg_catalog.pg_policy`. tree-sitter-sql has no rule for the statement at all, so every policy in an RLS schema was dropped silently (#3401, thanks @kwunyanlee-cmd).
 
 ## 0.9.56 (2026-09-07)
 

--- a/graphify/extractors/sql.py
+++ b/graphify/extractors/sql.py
@@ -32,11 +32,36 @@ from graphify.extractors.base import _file_stem, _make_id
 # 'SELECT AUTOCREATE PROCEDURE x FROM t;' in an error-bearing file minted a
 # phantom routine x() (delimited identifiers are span-skipped at the scan
 # site, but a bare word has no span).
+#
+# The name-part alternation is factored out because a second recovery pattern
+# (_POLICY_RECOVERY_RX) has to accept exactly the same identifier forms — a
+# policy on "public"."employees" is as ordinary as a routine named
+# [dbo].[usp_Load], and two hand-copied alternations would drift.
+_NAME_PART = r"(?:\"(?:[^\"\n]|\"\")+\"|\[(?:[^\]\n]|\]\])+\]|[\w$]+)"
+_QUALIFIED_NAME = rf"{_NAME_PART}(?:\s*\.\s*{_NAME_PART})*"
+
 _ROUTINE_RECOVERY_RX = re.compile(
     r"\bCREATE\s+(?:OR\s+(?:REPLACE|ALTER)\s+)?(?:FUNCTION|PROC(?:EDURE)?)\s+"
     r"(?:IF\s+NOT\s+EXISTS\s+)?"
-    r"((?:\"(?:[^\"\n]|\"\")+\"|\[(?:[^\]\n]|\]\])+\]|[\w$]+)"
-    r"(?:\s*\.\s*(?:\"(?:[^\"\n]|\"\")+\"|\[(?:[^\]\n]|\]\])+\]|[\w$]+))*)",
+    rf"({_QUALIFIED_NAME})",
+    re.IGNORECASE,
+)
+
+# CREATE POLICY has NO rule in tree-sitter-sql — not an unparseable body like
+# PL/pgSQL, no rule at all — so the statement shreds into loose top-level
+# tokens plus an ERROR node and the walk has nothing to dispatch on. Adding an
+# `elif t == "create_policy"` branch would be dead code (#3401). Recovery is
+# regex, like routines, but the two patterns stay separate: a policy is not a
+# routine (bare-name label, no `()`), and it carries an `ON <table>` clause
+# that is the whole point of the node.
+#
+# `CREATE POLICY <name> ON <table>` is far more specific than a bare
+# `CREATE FUNCTION`, so this scan is NOT gated on a failed parse the way the
+# routine scan is: there is no plausible non-DDL text it matches, and gating on
+# has_error would make policy recovery evaporate the day the grammar learns to
+# parse the statement. Policy names are never schema-qualified; the table is.
+_POLICY_RECOVERY_RX = re.compile(
+    rf"\bCREATE\s+POLICY\s+({_NAME_PART})\s+ON\s+({_QUALIFIED_NAME})",
     re.IGNORECASE,
 )
 
@@ -672,7 +697,13 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
     # strings in MySQL's default mode, PostgreSQL dollar-quoted bodies). Every
     # observed drop shape leaves an ERROR node in the tree, so has_error loses
     # nothing while protecting clean corpora (#2180 follow-up).
-    if root.has_error:
+    #
+    # Policy recovery (#3401) shares the mask but not the gate — see
+    # _POLICY_RECOVERY_RX. The raw-text pre-check keeps a clean corpus from
+    # paying for _scan_sql: masking only ever blanks characters, so a pattern
+    # that cannot match the raw source cannot match the masked source either.
+    scan_policies = _POLICY_RECOVERY_RX.search(src_text) is not None
+    if root.has_error or scan_policies:
         # The mask blanks comments (nesting-aware) and single-quoted strings
         # (offset-preserving), so commented-out DDL and single-quoted dynamic
         # SQL cannot fabricate a routine when an unrelated error arms this
@@ -684,11 +715,33 @@ def extract_sql(path: Path, content: str | bytes | None = None) -> dict:
         # name a genuine statement captures is allowed to be a delimited
         # identifier; its CREATE never is.
         masked_src, ident_spans = _scan_sql(src_text)
-        for m in _ROUTINE_RECOVERY_RX.finditer(masked_src):
-            if any(s <= m.start() < e for s, e in ident_spans):
-                continue
-            fn_name = m.group(1)
-            fn_line = src_text[: m.start()].count("\n") + 1
-            _add_node(_make_id(stem, fn_name), f"{fn_name}()", fn_line)
+        if root.has_error:
+            for m in _ROUTINE_RECOVERY_RX.finditer(masked_src):
+                if any(s <= m.start() < e for s, e in ident_spans):
+                    continue
+                fn_name = m.group(1)
+                fn_line = src_text[: m.start()].count("\n") + 1
+                _add_node(_make_id(stem, fn_name), f"{fn_name}()", fn_line)
+        if scan_policies:
+            for m in _POLICY_RECOVERY_RX.finditer(masked_src):
+                if any(s <= m.start() < e for s, e in ident_spans):
+                    continue
+                pol_name, tbl_name = m.group(1), m.group(2)
+                pol_line = src_text[: m.start()].count("\n") + 1
+                # A policy name is unique per TABLE, not per schema or database:
+                # `tenant_isolation` on two tables is ordinary, and two policies
+                # named alike on one table is illegal. So the table belongs in
+                # the id, or the second policy would dedupe onto the first and
+                # the graph would lose it exactly as before.
+                pol_nid = _make_id(stem, tbl_name, pol_name)
+                _add_node(pol_nid, pol_name, pol_line)
+                tbl_nid = table_nids.get(_norm_ident(tbl_name)) or _ref_stub(tbl_name)
+                # `references` rather than a policy-specific relation: it is in
+                # both SEMANTIC_RELATIONS and DEFAULT_AFFECTED_RELATIONS, so
+                # `graphify affected "<table>"` reaches the policies guarding it.
+                # A novel relation would put the node in the graph and still
+                # leave it invisible to the traversal that asks who may read the
+                # row — half a fix.
+                _add_edge(pol_nid, tbl_nid, "references", pol_line)
 
     return {"nodes": nodes, "edges": edges}

--- a/graphify/pg_introspect.py
+++ b/graphify/pg_introspect.py
@@ -96,6 +96,25 @@ def introspect_postgres(dsn: str | None = None) -> dict:
                 ORDER BY ns.nspname, rel.relname, con.conname;
             """)
             fks = cur.fetchall()
+
+            # 5. Query row-level-security policies. There is no
+            # information_schema view for these, and pg_policies (the
+            # human-readable one) filters rows the current role cannot see, so
+            # read pg_catalog.pg_policy directly — same reasoning as the FK
+            # query above. Policies are the access-control layer of an RLS
+            # schema; without them the graph shows the tables but nothing about
+            # who may read a row (#3401).
+            cur.execute("""
+                SELECT ns.nspname AS table_schema,
+                       rel.relname AS table_name,
+                       pol.polname AS policy_name
+                FROM pg_catalog.pg_policy pol
+                JOIN pg_catalog.pg_class rel ON rel.oid = pol.polrelid
+                JOIN pg_catalog.pg_namespace ns ON ns.oid = rel.relnamespace
+                WHERE ns.nspname NOT IN ('pg_catalog', 'information_schema')
+                ORDER BY ns.nspname, rel.relname, pol.polname;
+            """)
+            policies = cur.fetchall()
     finally:
         conn.close()
 
@@ -143,6 +162,20 @@ def introspect_postgres(dsn: str | None = None) -> dict:
                 f"CREATE FUNCTION {fn_sig} RETURNS void"
                 f" AS $gfx$ {actual_body} $gfx$ LANGUAGE {lang};"
             )
+
+    # RLS policies — emitted LAST, for the mirror image of the reason the FKs are
+    # emitted first. tree-sitter-sql has no rule for CREATE POLICY at all, so each
+    # of these statements shreds into an ERROR node that consumes the statements
+    # following it; anything after them would be lost from the AST. They survive
+    # being last because the SQL extractor recovers policies by regex over the
+    # whole file rather than from the tree (see _POLICY_RECOVERY_RX), which is
+    # also why no body/USING clause is reconstructed here: only the name and the
+    # table it guards are read, and both fit in the header.
+    for p_schema, p_table, p_name in policies:
+        ddl.append(
+            f"CREATE POLICY {_quote_ident(p_name)} "
+            f"ON {_quote_ident(p_schema)}.{_quote_ident(p_table)};"
+        )
 
     ddl_string = "\n".join(ddl)
 

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1356,3 +1356,162 @@ def test_sql_quoted_plpgsql_file_stays_clean():
     contains_targets = {e["target"] for e in r["edges"] if e["relation"] == "contains"}
     fn_ids = {n["id"] for n in r["nodes"] if n["label"].endswith("()")}
     assert fn_ids <= contains_targets
+
+
+# ── SQL: row-level-security policies (#3401) ──────────────────────────────────
+
+def _policy_pairs(r):
+    """{(policy label, table label)} for every references edge in a result."""
+    labels = {n["id"]: n["label"] for n in r["nodes"]}
+    return {
+        (labels[e["source"]], labels[e["target"]])
+        for e in r["edges"]
+        if e["relation"] == "references"
+    }
+
+
+def test_sql_create_policy_becomes_a_node_attached_to_its_table(tmp_path):
+    """#3401: CREATE POLICY has no rule in tree-sitter-sql, so the statement
+    shredded into loose tokens plus an ERROR node and nothing dispatched on it —
+    every policy in an RLS schema was dropped silently. On the reported project
+    that was 59 statements / 45 distinct policy names, and the graph showed the
+    tables with no indication of who may read a row."""
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "rls.sql"
+    p.write_text(
+        "CREATE TABLE public.employees (id INT, tenant_id INT);\n"
+        "ALTER TABLE public.employees ENABLE ROW LEVEL SECURITY;\n"
+        "CREATE POLICY employees_select ON public.employees\n"
+        "    FOR SELECT USING (tenant_id = current_setting('app.tenant')::int);\n"
+        "CREATE POLICY employees_update ON public.employees\n"
+        "    FOR UPDATE USING (tenant_id = current_setting('app.tenant')::int);\n"
+    )
+    r = extract_sql(p)
+    labels = [n["label"] for n in r["nodes"] if n["label"] != "rls.sql"]
+    assert "employees_select" in labels, labels
+    assert "employees_update" in labels, labels
+    # Each policy points at the table it guards.
+    assert _policy_pairs(r) == {
+        ("employees_select", "public.employees"),
+        ("employees_update", "public.employees"),
+    }
+    # And both are reachable from the file node like any other object.
+    contains = {e["target"] for e in r["edges"] if e["relation"] == "contains"}
+    pol_ids = {n["id"] for n in r["nodes"] if n["label"].startswith("employees_")}
+    assert pol_ids <= contains
+    for e in r["edges"]:
+        assert e["source"] in {n["id"] for n in r["nodes"]}
+
+
+def test_sql_policy_name_is_qualified_by_its_table(tmp_path):
+    """A policy name is unique per TABLE, not per schema: `tenant_isolation` on
+    two tables is ordinary SQL, and two policies named alike on one table is
+    illegal. Keying the node on the bare name would dedupe the second policy
+    onto the first and lose it exactly as before the fix."""
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "rls.sql"
+    p.write_text(
+        "CREATE TABLE public.employees (id INT);\n"
+        "CREATE TABLE public.invoices (id INT);\n"
+        "CREATE POLICY tenant_isolation ON public.employees FOR ALL USING (true);\n"
+        "CREATE POLICY tenant_isolation ON public.invoices FOR ALL USING (true);\n"
+    )
+    r = extract_sql(p)
+    policies = [n for n in r["nodes"] if n["label"] == "tenant_isolation"]
+    assert len(policies) == 2, f"same-named policies collapsed: {policies}"
+    assert len({n["id"] for n in policies}) == 2
+    assert _policy_pairs(r) == {
+        ("tenant_isolation", "public.employees"),
+        ("tenant_isolation", "public.invoices"),
+    }
+
+
+def test_sql_policy_recovery_accepts_delimited_identifiers(tmp_path):
+    """Generated PostgreSQL DDL quotes every identifier, and the policy pattern
+    shares its name grammar with the routine pattern, so a quoted policy on a
+    quoted table must recover exactly like a bare one (#2180's lesson)."""
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "rls.sql"
+    p.write_text(
+        'CREATE TABLE "public"."Employee" ("id" INT);\n'
+        'CREATE POLICY "Employee select own" ON "public"."Employee"\n'
+        '    FOR SELECT USING (true);\n'
+    )
+    r = extract_sql(p)
+    assert _policy_pairs(r) == {('"Employee select own"', '"public"."Employee"')}
+
+
+def test_sql_policy_on_a_table_defined_in_another_file(tmp_path):
+    """Policies and the tables they guard routinely live in different migration
+    files, so the table reference has to go through the sourceless-stub rewire
+    and land on the real definition instead of dangling (#2324's path)."""
+    pytest.importorskip("tree_sitter_sql")
+    (tmp_path / "001_tables.sql").write_text(
+        'CREATE TABLE "Tenant" (id TEXT NOT NULL);\n'
+    )
+    (tmp_path / "002_policies.sql").write_text(
+        'CREATE POLICY tenant_isolation ON "Tenant" FOR ALL USING (true);\n'
+    )
+    r = extract(
+        [tmp_path / "001_tables.sql", tmp_path / "002_policies.sql"], root=tmp_path
+    )
+    node_ids = {n["id"] for n in r["nodes"]}
+    for e in r["edges"]:
+        assert e["source"] in node_ids, f"dangling source: {e['source']}"
+        assert e["target"] in node_ids, f"dangling target: {e['target']}"
+    tenant_ids = [i for i in node_ids if i.endswith("001_tables_tenant")]
+    assert len(tenant_ids) == 1, f"expected one real Tenant node, got {tenant_ids}"
+    assert tenant_ids[0] in {
+        e["target"] for e in r["edges"] if e["relation"] == "references"
+    }, "cross-file policy did not rewire onto the real table"
+
+
+def test_sql_policy_ddl_that_does_not_create_a_policy_is_not_fabricated(tmp_path):
+    """The scan must not invent policies from DDL that only mentions them: a
+    DROP/ALTER, a commented-out CREATE POLICY, or one buried in dynamic SQL. The
+    masked scan is what makes the last two impossible."""
+    pytest.importorskip("tree_sitter_sql")
+    p = tmp_path / "rls.sql"
+    p.write_text(
+        "CREATE TABLE public.employees (id INT);\n"
+        "DROP POLICY old_policy ON public.employees;\n"
+        "ALTER POLICY renamed_policy ON public.employees RENAME TO x;\n"
+        "-- CREATE POLICY line_comment_policy ON public.employees FOR ALL USING (true);\n"
+        "/*\nCREATE POLICY block_comment_policy ON public.employees FOR ALL USING (true);\n*/\n"
+        "EXECUTE 'CREATE POLICY dynamic_policy ON public.employees FOR ALL USING (true)';\n"
+        "CREATE POLICY real_policy ON public.employees FOR ALL USING (true);\n"
+    )
+    r = extract_sql(p)
+    labels = [n["label"] for n in r["nodes"]]
+    assert "real_policy" in labels, labels
+    for phantom in (
+        "old_policy",
+        "renamed_policy",
+        "line_comment_policy",
+        "block_comment_policy",
+        "dynamic_policy",
+    ):
+        assert phantom not in labels, f"fabricated a policy node: {phantom}"
+
+
+def test_sql_policy_pattern_shares_the_routine_name_grammar():
+    """Unit pin: the two recovery patterns accept the same identifier forms, so
+    a hand-copied alternation cannot drift on one side and leave policies on
+    bracketed/quoted tables unrecoverable."""
+    pytest.importorskip("tree_sitter_sql")
+    from graphify.extractors.sql import _POLICY_RECOVERY_RX
+
+    for src, name, table in (
+        ("CREATE POLICY p ON t", "p", "t"),
+        ('create policy "P 1" on "s"."T"', '"P 1"', '"s"."T"'),
+        ("CREATE POLICY [p] ON [dbo].[T]", "[p]", "[dbo].[T]"),
+        ('CREATE POLICY "a""b" ON "s" . "t"', '"a""b"', '"s" . "t"'),
+        ("CREATE\tPOLICY\n  p\n  ON\n  s.t", "p", "s.t"),
+    ):
+        m = _POLICY_RECOVERY_RX.search(src)
+        assert m, src
+        assert (m.group(1), m.group(2)) == (name, table), src
+    # A policy is not a routine and vice versa — the patterns do not overlap.
+    from graphify.extractors.sql import _ROUTINE_RECOVERY_RX
+    assert not _ROUTINE_RECOVERY_RX.search("CREATE POLICY p ON t")
+    assert not _POLICY_RECOVERY_RX.search("CREATE PROCEDURE dbo.p AS BEGIN END")

--- a/tests/test_pg_introspect.py
+++ b/tests/test_pg_introspect.py
@@ -13,7 +13,7 @@ from graphify.validate import validate_extraction
 # Shared mock infrastructure
 # ---------------------------------------------------------------------------
 
-def _make_mock_psycopg(tables, views, routines, fks,
+def _make_mock_psycopg(tables, views, routines, fks, policies=(),
                         host="myhost", dbname="mydb",
                         connect_raises=None):
     """Return a mock psycopg module wired to the provided catalog data.
@@ -21,6 +21,7 @@ def _make_mock_psycopg(tables, views, routines, fks,
     ``routines`` rows must be 5-tuples: (schema, name, rtype, body, ext_lang).
     ``fks`` rows must be 7-tuples:
         (constraint_name, t_schema, t_name, [cols], r_schema, r_name, [r_cols])
+    ``policies`` rows must be 3-tuples: (schema, table, policy_name).
     ``connect_raises``, if set, is an exception *instance* raised by connect().
     """
 
@@ -47,6 +48,8 @@ def _make_mock_psycopg(tables, views, routines, fks,
                 return routines
             elif "pg_constraint" in q:
                 return fks
+            elif "pg_policy" in q:
+                return policies
             return []
 
     class MockConnection:
@@ -329,6 +332,91 @@ def test_pg_introspect_fk_edges_survive_unparseable_function_stubs():
         f"FK edges lost to parser error recovery: expected {n}, "
         f"got {len(ref_pairs)}: {sorted(ref_pairs)}"
     )
+
+
+def test_pg_introspect_emits_rls_policies():
+    """#3401: an RLS schema's policies must reach the graph, attached to the
+    table they guard.
+
+    Nothing in the introspection path queried pg_policy, so a database whose
+    entire access-control story is row-level security produced a graph of tables
+    with no indication of who may read a row.
+    """
+    mock_tables = [("public", "employees", "BASE TABLE"),
+                   ("app", "audit_log", "BASE TABLE")]
+    mock_policies = [
+        ("app", "audit_log", "audit_append_only"),
+        ("public", "employees", "employees_select_own"),
+        ("public", "employees", "employees_update_own"),
+    ]
+
+    mock_psycopg = _make_mock_psycopg(mock_tables, [], [], [], policies=mock_policies)
+
+    with patch.dict("sys.modules", {"psycopg": mock_psycopg}):
+        res = introspect_postgres("postgresql://myuser:secret@myhost/mydb")
+
+    errors = validate_extraction(res)
+    assert errors == [], f"Validation errors: {errors}"
+
+    ids_to_labels = {node["id"]: node["label"] for node in res["nodes"]}
+    labels = set(ids_to_labels.values())
+    for _schema, _table, pol in mock_policies:
+        assert f'"{pol}"' in labels, f"policy {pol} missing; got {sorted(labels)}"
+
+    # Each policy points at its own table — two policies on employees, one on
+    # audit_log, and no cross-wiring between the two tables.
+    guarded = {
+        (ids_to_labels[e["source"]], ids_to_labels[e["target"]])
+        for e in res["edges"]
+        if e["relation"] == "references"
+    }
+    assert guarded == {
+        ('"audit_append_only"', _q("app", "audit_log")),
+        ('"employees_select_own"', _q("public", "employees")),
+        ('"employees_update_own"', _q("public", "employees")),
+    }, f"policies not attached to their tables: {sorted(guarded)}"
+
+
+def test_pg_introspect_policies_do_not_damage_the_rest_of_the_ddl():
+    """CREATE POLICY has no rule in tree-sitter-sql, so each statement becomes an
+    ERROR node whose recovery consumes what follows it. Policies are therefore
+    emitted last — tables, FKs and routines must be unaffected by their presence.
+    """
+    mock_tables = [("public", "employees", "BASE TABLE"),
+                   ("public", "departments", "BASE TABLE")]
+    mock_routines = [("public", "is_admin", "FUNCTION", "BEGIN SELECT 1; END;", "PLPGSQL")]
+    mock_fks = [("fk_dept", "public", "employees", ["dept_id"],
+                 "public", "departments", ["id"])]
+    mock_policies = [("public", "employees", "employees_select_own")]
+
+    def _extract(policies):
+        mock_psycopg = _make_mock_psycopg(
+            mock_tables, [], mock_routines, mock_fks, policies=policies
+        )
+        with patch.dict("sys.modules", {"psycopg": mock_psycopg}):
+            return introspect_postgres("postgresql://myuser:secret@myhost/mydb")
+
+    without = _extract(())
+    with_policies = _extract(mock_policies)
+
+    base_labels = {n["label"] for n in without["nodes"]}
+    assert base_labels <= {n["label"] for n in with_policies["nodes"]}, (
+        "adding policies to the DDL lost nodes that were there without them"
+    )
+    assert f'{_q("public", "is_admin")}()' in base_labels
+
+    def _fk_pairs(res):
+        ids = {n["id"]: n["label"] for n in res["nodes"]}
+        return {
+            (ids[e["source"]], ids[e["target"]])
+            for e in res["edges"]
+            if e["relation"] == "references"
+            and ids[e["source"]] == _q("public", "employees")
+        }
+
+    assert _fk_pairs(with_policies) == _fk_pairs(without) == {
+        (_q("public", "employees"), _q("public", "departments"))
+    }
 
 
 def test_pg_introspect_connection_error():


### PR DESCRIPTION
Fixes #3401.

## The bug

`tree-sitter-sql` has **no `create_policy` rule at all** — not an unparseable body like PL/pgSQL, no rule. A `CREATE POLICY` statement shreds into loose top-level tokens plus an `ERROR` node, so the walk had nothing to dispatch on and every row-level-security policy was dropped silently (59 statements / 45 distinct policy names on the reporter's project, exit 0, no warning). Adding an `elif t == "create_policy"` branch would be dead code.

For a schema whose entire access-control story is RLS, the graph showed the tables with no indication of who may read a row.

## The fix

Recovery is a regex over the masked file, like the existing routine recovery — but a **separate pattern**: a policy is not a routine (bare name, no `()`), and it carries the `ON <table>` clause that is the whole point of the node. The identifier alternation both patterns need is factored into `_NAME_PART` / `_QUALIFIED_NAME` so they cannot drift; a policy on `"public"."employees"` is as ordinary as a routine named `[dbo].[usp_Load]`. The refactored `_ROUTINE_RECOVERY_RX` pattern and flags are byte-identical to before.

Two deliberate choices worth review:

- **The policy scan is not gated on `root.has_error`** the way the routine scan is. `CREATE POLICY <name> ON <table>` has no plausible non-DDL match, and gating on a failed parse would make policy recovery evaporate the day the grammar learns the statement. A raw-text pre-check keeps a clean corpus from paying for the mask (masking only ever blanks characters, so a pattern that can't match the raw source can't match the masked source either).
- **The node id is qualified by the table.** Policy names are unique per *table*, not per schema — `tenant_isolation` on two tables is ordinary SQL, two policies named alike on one table is illegal. Keying on the bare name would dedupe the second onto the first and lose it exactly as before.

The edge is `references`, which is in both `SEMANTIC_RELATIONS` and `DEFAULT_AFFECTED_RELATIONS`, so `graphify affected "<table>"` reaches the policies guarding it. A policy-specific relation would put the node in the graph and still leave it invisible to the traversal that asks who may read the row — half a fix.

## `--postgres`

Same hole one layer down: nothing queried `pg_policy`. Added, reading `pg_catalog.pg_policy` directly rather than the `pg_policies` view — same privilege-filtering reason as the FK query (#1746). The reconstructed DDL is emitted **last**, the mirror image of why FKs are emitted **first** (#1854): an unparseable statement's error recovery consumes what follows it, and policies are recovered by regex over the whole file, so they survive being last while anything after them would not.

## Tests

`tests/test_multilang.py` (6) and `tests/test_pg_introspect.py` (2):

- a policy becomes a node attached to its table, reachable from the file node
- same policy name on two tables stays two nodes
- delimited/quoted identifiers recover (the #2180 lesson)
- a policy on a table defined in **another file** rewires onto the real definition instead of dangling
- `DROP POLICY` / `ALTER POLICY` / commented-out / dynamic-SQL `CREATE POLICY` fabricate nothing
- unit pin that the two recovery patterns accept the same identifier forms and do not overlap
- `--postgres` emits policies attached to their own tables, and their presence does not damage the tables/FKs/routines around them

6 of the 8 fail on unpatched code (the two remaining are regression guards, vacuously true before the fix). Full suite: `5501 passed`, with only the 3 pre-existing environment-dependent failures on this tree (`test_extract_code_only_cli`, 2× `test_ollama`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)