### PR TITLE
Import Iterable in build.py, the annotations already use it

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -27,6 +27,7 @@ import os
 import re
 import sys
 import unicodedata
+from collections.abc import Iterable
 from pathlib import Path
 import networkx as nx
 from .ids import make_id, normalize_id as _normalize_id

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1983,3 +1983,21 @@ def test_build_merge_explicit_ast_sources_argument(tmp_path):
 
     G1 = build_merge([sln_chunk], graph_path, dedup=False, root=root, ast_sources=["A.sln"])
     assert "nuget_pkg" in G1, "ast_sources explicit arg must protect undispatched A.csproj"
+
+
+def test_build_annotations_all_resolve():
+    # build.py imports every annotated name at module scope -- no TYPE_CHECKING-only
+    # names -- so an unresolvable hint here means a missing import, not a lazy one.
+    import inspect
+    import typing
+
+    from graphify import build as build_module
+
+    unresolvable = []
+    for name, obj in vars(build_module).items():
+        if inspect.isfunction(obj) and obj.__module__ == build_module.__name__:
+            try:
+                typing.get_type_hints(obj)
+            except NameError as exc:
+                unresolvable.append(f"{name}: {exc}")
+    assert not unresolvable, "\n".join(unresolvable)


### PR DESCRIPTION
Fixes #3462.

## Summary

`graphify/build.py` annotates `chunks` and `ast_sources` with `Iterable` but never imports it.
`ruff check graphify/` fails on `v8` with four `F821 Undefined name 'Iterable'`
(`build.py:1563`, `:1565`, `:1634`, `:1781`), and `typing.get_type_hints()` raises `NameError`
on the three functions that carry those hints — `_tier_replacement_sources`,
`merge_raw_extraction`, `build_merge`.

Nothing breaks at import time: `from __future__ import annotations` keeps the annotations as
strings, so the suite is green either way. That is why it reached `v8`; `ruff check` is not run
in `.github/workflows`.

## Change

```python
+from collections.abc import Iterable
```

`ruff check graphify/ tests/` → `All checks passed!` (was 4 errors).

## Test

`test_build_annotations_all_resolve` in `tests/test_build.py` calls `get_type_hints()` on every
function `build.py` defines and reports the ones that raise `NameError`. Deleting the import
again turns it red.

Scoped to `build.py` on purpose. `cross_repo_calls.py`, `cross_repo_types.py` and `prs.py` also
have hints `get_type_hints()` cannot resolve, but there the name is `nx` under
`if TYPE_CHECKING:` — deliberate, and correctly not flagged by ruff. `build.py` imports
`networkx` at module scope and has no `TYPE_CHECKING` block, so every annotated name in it
resolving is a real invariant rather than a coincidence.

Full suite: 5372 passed, 94 skipped.
`tests/test_ts_import_type_arguments.py::test_ts_normalizer_scales_linearly_on_large_files` is
deselected — it fails identically on unmodified `v8` in a full run and passes in isolation, a
machine-dependent `process_time` ratio.

## Adjacent, not in this PR

Adding `ruff check` to CI would have caught this at `32b209a`. Happy to open that separately if
you want it — it is a workflow change rather than a code fix, and it would want its own review.
