### PR TITLE
explain: add path::Symbol resolution and fix the ambiguity retry hint

### DIFF
--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -1750,7 +1750,10 @@ def dispatch_command(cmd: str) -> None:
             for rival in rivals:
                 print(f"  {G.nodes[rival].get('source_file') or rival}")
                 print(f"    id: {rival}")
-            print("Retry with the repo-relative path or the full node id.")
+            print(
+                f"Retry with path::symbol using one of the paths above (e.g. "
+                f"<path>::{label}) or the full node id."
+            )
             sys.exit(1)
         nid = matches[0]
         d = G.nodes[nid]

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -1537,7 +1537,8 @@ def _resolve_single_node(G: nx.Graph, label: str) -> tuple[str | None, str | Non
         return None, (
             f"Ambiguous: '{label}' matches {len(rivals)} nodes in different files.\n"
             f"{listing}\n"
-            "Retry with the repo-relative path or the full node id."
+            f"Retry with path::symbol using one of the paths above (e.g. "
+            f"<path>::{label}) or the full node id."
         )
     return matches[0], None
 

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -1335,6 +1335,55 @@ def _query_graph_text(
     return header + _subgraph_to_text(traversal_graph, nodes, edges, token_budget, seeds=start_nodes)
 
 
+def _resolve_path_scoped_symbol(G: nx.Graph, path_part: str, symbol_part: str) -> list[str]:
+    """Nodes whose source_file matches path_part and label/id matches symbol_part.
+
+    Backs the `path::Symbol` query form (#3485): a bare path resolves to the
+    FILE node (`_find_node_tiers`'s own `source_exact` tier, which prefers
+    the file over its members once #2032-disambiguated), and a bare symbol
+    name can be ambiguous across files -- the same-named local declaration
+    guard from #3176 exists for exactly that case, and its own suggested
+    retry ("the repo-relative path") pointed at a form that resolved to the
+    wrong node or nothing at all, since no prior tier combined a path with
+    a label. This combines both constraints in one query, so a specific
+    symbol in a specific file is reachable without needing its opaque id.
+    """
+    path_tokens = " ".join(_search_tokens(path_part))
+    norm_path_query = _strip_diacritics(path_part).lower().strip()
+    symbol_term = " ".join(_search_tokens(symbol_part))
+    norm_symbol_query = _strip_diacritics(symbol_part).lower().strip()
+    if not (path_tokens or norm_path_query) or not (symbol_term or norm_symbol_query):
+        return []
+    candidate_ids = _trigram_candidates(G, [symbol_term, norm_symbol_query])
+    node_iter = (
+        G.nodes(data=True) if candidate_ids is None
+        else ((nid, G.nodes[nid]) for nid in candidate_ids)
+    )
+    matches: list[str] = []
+    for nid, d in node_iter:
+        source_file = d.get("source_file") or ""
+        source_tokens = " ".join(_search_tokens(source_file))
+        norm_source = _strip_diacritics(source_file).lower().strip()
+        if not (
+            source_tokens == path_tokens
+            or norm_source == norm_path_query
+            or (norm_path_query and norm_source.endswith("/" + norm_path_query))
+            or (path_tokens and source_tokens.endswith(" " + path_tokens))
+        ):
+            continue
+        norm_label = d.get("norm_label") or _strip_diacritics(d.get("label") or "").lower()
+        bare_label = norm_label.rstrip("()")
+        label_tokens = " ".join(_search_tokens(d.get("label") or ""))
+        nid_lower = nid.lower()
+        if (
+            symbol_term == norm_label or symbol_term == bare_label
+            or symbol_term == label_tokens or symbol_term == nid_lower
+            or norm_symbol_query == norm_label or norm_symbol_query == bare_label
+        ):
+            matches.append(nid)
+    return matches
+
+
 def _find_node_tiers(
     G: nx.Graph, label: str
 ) -> tuple[list[str], list[str], list[str], list[str]]:
@@ -1345,9 +1394,26 @@ def _find_node_tiers(
     its consumers take `[0]` — which resolves by graph-iteration order when one
     tier holds several nodes from different files. See `find_node_ambiguity`.
     """
+    # `path::Symbol` restricts the label match to nodes defined in that
+    # file (#3485) -- checked before the ordinary tiers below so a
+    # deliberately path-scoped query never falls back to guessing among
+    # same-named symbols in other files. Returned as source_exact (the
+    # tier `find_node_ambiguity` already treats as maximally specific) so
+    # existing callers need no changes; an empty result falls through to
+    # ordinary matching rather than reporting no match outright, in case
+    # "::" is meaningful some other way to a caller this was not designed
+    # for.
+    if "::" in label:
+        path_part, _, symbol_part = label.partition("::")
+        path_part, symbol_part = path_part.strip(), symbol_part.strip()
+        if path_part and symbol_part:
+            scoped = _resolve_path_scoped_symbol(G, path_part, symbol_part)
+            if scoped:
+                return scoped, [], [], []
+
     term = " ".join(_search_tokens(label))
     if not term:
-        return []
+        return [], [], [], []
     # Punctuation-preserving normalized query. `term` tokenizes on \w+ (so
     # "blockStream.ts" -> "blockstream ts", space where the '.' was), but a node's
     # stored `norm_label` keeps punctuation ("blockstream.ts"). Matching only via

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -1384,6 +1384,35 @@ def _resolve_path_scoped_symbol(G: nx.Graph, path_part: str, symbol_part: str) -
     return matches
 
 
+def _label_has_literal_exact_match(G: nx.Graph, term: str, norm_query: str) -> bool:
+    """Does the RAW, unsplit query already exact-match some node's own label/id?
+
+    Mirrors the `exact` tier's own condition below, run early and standalone so
+    `_find_node_tiers` can tell a literal `::`-bearing label (Rust modules, C++
+    namespaces) from a deliberately path-scoped query before choosing between
+    them. A real label essentially never equals a whole `path::symbol` string
+    verbatim, so this is a safe way to prefer the literal interpretation
+    whenever one genuinely exists.
+    """
+    candidate_ids = _trigram_candidates(G, [term, norm_query])
+    node_iter = (
+        G.nodes(data=True) if candidate_ids is None
+        else ((nid, G.nodes[nid]) for nid in candidate_ids)
+    )
+    for nid, d in node_iter:
+        norm_label = d.get("norm_label") or _strip_diacritics(d.get("label") or "").lower()
+        bare_label = norm_label.rstrip("()")
+        label_tokens = " ".join(_search_tokens(d.get("label") or ""))
+        nid_lower = nid.lower()
+        nid_norm = nid_lower if nid.isascii() else _strip_diacritics(nid).lower()
+        if (
+            term == norm_label or term == bare_label or term == label_tokens or term == nid_lower
+            or norm_query == norm_label or norm_query == bare_label or norm_query == nid_norm
+        ):
+            return True
+    return False
+
+
 def _find_node_tiers(
     G: nx.Graph, label: str
 ) -> tuple[list[str], list[str], list[str], list[str]]:
@@ -1394,26 +1423,7 @@ def _find_node_tiers(
     its consumers take `[0]` — which resolves by graph-iteration order when one
     tier holds several nodes from different files. See `find_node_ambiguity`.
     """
-    # `path::Symbol` restricts the label match to nodes defined in that
-    # file (#3485) -- checked before the ordinary tiers below so a
-    # deliberately path-scoped query never falls back to guessing among
-    # same-named symbols in other files. Returned as source_exact (the
-    # tier `find_node_ambiguity` already treats as maximally specific) so
-    # existing callers need no changes; an empty result falls through to
-    # ordinary matching rather than reporting no match outright, in case
-    # "::" is meaningful some other way to a caller this was not designed
-    # for.
-    if "::" in label:
-        path_part, _, symbol_part = label.partition("::")
-        path_part, symbol_part = path_part.strip(), symbol_part.strip()
-        if path_part and symbol_part:
-            scoped = _resolve_path_scoped_symbol(G, path_part, symbol_part)
-            if scoped:
-                return scoped, [], [], []
-
     term = " ".join(_search_tokens(label))
-    if not term:
-        return [], [], [], []
     # Punctuation-preserving normalized query. `term` tokenizes on \w+ (so
     # "blockStream.ts" -> "blockstream ts", space where the '.' was), but a node's
     # stored `norm_label` keeps punctuation ("blockstream.ts"). Matching only via
@@ -1423,6 +1433,29 @@ def _find_node_tiers(
     # `nid_norm` below extends that symmetry to node ids, which keep their
     # punctuation too and are compared raw against the tokenized `term` (#2467).
     norm_query = _strip_diacritics(str(label)).lower().strip()
+
+    # `path::Symbol` restricts the label match to nodes defined in that
+    # file (#3485) -- checked before the ordinary tiers below so a
+    # deliberately path-scoped query never falls back to guessing among
+    # same-named symbols in other files. Returned as source_exact (the
+    # tier `find_node_ambiguity` already treats as maximally specific) so
+    # existing callers need no changes; an empty result falls through to
+    # ordinary matching rather than reporting no match outright, in case
+    # "::" is meaningful some other way to a caller this was not designed
+    # for. Skipped when the raw label already literally matches a node (a
+    # native `::`-bearing label, e.g. Rust modules or C++ namespaces) so that
+    # an unrelated file whose path happens to resemble the label's prefix
+    # cannot hijack a query that was never meant to be path-scoped.
+    if "::" in label and not _label_has_literal_exact_match(G, term, norm_query):
+        path_part, _, symbol_part = label.partition("::")
+        path_part, symbol_part = path_part.strip(), symbol_part.strip()
+        if path_part and symbol_part:
+            scoped = _resolve_path_scoped_symbol(G, path_part, symbol_part)
+            if scoped:
+                return scoped, [], [], []
+
+    if not term:
+        return [], [], [], []
     source_exact: list[str] = []
     exact: list[str] = []
     prefix: list[str] = []

--- a/tests/test_explain_cli.py
+++ b/tests/test_explain_cli.py
@@ -377,3 +377,25 @@ def test_explain_double_colon_label_without_path_match_still_resolves(monkeypatc
     out = _run(monkeypatch, p, "Foo::Bar", capsys)
     assert "Ambiguous" not in out
     assert "ID:        mymod_foo_bar" in out
+
+
+def test_explain_double_colon_label_not_hijacked_by_a_coincidental_path_match(monkeypatch, tmp_path, capsys):
+    """A native "::" label must resolve to itself even when its prefix happens
+    to match an unrelated file elsewhere in the graph (an extensionless file
+    literally named the same as the module) -- the path::Symbol form must not
+    shadow a query the literal label already answers."""
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": "mylib_bar", "label": "mylib::Bar",
+             "source_file": "src/mylib.rs", "community": 0},
+            {"id": "mylib_file_bar", "label": "Bar",
+             "source_file": "mylib", "community": 1},
+        ],
+        "links": [],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    out = _run(monkeypatch, p, "mylib::Bar", capsys)
+    assert "Ambiguous" not in out
+    assert "ID:        mylib_bar" in out

--- a/tests/test_explain_cli.py
+++ b/tests/test_explain_cli.py
@@ -320,3 +320,60 @@ def test_explain_matches_within_one_file_are_not_ambiguous(monkeypatch, tmp_path
     out = _run(monkeypatch, p, "MetricsPort", capsys)
     assert "Ambiguous" not in out
     assert "Node: MetricsPort" in out
+
+
+def test_explain_path_scoped_symbol_resolves_the_ambiguous_case(monkeypatch, tmp_path, capsys):
+    """#3485: the ambiguity message suggests retrying with "the repo-relative
+    path", but a bare path resolves to the FILE node, not the symbol, so
+    that retry either finds nothing or the wrong thing. `path::Symbol`
+    restricts the label match to the given file, so the same query that
+    produced the ambiguity now resolves to the specific symbol asked
+    about."""
+    p = _write_ambiguous_graph(tmp_path)
+    out = _run(
+        monkeypatch, p,
+        "services/chat/src/application/ports/metrics.port.ts::MetricsPort",
+        capsys,
+    )
+    assert "Ambiguous" not in out
+    assert "ID:        chat_metrics_port" in out
+
+    out2 = _run(
+        monkeypatch, p,
+        "services/scraping/src/application/ports/metrics.port.ts::MetricsPort",
+        capsys,
+    )
+    assert "Ambiguous" not in out2
+    assert "ID:        scraping_metrics_port" in out2
+
+
+def test_explain_path_scoped_symbol_falls_back_when_nothing_matches(monkeypatch, tmp_path, capsys):
+    """A path part that matches no file, or a symbol not in that file, must
+    fall through to the ordinary "no match" behavior rather than crash or
+    silently pick something else."""
+    p = _write_ambiguous_graph(tmp_path)
+    out, code = _run_expect_exit(
+        monkeypatch, p,
+        "services/chat/src/application/ports/metrics.port.ts::NotThere",
+        capsys,
+    )
+    assert "No node matching" in out
+
+
+def test_explain_double_colon_label_without_path_match_still_resolves(monkeypatch, tmp_path, capsys):
+    """A language that genuinely uses "::" in a label (Rust modules, C++
+    namespaces) must still resolve via ordinary matching when the string
+    before "::" does not happen to match any file path."""
+    graph_data = {
+        "directed": False, "multigraph": False, "graph": {},
+        "nodes": [
+            {"id": "mymod_foo_bar", "label": "Foo::Bar",
+             "source_file": "src/lib.rs", "community": 0},
+        ],
+        "links": [],
+    }
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps(graph_data))
+    out = _run(monkeypatch, p, "Foo::Bar", capsys)
+    assert "Ambiguous" not in out
+    assert "ID:        mymod_foo_bar" in out


### PR DESCRIPTION
## Summary

Fixes #3485. `explain`'s ambiguity message told callers to retry with "the repo relative path", but a bare path resolves to the FILE node, not the symbol, and there was no query form that scoped a symbol to a specific file.

- Adds a `path::Symbol` query form, resolved in `_find_node_tiers` before the ordinary tiers, so `explain` and the MCP tools `get_node`/`get_neighbors` (which share the same resolver) can all disambiguate a symbol by file.
- Updates the ambiguity message in both the `explain` CLI and the shared MCP resolver to recommend `path::symbol` instead of the old, misleading suggestion, using a generic `<path>::symbol` placeholder so the message stays identical regardless of node iteration order (there is an existing test guarding exactly that property).

## Test plan

- [x] Added 3 regression tests in `tests/test_explain_cli.py`: the exact ambiguous scenario from the issue resolves to the right node either way, a symbol not present in the given file falls through to "no match" cleanly, and a genuine `Foo::Bar` style label (Rust/C++ conventions) still resolves via ordinary matching when nothing before `::` matches a file path.
- [x] Full suite: `python3 -m pytest -q` — 5423 passed, only the pre-existing unrelated failures (`test_ollama_retry_cap.py` missing `openai` in this env, one flaky timing assertion in `test_ts_import_type_arguments.py`).
- [x] `python3 -m tools.skillgen --check` — OK.
- [x] Manually reproduced the issue's exact repro and confirmed the new message and resolution end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qfdzgbA5KedGEjD1AayNh
