### PR TITLE
fix(tests): isolate backend-detection tests from the developer's environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: `graphify install` no longer aborts when the always-on registration target is unwritable (read-only or symlinked config); it skips that step with an actionable warning and still installs the skill (#3474, thanks @dajiaohuang).
 - Fix: community labelling falls back to an installed `claude` CLI resolved at run time instead of pinning a path that expires (e.g. under snap/nvm), so labelling keeps working across updates (#3475, thanks @ktsang622).
 - Fix: the `all` extra now includes `psycopg[binary]`, so `pip install 'graphifyy[all]'` provides the postgres driver (#3482, thanks @L4XB).
+- Fix (tests): the backend-detection tests no longer depend on the developer's shell — an autouse fixture clears every variable `detect_backend()` reads (API keys of all backends, `AZURE_OPENAI_ENDPOINT`, `AWS_*`, `OLLAMA_BASE_URL`/`OLLAMA_HOST`), so `GOOGLE_API_KEY` & co. exported locally can't fail a clean checkout (#3481, thanks @AirRocker).
 
 ## 0.9.57 (2026-09-09)
 


### PR DESCRIPTION
Fixes #3481.

`detect_backend()` probes whatever the shell exports, and each detection test cleared only a hand-picked subset of the dozen variables it reads. On `v8` with `GOOGLE_API_KEY=dummy` exported, `pytest tests/test_ollama.py -k detect_backend` gives `3 failed, 1 passed`; other variables break one or two tests, and the Azure pair or `OLLAMA_HOST` also break `test_provider_registry.py::test_detect_backend_custom_provider_after_builtins`. CI never sees it because no workflow exports any of them.

**Change**

- `graphify/llm.py`: `backend_detection_env_vars()` next to `detect_backend()` returns every variable it consults: the API-key variables of every registered backend (built-in and custom, via `_backend_env_keys`) plus `AZURE_OPENAI_ENDPOINT`, `AWS_PROFILE`/`AWS_REGION`/`AWS_DEFAULT_REGION`, `OLLAMA_BASE_URL`/`OLLAMA_HOST`. The extra list sits directly above the function so a new probe gets added in one place.
- `tests/conftest.py`: autouse fixture `_isolate_backend_env` clears that whole set before each test (same pattern as the existing `_sandbox_home`). Tests that want a backend still set it with `monkeypatch.setenv`, which runs after the fixture.
- `tests/test_backend_env_isolation.py`: keeps the list complete (every `os.environ.get("...")` in `detect_backend()`/`_resolve_ollama_base_url` and every built-in backend key must be listed), checks the fixture leaves a clean environment, and re-runs the detection tests in a subprocess with every variable exported to a dummy value (the report's repro, widened to all 13).
- CHANGELOG entry under 0.9.57.

**Verification**

```
GOOGLE_API_KEY=dummy pytest tests/test_ollama.py tests/test_provider_registry.py tests/test_llm_backends.py -k detect_backend   # 7 passed (3 failed on v8)
pytest tests/test_backend_env_isolation.py   # 3 passed
```

The existing per-test `delenv` calls are left in place; they are now redundant but harmless, and removing them would only add churn.
