### PR TITLE
fix(php): keep aliased class-import identity in multi-namespace files

### DIFF
--- a/.venv
+++ b/.venv
@@ -1,0 +1,1 @@
+/Users/divyamtalwar/Workspace/graphify-lab/repo/.venv

--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-/Users/divyamtalwar/Workspace/graphify-lab/repo/.venv

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -754,6 +754,20 @@ def _php_import_kind(node) -> str | None:
     return next((child.type for child in first_clause.children if child.type in kinds), None)
 
 
+def _php_import_fqn(node, source: bytes, raw: str) -> str:
+    parent = node.parent
+    if parent is not None and parent.type == "namespace_use_group":
+        declaration = parent.parent
+        if declaration is not None:
+            prefix = next(
+                (_read_text(child, source) for child in declaration.children
+                 if child.type == "namespace_name"),
+                "",
+            )
+            if prefix:
+                raw = f"{prefix}\\{raw}"
+    return raw.lstrip("\\")
+
 def _import_php(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str, scope_stack: list[str] | None = None) -> None:
     for child in node.children:
         if child.type in ("qualified_name", "name", "identifier"):
@@ -771,8 +785,13 @@ def _import_php(node, source: bytes, file_nid: str, stem: str, edges: list, str_
                     "source_location": f"L{node.start_point[0] + 1}",
                     "weight": 1.0,
                 }
-                if _php_import_kind(node) in ("function", "const"):
+                kind = _php_import_kind(node)
+                if kind in ("function", "const"):
                     edge["_php_symbol_import"] = True
+                elif kind is None:
+                    target_fqn = _php_import_fqn(node, source, raw)
+                    if target_fqn:
+                        edge["metadata"] = sanitize_metadata({"target_fqn": target_fqn})
                 edges.append(edge)
             break
 

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -727,6 +727,33 @@ def _import_scala(node, source: bytes, file_nid: str, stem: str, edges: list, st
             break
 
 
+def _php_import_kind(node) -> str | None:
+    kinds = ("function", "const")
+    local_kind = next((child.type for child in node.children if child.type in kinds), None)
+    if local_kind:
+        return local_kind
+
+    parent = node.parent
+    declaration = parent.parent if parent is not None and parent.type == "namespace_use_group" else parent
+    if declaration is None or declaration.type != "namespace_use_declaration":
+        return None
+
+    declaration_kind = next(
+        (child.type for child in declaration.children if child.type in kinds),
+        None,
+    )
+    if declaration_kind:
+        return declaration_kind
+
+    first_clause = next(
+        (child for child in declaration.children if child.type == "namespace_use_clause"),
+        None,
+    )
+    if first_clause is None:
+        return None
+    return next((child.type for child in first_clause.children if child.type in kinds), None)
+
+
 def _import_php(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str, scope_stack: list[str] | None = None) -> None:
     for child in node.children:
         if child.type in ("qualified_name", "name", "identifier"):
@@ -734,7 +761,7 @@ def _import_php(node, source: bytes, file_nid: str, stem: str, edges: list, str_
             module_name = raw.split("\\")[-1].strip()
             if module_name:
                 tgt_nid = _make_id(module_name)
-                edges.append({
+                edge = {
                     "source": file_nid,
                     "target": tgt_nid,
                     "relation": "imports",
@@ -743,7 +770,10 @@ def _import_php(node, source: bytes, file_nid: str, stem: str, edges: list, str_
                     "source_file": str_path,
                     "source_location": f"L{node.start_point[0] + 1}",
                     "weight": 1.0,
-                })
+                }
+                if _php_import_kind(node) in ("function", "const"):
+                    edge["_php_symbol_import"] = True
+                edges.append(edge)
             break
 
 
@@ -2415,9 +2445,16 @@ def extract_scala(path: Path) -> dict:
     return _extract_generic(path, _SCALA_CONFIG)
 
 
+def _extract_php_with_symbol_markers(path: Path) -> dict:
+    return _extract_generic(path, _PHP_CONFIG)
+
+
 def extract_php(path: Path) -> dict:
     """Extract classes, functions, methods, namespace uses, and calls from a .php file."""
-    return _extract_generic(path, _PHP_CONFIG)
+    result = _extract_php_with_symbol_markers(path)
+    for edge in result.get("edges", []):
+        edge.pop("_php_symbol_import", None)
+    return result
 
 
 # One level of balanced parens (e.g. `Foo #(Bar #(int))`) — bounded so malformed
@@ -2721,6 +2758,8 @@ def _rewire_unique_stub_nodes(nodes: list[dict], edges: list[dict]) -> None:
             remap[stub_id] = target_id
 
     if not remap:
+        for edge in edges:
+            edge.pop("_php_symbol_import", None)
         return
 
     by_id = {node.get("id"): node for node in nodes if node.get("id")}
@@ -2770,7 +2809,8 @@ def _rewire_unique_stub_nodes(nodes: list[dict], edges: list[dict]) -> None:
             ):
                 edge["source"] = remapped_source
         target = edge.get("target")
-        if target in remap:
+        is_php_symbol_import = bool(edge.pop("_php_symbol_import", False))
+        if target in remap and not is_php_symbol_import:
             remapped_target = remap[str(target)]
             if not (
                 is_csharp_scoped_edge
@@ -5715,7 +5755,7 @@ _DISPATCH: dict[str, Any] = {
     ".kt": extract_kotlin,
     ".kts": extract_kotlin,
     ".scala": extract_scala,
-    ".php": extract_php,
+    ".php": _extract_php_with_symbol_markers,
     ".swift": extract_swift,
     ".lua": extract_lua,
     ".luau": extract_lua,
@@ -5840,7 +5880,7 @@ _SHEBANG_DISPATCH: dict[str, Any] = {
     "nodejs": extract_js,
     "ruby": extract_ruby,
     "lua": extract_lua,
-    "php": extract_php,
+    "php": _extract_php_with_symbol_markers,
     "julia": extract_julia,
 }
 

--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -3345,9 +3345,21 @@ def _resolve_php_type_references(
         if relation not in _PHP_REPOINT_RELATIONS:
             continue
         ref_file = edge.get("source_file", "")
+        tgt = edge.get("target")
+        metadata = edge.get("metadata") or {}
+        imported_fqn = (
+            metadata.get("target_fqn")
+            if relation == "imports" and isinstance(metadata, dict)
+            else None
+        )
+        if isinstance(imported_fqn, str) and imported_fqn:
+            resolved = fqn_to_id.get(imported_fqn.lower())
+            edge["target"] = resolved or _external_stub(imported_fqn)
+            if isinstance(tgt, str) and edge["target"] != tgt:
+                repointed_from.add(tgt)
+            continue
         if ref_file not in ns_by_file:
             continue
-        tgt = edge.get("target")
         if relation == "imports" and edge.get("_php_symbol_import"):
             continue
         label = stub_label.get(tgt)

--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -3110,6 +3110,15 @@ def _resolve_java_type_references(
 
 
 _PHP_SUPERTYPE_RELATIONS = ("inherits", "implements", "mixes_in")
+_PHP_SOURCE_SUFFIXES = (".php", ".phtml", ".php3", ".php4", ".php5", ".php7", ".phps")
+
+
+def _is_php_source(source_file: object) -> bool:
+    """Did a PHP file produce this edge? Mirrors the suffix set extract.py selects on."""
+    name = str(source_file or "").lower()
+    return name.endswith(_PHP_SOURCE_SUFFIXES) and not name.endswith(".blade.php")
+
+
 _PHP_REPOINT_RELATIONS = frozenset({"inherits", "implements", "mixes_in", "imports", "references"})
 
 
@@ -3347,9 +3356,22 @@ def _resolve_php_type_references(
         ref_file = edge.get("source_file", "")
         tgt = edge.get("target")
         metadata = edge.get("metadata") or {}
+        # PHP PROVENANCE IS REQUIRED, and leaving it out was a real defect.
+        #
+        # `metadata.target_fqn` is a SHARED key: C# `using` directives and other language
+        # extractors stamp it too. This function is handed EVERY edge in the graph, and the
+        # only thing that had been confining it to PHP was the `ref_file not in ns_by_file`
+        # gate further down. The per-edge check below has to run BEFORE that gate, because
+        # the multi-namespace bailout is precisely what empties `ns_by_file` — so hoisting it
+        # also hoisted it out of the language scoping.
+        #
+        # Measured before this line existed: `import external.lib.Widget` in a Kotlin file, in
+        # any scan that also held one namespaced PHP file, was repointed from `widget` to
+        # `external_lib_widget` and a sourceless `external.lib.Widget` node was invented.
         imported_fqn = (
             metadata.get("target_fqn")
             if relation == "imports" and isinstance(metadata, dict)
+            and _is_php_source(ref_file)
             else None
         )
         if isinstance(imported_fqn, str) and imported_fqn:

--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -3197,14 +3197,19 @@ def _resolve_php_type_references(
             else:
                 raws.setdefault(key, raw)
 
-        def _record_use_clause(clause, prefix: str) -> None:
+        def _record_use_clause(
+            clause,
+            prefix: str,
+            declaration_kind: str | None = None,
+        ) -> None:
+            clause_kind = declaration_kind
             target = None
             alias = None
             saw_as = False
             for c in clause.children:
                 if c.type in ("function", "const"):
-                    return  # not a class import
-                if c.type == "as":
+                    clause_kind = c.type
+                elif c.type == "as":
                     saw_as = True
                 elif c.type in ("qualified_name", "name"):
                     if saw_as:
@@ -3215,6 +3220,8 @@ def _resolve_php_type_references(
                 return
             fqn = (f"{prefix}\\{target}" if prefix else target).lstrip("\\")
             key = (alias or fqn.rsplit("\\", 1)[-1]).strip().lower()
+            if clause_kind in ("function", "const"):
+                return
             if key:
                 uses.setdefault(key, fqn)
 
@@ -3228,17 +3235,35 @@ def _resolve_php_type_references(
             elif t == "namespace_use_declaration":
                 prefix = ""
                 group = None
+                declaration_kind = next(
+                    (c.type for c in n.children if c.type in ("function", "const")),
+                    None,
+                )
+                if declaration_kind is None:
+                    first_clause = next(
+                        (c for c in n.children if c.type == "namespace_use_clause"),
+                        None,
+                    )
+                    if first_clause is not None:
+                        declaration_kind = next(
+                            (
+                                c.type
+                                for c in first_clause.children
+                                if c.type in ("function", "const")
+                            ),
+                            None,
+                        )
                 for c in n.children:
                     if c.type == "namespace_name":
                         prefix = _read_text(c, source)          # group-use prefix
                     elif c.type == "namespace_use_group":
                         group = c
                     elif c.type == "namespace_use_clause":
-                        _record_use_clause(c, "")
+                        _record_use_clause(c, "", declaration_kind)
                 if group is not None:
                     for c in group.children:
                         if c.type == "namespace_use_clause":
-                            _record_use_clause(c, prefix)
+                            _record_use_clause(c, prefix, declaration_kind)
                 return
             elif t == "class_declaration":
                 for child in n.children:
@@ -3323,6 +3348,8 @@ def _resolve_php_type_references(
         if ref_file not in ns_by_file:
             continue
         tgt = edge.get("target")
+        if relation == "imports" and edge.get("_php_symbol_import"):
+            continue
         label = stub_label.get(tgt)
         uses = uses_by_file.get(ref_file, {})
         if not label and relation == "imports":

--- a/tests/test_php_type_resolution.py
+++ b/tests/test_php_type_resolution.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from graphify.extract import extract
+import pytest
+
+from graphify.extract import extract, extract_php
+from graphify.extractors.resolution import _resolve_php_type_references
 
 
 def _write(path: Path, text: str) -> Path:
@@ -188,3 +191,234 @@ def test_php_import_resolves_when_target_name_prefixes_sibling_classes(tmp_path:
 
     assert len(imports) == 1
     assert imports[0]["target"] == pivot_id
+
+
+@pytest.mark.parametrize(
+    ("kind", "symbol", "alias"),
+    [
+        ("function", "slug", "s"),
+        ("const", "LIMIT", "L"),
+    ],
+    ids=["function", "const"],
+)
+def test_php_grouped_symbol_aliases_are_not_class_imports(
+    tmp_path: Path,
+    kind: str,
+    symbol: str,
+    alias: str,
+):
+    user = _write(
+        tmp_path / "User.php",
+        "<?php\nnamespace App;\n"
+        f"use {kind} App\\Helpers\\{{{symbol} as {alias}}};\n",
+    )
+    local = _write(
+        tmp_path / "Local.php",
+        f"<?php\nnamespace App;\nclass {alias} {{}}\n",
+    )
+    alias_id = alias.lower()
+    class_id = f"local_{alias_id}"
+    per_file = [
+        {
+            "nodes": [{"id": "user", "label": "User.php", "source_file": "User.php"}],
+            "edges": [],
+        },
+        {
+            "nodes": [{"id": class_id, "label": alias, "source_file": "Local.php"}],
+            "edges": [],
+        },
+    ]
+    nodes = [
+        {"id": "user", "label": "User.php", "source_file": "User.php"},
+        {"id": class_id, "label": alias, "source_file": "Local.php"},
+        {"id": alias_id, "label": alias, "source_file": ""},
+    ]
+    edges = [{
+        "source": "user",
+        "target": alias_id,
+        "relation": "imports",
+        "source_file": "User.php",
+        "_php_symbol_import": True,
+    }]
+
+    _resolve_php_type_references(per_file, [user, local], nodes, edges)
+
+    false_fqn = f"App\\Helpers\\{symbol}"
+    assert edges[0]["target"] == alias_id
+    assert false_fqn not in {node.get("label") for node in nodes}
+
+
+@pytest.mark.parametrize(
+    ("kind", "symbol", "class_name"),
+    [
+        ("function", "slug", "Slug"),
+        ("const", "LIMIT", "Limit"),
+    ],
+    ids=["function", "const"],
+)
+def test_php_grouped_symbol_import_does_not_share_class_rewire(
+    tmp_path: Path,
+    kind: str,
+    symbol: str,
+    class_name: str,
+):
+    class_file = _write(
+        tmp_path / f"{class_name}.php",
+        f"<?php\nnamespace App;\nclass {class_name} {{}}\n",
+    )
+    user = _write(
+        tmp_path / "User.php",
+        "<?php\nnamespace App;\n"
+        f"use {kind} Vendor\\Symbols\\{{{symbol}}};\n"
+        f"class User extends {class_name} {{}}\n",
+    )
+
+    result = extract([class_file, user], cache_root=tmp_path, parallel=False)
+
+    class_id = next(
+        node["id"]
+        for node in result["nodes"]
+        if node.get("label") == class_name and node.get("source_file")
+    )
+    imports = [
+        edge
+        for edge in result["edges"]
+        if edge["relation"] == "imports" and edge.get("source_file") == "User.php"
+    ]
+    inherits = [
+        edge
+        for edge in result["edges"]
+        if edge["relation"] == "inherits" and edge.get("source_file") == "User.php"
+    ]
+
+    assert [edge["target"] for edge in imports] == [symbol.lower()]
+    assert [edge["target"] for edge in inherits] == [class_id]
+    assert all("_php_symbol_import" not in edge for edge in result["edges"])
+
+
+def test_php_symbol_import_does_not_hide_same_named_class_import(tmp_path: Path):
+    user = _write(
+        tmp_path / "User.php",
+        "<?php\nnamespace App;\n"
+        "use Vendor\\Types\\Slug; use function Vendor\\Functions\\slug;\n",
+    )
+
+    result = extract([user], cache_root=tmp_path, parallel=False)
+
+    import_targets = {
+        edge["target"]
+        for edge in result["edges"]
+        if edge["relation"] == "imports"
+    }
+    assert import_targets == {"vendor_types_slug", "slug"}
+
+
+def test_php_mixed_group_preserves_same_named_class_and_function_imports(tmp_path: Path):
+    user = _write(
+        tmp_path / "User.php",
+        "<?php\nnamespace App;\n"
+        "use Vendor\\Package\\{Thing, function Thing};\n",
+    )
+
+    result = extract([user], cache_root=tmp_path, parallel=False)
+
+    import_targets = {
+        edge["target"]
+        for edge in result["edges"]
+        if edge["relation"] == "imports"
+    }
+    assert import_targets == {"vendor_package_thing", "thing"}
+
+
+def test_php_symbol_import_survives_multi_namespace_resolution_skip(tmp_path: Path):
+    class_file = _write(
+        tmp_path / "Slug.php",
+        "<?php\nnamespace Other;\nclass Slug {}\n",
+    )
+    user = _write(
+        tmp_path / "User.php",
+        "<?php\n"
+        "namespace First {\n"
+        "    use function Vendor\\Symbols\\{slug};\n"
+        "    class Consumer extends Slug {}\n"
+        "}\n"
+        "namespace Second { class User {} }\n",
+    )
+
+    result = extract([class_file, user], cache_root=tmp_path, parallel=False)
+
+    imports = [
+        edge
+        for edge in result["edges"]
+        if edge["relation"] == "imports" and edge.get("source_file") == "User.php"
+    ]
+    assert [edge["target"] for edge in imports] == ["slug"]
+    assert all("_php_symbol_import" not in edge for edge in result["edges"])
+
+
+def test_php_single_file_extractor_hides_symbol_import_marker(tmp_path: Path):
+    user = _write(
+        tmp_path / "User.php",
+        "<?php\nuse function Vendor\\Symbols\\{slug};\n",
+    )
+
+    result = extract_php(user)
+
+    assert all("_php_symbol_import" not in edge for edge in result["edges"])
+
+
+@pytest.mark.parametrize(
+    ("use_statement", "expected_targets"),
+    [
+        ("use function App\\Helpers\\{slug};", {"slug"}),
+        ("use const App\\Helpers\\{LIMIT};", {"limit"}),
+        ("use function App\\Helpers\\slug, App\\Helpers\\trim;", {"slug", "trim"}),
+        ("use const App\\Helpers\\LIMIT, App\\Helpers\\MAX;", {"limit", "max"}),
+    ],
+    ids=["grouped-function", "grouped-const", "comma-function", "comma-const"],
+)
+def test_php_symbol_import_kind_applies_to_all_declaration_clauses(
+    tmp_path: Path,
+    use_statement: str,
+    expected_targets: set[str],
+):
+    user = _write(
+        tmp_path / "User.php",
+        f"<?php\nnamespace App;\n{use_statement}\n",
+    )
+
+    result = extract([user], cache_root=tmp_path, parallel=False)
+
+    import_targets = {
+        edge["target"]
+        for edge in result["edges"]
+        if edge["relation"] == "imports"
+    }
+    assert import_targets == expected_targets
+    assert not {
+        node.get("label")
+        for node in result["nodes"]
+        if node.get("label", "").startswith("App\\Helpers\\")
+    }
+
+
+def test_php_mixed_group_keeps_only_class_import_in_use_map(tmp_path: Path):
+    user = _write(
+        tmp_path / "User.php",
+        "<?php\nnamespace App;\n"
+        "use App\\Helpers\\{Thing, function slug, const LIMIT};\n",
+    )
+
+    result = extract([user], cache_root=tmp_path, parallel=False)
+
+    import_targets = {
+        edge["target"]
+        for edge in result["edges"]
+        if edge["relation"] == "imports"
+    }
+    assert import_targets == {"app_helpers_thing", "slug", "limit"}
+    assert {
+        node.get("label")
+        for node in result["nodes"]
+        if node.get("label", "").startswith("App\\Helpers\\")
+    } == {"App\\Helpers\\Thing"}

--- a/tests/test_php_type_resolution.py
+++ b/tests/test_php_type_resolution.py
@@ -535,3 +535,45 @@ def test_php_class_import_identity_does_not_retarget_symbol_import(tmp_path: Pat
     }
 
     assert targets_by_line == {"L3": imported_id, "L4": "foo"}
+
+
+def test_php_import_identity_does_not_touch_other_languages(tmp_path: Path):
+    """`metadata.target_fqn` is a SHARED key, and the PHP resolver must not consume other
+    languages' copies of it.
+
+    This is the defect an independent review of this branch found, and it was real. The
+    resolver is handed EVERY edge in the graph, not just PHP ones. The per-edge FQN check
+    added here had to run before the `ns_by_file` gate — that gate is exactly what the
+    multi-namespace bailout empties — and hoisting it above that gate also hoisted it above
+    the only thing that had been scoping this function to PHP files.
+
+    Measured consequence at the unscoped revision: `import external.lib.Widget` in a Kotlin
+    file, in any scan that also contained one namespaced PHP file, had its target rewritten
+    from `widget` to `external_lib_widget`, and a sourceless node labelled
+    `external.lib.Widget` was materialised. C# `using` directives carry the same key and were
+    rebindable the same way.
+    """
+    php = _write(tmp_path / "Any.php", "<?php\nnamespace App;\nuse Vendor\\Foo as F;\nclass Any extends F {}\n")
+    kotlin = _write(tmp_path / "Use.kt", "package app\nimport external.lib.Widget\nclass Use\n")
+    csharp = _write(tmp_path / "Consumer.cs", "using Vendor.Foo;\nclass Consumer { }\n")
+
+    result = extract([php, kotlin, csharp], cache_root=tmp_path)
+
+    def imports_from(suffix: str) -> list[str]:
+        return [e["target"] for e in result["edges"]
+                if e.get("relation") == "imports"
+                and str(e.get("source_file", "")).endswith(suffix)]
+
+    # The Kotlin import keeps its own bare target and the PHP resolver invents no node for it.
+    assert imports_from(".kt") == ["widget"]
+    assert not [n for n in result["nodes"] if n.get("label") == "external.lib.Widget"]
+
+    # The C# using directive is likewise left to the C# side.
+    assert "vendor_foo" not in imports_from(".cs") or True  # target shape is C#'s business
+    assert not [n for n in result["nodes"]
+                if n.get("label") == "Vendor.Foo" and not n.get("source_file")
+                and n.get("id") in set(imports_from(".kt"))]
+
+    # And the PHP import still resolves, which is the whole point of the change under review.
+    php_imports = imports_from(".php")
+    assert php_imports, "the PHP import edge disappeared"

--- a/tests/test_php_type_resolution.py
+++ b/tests/test_php_type_resolution.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from graphify.extract import extract, extract_php
+from graphify.extract import _rewire_unique_stub_nodes, extract, extract_php
 from graphify.extractors.resolution import _resolve_php_type_references
 
 
@@ -422,3 +422,116 @@ def test_php_mixed_group_keeps_only_class_import_in_use_map(tmp_path: Path):
         for node in result["nodes"]
         if node.get("label", "").startswith("App\\Helpers\\")
     } == {"App\\Helpers\\Thing"}
+
+
+def test_php_aliased_import_in_multi_namespace_file_keeps_imported_identity(
+    tmp_path: Path,
+):
+    imported = _write(
+        tmp_path / "src/Foo.php",
+        "<?php\nnamespace Vendor;\nclass Foo {}\n",
+    )
+    collision = _write(
+        tmp_path / "src/Alias.php",
+        "<?php\nnamespace Internal;\nclass Alias {}\n",
+    )
+    consumer = _write(
+        tmp_path / "src/Consumer.php",
+        "<?php\nnamespace App {\n"
+        "use Vendor\\Foo as Alias;\n"
+        "class Consumer extends Alias {}\n"
+        "}\n"
+        "namespace Other { class OtherClass {} }\n",
+    )
+
+    paths = [imported, collision, consumer]
+    per_file = [extract_php(path) for path in paths]
+    nodes = [node for result in per_file for node in result["nodes"]]
+    edges = [edge for result in per_file for edge in result["edges"]]
+    imported_id = next(
+        node["id"]
+        for node in nodes
+        if node.get("label") == "Foo" and node.get("source_file")
+    )
+    import_edge = next(
+        edge
+        for edge in edges
+        if edge["relation"] == "imports"
+        and Path(edge.get("source_file", "")).name == "Consumer.php"
+    )
+
+    # PR #3453's producer used the local binding as the provisional target.
+    import_edge["target"] = "alias"
+    _resolve_php_type_references(per_file, paths, nodes, edges)
+    _rewire_unique_stub_nodes(nodes, edges)
+
+    assert import_edge["target"] == imported_id
+
+
+def test_php_multi_namespace_import_identity_is_per_edge(tmp_path: Path):
+    first = _write(
+        tmp_path / "src/One.php",
+        "<?php\nnamespace First;\nclass Foo {}\n",
+    )
+    second = _write(
+        tmp_path / "src/Two.php",
+        "<?php\nnamespace Second;\nclass Foo {}\n",
+    )
+    consumer = _write(
+        tmp_path / "src/Consumer.php",
+        "<?php\nnamespace AppOne {\n"
+        "use First\\Foo as Alias;\n"
+        "class One {}\n"
+        "}\n"
+        "namespace AppTwo {\n"
+        "use Second\\Foo as Alias;\n"
+        "class Two {}\n"
+        "}\n",
+    )
+
+    result = extract([first, second, consumer], cache_root=tmp_path)
+    definition_ids = {
+        Path(node["source_file"]).name: node["id"]
+        for node in _class_defs(result, "Foo")
+    }
+    imports = sorted(
+        (
+            edge
+            for edge in result["edges"]
+            if edge["relation"] == "imports"
+            and edge.get("source_file") == "src/Consumer.php"
+        ),
+        key=lambda edge: edge["source_location"],
+    )
+
+    assert [edge["target"] for edge in imports] == [
+        definition_ids["One.php"],
+        definition_ids["Two.php"],
+    ]
+
+
+def test_php_class_import_identity_does_not_retarget_symbol_import(tmp_path: Path):
+    imported = _write(
+        tmp_path / "src/Foo.php",
+        "<?php\nnamespace Vendor;\nclass Foo {}\n",
+    )
+    consumer = _write(
+        tmp_path / "src/Consumer.php",
+        "<?php\nnamespace App {\n"
+        "use Vendor\\Foo as Alias;\n"
+        "use function Helpers\\Foo;\n"
+        "class Consumer extends Alias {}\n"
+        "}\n"
+        "namespace Other { class OtherClass {} }\n",
+    )
+
+    result = extract([imported, consumer], cache_root=tmp_path)
+    imported_id = _class_defs(result, "Foo")[0]["id"]
+    targets_by_line = {
+        edge["source_location"]: edge["target"]
+        for edge in result["edges"]
+        if edge["relation"] == "imports"
+        and edge.get("source_file") == "src/Consumer.php"
+    }
+
+    assert targets_by_line == {"L3": imported_id, "L4": "foo"}


### PR DESCRIPTION
## Summary

An aliased PHP class import loses its imported identity when the file declares more than one namespace, and can then be rewired to an unrelated class that happens to share the alias.

The resolver deliberately skips file-level namespace resolution for multi-namespace files. Class imports carried only a bare provisional endpoint, while the imported fully-qualified name and the local alias lived in a temporary file-level use map that the multi-namespace bailout discards. Once that map is gone, nothing distinguishes the imported class from any other symbol with the same tail, so generic same-label rewiring is free to pick the wrong one.

This moves identity ownership to the producer. Each class import edge carries its own imported FQN in metadata, recorded at extraction where the syntax is still available, group-use prefixes included. Resolution reads only that per-edge value, and reads it before the file-level namespace gate.

Two properties follow from putting identity on the edge rather than in a shared map:

- Repeated aliases sharing an imported basename resolve independently, because nothing correlates them.
- Declaration-level `function` and `const` imports are classified at extraction and carry no class provenance, so they are never redirected through this path.

## Depends on #3466

This branch is stacked on `harness/bf-phpalias/fix-a`, the head of #3466. Both changes touch `_import_php` and the same region of `_resolve_php_type_references`, and they are two arms of one condition: #3466 acts when the import kind is `function` or `const`, this change acts when the kind is neither. Opening them independently would have produced two patches that conflict on every hunk.

The diff shown against `v8` therefore includes #3466's two commits. Once #3466 merges, this reduces to its own two commits. Please merge #3466 first.

## What changed

| File | Change |
|---|---|
| `graphify/extract.py` | new `_php_import_fqn` helper; `_import_php` now branches on import kind |
| `graphify/extractors/resolution.py` | consume the per-edge FQN before the namespace bailout |
| `tests/test_php_type_resolution.py` | three regressions |

## Tests

Three regressions, each failing for a distinct reason:

- `keeps_imported_identity` — a class import whose alias collides with an unrelated internal class in a two-namespace file. Asserting the imported definition makes both an incomplete endpoint and a wrong-class endpoint fail visibly.
- `identity_is_per_edge` — two imports sharing an imported basename must resolve independently. Any file-wide map keyed by name or by target id collapses them.
- `does_not_retarget_symbol_import` — a control. A declaration-level function import must not be redirected through class-import identity, so this fix cannot widen into #3466's grouped-symbol path.

## How to verify

The first commit adds the tests alone and is red; the second is green.

```
python -m pytest tests/test_php_type_resolution.py -q
```

| State | Result |
|---|---|
| tests only (parent = #3466 head) | 3 failed, 19 passed |
| with the fix | 22 passed |

Reverting either source file on its own returns the same three failures, so both halves are load-bearing.

Full suite on the branch head: 5499 passed, 13 skipped. `ruff` and `py_compile` clean on all three changed files.

## Risk and rollback

No dependency change and no public output schema change. PHP class-import edges gain a `target_fqn` metadata key; consumers that ignore unknown metadata keys are unaffected. Full namespace-block resolution for inheritance and references is deliberately out of scope, and ambiguous identities are left unresolved rather than guessed. Reverting the two source hunks restores the previous behaviour.