### PR TITLE
fix(imports): pick workspace exports by importer platform, runtime before types (#3487)

### DIFF
--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -413,26 +413,89 @@ def _load_workspace_packages(start_dir: Path) -> dict[str, Path]:
     _WORKSPACE_PACKAGE_CACHE[key] = packages
     return packages
 
+# `types` is LAST. It is a declaration-only condition that normally points into
+# `dist/`, which is build output and not part of the corpus, so letting it win
+# creates an edge to a node that does not exist while the runtime target the
+# source actually lives behind is skipped (#3487). This is the order #1308
+# specified when the exports map was added; the tuple had `types` ahead of
+# `require`/`default` instead.
 _EXPORT_CONDITION_PRIORITY = (
-    "source", "import", "module", "svelte", "types", "require", "default",
+    "source", "import", "module", "svelte", "require", "default", "types",
 )
+
+# Conditions a bundler opts into per platform. `react-native` is a custom
+# condition, so it is honoured only for an importer that is itself native — a
+# web importer resolves the same specifier through `default`, or the native file
+# is attributed to code that never imports it (#3487).
+_PLATFORM_EXPORT_CONDITIONS = {"native": ("react-native",)}
+
+_PLATFORM_SUFFIXES = ("web", "native", "ios", "android")
+
+# Whole-path-segment hints only: `apps/mobile/src` is native, `packages/web-utils`
+# is not web, so segment-wide matching keeps this from firing on package names.
+_PLATFORM_PATH_HINTS = (
+    ("native", ("native", "mobile", "ios", "android", "react-native")),
+    ("web", ("web", "browser", "desktop", "electron")),
+)
+
+def _importer_platform(start_dir: Path) -> str | None:
+    """Best-effort platform of the importing file, from its directory path.
+
+    Exports conditions and platform-suffixed files are chosen per importer
+    (#3487), and `start_dir` is the importer's directory — the filename itself
+    is not available at this point, so a platform-named segment is the signal.
+    Returns None when nothing distinguishes the importer, which leaves every
+    platform at the same priority afterwards."""
+    for part in reversed(start_dir.parts):
+        segment = part.lower()
+        for platform, hints in _PLATFORM_PATH_HINTS:
+            if segment in hints:
+                return platform
+    return None
+
+def _platform_variants(candidate: Path, platform: str | None) -> list[Path]:
+    """Platform-suffixed siblings of an `exports` target, importer's first.
+
+    `"./controls/*": {"default": "./src/controls/*.tsx"}` names `BottomNav.tsx`,
+    which does not exist — the real files are `BottomNav.web.tsx` and
+    `BottomNav.native.tsx`, and a bundler finds them through its platform list.
+    The importer's own platform wins; the rest stay in a fixed order so an
+    ambiguous importer resolves deterministically rather than dropping the edge
+    entirely (#3487)."""
+    order = [p for p in (platform,) if p in _PLATFORM_SUFFIXES]
+    order.extend(p for p in _PLATFORM_SUFFIXES if p not in order)
+    return [
+        candidate.parent / f"{candidate.stem}.{p}{candidate.suffix}"
+        for p in order
+    ]
+
+def _resolve_export_targets(value: Any, platform: str | None = None) -> list[str]:
+    """Every target an `exports` value offers, in preference order.
+
+    Keeping the whole list rather than the first match lets a target that is
+    not on disk fall through to the next condition instead of dropping the
+    import: a package whose `import`/`default`/`types` split across `dist/` and
+    `src/` still resolves to the one target that is real source (#3487).
+    Only conditions in _EXPORT_CONDITION_PRIORITY are considered, plus the
+    platform's own conditions when the importer has a platform."""
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        targets: list[str] = []
+        for cond in (*_PLATFORM_EXPORT_CONDITIONS.get(platform or "", ()),
+                     *_EXPORT_CONDITION_PRIORITY):
+            v = value.get(cond)
+            if isinstance(v, (str, dict)):
+                targets.extend(_resolve_export_targets(v, platform))
+        return targets
+    return []
 
 def _resolve_export_target(value: Any) -> str | None:
     """Resolve an `exports` map value (string or condition object) to a
     relative target string, honouring _EXPORT_CONDITION_PRIORITY for objects
     and recursing into nested condition objects."""
-    if isinstance(value, str):
-        return value
-    if isinstance(value, dict):
-        for cond in _EXPORT_CONDITION_PRIORITY:
-            v = value.get(cond)
-            if isinstance(v, str):
-                return v
-            if isinstance(v, dict):
-                nested = _resolve_export_target(v)
-                if nested:
-                    return nested
-    return None
+    targets = _resolve_export_targets(value)
+    return targets[0] if targets else None
 
 def _contained_in_package(resolved: Path, package_dir: Path) -> bool:
     """Guard against `exports` targets that escape the package directory
@@ -443,7 +506,30 @@ def _contained_in_package(resolved: Path, package_dir: Path) -> bool:
     except ValueError:
         return False
 
-def _package_entry_candidates(package_dir: Path, subpath: str) -> list[Path]:
+def _exports_candidates(
+    package_dir: Path,
+    targets: list[str],
+    platform: str | None,
+) -> list[Path]:
+    """Turn ordered `exports` targets into ordered on-disk candidates.
+
+    Each target is followed by its platform-suffixed siblings, so a target that
+    is absent falls through to the platform split next to it. Targets that
+    escape the package directory are rejected (#1308 security guard)."""
+    candidates: list[Path] = []
+    for target in targets:
+        candidate = package_dir / target
+        if not _contained_in_package(candidate, package_dir):
+            continue
+        candidates.append(candidate)
+        candidates.extend(_platform_variants(candidate, platform))
+    return candidates
+
+def _package_entry_candidates(
+    package_dir: Path,
+    subpath: str,
+    platform: str | None = None,
+) -> list[Path]:
     manifest = package_dir / "package.json"
     manifest_data: dict[str, Any] = {}
     try:
@@ -454,16 +540,19 @@ def _package_entry_candidates(package_dir: Path, subpath: str) -> list[Path]:
     if subpath:
         # Consult the package's `exports` subpath map before the bare-path
         # fallback (#1308): "./browser" -> conditions -> file, plus single
-        # wildcard "./*" patterns. Targets that escape the package dir are
-        # rejected; resolution then falls through to the bare path.
+        # wildcard "./*" patterns. Every matching condition is kept in
+        # preference order, so one whose target is not on disk does not take
+        # the whole import down with it (#3487). Targets that escape the
+        # package dir are rejected; resolution then falls through to the bare
+        # path.
         exports = manifest_data.get("exports")
         if isinstance(exports, dict):
             subpath_key = "./" + subpath
-            target = _resolve_export_target(exports.get(subpath_key))
-            if target:
-                candidate = package_dir / target
-                if _contained_in_package(candidate, package_dir):
-                    return [candidate]
+            targets = _resolve_export_targets(exports.get(subpath_key), platform)
+            if targets:
+                candidates = _exports_candidates(package_dir, targets, platform)
+                if candidates:
+                    return candidates
             else:
                 for pattern, pattern_value in exports.items():
                     if "*" in pattern and pattern.count("*") == 1:
@@ -471,20 +560,26 @@ def _package_entry_candidates(package_dir: Path, subpath: str) -> list[Path]:
                         if (subpath_key.startswith(prefix)
                                 and (not suffix or subpath_key.endswith(suffix))):
                             matched = subpath_key[len(prefix):len(subpath_key) - len(suffix) if suffix else None]
-                            resolved = _resolve_export_target(pattern_value)
-                            if resolved and "*" in resolved:
-                                candidate = package_dir / resolved.replace("*", matched)
-                                if _contained_in_package(candidate, package_dir):
-                                    return [candidate]
+                            wildcard_targets = [
+                                resolved.replace("*", matched)
+                                for resolved in _resolve_export_targets(pattern_value, platform)
+                                if "*" in resolved
+                            ]
+                            if wildcard_targets:
+                                candidates = _exports_candidates(
+                                    package_dir, wildcard_targets, platform
+                                )
+                                if candidates:
+                                    return candidates
         return [package_dir / subpath]
 
     exports = manifest_data.get("exports")
     if isinstance(exports, str):
         return [package_dir / exports]
     if isinstance(exports, dict):
-        dot_target = _resolve_export_target(exports.get("."))
-        if dot_target:
-            return [package_dir / dot_target]
+        dot_targets = _resolve_export_targets(exports.get("."), platform)
+        if dot_targets:
+            return _exports_candidates(package_dir, dot_targets, platform)
 
     candidates: list[Path] = []
     for key in ("svelte", "module", "main", "types"):
@@ -497,6 +592,7 @@ def _package_entry_candidates(package_dir: Path, subpath: str) -> list[Path]:
 
 def _resolve_workspace_import(raw: str, start_dir: Path) -> Path | None:
     packages = _load_workspace_packages(start_dir)
+    platform = _importer_platform(start_dir)
     for package_name, package_dir in packages.items():
         if raw == package_name:
             subpath = ""
@@ -504,7 +600,7 @@ def _resolve_workspace_import(raw: str, start_dir: Path) -> Path | None:
             subpath = raw[len(package_name) + 1:]
         else:
             continue
-        for candidate in _package_entry_candidates(package_dir, subpath):
+        for candidate in _package_entry_candidates(package_dir, subpath, platform):
             resolved = _resolve_js_import_path(candidate)
             if resolved.is_file():
                 return resolved

--- a/tests/test_js_import_resolution.py
+++ b/tests/test_js_import_resolution.py
@@ -1665,3 +1665,218 @@ def test_ambiguous_barrel_reexport_chain_does_not_guess(tmp_path, monkeypatch):
     }
     assert _make_id(_file_stem(Path("src/lib/a.ts")), "dup") in reexport_targets
     assert _make_id(_file_stem(Path("src/lib/b.ts")), "dup") in reexport_targets
+
+
+# ── #3487: the exports-map condition must follow the importer ────────────────
+
+
+def _write_workspace_package(root: Path, name: str, exports: dict | str) -> None:
+    _write(
+        root / "pnpm-workspace.yaml",
+        "packages:\n  - 'apps/*'\n  - 'packages/*'\n",
+    )
+    _write(
+        root / "packages/pkg-a/package.json",
+        json.dumps({"name": name, "exports": exports}),
+    )
+
+
+def test_export_types_condition_never_beats_a_real_runtime_target(tmp_path: Path):
+    """#3487 detail 1. `types` points into unbuilt `dist/`, so resolving to it
+    produces an edge to a node that does not exist — and because that target is
+    what got returned, the `default` source beside it was never tried."""
+    _write_workspace_package(tmp_path, "@example/pkg-a", {
+        "./browser": {
+            "types": "./dist/browser.d.ts",
+            "default": "./src/browser.ts",
+        },
+    })
+    target = _write(
+        tmp_path / "packages/pkg-a/src/browser.ts",
+        'export const value = "ok"\n',
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/consumer.ts",
+        "import { value } from '@example/pkg-a/browser'\nexport const v = value\n",
+    )
+
+    result = _extract_for([target, importer], tmp_path)
+
+    assert _has_edge(result, "apps/web/src/consumer.ts", "packages/pkg-a/src/browser.ts")
+
+
+def test_export_types_loses_even_when_the_declaration_exists(tmp_path: Path):
+    """The lock on the ordering itself: `types` is a declaration, so it must not
+    win merely because `dist/` happens to be present in the corpus."""
+    _write_workspace_package(tmp_path, "@example/pkg-a", {
+        "./browser": {
+            "types": "./dist/browser.d.ts",
+            "default": "./src/browser.ts",
+        },
+    })
+    declaration = _write(
+        tmp_path / "packages/pkg-a/dist/browser.d.ts",
+        "export declare const value: string\n",
+    )
+    target = _write(
+        tmp_path / "packages/pkg-a/src/browser.ts",
+        'export const value = "ok"\n',
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/consumer.ts",
+        "import { value } from '@example/pkg-a/browser'\nexport const v = value\n",
+    )
+
+    result = _extract_for([declaration, target, importer], tmp_path)
+
+    assert _has_edge(result, "apps/web/src/consumer.ts", "packages/pkg-a/src/browser.ts")
+    assert not _has_edge(
+        result, "apps/web/src/consumer.ts", "packages/pkg-a/dist/browser.d.ts"
+    )
+
+
+def test_export_react_native_condition_selected_for_native_importer(tmp_path: Path):
+    """#3487 detail 2. `react-native` is a custom condition, so it applies to the
+    importer that opts into it rather than to the package as a whole."""
+    _write_workspace_package(tmp_path, "@example/pkg-a", {
+        "./Icon": {
+            "types": "./dist/Icon.d.ts",
+            "react-native": "./src/Icon.native.tsx",
+            "default": "./src/Icon.web.tsx",
+        },
+    })
+    native_target = _write(
+        tmp_path / "packages/pkg-a/src/Icon.native.tsx",
+        "export function Icon() { return null }\n",
+    )
+    web_target = _write(
+        tmp_path / "packages/pkg-a/src/Icon.web.tsx",
+        "export function Icon() { return null }\n",
+    )
+    importer = _write(
+        tmp_path / "apps/mobile/src/App.tsx",
+        "import { Icon } from '@example/pkg-a/Icon'\nexport const a = Icon\n",
+    )
+
+    result = _extract_for([native_target, web_target, importer], tmp_path)
+
+    assert _has_edge(
+        result, "apps/mobile/src/App.tsx", "packages/pkg-a/src/Icon.native.tsx"
+    )
+    assert not _has_edge(
+        result, "apps/mobile/src/App.tsx", "packages/pkg-a/src/Icon.web.tsx"
+    )
+
+
+def test_export_react_native_condition_ignored_for_web_importer(tmp_path: Path):
+    """The other half of detail 2: a web importer resolves through `default`, or
+    the native file is attributed to code that never imports it."""
+    _write_workspace_package(tmp_path, "@example/pkg-a", {
+        "./Icon": {
+            "react-native": "./src/Icon.native.tsx",
+            "default": "./src/Icon.web.tsx",
+        },
+    })
+    native_target = _write(
+        tmp_path / "packages/pkg-a/src/Icon.native.tsx",
+        "export function Icon() { return null }\n",
+    )
+    web_target = _write(
+        tmp_path / "packages/pkg-a/src/Icon.web.tsx",
+        "export function Icon() { return null }\n",
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/Page.tsx",
+        "import { Icon } from '@example/pkg-a/Icon'\nexport const a = Icon\n",
+    )
+
+    result = _extract_for([native_target, web_target, importer], tmp_path)
+
+    assert _has_edge(
+        result, "apps/web/src/Page.tsx", "packages/pkg-a/src/Icon.web.tsx"
+    )
+    assert not _has_edge(
+        result, "apps/web/src/Page.tsx", "packages/pkg-a/src/Icon.native.tsx"
+    )
+
+
+def test_export_wildcard_target_absent_falls_through_to_platform_sibling(tmp_path: Path):
+    """#3487 detail 3. `./src/controls/*.tsx` names `BottomNav.tsx`, which does
+    not exist — a bundler reaches `BottomNav.web.tsx` through its platform list,
+    and the import must not be dropped for naming a file that was never there."""
+    _write_workspace_package(tmp_path, "@example/pkg-a", {
+        "./controls/*": {"default": "./src/controls/*.tsx"},
+    })
+    target = _write(
+        tmp_path / "packages/pkg-a/src/controls/BottomNav.web.tsx",
+        "export function BottomNav() { return null }\n",
+    )
+    other = _write(
+        tmp_path / "packages/pkg-a/src/controls/BottomNav.native.tsx",
+        "export function BottomNav() { return null }\n",
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/consumer.tsx",
+        "import { BottomNav } from '@example/pkg-a/controls/BottomNav'\n"
+        "export const b = BottomNav\n",
+    )
+
+    result = _extract_for([target, other, importer], tmp_path)
+
+    assert _has_edge(
+        result,
+        "apps/web/src/consumer.tsx",
+        "packages/pkg-a/src/controls/BottomNav.web.tsx",
+    )
+
+
+def test_export_rejected_target_still_falls_back_to_the_bare_path(tmp_path: Path):
+    """A rejected (escaping) target must not consume the import: resolution
+    still reaches the bare-path fallback, which is a real file here."""
+    _write_workspace_package(tmp_path, "@example/pkg-a", {
+        "./widget": "../../../../secret.ts",
+    })
+    outside = _write(tmp_path / "secret.ts", "export const leak = 1\n")
+    target = _write(
+        tmp_path / "packages/pkg-a/widget.ts",
+        'export const value = "ok"\n',
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/consumer.ts",
+        "import { value } from '@example/pkg-a/widget'\nexport const v = value\n",
+    )
+
+    result = _extract_for([outside, target, importer], tmp_path)
+
+    assert _has_edge(result, "apps/web/src/consumer.ts", "packages/pkg-a/widget.ts")
+    assert not _has_edge(result, "apps/web/src/consumer.ts", "secret.ts")
+
+
+def test_export_bare_root_types_condition_falls_through_to_default(tmp_path: Path):
+    """The bare-root form carries the same defect: `import { x } from
+    '@scope/pkg'` resolved to the `types` target and stopped there."""
+    _write(tmp_path / "pnpm-workspace.yaml", "packages:\n  - 'apps/*'\n  - 'packages/*'\n")
+    _write(
+        tmp_path / "packages/pkg-a/package.json",
+        json.dumps({
+            "name": "@example/pkg-a",
+            "exports": {
+                ".": {
+                    "types": "./dist/index.d.ts",
+                    "default": "./src/index.ts",
+                },
+            },
+        }),
+    )
+    target = _write(
+        tmp_path / "packages/pkg-a/src/index.ts",
+        'export const value = "ok"\n',
+    )
+    importer = _write(
+        tmp_path / "apps/web/src/consumer.ts",
+        "import { value } from '@example/pkg-a'\nexport const v = value\n",
+    )
+
+    result = _extract_for([target, importer], tmp_path)
+
+    assert _has_edge(result, "apps/web/src/consumer.ts", "packages/pkg-a/src/index.ts")


### PR DESCRIPTION
Fixes #3487.

## What actually goes wrong

The `exports` map **is** consulted â€” #1308 added that, in `e8dabad`. The defect is in how a condition object is reduced to one target.

`_EXPORT_CONDITION_PRIORITY` shipped as:

```python
("source", "import", "module", "svelte", "types", "require", "default")
```

`types` is a declaration-only condition and normally points into `dist/`, which is build output and not in the corpus. So for

```json
"./components/Icon": {
  "types": "./dist/components/Icon.web.d.ts",
  "react-native": "./src/components/Icon.native.tsx",
  "default": "./src/components/Icon.web.tsx"
}
```

the resolver returned the `dist` path, found nothing on disk, and **stopped**. There was no fall-through, because `_package_entry_candidates` returned `[candidate]` as soon as any condition matched â€” so the `default` source sitting right beside it was never tried, and the import became a dangling `ref_*` external.

That is not the order the map was added with. The commit that introduced it says *"`default` is consulted LAST â€¦ so a matching `import`/`module`/`svelte` condition wins"*, and #1308 specifies `source -> import -> module -> default -> require -> types`. The tuple put `types` ahead of `require` and `default` instead.

Two more gaps in the same path: `react-native` was never consulted, and no platform-suffixed sibling was ever tried, so `"./controls/*": {"default": "./src/controls/*.tsx"}` could not reach the real `BottomNav.web.tsx` / `BottomNav.native.tsx`.

## The fix

- **`types` moves to the end** of `_EXPORT_CONDITION_PRIORITY`, restoring the order #1308 specified. A runtime target always beats a declaration. `require`/`default` keep their relative order, so the behaviour pinned by `test_workspace_subpath_export_default_consulted_last` is unchanged.
- **`_resolve_export_targets`** keeps *every* condition target in preference order rather than returning the first, so a target that is not on disk falls through to the next condition instead of taking the import down with it.
- **`react-native` is honoured only for a native importer**, so a web importer resolves the same specifier through `default` rather than being attributed a native file it never imports. This is a custom condition, so it is per-importer by nature.
- **Each target is tried alongside its platform-suffixed siblings** (`Icon.tsx` â†’ `Icon.web.tsx` / `Icon.native.tsx`), which is how a bundler reaches a platform split whose `exports` target names the unsuffixed path.
- `_resolve_export_target` keeps its signature and semantics for the `package.json` `imports` path; platform expansion applies only to the workspace `exports` path, so relative imports elsewhere are untouched.

## Behaviour notes for review

- When every `exports` target escapes the package directory, resolution still falls through to the bare-path fallback exactly as before. A new test pins this â€” my first revision accidentally swallowed that fallback, and the containment guard made it reachable.
- The `"."` branch now applies the same containment guard the subpath branch already applied. This is the only change beyond the reported defect, and it is a consistency fix: such a package previously resolved outside its own directory.
- Importer platform is inferred from whole path segments (`apps/mobile/src` â†’ native; `packages/web-utils` â†’ none, since matching is segment-wide, not substring). It is best-effort by design: when nothing distinguishes the importer every platform keeps the same priority, so resolution stays deterministic rather than dropping the edge.

## Verified

Measured through `_resolve_js_module_path` on the fixture from the issue, before and after:

| Case | Specifier | Importer | Before | After |
|---|---|---|---|---|
| A | `@acme/ui/components/Icon` (`{types, react-native, default}`) | web | unresolved | `Icon.web.tsx` |
| B | same | native | unresolved | `Icon.native.tsx` |
| C | `@acme/ui2/controls/BottomNav` (wildcard, target absent) | web | unresolved | `BottomNav.web.tsx` |
| C2 | same | native | unresolved | `BottomNav.native.tsx` |
| D | `@acme/lib/util` (exact subpath, target exists) | web | resolved | resolved (control) |
| E | `@acme/root` (bare root, `"."` exists) | web | resolved | resolved (control) |
| F | `@acme/nodot` (exports has no `"."`) | web | unresolved | unresolved (control) |

The controls were already correct before the change, which localises the defect to condition selection and fall-through rather than to a missing resolution path.

Seven tests added to `tests/test_js_import_resolution.py`, one per behaviour above plus locks on the ordering and the containment fall-through. Focused run: `tests/test_js_import_resolution.py` + `tests/test_import_extension_resolution.py` â†’ 109 passed (PR #3488's tests still pass unchanged). `ruff check` clean. `tools.skillgen` CI-parity checks all OK.

Full suite, same commands CI runs:

```
before:  29 failed, 5500 passed, 44 skipped in 227.16s
after:   29 failed, 5507 passed, 44 skipped in 238.04s
```

Byte-identical failure sets â€” `diff` of the sorted `FAILED` lines is empty. The 29 are pre-existing and unrelated to this path (non-regular-file, watch and uninstall-scope tests on Windows). The +7 passing are the tests added here. `graphify --help` and `graphify install` both exit 0.

## Note on #3487's reporter

@cbartens reports in the issue that they have this working and offered to contribute it. I could not tell from the thread whether maintainers want that, so I am putting this up as a concrete patch â€” happy to close it in favour of theirs, or to have it serve as a reference implementation. No maintainer has replied on the issue, and nothing here is claimed or assigned.
