### PR TITLE
Fix: fall back to sequential extraction when the process pool cannot start

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -6259,6 +6259,16 @@ def _extract_parallel(
             flush=True,
         )
         return False
+    except OSError as exc:
+        # The pool could not even start. On macOS, leaked POSIX semaphores
+        # exhaust kern.posix.sem.max and sem_open fails with ENOSPC ("No space
+        # left on device", disk nowhere near full). Sequential needs no pool.
+        print(
+            f"  warning: parallel extraction unavailable ({exc}); "
+            "falling back to sequential.",
+            flush=True,
+        )
+        return False
     if failed:
         # #2445: retry per-future failures once, in-process, instead of leaving
         # their per_file slots None (which the defensive fill downstream turned

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2222,6 +2222,34 @@ def test_extract_parallel_returns_false_on_broken_pool(tmp_path, monkeypatch, ca
     assert "__main__" in out, "warning must hint at the Windows __main__ guard idiom"
 
 
+def test_extract_parallel_returns_false_when_pool_cannot_start(tmp_path, monkeypatch, capsys):
+    """_extract_parallel must fall back, not raise, when the pool cannot be created.
+
+    ProcessPoolExecutor allocates a POSIX named semaphore at construction. On
+    macOS, once leaked semaphores exhaust the system-wide table
+    (kern.posix.sem.max), sem_open fails with OSError(ENOSPC) — "No space left
+    on device" with the disk nowhere near full — and the whole extraction died
+    instead of running sequentially.
+    """
+    import concurrent.futures
+    # Loaded lazily on first ProcessPoolExecutor access; with that patched out,
+    # the BrokenProcessPool handler's attribute lookup would itself raise.
+    import concurrent.futures.process  # noqa: F401
+    import errno
+    from graphify import extract as extract_mod
+
+    def no_semaphores(*a, **kw):
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr(concurrent.futures, "ProcessPoolExecutor", no_semaphores)
+
+    uncached = [(0, FIXTURES / "sample.py")]
+    per_file: list = [None]
+    ok = extract_mod._extract_parallel(uncached, per_file, tmp_path, 2, 1)
+    assert ok is False, "a pool that cannot start must hand back to sequential, not raise"
+    assert "No space left on device" in capsys.readouterr().out, "warning must name the OS error"
+
+
 def test_extract_parallel_skips_pool_when_max_workers_is_one(tmp_path, monkeypatch):
     """#2173: a resolved worker count of 1 must not spawn a ProcessPoolExecutor.
 


### PR DESCRIPTION
## Problem

`_extract_parallel` falls back to sequential extraction on `BrokenProcessPool`, but an `OSError` raised while *constructing* the `ProcessPoolExecutor` escapes and kills the whole extraction — and with it `graphify update`.

Seen on macOS: `ProcessPoolExecutor.__init__` → `multiprocessing` `SemLock` → `sem_open` fails with `OSError: [Errno 28] No space left on device` once leaked POSIX named semaphores exhaust the system-wide `kern.posix.sem.max` (10000). The disk had 41 GiB free, and `python -c 'import multiprocessing as m; m.Lock()'` failed the same way in any interpreter. `graphify update` printed `[graphify watch] Rebuild failed: [Errno 28] No space left on device` and left the graph stale, although sequential extraction needs no semaphore at all.

```
graphify/extract.py, in _extract_parallel
    with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as pool:
concurrent/futures/process.py, in __init__
    self._call_queue = _SafeQueue(...)
multiprocessing/queues.py, in __init__
    self._rlock = ctx.Lock()
multiprocessing/synchronize.py, in __init__
    sl = self._semlock = _multiprocessing.SemLock(...)
OSError: [Errno 28] No space left on device
```

(Traceback from 0.8.37; the same unguarded path is on `v8`.)

## Fix

A second handler after the `BrokenProcessPool` one: `except OSError` prints a warning naming the error and returns `False`, so `extract()` runs `_extract_sequential` — the same contract the existing handler uses. It's a separate branch because the `BrokenProcessPool` warning's Windows `__main__` hint would be wrong here.

## Test

`test_extract_parallel_returns_false_when_pool_cannot_start` patches `ProcessPoolExecutor` to raise `OSError(ENOSPC)` and asserts `_extract_parallel` returns `False` and warns. It imports `concurrent.futures.process` explicitly: that submodule loads lazily on first `ProcessPoolExecutor` access, so with the class patched out, the `BrokenProcessPool` handler's attribute lookup would itself raise `AttributeError` and the test would fail for the wrong reason.

- The new test fails before the fix with the `OSError`, and passes after.
- `tests/test_extract.py`: 226 passed, 4 skipped (baseline 225 plus the new test).
- `tests/test_hooks.py`: 107 passed.
- `ruff check` (v0.15.14, repo config) on both files: clean.

No CHANGELOG entry, since entries cite the PR number — happy to add one if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
