### PR TITLE
fix(ts): keep star-export resolution off same-named interface methods

### DIFF
--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -986,13 +986,28 @@ def _apply_symbol_resolution_facts(
     path_by_resolved = {path.resolve(): path for path in paths}
     source_file_id = {path.resolve(): _make_id(str(path)) for path in paths}
     symbol_nodes: dict[tuple[Path, str], str] = {}
+    # Member nodes (`.method()` labels) share their bare name with top-level
+    # symbols once the leading dot is stripped. A module can only re-export
+    # top-level bindings, so a star-export walk must never bind an imported
+    # name to a class/interface member (#3436). Track those keys separately
+    # and never let a member shadow a same-named top-level symbol.
+    member_symbol_keys: set[tuple[Path, str]] = set()
     for node in nodes:
         source_path = _js_source_path(str(node.get("source_file", "")), root)
         if source_path is None:
             continue
-        label = str(node.get("label", "")).strip().strip("()").lstrip(".")
-        if label and node.get("id"):
-            symbol_nodes[(source_path, label)] = str(node["id"])
+        raw_label = str(node.get("label", "")).strip()
+        label = raw_label.strip("()").lstrip(".")
+        if not label or not node.get("id"):
+            continue
+        key = (source_path, label)
+        if raw_label.startswith("."):
+            if key in symbol_nodes:
+                continue
+            member_symbol_keys.add(key)
+        else:
+            member_symbol_keys.discard(key)
+        symbol_nodes[key] = str(node["id"])
 
     def ensure_symbol_node(path: Path, name: str, line: int) -> str:
         resolved_path = path.resolve()
@@ -1177,10 +1192,10 @@ def _apply_symbol_resolution_facts(
             return resolve_exported_origin(origin[0], origin[1], seen)
         for star_target in star_exports_by_file.get(target_path, []):
             star_key = (star_target, imported_name)
-            if star_key in symbol_nodes:
+            if star_key in symbol_nodes and star_key not in member_symbol_keys:
                 return star_key
             resolved = resolve_exported_origin(star_target, imported_name, seen)
-            if resolved in symbol_nodes:
+            if resolved in symbol_nodes and resolved not in member_symbol_keys:
                 return resolved
         return key
 

--- a/tests/test_js_import_resolution.py
+++ b/tests/test_js_import_resolution.py
@@ -140,6 +140,58 @@ def test_ts_export_star_from_index_resolves_imported_symbol_to_origin(tmp_path: 
     assert _has_symbol_edge(result, "src/routes/page.ts", "src/lib/foo.ts", "Foo")
 
 
+def test_ts_export_star_skips_same_named_interface_method_and_binds_the_function(tmp_path: Path):
+    # #3436: `export *` can only forward top-level bindings. When the first
+    # star target declares an interface with a METHOD of the same bare name as a
+    # function exported by a later star target, the imported name must bind to
+    # the function, and the call must land on it -- not on the method node.
+    types = _write(
+        tmp_path / "packages/domain/src/types.ts",
+        "export interface Rule {\n  code: string\n  evaluate(ctx: number): string | null\n}\n",
+    )
+    engine = _write(
+        tmp_path / "packages/domain/src/engine.ts",
+        "import type { Rule } from './types.js'\n\n"
+        "export function evaluate(rules: readonly Rule[], ctx: number): string[] {\n"
+        "  return rules.map((rule) => rule.evaluate(ctx)).filter((f) => f !== null)\n"
+        "}\n",
+    )
+    barrel = _write(
+        tmp_path / "packages/domain/src/index.ts",
+        "export * from './types.js'\nexport * from './engine.js'\n",
+    )
+    consumer = _write(
+        tmp_path / "packages/api/src/cache.ts",
+        "import { evaluate } from '../../domain/src/index.js'\n"
+        "import type { Rule } from '../../domain/src/index.js'\n\n"
+        "export function warm(rules: readonly Rule[]): string[] {\n"
+        "  return evaluate(rules, 1)\n"
+        "}\n",
+    )
+
+    result = _extract_for([types, engine, barrel, consumer], tmp_path)
+
+    assert _has_symbol_edge(
+        result, "packages/api/src/cache.ts", "packages/domain/src/engine.ts", "evaluate"
+    )
+    assert _has_symbol_to_symbol_edge(
+        result,
+        "packages/api/src/cache.ts",
+        "warm",
+        "packages/domain/src/engine.ts",
+        "evaluate",
+        "calls",
+    )
+    assert _has_no_symbol_to_symbol_edge(
+        result,
+        "packages/api/src/cache.ts",
+        "warm",
+        "packages/domain/src/types.ts",
+        "rule_evaluate",
+        "calls",
+    )
+
+
 @pytest.mark.parametrize("suffix", ["ts", "js"])
 def test_js_namespace_reexport_import_targets_real_binding(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Fixes #3436.

In a pnpm workspace, `import { evaluate } from '@repro/domain'` where the barrel is

```ts
export * from './types.js'   // interface Rule { evaluate(ctx): ... }
export * from './engine.js'  // export function evaluate(...)
```

bound the import (and the `warm() --calls-->` edge) to the interface **method** node `Rule.evaluate` instead of the exported function. The function ended up with no inbound `calls` edge.

## Root cause

`resolve_exported_origin` in `graphify/extractors/resolution.py` walks the `export *` targets and returns the first `(star_target, imported_name)` that has a symbol node. The symbol map is keyed by the label with the leading dot stripped, so the method node `.evaluate()` in `types.ts` matched the name before the walk reached `engine.ts`.

## Fix

- Track member nodes (labels starting with `.`) in a separate `member_symbol_keys` set while building `symbol_nodes`, and never let a member shadow a same-named top-level symbol in the map.
- The star-export walk skips member keys: a module can only re-export top-level bindings.

Driver output from the issue after the fix:

```
  engine.ts      --contains--> evaluate()
  Rule           --method--> .evaluate()
  cache.ts       --imports--> evaluate()
  warm()         --calls--> evaluate()
```

## Tests

- New `test_ts_export_star_skips_same_named_interface_method_and_binds_the_function` in `tests/test_js_import_resolution.py` (fails on `v8`, passes with the fix): asserts the `imports` edge and the `calls` edge land on `engine.ts::evaluate`, and that no `calls` edge lands on the method node.
- `pytest tests/` : same failure set with and without the patch (24 pre-existing failures locally in `test_terraform.py` / the linear-scaling timing test, unrelated), `ruff check` clean.
