### PR TITLE
Never infer an empty repo tag for global add

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -3126,7 +3126,12 @@ def dispatch_command(cmd: str) -> None:
             if not source:
                 print("Usage: graphify global add <graph.json> [--as <repo-tag>]", file=sys.stderr)
                 sys.exit(1)
-            tag = tag or source.parent.parent.name
+            if not tag:
+                # Inferred through merge-graphs' own helper, which degrades to "repo"
+                # instead of "": an empty tag prunes by "" and registers a manifest
+                # entry no later add can address.
+                from graphify.build import distinct_repo_tags
+                tag = distinct_repo_tags([source.absolute()])[0]
             try:
                 result = _global_add(source, tag)
                 if result["skipped"]:
@@ -3140,9 +3145,11 @@ def dispatch_command(cmd: str) -> None:
             except Exception as exc:
                 print(f"error: {exc}", file=sys.stderr); sys.exit(1)
         elif subcmd == "remove":
-            tag = sys.argv[3] if len(sys.argv) > 3 else ""
-            if not tag:
+            # An omitted tag is a usage error; an explicitly empty one still has to be
+            # addressable, since earlier versions could register a repo under "".
+            if len(sys.argv) <= 3:
                 print("Usage: graphify global remove <repo-tag>", file=sys.stderr); sys.exit(1)
+            tag = sys.argv[3]
             try:
                 removed = _global_remove(tag)
                 print(f"Removed '{tag}' from global graph ({removed} nodes pruned).")

--- a/tests/test_global_add_tag_inference.py
+++ b/tests/test_global_add_tag_inference.py
@@ -1,0 +1,116 @@
+"""`graphify global add` repo-tag inference, and addressing the tag it produces.
+
+The tag was `source.parent.parent.name`, which is empty whenever the graph is not two
+levels below a named directory — `graphify global add /tmp/graph.json`, or any relative
+path such as `graphify-out/graph.json`. The empty tag then prefixes every node with
+`::`, prunes by `""`, and registers a manifest entry the `remove` subcommand rejected
+as a missing argument, so the store could not be cleaned up again.
+"""
+from __future__ import annotations
+
+import json
+
+import networkx as nx
+import pytest
+from networkx.readwrite import json_graph as jg
+
+import graphify.__main__ as mainmod
+
+
+def _write_graph(path):
+    G = nx.Graph()
+    G.add_node("a", label="A", source_file="src/a.py")
+    G.add_node("b", label="B", source_file="src/b.py")
+    G.add_edge("a", "b", relation="calls")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        data = jg.node_link_data(G, edges="links")
+    except TypeError:
+        data = jg.node_link_data(G)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+@pytest.fixture
+def store(monkeypatch, tmp_path):
+    """Point the global store at a scratch dir and yield its manifest reader."""
+    where = tmp_path / "store"
+    monkeypatch.setattr("graphify.global_graph._GLOBAL_DIR", where)
+    monkeypatch.setattr("graphify.global_graph._GLOBAL_GRAPH", where / "global-graph.json")
+    monkeypatch.setattr("graphify.global_graph._GLOBAL_MANIFEST", where / "global-manifest.json")
+    return where
+
+
+def _run(monkeypatch, argv):
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(mainmod.sys, "argv", argv)
+    try:
+        mainmod.main()
+    except SystemExit as exc:
+        return exc.code or 0
+    return 0
+
+
+def _manifest(store):
+    return json.loads((store / "global-manifest.json").read_text(encoding="utf-8"))["repos"]
+
+
+def _nodes(store):
+    return json.loads((store / "global-graph.json").read_text(encoding="utf-8"))["nodes"]
+
+
+def test_bare_graph_path_gets_a_non_empty_tag(monkeypatch, tmp_path, store):
+    repo = tmp_path / "myrepo"
+    _write_graph(repo / "graph.json")
+    monkeypatch.chdir(repo)
+
+    assert _run(monkeypatch, ["graphify", "global", "add", "graph.json"]) == 0
+
+    tags = list(_manifest(store))
+    assert tags == [tmp_path.name]
+    assert all(n["id"].startswith(f"{tmp_path.name}::") for n in _nodes(store))
+
+
+def test_a_nameless_repo_dir_degrades_to_repo():
+    """The tag the CLI inherits for a graph at the filesystem root."""
+    from pathlib import Path
+
+    from graphify.build import distinct_repo_tags
+
+    assert distinct_repo_tags([Path("/graph.json")]) == ["repo"]
+
+
+def test_relative_path_infers_from_the_resolved_repo_dir(monkeypatch, tmp_path, store):
+    repo = tmp_path / "myrepo"
+    _write_graph(repo / "graphify-out" / "graph.json")
+    monkeypatch.chdir(repo)
+
+    assert _run(monkeypatch, ["graphify", "global", "add", "graphify-out/graph.json"]) == 0
+
+    assert list(_manifest(store)) == ["myrepo"]
+
+
+def test_explicit_as_tag_still_wins(monkeypatch, tmp_path, store):
+    graph = tmp_path / "graph.json"
+    _write_graph(graph)
+
+    assert _run(monkeypatch, ["graphify", "global", "add", str(graph), "--as", "chosen"]) == 0
+
+    assert list(_manifest(store)) == ["chosen"]
+
+
+def test_remove_without_a_tag_is_still_a_usage_error(monkeypatch, store):
+    assert _run(monkeypatch, ["graphify", "global", "remove"]) == 1
+
+
+def test_remove_can_address_a_repo_registered_under_an_empty_tag(monkeypatch, tmp_path, store):
+    graph = tmp_path / "graph.json"
+    _write_graph(graph)
+    from graphify.global_graph import global_add
+
+    global_add(graph, "")  # what an older revision's inference produced
+    assert "" in _manifest(store)
+
+    assert _run(monkeypatch, ["graphify", "global", "remove", ""]) == 0
+
+    assert "" not in _manifest(store)
+    assert _nodes(store) == []


### PR DESCRIPTION
Fixes #3464.

### The defect

`global add`'s tag inference was `tag or source.parent.parent.name`. That is empty for any graph
that is not two levels below a named directory — `/tmp/graph.json`, or a relative
`graphify-out/graph.json`. The empty tag prefixes every node with `::`, sets `repo` to `""`, prunes
by `""` (so a second empty-tag add replaces an unrelated repo's nodes), and registers a manifest
entry `global remove` will not accept, because it reads an empty tag as a missing argument.

`merge-graphs` already infers through `distinct_repo_tags`, whose `d.name or "repo"` is exactly the
degrade missing here.

### The change

`graphify/cli.py`

- Infer through `distinct_repo_tags([source.absolute()])[0]`. Routing both entry points through the
  same helper is what keeps them from diverging again; `absolute()` (not `resolve()`) makes a
  relative path name its repo dir without rewriting symlinked prefixes — on macOS `resolve()` turns
  `/tmp/graph.json` into a `private` tag.
- `global remove` distinguishes an omitted tag from an empty one. Omitted is still a usage error;
  `graphify global remove ""` can now clean up a store an earlier revision wrote.

An explicit `--as <tag>` is unaffected, and the canonical
`<repo>/graphify-out/graph.json` layout yields the same tag as before, so existing manifests keep
resolving to the entries they already have.

### Tests

`tests/test_global_add_tag_inference.py`, exercising the real CLI through `graphify.__main__.main`:

| test | pins |
| --- | --- |
| `test_bare_graph_path_gets_a_non_empty_tag` | relative `graph.json` → non-empty tag, nodes prefixed |
| `test_relative_path_infers_from_the_resolved_repo_dir` | `graphify-out/graph.json` → the repo dir name |
| `test_a_nameless_repo_dir_degrades_to_repo` | the `"repo"` degrade the CLI inherits at the filesystem root |
| `test_explicit_as_tag_still_wins` | `--as` unchanged |
| `test_remove_without_a_tag_is_still_a_usage_error` | omitted argument still exits 1 |
| `test_remove_can_address_a_repo_registered_under_an_empty_tag` | an `""` entry becomes removable |

Three of the six fail on v8 and pass with the change (verified by reverting `cli.py` alone with
`__pycache__` cleared).

### Verification

- `ruff check graphify/cli.py tests/test_global_add_tag_inference.py` — clean.
- Full suite: 5377 passed, 94 skipped. `tests/test_ollama_retry_cap.py` is ignored (no `openai`
  installed locally) and `test_ts_normalizer_scales_linearly_on_large_files` deselected — it is a
  machine-dependent `process_time` ratio that also fails on unmodified v8 here and passes in
  isolation.
