### PR TITLE
fix: label via an installed claude CLI, and stop pinning a path that expires

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -101,11 +101,19 @@ fi
 # Scan the uv tool envs directly; UV_TOOL_DIR overrides the default
 # location. A tool env is adopted only if its python passes the probe, so a
 # co-installed tool without graphify never satisfies it.
+#
+# The snap roots matter because an install made from inside a snap-confined
+# editor lands in that snap's private HOME, which the plain $HOME roots above
+# never see once the hook runs from an ordinary shell. Revisions are globbed
+# rather than pinned: snap rotates them on update, which is exactly what makes
+# a pinned path unsafe (see _is_rotating_prefix).
 if [ -z "$GRAPHIFY_PYTHON" ]; then
     for _GFY_TOOLS in \
         "${UV_TOOL_DIR:-}" \
         "$HOME/.local/share/uv/tools" \
-        "$HOME/AppData/Roaming/uv/tools"; do
+        "$HOME/AppData/Roaming/uv/tools" \
+        "$HOME"/snap/*/current/.local/share/uv/tools \
+        "$HOME"/snap/*/[0-9]*/.local/share/uv/tools; do
         [ -n "$_GFY_TOOLS" ] || continue
         for _GFY_CAND in "$_GFY_TOOLS"/*/bin/python "$_GFY_TOOLS"/*/Scripts/python.exe; do
             [ -x "$_GFY_CAND" ] || continue
@@ -647,7 +655,29 @@ def _pinned_python() -> str:
     """
     if re.search(r"[^a-zA-Z0-9/_.@: \\-]", sys.executable):
         return ""
+    if _is_rotating_prefix(sys.executable):
+        return ""
     return sys.executable
+
+
+# ``~/snap/<app>/<revision>/`` — snap swaps <revision> on every package update and
+# prunes the old tree, so anything under it is a path with an expiry date.
+_ROTATING_PREFIX_RE = re.compile(r"/snap/[^/]+/(\d+|current)/")
+
+
+def _is_rotating_prefix(path: str) -> bool:
+    """True if `path` lives under a directory the packaging system rotates.
+
+    A pin is only worth writing if it will still resolve tomorrow. An interpreter
+    inside a snap revision will not: the revision number changes on update and the
+    old tree is removed, which silently kills every hook pinned to it — observed
+    across 15 repositories at once when an editor snap moved past its revision.
+
+    Returning "" here is the documented safe degradation: the hook falls through to
+    its other probes, including the uv-tools scan, which searches snap-confined
+    homes too.
+    """
+    return bool(_ROTATING_PREFIX_RE.search(path.replace("\\", "/")))
 
 
 def _merge_attr_line() -> str:

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -3177,6 +3177,21 @@ def detect_backend() -> str | None:
     return None
 
 
+def _claude_cli_available() -> bool:
+    """True if the Claude Code CLI can actually be launched.
+
+    Mirrors the resolution in the claude-cli request path: a bare ``claude`` on
+    POSIX, and ``claude.cmd`` on Windows, where CreateProcess cannot resolve the
+    npm shim from the bare name.
+    """
+    import platform
+    import shutil
+
+    if platform.system() == "Windows":
+        return bool(shutil.which("claude.cmd") or shutil.which("claude"))
+    return shutil.which("claude") is not None
+
+
 # ── Community labeling ────────────────────────────────────────────────────────
 # When graphify runs inside an orchestrating agent (Claude Code / Gemini CLI),
 # the agent names communities itself per skill.md Step 5 - it reads the analysis
@@ -3470,6 +3485,15 @@ def generate_community_labels(
             backend = detect_backend()
         except Exception:
             backend = None
+    if not backend and _claude_cli_available():
+        # `detect_backend` is key-based, and claude-cli is the one backend with no
+        # key to find, so it can never be detected there — and widening detection
+        # itself would change extraction's contract, which deliberately refuses to
+        # run without a configured backend. Here the alternative is not an error but
+        # a SILENT DOWNGRADE: replacing every real community name with
+        # "Community N" and exiting 0, which overwrites a good graph with a worse
+        # one while reporting success. An installed CLI is better than that.
+        backend = "claude-cli"
     if not backend:
         if not quiet:
             print(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1273,3 +1273,62 @@ def test_rebuild_bodies_tolerate_a_bom_in_graphify_root(name, body):
     assert "encoding='utf-8')" not in body, (
         f"{name} rebuild body still has a BOM-intolerant read"
     )
+
+
+@pytest.mark.parametrize("exe", [
+    "/home/dev/snap/code/259/.local/share/uv/tools/graphifyy/bin/python",
+    "/home/dev/snap/code/current/.local/share/uv/tools/graphifyy/bin/python",
+    "/root/snap/pycharm-community/42/.local/share/uv/tools/graphifyy/bin/python",
+])
+def test_pinned_python_refuses_a_rotating_snap_revision(exe, monkeypatch):
+    """A pin is only worth writing if it still resolves tomorrow.
+
+    graphify installed from inside a snap-confined editor lives under
+    ``~/snap/<app>/<revision>/``. Snap swaps that revision on update and prunes the
+    old tree, so the pin dies silently — observed across 15 repositories at once
+    when an editor snap moved past revision 259. Every commit then printed "could
+    not locate a Python with graphify installed" and the graphs quietly stopped
+    tracking the code.
+
+    Empty is the documented safe degradation: the hook falls through to its other
+    probes, and the uv-tools probe searches snap homes by glob.
+    """
+    import sys as _sys
+
+    from graphify.hooks import _pinned_python
+
+    monkeypatch.setattr(_sys, "executable", exe)
+    assert _pinned_python() == "", "a path under a rotating snap revision must not be pinned"
+
+
+def test_pinned_python_still_pins_a_stable_path(monkeypatch):
+    """The rotating-prefix rule must not swallow ordinary installs.
+
+    Control for the test above: 'snap' appearing anywhere else in a path — a user
+    named snap, a project directory called snap — is not a snap revision tree.
+    """
+    import sys as _sys
+
+    from graphify.hooks import _pinned_python
+
+    for exe in (
+        "/home/dev/.local/share/uv/tools/graphifyy/bin/python",
+        "/usr/bin/python3",
+        "/home/snap/projects/venv/bin/python",
+    ):
+        monkeypatch.setattr(_sys, "executable", exe)
+        assert _pinned_python() == exe, f"{exe} is stable and must still be pinned"
+
+
+def test_hook_probes_snap_confined_uv_tool_dirs():
+    """The uv-tools probe must look inside snap-confined HOMEs.
+
+    An install made from a snap-confined editor lands in that snap's private HOME.
+    Once the hook runs from an ordinary shell, $HOME is the real one, so the plain
+    roots never see it — which is what left the pin as the only thing that could
+    ever find such an install.
+    """
+    from graphify.hooks import _HOOK_SCRIPT
+
+    assert '"$HOME"/snap/*/[0-9]*/.local/share/uv/tools' in _HOOK_SCRIPT
+    assert '"$HOME"/snap/*/current/.local/share/uv/tools' in _HOOK_SCRIPT

--- a/tests/test_llm_backends.py
+++ b/tests/test_llm_backends.py
@@ -1475,3 +1475,81 @@ def test_max_retry_depth_reads_the_env_var(monkeypatch):
     assert llm._resolve_max_retry_depth() == 3
     monkeypatch.setenv("GRAPHIFY_MAX_RETRY_DEPTH", "-2")
     assert llm._resolve_max_retry_depth() == 3
+
+
+import shutil  # patched by the claude-cli detection tests below
+
+
+def _clear_every_backend_signal(monkeypatch):
+    """Empty the environment of every signal detect_backend() looks at."""
+    _clear_backend_env(monkeypatch)
+    for env_key in (
+        "AWS_PROFILE",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "OLLAMA_BASE_URL",
+        "OLLAMA_HOST",
+    ):
+        monkeypatch.delenv(env_key, raising=False)
+
+
+def test_labelling_falls_back_to_the_claude_cli_instead_of_placeholders(monkeypatch):
+    """The one backend with no API key must not cost you your community names.
+
+    `detect_backend` is key-based, so claude-cli can never be found there. On a
+    machine with the Claude Code CLI and no key, labelling therefore announced "no
+    LLM backend configured", replaced every real name with a `Community N`
+    placeholder, and exited 0 — overwriting a good graph with a worse one while
+    reporting success.
+
+    Detection itself is deliberately NOT widened: extraction refuses to run without
+    a configured backend and points at --code-only, and that contract stays.
+    """
+    _clear_every_backend_signal(monkeypatch)
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/claude")
+    seen = {}
+
+    def _fake_label(G, communities, *, backend, **kwargs):
+        seen["backend"] = backend
+        return {int(c): f"Named {c}" for c in communities}
+
+    monkeypatch.setattr(llm, "label_communities", _fake_label)
+
+    labels, source = llm.generate_community_labels(None, [0, 1], quiet=True)
+
+    assert seen["backend"] == "claude-cli"
+    assert source == "llm"
+    assert labels == {0: "Named 0", 1: "Named 1"}
+
+
+def test_labelling_still_placeholders_when_no_cli_and_no_key(monkeypatch):
+    """Without a key AND without the CLI there is genuinely nothing to call."""
+    _clear_every_backend_signal(monkeypatch)
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+
+    labels, source = llm.generate_community_labels(None, [0, 1], quiet=True)
+
+    assert source == "placeholder"
+    assert labels == {0: "Community 0", 1: "Community 1"}
+
+
+def test_detection_is_not_widened_by_the_labelling_fallback(monkeypatch):
+    """Extraction's contract must be untouched: no key still means no backend.
+
+    Widening `detect_backend` itself would make `graphify extract` start shelling
+    out to the CLI on any machine that happens to have it, instead of erroring and
+    pointing at --code-only.
+    """
+    _clear_every_backend_signal(monkeypatch)
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/claude")
+
+    assert llm.detect_backend() is None
+
+
+def test_claude_cli_never_shadows_a_configured_api_key(monkeypatch):
+    """An incidental CLI on PATH must not outrank a key the user configured."""
+    _clear_every_backend_signal(monkeypatch)
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/claude")
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+
+    assert llm.detect_backend() == "gemini"


### PR DESCRIPTION
Two independent silent failures, found while repairing 16 repositories whose graphs had quietly stopped tracking their code. Neither one announced itself: one exits 0 while making the graph worse, the other stops the hook from ever running again.

## 1. `graphify label` downgrades a graph and reports success

`detect_backend()` is key-based, and `claude-cli` is the one backend with no API key to find — `_get_backend_api_key` can never return one for it, and the fallback loop excludes it by name. Nothing else looks for it.

So on a machine with the Claude Code CLI installed and no API key:

```
$ graphify label .
[graphify label] no LLM backend configured; keeping Community N placeholders. ...
Done - 114 communities. GRAPH_REPORT.md, graph.json and graph.html updated.
$ echo $?
0
```

Every real community name is replaced with `Community 1`, `Community 2`, … and the command exits 0. Over an existing graph that is a downgrade wearing the appearance of success — worse than the hub-derived names a bare rebuild leaves behind. `--backend=claude-cli` works perfectly; it just has to be named, and nothing tells you that.

**The fallback is in the labelling path, deliberately not in `detect_backend()`.** Widening detection was my first attempt and it broke `test_mixed_repo_without_key_errors_and_points_at_code_only`: extraction refuses to run without a configured backend and points at `--code-only`, and on any machine with the CLI present that contract would have silently become "shell out to the CLI instead". That seemed clearly not yours to change by accident, so it is unchanged, and `test_detection_is_not_widened_by_the_labelling_fallback` now pins it.

The fallback is also last, for the same reason ollama is: a configured paid key must never be shadowed by an incidental CLI on `PATH`.

## 2. The post-commit hook pins a path with an expiry date

`_pinned_python()` writes `sys.executable` verbatim. graphify installed from inside a snap-confined editor lives under `~/snap/<app>/<revision>/`, and snap swaps that revision on update and prunes the old tree.

When an editor snap moved past revision 259, **15 repositories lost their hook at once**. Each commit printed:

```
[graphify hook] could not locate a Python with graphify installed. Add the graphify bin dir to PATH or re-run 'graphify hook install' from the env where graphify lives.
```

…and the graphs simply stopped following the code. One had drifted by more than 200 communities' worth of structure before anyone noticed.

Two changes, both extending what is already there:

- `_pinned_python()` declines to pin a path under a rotating revision directory. Its docstring already describes an empty return as safe degradation — the other probes take over.
- The uv-tools probe, which already scans tool environments, also scans snap-confined `HOME`s **by glob**. An install made inside a snap lands in that snap's private `HOME`, which the plain `$HOME` roots never see once the hook runs from an ordinary shell — so before this, the pin was the only thing that could ever find such an install, and the pin was the thing guaranteed to expire.

Note `~/snap/<app>/current` is included but not relied on: on the machine where this was found, `current` pointed at 259 while 261 and 262 existed.

## Verification

Both changes mutation-tested — removing either fails a test the other still passes.

| | failed | passed |
|---|---:|---:|
| this branch | 25 | **5119** |
| `main` | 25 | **5110** |

Same 25 failures either way (terraform fixtures and a TS scaling test, unrelated to these paths); +9 passing is exactly the nine tests added here. Run in one venv, the branch stashed and unstashed between runs, rather than assuming the pre-existing failures were pre-existing.

Happy to split this into two PRs if you would rather review them separately.
