### PR TITLE
fix(packaging): include psycopg[binary] in the all extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 ## 0.9.57 (unreleased)
 
+- Fix: `graphifyy[all]` now includes `psycopg[binary]`, so the documented “Everything above” install can run `graphify extract --postgres` without a second extra; a packaging test asserts `[all]` is the union of every other extra (#3482, thanks @GREYGROUPJP).
 - Fix: an incremental rebuild no longer wipes cross-file project AST nodes — re-extracting one `.csproj`/`.sln` was dropping package/framework nodes of a *referenced* project (whose stub carried the referenced file's `source_file`); the AST-replacement set is now derived from the files actually extracted (#3411, thanks @hopstreax).
 - Fix: when duplicate nodes merge, the richer (more complete) node is now kept as the survivor and the losers' non-empty fields are folded in, instead of a shorter-id passing mention winning and dropping content (#3372, thanks @abhay-codes07).
 - Fix: a C# generic call site with explicit type arguments — `Get<int>(...)`, unqualified or through `this` — now resolves to the method definition instead of capturing `Get<int>` as the callee and failing to match (#3406, thanks @abhay-codes07).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ commonlisp = ["tree-sitter-commonlisp"]
 # every platform, no C toolchain; optional because Robot Framework corpora are
 # QA-automation specific.
 robot = ["robotframework>=4.0"]
-all = ["mcp>=1,<3", "starlette>=1.3.1,<2", "neo4j", "falkordb", "pypdf>=6.12.0", "markdownify", "watchdog", "graspologic; python_version < '3.13'", "python-docx", "openpyxl", "faster-whisper; python_version >= '3.11'", "yt-dlp>=2026.6.9", "matplotlib", "numpy>=2.0; python_version >= '3.13'", "openai", "tiktoken", "boto3", "anthropic", "tree-sitter-sql", "jieba", "tree-sitter-dm", "tree-sitter-hcl", "tree-sitter-pascal", "tree-sitter-ocaml", "tree-sitter-commonlisp", "robotframework>=4.0"]
+all = ["mcp>=1,<3", "starlette>=1.3.1,<2", "neo4j", "falkordb", "pypdf>=6.12.0", "markdownify", "watchdog", "graspologic; python_version < '3.13'", "python-docx", "openpyxl", "faster-whisper; python_version >= '3.11'", "yt-dlp>=2026.6.9", "matplotlib", "numpy>=2.0; python_version >= '3.13'", "openai", "tiktoken", "boto3", "anthropic", "psycopg[binary]", "tree-sitter-sql", "jieba", "tree-sitter-dm", "tree-sitter-hcl", "tree-sitter-pascal", "tree-sitter-ocaml", "tree-sitter-commonlisp", "robotframework>=4.0"]
 
 [project.scripts]
 graphify = "graphify.__main__:main"

--- a/tests/test_backend_extras.py
+++ b/tests/test_backend_extras.py
@@ -39,3 +39,13 @@ def test_backend_pkg_hint_points_at_uv_tool_and_extra():
     assert "uv tool install" in msg
     assert 'graphifyy[anthropic]' in msg
     assert "pip install anthropic" in msg  # pip/venv fallback still mentioned
+
+
+def test_all_extra_is_the_union_of_every_other_extra():
+    """README documents `[all]` as "Everything above": every dependency of every
+    other extra must be in it. `psycopg[binary]` from `[postgres]` was missing, so
+    an `[all]` install still failed on `graphify extract --postgres` (#3482)."""
+    extras = _extras()
+    union = {dep for name, deps in extras.items() if name != "all" for dep in deps}
+    missing = sorted(union - set(extras["all"]))
+    assert not missing, f"[all] is missing dependencies from other extras: {missing}"


### PR DESCRIPTION
Fixes #3482.

README documents `graphifyy[all]` as "Everything above", but the `all` list carried only `tree-sitter-sql` from the `postgres` extra and not `psycopg[binary]`, so an `[all]` install still exited with `psycopg is required for --postgres` when Postgres introspection started. Comparing `all` against the union of every other extra on `v8` reports exactly that one omission:

```
missing on v8: ['psycopg[binary]']
```

**Change**

- `pyproject.toml`: `psycopg[binary]` added to `all` (next to `tree-sitter-sql`).
- `tests/test_backend_extras.py::test_all_extra_is_the_union_of_every_other_extra`: asserts `[all]` contains every dependency of every other extra, so the next new extra cannot drift the same way (#3047 closed the same class of gap in the other direction). The test fails on `v8` with the message above and passes here.
- CHANGELOG entry under 0.9.57.

`uv.lock` is untouched; let me know if you want it regenerated in this PR.
