### PR TITLE
Fix same-file source path collision during incremental merge

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -1426,6 +1426,7 @@ def build(
         combined["hyperedges"].extend(ext.get("hyperedges", []))
         combined["input_tokens"] += ext.get("input_tokens", 0)
         combined["output_tokens"] += ext.get("output_tokens", 0)
+    _root = str(Path(root).resolve()) if root else None
     if dedup and combined["nodes"]:
         # Numeric ids must be str before dedup, which keys on them and would
         # raise TypeError in _pick_winner's regex search (#2326). build_from_json
@@ -1438,14 +1439,23 @@ def build(
         for n in combined["nodes"]:
             if isinstance(n, dict):
                 _fold_node_aliases(n)
+                # Normalize source_file and definition_file to the build root before
+                # deduplication (#3472), so exact-ID collision checks and same-file
+                # attribute merging operate on canonical repo-relative paths rather
+                # than false-flagging absolute paths from semantic subagents as
+                # different files.
+                if "source_file" in n:
+                    n["source_file"] = _norm_source_file(n["source_file"], _root)
+                if "definition_file" in n:
+                    n["definition_file"] = _norm_source_file(n["definition_file"], _root)
         combined["nodes"], combined["edges"] = deduplicate_entities(
             combined["nodes"], combined["edges"], communities={},
-            dedup_llm_backend=dedup_llm_backend, root=root,
+            dedup_llm_backend=dedup_llm_backend, root=_root,
             # Hyperedge members reference node ids too, so they need the same
             # survivor rewiring the edges get (#2805).
             hyperedges=combined.get("hyperedges"),
         )
-    return build_from_json(combined, directed=directed, root=root)
+    return build_from_json(combined, directed=directed, root=_root)
 
 
 def _norm_label(label: str | None) -> str:
@@ -2018,7 +2028,7 @@ def build_merge(
     )
 
     all_chunks = base + list(new_chunks)
-    G = build(all_chunks, directed=directed, dedup=dedup, dedup_llm_backend=dedup_llm_backend, root=root)
+    G = build(all_chunks, directed=directed, dedup=dedup, dedup_llm_backend=dedup_llm_backend, root=_eff_root)
 
     # Prune nodes and edges from deleted source files
     if prune_sources:

--- a/tests/test_issue_3472_source_file_collision.py
+++ b/tests/test_issue_3472_source_file_collision.py
@@ -1,0 +1,212 @@
+"""Tests for issue #3472:
+Same file, two path forms: absolute source_file from semantic extraction collides with
+the relative AST id and the semantic node is dropped.
+"""
+import json
+from pathlib import Path
+
+import networkx as nx
+import pytest
+
+from graphify.build import build, build_merge
+
+
+def test_semantic_absolute_path_same_file_retains_attributes(tmp_path, capsys):
+    """AST node in graph.json has relative source_file; incoming semantic node has
+    absolute source_file. Both encode the same physical file and ID.
+    The collision logic must recognize them as the same file:
+    - no 'minted by two different files' warning
+    - shorter/canonical AST label survives
+    - source_file is repo-relative
+    - semantic attributes (rationale, summary) are merged onto survivor
+    """
+    root = tmp_path.resolve()
+    graph_path = root / "graphify-out" / "graph.json"
+    graph_path.parent.mkdir(parents=True)
+
+    ast_node = {
+        "id": "docs_architecture_retrieval",
+        "label": "Retrieval",
+        "file_type": "document",
+        "source_file": "docs/ARCHITECTURE.md",
+        "source_location": "L42",
+        "_origin": "ast",
+    }
+    G0 = build([{"nodes": [ast_node], "edges": []}], dedup=False)
+    graph_path.write_text(json.dumps(nx.node_link_data(G0, edges="edges")), encoding="utf-8")
+
+    abs_sf = str((root / "docs" / "ARCHITECTURE.md").resolve())
+    sem_node = {
+        "id": "docs_architecture_retrieval",
+        "label": "Hybrid Retrieval",
+        "file_type": "document",
+        "source_file": abs_sf,
+        "source_location": None,
+        "rationale": "Detailed hybrid search rationale",
+        "summary": "Hybrid search architecture",
+    }
+
+    G = build_merge([{"nodes": [sem_node], "edges": []}], graph_path=graph_path, root=root)
+
+    assert G.number_of_nodes() == 1
+    surv = G.nodes["docs_architecture_retrieval"]
+    assert surv["label"] == "Retrieval"
+    assert surv["source_file"] == "docs/ARCHITECTURE.md"
+    assert surv["source_location"] == "L42"
+    assert surv["_origin"] == "ast"
+    assert surv["rationale"] == "Detailed hybrid search rationale"
+    assert surv["summary"] == "Hybrid search architecture"
+
+    err = capsys.readouterr().err
+    assert "minted by two different files" not in err
+    assert "WARNING" not in err
+    assert "note:" in err
+
+
+def test_semantic_absolute_path_inverse_arrival_order(tmp_path, capsys):
+    """Arrival order independence: if semantic chunk arrives before AST chunk,
+    the canonical AST label and merged attributes must be identical.
+    """
+    root = tmp_path.resolve()
+    abs_sf = str((root / "docs" / "ARCHITECTURE.md").resolve())
+
+    sem_node = {
+        "id": "docs_architecture_retrieval",
+        "label": "Hybrid Retrieval",
+        "file_type": "document",
+        "source_file": abs_sf,
+        "source_location": None,
+        "rationale": "Detailed hybrid search rationale",
+        "summary": "Hybrid search architecture",
+    }
+    ast_node = {
+        "id": "docs_architecture_retrieval",
+        "label": "Retrieval",
+        "file_type": "document",
+        "source_file": "docs/ARCHITECTURE.md",
+        "source_location": "L42",
+        "_origin": "ast",
+    }
+
+    # Semantic chunk first, AST chunk second
+    G = build(
+        [{"nodes": [sem_node], "edges": []}, {"nodes": [ast_node], "edges": []}],
+        root=root,
+        dedup=True,
+    )
+
+    assert G.number_of_nodes() == 1
+    surv = G.nodes["docs_architecture_retrieval"]
+    assert surv["label"] == "Retrieval"
+    assert surv["source_file"] == "docs/ARCHITECTURE.md"
+    assert surv["source_location"] == "L42"
+    assert surv["_origin"] == "ast"
+    assert surv["rationale"] == "Detailed hybrid search rationale"
+    assert surv["summary"] == "Hybrid search architecture"
+
+    err = capsys.readouterr().err
+    assert "minted by two different files" not in err
+    assert "WARNING" not in err
+
+
+def test_build_merge_infers_root_for_semantic_absolute_path(tmp_path, capsys):
+    """When root is omitted, build_merge infers _eff_root and passes it downstream,
+    so absolute source_file from semantic chunks still collapses with stored relative keys.
+    """
+    root = tmp_path.resolve()
+    graph_path = root / "graphify-out" / "graph.json"
+    graph_path.parent.mkdir(parents=True)
+
+    ast_node = {
+        "id": "docs_architecture_retrieval",
+        "label": "Retrieval",
+        "file_type": "document",
+        "source_file": "docs/ARCHITECTURE.md",
+        "source_location": "L42",
+        "_origin": "ast",
+    }
+    G0 = build([{"nodes": [ast_node], "edges": []}], dedup=False)
+    graph_path.write_text(json.dumps(nx.node_link_data(G0, edges="edges")), encoding="utf-8")
+
+    abs_sf = str((root / "docs" / "ARCHITECTURE.md").resolve())
+    sem_node = {
+        "id": "docs_architecture_retrieval",
+        "label": "Hybrid Retrieval",
+        "file_type": "document",
+        "source_file": abs_sf,
+        "source_location": None,
+        "rationale": "Detailed hybrid search rationale",
+    }
+
+    # Call build_merge WITHOUT root parameter
+    G = build_merge([{"nodes": [sem_node], "edges": []}], graph_path=graph_path)
+
+    assert G.number_of_nodes() == 1
+    surv = G.nodes["docs_architecture_retrieval"]
+    assert surv["label"] == "Retrieval"
+    assert surv["source_file"] == "docs/ARCHITECTURE.md"
+    assert surv["rationale"] == "Detailed hybrid search rationale"
+
+    err = capsys.readouterr().err
+    assert "minted by two different files" not in err
+    assert "WARNING" not in err
+
+
+def test_genuine_cross_file_collision_remains_isolated(tmp_path, capsys):
+    """Two genuinely different files that happen to mint the same ID must still
+    be treated as a cross-file collision:
+    - warning is emitted
+    - attributes from the loser are NOT merged into the survivor
+    """
+    root = tmp_path.resolve()
+    abs_sf_b = str((root / "docs" / "DESIGN.md").resolve())
+
+    node_a = {
+        "id": "docs_retrieval",
+        "label": "Retrieval",
+        "file_type": "document",
+        "source_file": "docs/ARCHITECTURE.md",
+        "source_location": "L10",
+        "summary": "Architecture retrieval",
+    }
+    node_b = {
+        "id": "docs_retrieval",
+        "label": "Detailed Retrieval",
+        "file_type": "document",
+        "source_file": abs_sf_b,
+        "source_location": "L25",
+        "summary": "Design retrieval",
+        "rationale": "Design rationale",
+    }
+
+    G = build([{"nodes": [node_a, node_b], "edges": []}], root=root, dedup=True)
+
+    assert G.number_of_nodes() == 1
+    surv = G.nodes["docs_retrieval"]
+    assert surv["source_file"] == "docs/ARCHITECTURE.md"
+    assert surv["label"] == "Retrieval"
+    assert surv["summary"] == "Architecture retrieval"
+    # The loser's rationale must NOT be merged into the survivor from a different file!
+    assert "rationale" not in surv
+
+    err = capsys.readouterr().err
+    assert "minted by two different files" in err
+    assert "WARNING" in err
+
+
+def test_definition_file_normalized_before_dedup(tmp_path):
+    """definition_file should also be normalized to repo-relative against root."""
+    root = tmp_path.resolve()
+    abs_df = str((root / "src" / "impl.py").resolve())
+
+    node = {
+        "id": "src_impl_func",
+        "label": "func",
+        "file_type": "code",
+        "source_file": "src/decl.py",
+        "definition_file": abs_df,
+    }
+
+    G = build([{"nodes": [node], "edges": []}], root=root, dedup=True)
+
+    assert G.nodes["src_impl_func"]["definition_file"] == "src/impl.py"


### PR DESCRIPTION
## Summary

Fixes #3472, where the same source file could be represented by both an absolute and repo-relative `source_file` path during an incremental `--update`.

This caused `build_merge` to incorrectly report a "minted by two different files" collision and drop the semantic node, including richer attributes such as `rationale` and `summary`.

## Root cause

Semantic extraction emits the absolute `source_file` path from `FILE_LIST`, while existing AST nodes loaded from `graph.json` use repo-relative paths.

Deduplication ran before path normalization, so:

```text
docs/ARCHITECTURE.md
/absolute/path/to/repo/docs/ARCHITECTURE.md
```

were treated as different source files.

## Fix

* Normalize `source_file` and `definition_file` against the build root before deduplication.
* Propagate the effective merge root from `build_merge` into `build`, including when the root is inferred.
* Reuse the existing path normalization logic.
* Preserve existing deduplication and survivor-selection semantics.

Same-file duplicates now correctly merge complementary semantic attributes while genuine cross-file ID collisions remain isolated.

## Tests

Added regression coverage for:

* absolute semantic path + relative AST path
* inverse arrival order
* inferred merge root
* genuine cross-file collisions
* `definition_file` normalization

Relevant test suite:

* `240 passed, 1 skipped`
* #3472 regression tests: `5 passed`
