### PR TITLE
hooks: keep the rebuild root inside the repo (#3265)

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -188,7 +188,17 @@ try:
     if _saved.exists():
         _txt = _saved.read_text(encoding='utf-8-sig').strip()
         if _txt:
-            _root = Path(_txt)
+            _candidate = Path(_txt)
+            try:
+                _cwd = Path.cwd().resolve()
+                _resolved = _candidate.resolve()
+                _in_repo = _resolved == _cwd or _cwd in _resolved.parents
+            except OSError:
+                _in_repo = False
+            if _in_repo:
+                _root = _candidate
+            else:
+                print(f'[graphify hook] ignoring out-of-repo .graphify_root: {_txt}')
     _rebuild_code(_root, changed_paths=changed, force=_force)
     # Refresh the work-memory lessons doc when saved Q&A outcomes exist
     # (best-effort; never fails the hook).
@@ -250,7 +260,17 @@ try:
     if _saved.exists():
         _txt = _saved.read_text(encoding='utf-8-sig').strip()
         if _txt:
-            _root = Path(_txt)
+            _candidate = Path(_txt)
+            try:
+                _cwd = Path.cwd().resolve()
+                _resolved = _candidate.resolve()
+                _in_repo = _resolved == _cwd or _cwd in _resolved.parents
+            except OSError:
+                _in_repo = False
+            if _in_repo:
+                _root = _candidate
+            else:
+                print(f'[graphify] ignoring out-of-repo .graphify_root: {_txt}')
     _rebuild_code(_root, force=_force)
     # Refresh the work-memory lessons doc when saved Q&A outcomes exist
     # (best-effort; never fails the hook).

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -193,7 +193,7 @@ try:
                 _cwd = Path.cwd().resolve()
                 _resolved = _candidate.resolve()
                 _in_repo = _resolved == _cwd or _cwd in _resolved.parents
-            except OSError:
+            except (OSError, RuntimeError):
                 _in_repo = False
             if _in_repo:
                 _root = _candidate
@@ -265,7 +265,7 @@ try:
                 _cwd = Path.cwd().resolve()
                 _resolved = _candidate.resolve()
                 _in_repo = _resolved == _cwd or _cwd in _resolved.parents
-            except OSError:
+            except (OSError, RuntimeError):
                 _in_repo = False
             if _in_repo:
                 _root = _candidate

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -2,6 +2,7 @@
 import os
 import shutil
 import subprocess
+import textwrap
 from types import SimpleNamespace
 from pathlib import Path
 import pytest
@@ -330,6 +331,56 @@ def test_rebuild_bodies_with_graphify_root_are_valid_python():
     that crashes the moment git fires it (#1173)."""
     for body in (_REBUILD_BODY_COMMIT, _REBUILD_BODY_CHECKOUT):
         ast.parse(body)
+
+
+def _extract_root_resolution(body: str) -> str:
+    """Pull the `.graphify_root` -> `_root` snippet out of a rebuild body, so a
+    test can execute the shipped logic itself rather than a hand copy that could
+    quietly drift from it."""
+    match = re.search(r"(    _root = Path\('\.'\).*?)\n    _rebuild_code\(", body, re.DOTALL)
+    assert match, "root resolution snippet not found"
+    return textwrap.dedent(match.group(1))
+
+
+@pytest.mark.parametrize(
+    "name,body",
+    [("post-commit", _REBUILD_BODY_COMMIT), ("post-checkout", _REBUILD_BODY_CHECKOUT)],
+)
+def test_rebuild_bodies_reject_an_out_of_repo_graphify_root(name, body, tmp_path, monkeypatch):
+    """#3265: `.graphify_root` sits inside graphify-out/, a directory the
+    documented team workflow says to commit, so its contents are checkout
+    controlled. Without a bound, a value planted there by a malicious fork or PR
+    (an absolute path outside the repository) would steer the rebuild -- and so
+    what gets read, and what gets written into the same committed graphify-out/
+    -- to wherever the checkout names, not the repository the hook was installed
+    into. The recovered root must stay inside the working tree the hook actually
+    runs from."""
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    (repo / "graphify-out").mkdir(parents=True)
+    outside.mkdir()
+    (repo / "graphify-out" / ".graphify_root").write_text(str(outside), encoding="utf-8")
+    monkeypatch.chdir(repo)
+    ns = {"Path": Path, "os": os}
+    exec(compile(_extract_root_resolution(body), "<rebuild_body>", "exec"), ns)
+    assert ns["_root"].resolve() == repo.resolve(), f"{name} honoured an out-of-repo root"
+
+
+@pytest.mark.parametrize(
+    "name,body",
+    [("post-commit", _REBUILD_BODY_COMMIT), ("post-checkout", _REBUILD_BODY_CHECKOUT)],
+)
+def test_rebuild_bodies_honour_an_in_repo_graphify_root(name, body, tmp_path, monkeypatch):
+    """The legitimate case the #3265 guard must not break: a subdirectory-scoped
+    root (#1173) is still recovered."""
+    repo = tmp_path / "repo"
+    (repo / "graphify-out").mkdir(parents=True)
+    (repo / "backend").mkdir()
+    (repo / "graphify-out" / ".graphify_root").write_text("backend", encoding="utf-8")
+    monkeypatch.chdir(repo)
+    ns = {"Path": Path, "os": os}
+    exec(compile(_extract_root_resolution(body), "<rebuild_body>", "exec"), ns)
+    assert ns["_root"].resolve() == (repo / "backend").resolve(), f"{name} lost the scoped root"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -2,6 +2,7 @@
 import os
 import shutil
 import subprocess
+import sys
 import textwrap
 from types import SimpleNamespace
 from pathlib import Path
@@ -381,6 +382,28 @@ def test_rebuild_bodies_honour_an_in_repo_graphify_root(name, body, tmp_path, mo
     ns = {"Path": Path, "os": os}
     exec(compile(_extract_root_resolution(body), "<rebuild_body>", "exec"), ns)
     assert ns["_root"].resolve() == (repo / "backend").resolve(), f"{name} lost the scoped root"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink setup differs on Windows")
+@pytest.mark.parametrize(
+    "name,body",
+    [("post-commit", _REBUILD_BODY_COMMIT), ("post-checkout", _REBUILD_BODY_CHECKOUT)],
+)
+def test_rebuild_bodies_survive_a_graphify_root_symlink_loop(name, body, tmp_path, monkeypatch):
+    """A committed `.graphify_root` naming a path that resolves through a
+    symlink loop (two symlinks pointing at each other) must fall back to the
+    repo top rather than let `Path.resolve()`'s RuntimeError escape the #3265
+    guard uncaught -- the guard's own `except OSError` doesn't catch it, since
+    a symlink loop is a RuntimeError on this platform, not an OSError."""
+    repo = tmp_path / "repo"
+    (repo / "graphify-out").mkdir(parents=True)
+    (repo / "loop_a").symlink_to(repo / "loop_b")
+    (repo / "loop_b").symlink_to(repo / "loop_a")
+    (repo / "graphify-out" / ".graphify_root").write_text("loop_a", encoding="utf-8")
+    monkeypatch.chdir(repo)
+    ns = {"Path": Path, "os": os}
+    exec(compile(_extract_root_resolution(body), "<rebuild_body>", "exec"), ns)
+    assert ns["_root"].resolve() == repo.resolve(), f"{name} did not fall back on a symlink loop"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #3265. `.graphify_root` lives inside the directory Team setup documents committing, so its contents are checkout controlled — but the generated post-commit / post-checkout hooks read that file and pass its value straight to `_rebuild_code` with no bound. A value planted there by a malicious fork or PR (an absolute path outside the repository) would steer the rebuild, and therefore what it reads and what it writes back into that same committed directory, wherever the checkout names, not the repository the hook was installed into.

Both rebuild bodies (`_REBUILD_BODY_COMMIT` and `_REBUILD_BODY_CHECKOUT` in `graphify/hooks.py`) now only adopt the saved root when it resolves inside the working tree the hook is actually running from (`_root.resolve() == cwd` or a descendant of it); anything else falls back to the repo top, the previous default when the marker was absent, and prints a note saying so.

This does not narrow the legitimate case: a subdirectory scoped root (#1173, e.g. `graphify update backend/`) is still a descendant of the repo root the hook runs from, so it's still honoured — covered by a new test.

This PR only addresses the `.graphify_root` half of the report. The reporter's earlier `.graphify_python` follow-up explicitly asks for a maintainer preference among three directions (drop the working tree probe, relocate it outside the repo, or document it in `.gitignore`), so I've left that to a maintainer call rather than guessing.

## Test plan

- [x] Added 2 regression tests (parametrized over both hook bodies) in `tests/test_hooks.py`: one confirms a `.graphify_root` pointing outside the repo is rejected and falls back to the repo top, one confirms a subdirectory scoped root (#1173) is still honoured. Both execute the actual shipped snippet (extracted from the body text via regex) rather than a hand copy, so they can't drift from the real hook source.
- [x] Manually reproduced: wrote `.graphify_root` pointing at a directory outside the repo, confirmed the recovered root falls back to the repo top; wrote a subdirectory value, confirmed it's still honoured.
- [x] Full suite: `python3 -m pytest -q` — 5424 passed, only the pre-existing unrelated failures (`test_ollama_retry_cap.py` missing `openai` in this env, one flaky timing assertion in `test_ts_import_type_arguments.py`).
- [x] `python3 -m tools.skillgen --check` — OK.
- [x] Existing hook tests all pass unchanged, including the shell quote safety and prefix consistency checks the new code had to satisfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qfdzgbA5KedGEjD1AayNh
