### PR TITLE
fix(hook): cap the soft read nudge per session and suppress it after a fresh query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Fix: `graphify install` no longer aborts when the always-on registration target is unwritable (read-only or symlinked config); it skips that step with an actionable warning and still installs the skill (#3474, thanks @dajiaohuang).
 - Fix: community labelling falls back to an installed `claude` CLI resolved at run time instead of pinning a path that expires (e.g. under snap/nvm), so labelling keeps working across updates (#3475, thanks @ktsang622).
 - Fix: the `all` extra now includes `psycopg[binary]`, so `pip install 'graphifyy[all]'` provides the postgres driver (#3482, thanks @L4XB).
+- Fix: the soft PreToolUse read nudge is now suppressed while a recent `graphify query`/`explain`/`path` stamp is fresh, and is capped to once per session per `GRAPHIFY_HOOK_NUDGE_TTL` seconds (default 300) — previously it re-fired unconditionally on every qualifying read, measured at 8,348 injections (~651k tokens) in one repo at a ~4% response rate (#3435, thanks @Ashfaqbs).
 
 ## 0.9.57 (2026-09-09)
 

--- a/graphify/cli.py
+++ b/graphify/cli.py
@@ -738,6 +738,43 @@ def _mark_session_denied(session_id: str) -> bool:
         return False
 
 
+def _nudge_recently_shown(session_id: str) -> bool:
+    """True if the soft read nudge already fired for this session within
+    GRAPHIFY_HOOK_NUDGE_TTL seconds (default 300); otherwise records one now and
+    returns False (#3435: the nudge previously had no per-session cap, so it re-fired
+    on every qualifying read — 8,348 injections / ~651k tokens measured in one repo
+    at a ~4% response rate). Fail-open: any error returns False so the nudge is never
+    wrongly suppressed. Best-effort GC of markers older than 24h."""
+    from graphify.paths import out_path, write_text_atomic
+    sid = re.sub(r"[^A-Za-z0-9_-]", "_", str(session_id))[:64]
+    if not sid:
+        return False
+    try:
+        ttl = float(os.environ.get("GRAPHIFY_HOOK_NUDGE_TTL", "300"))
+        d = out_path("cache", "hook_sessions")
+        d.mkdir(parents=True, exist_ok=True)
+        marker = d / f"{sid}.nudged"
+        try:
+            if (time.time() - marker.stat().st_mtime) < ttl:
+                return True
+        except OSError:
+            pass
+        write_text_atomic(marker, str(time.time()))
+        try:
+            cutoff = time.time() - 86400
+            for entry in os.scandir(d):
+                try:
+                    if entry.stat().st_mtime < cutoff:
+                        os.unlink(entry.path)
+                except OSError:
+                    pass
+        except OSError:
+            pass
+        return False
+    except Exception:
+        return False
+
+
 _SEARCH_COMMANDS = frozenset({
     "grep", "egrep", "fgrep", "zgrep", "rg", "ripgrep", "find", "fd", "ack", "ag",
 })
@@ -936,6 +973,10 @@ def _run_hook_guard(kind: str, strict: bool = False) -> None:
                     and _target_is_indexed(fp, root) \
                     and _mark_session_denied(str(d.get("session_id") or "")):
                 sys.stdout.write(_READ_DENY)
+                return
+            # #3435: an agent that just oriented (query/explain/path) does not need
+            # reminding, and even once oriented the raw nudge must not repeat forever.
+            if _query_stamp_fresh() or _nudge_recently_shown(str(d.get("session_id") or "")):
                 return
             sys.stdout.write(_READ_NUDGE)
     except Exception:

--- a/tests/test_hook_strict.py
+++ b/tests/test_hook_strict.py
@@ -80,13 +80,14 @@ def test_strict_new_session_denies_again(tmp_path, monkeypatch):
     assert _is_deny(out)
 
 
-def test_fresh_query_stamp_suppresses_deny(tmp_path, monkeypatch):
+def test_fresh_query_stamp_suppresses_deny_and_nudge(tmp_path, monkeypatch):
     f = _fixture(tmp_path)
     stamp = tmp_path / "graphify-out" / "cache" / "last_query_stamp"
     stamp.parent.mkdir(parents=True, exist_ok=True)
     stamp.write_text(str(time.time()), encoding="utf-8")
     out = _invoke("read", _read(f), tmp_path, monkeypatch, strict=True)
-    assert not _is_deny(out) and "MANDATORY" in out
+    # #3435: an agent that just oriented is not reminded to orient again.
+    assert not _is_deny(out) and out.strip() == ""
 
 
 def test_expired_query_stamp_still_denies(tmp_path, monkeypatch):
@@ -187,6 +188,51 @@ def test_strict_enabled_env_precedence():
             _os.environ.pop("GRAPHIFY_HOOK_STRICT", None)
         else:
             _os.environ["GRAPHIFY_HOOK_STRICT"] = saved
+
+
+def test_fresh_query_stamp_suppresses_soft_nudge_too(tmp_path, monkeypatch):
+    f = _fixture(tmp_path)
+    stamp = tmp_path / "graphify-out" / "cache" / "last_query_stamp"
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.write_text(str(time.time()), encoding="utf-8")
+    out = _invoke("read", _read(f), tmp_path, monkeypatch, strict=False)
+    assert out.strip() == ""
+
+
+def test_soft_nudge_capped_per_session(tmp_path, monkeypatch):
+    f = _fixture(tmp_path)
+    out1 = _invoke("read", _read(f), tmp_path, monkeypatch, strict=False)
+    assert "MANDATORY" in out1
+    # marker created
+    assert (tmp_path / "graphify-out" / "cache" / "hook_sessions" / "s1.nudged").exists()
+    # same session again within the TTL -> no repeat nudge
+    out2 = _invoke("read", _read(f), tmp_path, monkeypatch, strict=False)
+    assert out2.strip() == ""
+
+
+def test_soft_nudge_cap_is_per_session(tmp_path, monkeypatch):
+    f = _fixture(tmp_path)
+    _invoke("read", _read(f, "sA"), tmp_path, monkeypatch, strict=False)
+    out = _invoke("read", _read(f, "sB"), tmp_path, monkeypatch, strict=False)
+    assert "MANDATORY" in out
+
+
+def test_soft_nudge_cap_expires_after_ttl(tmp_path, monkeypatch):
+    f = _fixture(tmp_path)
+    _invoke("read", _read(f), tmp_path, monkeypatch, strict=False, env={"GRAPHIFY_HOOK_NUDGE_TTL": "300"})
+    marker = tmp_path / "graphify-out" / "cache" / "hook_sessions" / "s1.nudged"
+    old = time.time() - 10_000
+    os.utime(marker, (old, old))
+    out = _invoke("read", _read(f), tmp_path, monkeypatch, strict=False, env={"GRAPHIFY_HOOK_NUDGE_TTL": "300"})
+    assert "MANDATORY" in out
+
+
+def test_soft_nudge_never_capped_without_session_id(tmp_path, monkeypatch):
+    f = _fixture(tmp_path)
+    payload = {"tool_name": "Read", "tool_input": {"file_path": str(f)}}  # no session_id
+    out1 = _invoke("read", payload, tmp_path, monkeypatch, strict=False)
+    out2 = _invoke("read", payload, tmp_path, monkeypatch, strict=False)
+    assert "MANDATORY" in out1 and "MANDATORY" in out2
 
 
 def test_install_hook_carries_strict_flag():


### PR DESCRIPTION
Fixes #3435.

## Problem

The soft PreToolUse read nudge (`_READ_NUDGE`) fired unconditionally on every qualifying Read, with no dedup, no session cap, and no suppression while the agent had recently run `graphify query`/`explain`/`path`. Only the opt-in strict deny was capped, via `_mark_session_denied`.

Measured across 87 Claude Code transcripts in one repo: 8,348 nudge injections producing 339 graphify calls (~4% response rate), at a standing cost of ~651k tokens — about 3.7x every graphify query in those sessions combined.

## Fix

- Suppress the nudge entirely while `_query_stamp_fresh()` is true — an agent that just oriented (query/explain/path) does not need reminding on its very next read.
- Otherwise cap it to once per session per `GRAPHIFY_HOOK_NUDGE_TTL` seconds (default 300), via a new `_nudge_recently_shown` helper that mirrors the existing `_mark_session_denied` marker-file pattern (best-effort GC of markers older than 24h, fails open on any error so the nudge is never wrongly suppressed).

Both suggested fixes from the issue (#1 and #2, the two highest value-to-effort items) are implemented; dedup-per-target and payload shortening (#3/#4) are left out to keep this PR narrowly scoped to the two changes that account for "well over 90%" of the measured cost per the issue's own estimate.

## Tests

- Updated `test_fresh_query_stamp_suppresses_deny` (renamed `..._and_nudge`) — a fresh query stamp now suppresses both the strict deny *and* the soft nudge, since the old assertion documented the exact bug being fixed.
- Added `test_fresh_query_stamp_suppresses_soft_nudge_too` — same suppression applies outside strict mode.
- Added `test_soft_nudge_capped_per_session` — a second read in the same session within the TTL produces no output.
- Added `test_soft_nudge_cap_is_per_session` — a different session id still gets the nudge.
- Added `test_soft_nudge_cap_expires_after_ttl` — an expired marker (backdated via `os.utime`) lets the nudge fire again.
- Added `test_soft_nudge_never_capped_without_session_id` — fail-open: no session id means no cap is possible, so the nudge keeps firing rather than risk silently swallowing it.

`uv run pytest tests/test_hook_strict.py tests/test_hook_guard.py tests/test_hook_guard_token_match.py tests/test_hook_out_of_project_paths.py tests/test_install_strings.py -q` — 162 passed.

Full suite (`uv run pytest -q`): 5410 passed, 30 failed, 99 skipped. All 30 failures are pre-existing and unrelated to this change (Windows-platform-specific: FIFO/unix-socket tests that don't apply on Windows, backslash path-separator assertions, shebang parsing) — none touch `graphify/cli.py`'s hook-guard code or `tests/test_hook_strict.py`.

## Caveats

- `GRAPHIFY_HOOK_NUDGE_TTL` default of 300s (5 minutes) is a judgment call, not something I could tune against real usage data beyond the one repo's transcripts cited in the issue. Happy to adjust if a maintainer has a better sense of the right default.
- Scope is deliberately narrow to the read nudge (`_READ_NUDGE`) reported in #3435. The search nudge (`_SEARCH_NUDGE`) has the same unconditional-fire shape but wasn't part of the measured cost in the issue, so I left it untouched rather than expanding scope.