### PR TITLE
fix(install): do not abort the install when always-on registration is unwritable (#3474)

### DIFF
--- a/graphify/install.py
+++ b/graphify/install.py
@@ -356,6 +356,34 @@ def _skill_registration(skill_path: str = "~/.claude/skills/graphify/SKILL.md") 
         "When the user types `/graphify`, use the installed graphify skill "
         "or instructions before doing anything else.\n"
     )
+def _register_always_on_block(target: Path, prefix: str, registration: str) -> None:
+    """Append an always-on registration to *target*, degrading instead of raising.
+
+    The skill files are copied before this runs, so a *target* that cannot be
+    read or written must not abort an otherwise-complete install (#3474). That
+    happens whenever the dotfile is managed declaratively -- nix/home-manager
+    symlinks ``~/.claude/CLAUDE.md`` into a read-only /nix/store, and chezmoi or
+    stow with read-only sources leave the same shape.
+    """
+    try:
+        if target.exists():
+            content = target.read_text(encoding="utf-8")
+            if "graphify" in content:
+                print(f"{prefix}already registered (no change)")
+            else:
+                target.write_text(content.rstrip() + registration, encoding="utf-8")
+                print(f"{prefix}skill registered in {target}")
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(registration.lstrip(), encoding="utf-8")
+            print(f"{prefix}created at {target}")
+    except OSError as exc:
+        print(f"{prefix}skipped: {exc.__class__.__name__}: {exc}", file=sys.stderr)
+        print(
+            f"  hint: the skill files were installed; add the graphify block to "
+            f"{target} manually to finish always-on registration",
+            file=sys.stderr,
+        )
 _PLATFORM_CONFIG: dict[str, dict] = {
     "claude": {
         "skill_file": "skill.md",
@@ -673,34 +701,17 @@ def install(platform: str = "claude", *, project: bool = False, project_dir: Pat
         else:
             claude_md = Path.home() / ".claude" / "CLAUDE.md"
             skill_ref = "~/.claude/skills/graphify/SKILL.md"
-        registration = _skill_registration(skill_ref)
-        if claude_md.exists():
-            content = claude_md.read_text(encoding="utf-8")
-            if "graphify" in content:
-                print(f"  CLAUDE.md        ->  already registered (no change)")
-            else:
-                claude_md.write_text(content.rstrip() + registration, encoding="utf-8")
-                print(f"  CLAUDE.md        ->  skill registered in {claude_md}")
-        else:
-            claude_md.parent.mkdir(parents=True, exist_ok=True)
-            claude_md.write_text(registration.lstrip(), encoding="utf-8")
-            print(f"  CLAUDE.md        ->  created at {claude_md}")
+        _register_always_on_block(
+            claude_md, "  CLAUDE.md        ->  ", _skill_registration(skill_ref)
+        )
 
     if platform == "codebuddy":
         # Register in ~/.codebuddy/CODEBUDDY.md (CodeBuddy only)
-        codebuddy_md = Path.home() / ".codebuddy" / "CODEBUDDY.md"
-        registration = _skill_registration("~/.codebuddy/skills/graphify/SKILL.md")
-        if codebuddy_md.exists():
-            content = codebuddy_md.read_text(encoding="utf-8")
-            if "graphify" in content:
-                print(f"  CODEBUDDY.md     ->  already registered (no change)")
-            else:
-                codebuddy_md.write_text(content.rstrip() + registration, encoding="utf-8")
-                print(f"  CODEBUDDY.md     ->  skill registered in {codebuddy_md}")
-        else:
-            codebuddy_md.parent.mkdir(parents=True, exist_ok=True)
-            codebuddy_md.write_text(registration.lstrip(), encoding="utf-8")
-            print(f"  CODEBUDDY.md     ->  created at {codebuddy_md}")
+        _register_always_on_block(
+            Path.home() / ".codebuddy" / "CODEBUDDY.md",
+            "  CODEBUDDY.md     ->  ",
+            _skill_registration("~/.codebuddy/skills/graphify/SKILL.md"),
+        )
 
     if platform == "opencode":
         _install_opencode_plugin(project_dir if project else Path("."))

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -86,6 +86,88 @@ def test_install_claude_md_defaults_to_home_when_config_dir_unset(tmp_path, monk
     assert "~/.claude/skills/graphify/SKILL.md" in md.read_text()
 
 
+def _deny_writes_to(target: Path, monkeypatch):
+    """Make write_text raise PermissionError for *target* only (simulates a
+    dotfile symlinked into a read-only store, e.g. /nix/store)."""
+    real_write_text = Path.write_text
+
+    def guarded(self, *args, **kwargs):
+        if self == target:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", guarded)
+
+
+def test_install_survives_unwritable_claude_md(tmp_path, monkeypatch, capsys):
+    """#3474: a read-only ~/.claude/CLAUDE.md must not abort the install.
+
+    install() copies the skill files first and registers the always-on block
+    afterwards, so an unguarded write left a half-completed install plus a
+    traceback on nix/home-manager, chezmoi and stow-with-read-only-sources.
+    """
+    from graphify.__main__ import install
+
+    home = tmp_path / "home"
+    home.mkdir()
+    target = home / ".claude" / "CLAUDE.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("# my rules\n")
+
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    with patch("graphify.__main__.Path.home", return_value=home):
+        _deny_writes_to(target, monkeypatch)
+        install(platform="claude")  # must not raise
+
+    assert (home / ".claude" / "skills" / "graphify" / "SKILL.md").exists(), (
+        "skill files should still be installed"
+    )
+    assert target.read_text() == "# my rules\n", "unwritable file must be untouched"
+    err = capsys.readouterr().err
+    assert "skipped" in err
+    assert "PermissionError" in err
+
+
+def test_install_survives_unwritable_codebuddy_md(tmp_path, monkeypatch, capsys):
+    """#3474 (same shape): an unwritable CODEBUDDY.md must not abort the install."""
+    from graphify.__main__ import install
+
+    home = tmp_path / "home"
+    home.mkdir()
+    target = home / ".codebuddy" / "CODEBUDDY.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("# my rules\n")
+
+    monkeypatch.chdir(tmp_path)
+    with patch("graphify.__main__.Path.home", return_value=home):
+        _deny_writes_to(target, monkeypatch)
+        install(platform="codebuddy")  # must not raise
+
+    assert (home / ".codebuddy" / "skills" / "graphify" / "SKILL.md").exists()
+    assert target.read_text() == "# my rules\n"
+    assert "skipped" in capsys.readouterr().err
+
+
+def test_install_claude_md_success_output_unchanged(tmp_path, monkeypatch, capsys):
+    """Regression guard: the writable path still reports the same messages."""
+    from graphify.__main__ import install
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    with patch("graphify.__main__.Path.home", return_value=home):
+        install(platform="claude")
+        first = capsys.readouterr().out
+        install(platform="claude")
+        second = capsys.readouterr().out
+
+    assert "  CLAUDE.md        ->  created at " in first
+    assert "  CLAUDE.md        ->  already registered (no change)" in second
+
+
 def test_install_codebuddy(tmp_path):
     _install(tmp_path, "codebuddy")
     assert (tmp_path / ".codebuddy" / "skills" / "graphify" / "SKILL.md").exists()


### PR DESCRIPTION
## What this fixes

`graphify install` aborts with a traceback when the always-on registration file
cannot be written, **after** the skill files have already been copied — a
half-completed install (reported in #3474).

`install()` lays down the skill first and registers the always-on block
afterwards, so this ordering is what turns a write failure into a partial
install:

- `graphify/install.py:682` / `:686` — unguarded `claude_md.write_text(...)`
- `graphify/install.py:698` / `:702` — the identical unguarded pattern for
  `CODEBUDDY.md`

It bites the normal declaratively-managed-dotfiles case: nix/home-manager
symlinks `~/.claude/CLAUDE.md` into a read-only `/nix/store`, and chezmoi or
stow with read-only sources leave the same shape.

## The change

Both registrations now route through one helper, `_register_always_on_block()`,
which catches `OSError` (covers `PermissionError`, `IsADirectoryError` and a
dangling symlink's `FileNotFoundError`), reports the skip on stderr, and lets
the install finish so the skill that was already installed stays usable.

The success-path output is unchanged byte for byte — the helper takes the
already-formatted label prefix, so the `CLAUDE.md        ->  ` column alignment
is preserved.

## Scope note

#3474 raises two things. This PR addresses only the second one (the unguarded
write). The first — that the block is redundant on Claude Code because the
harness already auto-discovers `~/.claude/skills/graphify/SKILL.md` — is a
behaviour change that would stop `install()` writing the file at all. That is
the maintainer's call, so I deliberately left it alone. Hence `Refs #3474`
rather than `Fixes`: the crash-on-install is fixed, the redundancy question
stays open.

I extended the same helper to the CodeBuddy registration because it is the same
defect, in the same function, three lines below — leaving it unguarded would
have looked like an oversight. Happy to split it out if you would rather keep
the diff to the claude path only.

## Verification

`tests/test_install.py`, three new tests:

- `test_install_survives_unwritable_claude_md` — the reported case.
- `test_install_survives_unwritable_codebuddy_md` — same shape, CodeBuddy path.
- `test_install_claude_md_success_output_unchanged` — regression guard that the
  writable path still prints `created at ` / `already registered (no change)`.

Both failure tests were confirmed to **fail on the parent commit** with exactly
the reported error before the fix:

```
tests/test_install.py:96: PermissionError: [Errno 13] Permission denied: ...\.codebuddy\CODEBUDDY.md
2 failed, 101 deselected
```

Results (`47041ee` vs parent `adf814f`), on the install-related surface
(`test_install`, `test_codebuddy`, `test_claude_md`, `test_install_roundtrip`,
`test_install_upgrade`, `test_install_strings`, `test_install_references`,
`test_install_version_stamp`, `test_install_version_warning`,
`test_uninstall_scope`, `test_agents_platform`, `test_antigravity_install`):

| | failed | passed |
|---|---|---|
| parent `adf814f` | 6 | 256 |
| this PR `47041ee` | 6 | 259 |

The same 6 pre-existing failures on both sides, so this change introduces none.
They are Windows-environment failures on platforms this PR does not touch
(`test_hermes_skill_destination_posix_uses_home`,
`test_skill_roundtrip_at_real_destination[user-hermes]`,
`test_gemini_install_references_all_resolve`,
`test_bare_call_still_removes_global[gemini]`,
`test_remove_user_skill_opt_in_with_project_dir[gemini]`,
`test_codex_skill_uses_graphify_with_existing_graph`) — the POSIX-path /
symlink caveats the README already documents for native Windows.

CI-parity guards, all green on this branch: `tools.skillgen --check` (134
artifacts), `--audit-coverage`, `--schema-singleton`, `--monolith-roundtrip`,
`--always-on-roundtrip`. `ruff check .` also passes.

> Caveat, stated plainly: I ran the full `pytest tests/ -q` suite but it did not
> finish within my working window, so the table above is the install-related
> subset rather than the whole suite. Nothing outside that surface imports
> `_register_always_on_block`; the helper is new and its only two call sites are
> the ones shown in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
