### PR TITLE
fix(paths): fall back on WinError 17 for os.replace, not just PermissionError (#3508)

### DIFF
--- a/graphify/cache.py
+++ b/graphify/cache.py
@@ -17,6 +17,7 @@ from pathlib import Path
 # absolute path ("/shared/graphify-out"). Single source of truth in graphify.paths
 # (#1423); re-exported here as _GRAPHIFY_OUT for the existing call sites.
 from graphify.paths import GRAPHIFY_OUT as _GRAPHIFY_OUT
+from graphify.paths import os_replace_with_fallback as _os_replace_with_fallback
 
 # AST cache entries are the output of graphify's own extractor code, so they
 # are only valid for the version that wrote them: keying purely on file
@@ -399,7 +400,7 @@ def _flush_stat_index() -> None:
         try:
             os.write(fd, json.dumps(on_disk, separators=(",", ":")).encode())
             os.close(fd)
-            os.replace(tmp, p)
+            _os_replace_with_fallback(tmp, p)
         except Exception:
             try:
                 os.close(fd)
@@ -1126,14 +1127,7 @@ def save_cached(path: Path, result: dict, root: Path = Path("."), kind: str = "a
     try:
         os.write(fd, json.dumps(on_disk).encode())
         os.close(fd)
-        try:
-            os.replace(tmp_path, entry)
-        except PermissionError:
-            # Windows: os.replace can fail with WinError 5 if the target is
-            # briefly locked. Fall back to copy-then-delete.
-            import shutil
-            shutil.copy2(tmp_path, entry)
-            os.unlink(tmp_path)
+        _os_replace_with_fallback(tmp_path, entry)
     except Exception:
         try:
             os.close(fd)

--- a/graphify/export.py
+++ b/graphify/export.py
@@ -16,7 +16,12 @@ from networkx.readwrite import json_graph
 from graphify.security import sanitize_label
 from graphify.analyze import _node_community_map
 from graphify.build import edge_data
-from graphify.paths import stem_filename_budget, write_json_atomic, write_text_atomic
+from graphify.paths import (
+    os_replace_with_fallback,
+    stem_filename_budget,
+    write_json_atomic,
+    write_text_atomic,
+)
 
 from graphify.exporters.graphdb import push_to_falkordb, push_to_neo4j  # noqa: E402,F401
 
@@ -1270,7 +1275,7 @@ def to_graphml(
     tmp = out.with_name(out.name + ".tmp")
     try:
         nx.write_graphml(H, str(tmp))
-        os.replace(str(tmp), str(out))
+        os_replace_with_fallback(str(tmp), str(out))
     finally:
         if tmp.exists():
             try:

--- a/graphify/install.py
+++ b/graphify/install.py
@@ -30,6 +30,7 @@ except Exception:
     __version__ = "unknown"
 
 from graphify.paths import GRAPHIFY_OUT as _GRAPHIFY_OUT
+from graphify.paths import os_replace_with_fallback as _os_replace_with_fallback
 
 
 def _write_version_stamp(skill_dst: Path, version: str) -> None:
@@ -45,7 +46,7 @@ def _write_version_stamp(skill_dst: Path, version: str) -> None:
     tmp = version_file.with_name(".graphify_version.tmp")
     try:
         tmp.write_text(version, encoding="utf-8")
-        os.replace(tmp, version_file)
+        _os_replace_with_fallback(tmp, version_file)
     except Exception:
         try:
             tmp.unlink(missing_ok=True)
@@ -250,7 +251,7 @@ def _copy_skill_file(platform_name: str, *, project: bool = False, project_dir: 
     tmp_dst = skill_dst.with_suffix(skill_dst.suffix + ".tmp")
     try:
         shutil.copy(skill_src, tmp_dst)
-        os.replace(tmp_dst, skill_dst)
+        _os_replace_with_fallback(tmp_dst, skill_dst)
     except Exception:
         try:
             tmp_dst.unlink(missing_ok=True)
@@ -898,7 +899,7 @@ def vscode_install(project_dir: Path | None = None) -> None:
     tmp_dst = skill_dst.with_suffix(skill_dst.suffix + ".tmp")
     try:
         shutil.copy(skill_src, tmp_dst)
-        os.replace(tmp_dst, skill_dst)
+        _os_replace_with_fallback(tmp_dst, skill_dst)
     except Exception:
         try:
             tmp_dst.unlink(missing_ok=True)

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -26,6 +26,27 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 GRAPHIFY_OUT = os.environ.get("GRAPHIFY_OUT", "graphify-out")
 
 
+def os_replace_with_fallback(src: "str | Path", dst: "str | Path") -> None:
+    """``os.replace(src, dst)``, falling back to copy-then-delete for a known
+    set of Windows quirks (#3508) that raise even when ``src``/``dst`` are the
+    same directory on the same drive: ``PermissionError`` (WinError 5/32 --
+    destination briefly locked by another handle, antivirus, an open reader)
+    and WinError 17 ("cannot move to a different disk drive", observed on some
+    Windows/filesystem combinations despite textbook same-volume semantics).
+    WinError 17 maps to a plain ``OSError`` in Python, not ``PermissionError``,
+    so it's checked via ``winerror`` rather than the exception type. Any other
+    failure is a real one and is re-raised.
+    """
+    try:
+        os.replace(src, dst)
+    except OSError as exc:
+        if not isinstance(exc, PermissionError) and getattr(exc, "winerror", None) != 17:
+            raise
+        import shutil
+        shutil.copy2(src, dst)
+        os.unlink(src)
+
+
 def _atomic_replace(path: "str | Path", write_fn) -> None:
     """Atomically replace ``path`` with content written by ``write_fn(f)``.
 
@@ -63,15 +84,7 @@ def _atomic_replace(path: "str | Path", write_fn) -> None:
             os.chmod(tmp, mode)
         except OSError:
             pass
-        try:
-            os.replace(tmp, str(real))
-        except PermissionError:
-            # Windows: os.replace fails (WinError 5/32) when the destination is
-            # briefly locked by another handle (antivirus, an open reader). Fall
-            # back to copy-then-delete, matching graphify.cache's atomic writer.
-            import shutil
-            shutil.copy2(tmp, str(real))
-            os.unlink(tmp)
+        os_replace_with_fallback(tmp, str(real))
     except BaseException:
         try:
             os.unlink(tmp)

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -42,12 +42,13 @@ def os_replace_with_fallback(src: "str | Path", dst: "str | Path") -> None:
     e.g. install.py's managed skill symlinks, #3286, rely on exactly this).
     A naive ``shutil.copy2(src, dst)`` does the opposite when ``dst`` is a
     symlink: opening it for writing follows the link and overwrites its
-    TARGET's content instead. So the fallback copies to a fresh temp file
-    in ``dst``'s directory first, then removes whatever is at ``dst`` (link
-    or file) and renames the temp copy into place -- matching replace's
-    "whatever was there is gone, a plain file replaces it" semantics, and
-    keeping the exposure window to two fast metadata operations rather than
-    however long the copy itself takes.
+    TARGET's content instead. So the fallback copies to a fresh temp file in
+    ``dst``'s directory first, renames whatever is currently at ``dst`` (link
+    or file) aside as a backup rather than deleting it outright, and only
+    then renames the temp copy into ``dst``'s place -- matching replace's
+    "whatever was there is gone, a plain file replaces it" semantics. If that
+    final rename fails, the backup is renamed straight back so a mid-swap
+    failure leaves the original in place rather than leaving ``dst`` missing.
     """
     try:
         os.replace(src, dst)
@@ -57,15 +58,31 @@ def os_replace_with_fallback(src: "str | Path", dst: "str | Path") -> None:
             raise
     import shutil
     dst = os.fspath(dst)
-    fd, tmp_copy = tempfile.mkstemp(dir=os.path.dirname(dst) or ".", prefix=".gfy-replace-", suffix=".tmp")
+    dst_dir = os.path.dirname(dst) or "."
+    fd, tmp_copy = tempfile.mkstemp(dir=dst_dir, prefix=".gfy-replace-", suffix=".tmp")
     os.close(fd)
     try:
         shutil.copy2(src, tmp_copy)
+        backup = None
+        if os.path.lexists(dst):
+            bfd, backup = tempfile.mkstemp(dir=dst_dir, prefix=".gfy-replace-bak-", suffix=".tmp")
+            os.close(bfd)
+            os.unlink(backup)  # reserve the name only; rename needs it free on Windows
+            os.rename(dst, backup)  # a plain rename moves a symlink itself, never its target
         try:
-            os.unlink(dst)
-        except FileNotFoundError:
-            pass
-        os.rename(tmp_copy, dst)
+            os.rename(tmp_copy, dst)
+        except BaseException:
+            if backup is not None:
+                try:
+                    os.rename(backup, dst)
+                except OSError:
+                    pass  # best-effort restore; the swap failure below still propagates
+            raise
+        if backup is not None:
+            try:
+                os.unlink(backup)
+            except OSError:
+                pass
     except BaseException:
         try:
             os.unlink(tmp_copy)

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -58,6 +58,12 @@ def os_replace_with_fallback(src: "str | Path", dst: "str | Path") -> None:
             raise
     import shutil
     dst = os.fspath(dst)
+    if os.path.normcase(os.path.abspath(os.fspath(src))) == os.path.normcase(os.path.abspath(dst)):
+        # Replacing a path with itself needs no swap at all; the rename-aside-
+        # then-back sequence below would rename src out from under itself via
+        # the "back up dst" step and then crash unlinking a path that no
+        # longer exists at the end.
+        return
     dst_dir = os.path.dirname(dst) or "."
     fd, tmp_copy = tempfile.mkstemp(dir=dst_dir, prefix=".gfy-replace-", suffix=".tmp")
     os.close(fd)

--- a/graphify/paths.py
+++ b/graphify/paths.py
@@ -27,24 +27,52 @@ GRAPHIFY_OUT = os.environ.get("GRAPHIFY_OUT", "graphify-out")
 
 
 def os_replace_with_fallback(src: "str | Path", dst: "str | Path") -> None:
-    """``os.replace(src, dst)``, falling back to copy-then-delete for a known
-    set of Windows quirks (#3508) that raise even when ``src``/``dst`` are the
-    same directory on the same drive: ``PermissionError`` (WinError 5/32 --
+    """``os.replace(src, dst)``, falling back to a copy for a known set of
+    Windows quirks (#3508) that raise even when ``src``/``dst`` are the same
+    directory on the same drive: ``PermissionError`` (WinError 5/32 --
     destination briefly locked by another handle, antivirus, an open reader)
     and WinError 17 ("cannot move to a different disk drive", observed on some
     Windows/filesystem combinations despite textbook same-volume semantics).
     WinError 17 maps to a plain ``OSError`` in Python, not ``PermissionError``,
     so it's checked via ``winerror`` rather than the exception type. Any other
     failure is a real one and is re-raised.
+
+    ``os.replace`` atomically swaps whatever sits at ``dst`` -- including a
+    symlink, which it REPLACES in place rather than following (some callers,
+    e.g. install.py's managed skill symlinks, #3286, rely on exactly this).
+    A naive ``shutil.copy2(src, dst)`` does the opposite when ``dst`` is a
+    symlink: opening it for writing follows the link and overwrites its
+    TARGET's content instead. So the fallback copies to a fresh temp file
+    in ``dst``'s directory first, then removes whatever is at ``dst`` (link
+    or file) and renames the temp copy into place -- matching replace's
+    "whatever was there is gone, a plain file replaces it" semantics, and
+    keeping the exposure window to two fast metadata operations rather than
+    however long the copy itself takes.
     """
     try:
         os.replace(src, dst)
+        return
     except OSError as exc:
         if not isinstance(exc, PermissionError) and getattr(exc, "winerror", None) != 17:
             raise
-        import shutil
-        shutil.copy2(src, dst)
-        os.unlink(src)
+    import shutil
+    dst = os.fspath(dst)
+    fd, tmp_copy = tempfile.mkstemp(dir=os.path.dirname(dst) or ".", prefix=".gfy-replace-", suffix=".tmp")
+    os.close(fd)
+    try:
+        shutil.copy2(src, tmp_copy)
+        try:
+            os.unlink(dst)
+        except FileNotFoundError:
+            pass
+        os.rename(tmp_copy, dst)
+    except BaseException:
+        try:
+            os.unlink(tmp_copy)
+        except OSError:
+            pass
+        raise
+    os.unlink(src)
 
 
 def _atomic_replace(path: "str | Path", write_fn) -> None:

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -268,6 +268,29 @@ def test_os_replace_with_fallback_restores_destination_on_final_rename_failure(t
     assert leftover == {"dst.json", "src.tmp"}, f"unexpected leftover files: {leftover}"
 
 
+def test_os_replace_with_fallback_is_a_noop_when_src_equals_dst(tmp_path, monkeypatch):
+    """Replacing a path with itself, if os.replace ever fails for that call,
+    must not crash. The swap sequence (back up dst, rename the copy into
+    place, unlink src) renames src out from under itself the moment src and
+    dst are the same path, then crashes trying to unlink a path that no
+    longer exists."""
+    from graphify.paths import os_replace_with_fallback
+
+    p = tmp_path / "x.json"
+    p.write_text("CONTENT", encoding="utf-8")
+
+    def flaky_replace(a, b):
+        exc = OSError("cannot move to a different disk drive")
+        exc.winerror = 17
+        raise exc
+
+    monkeypatch.setattr(os, "replace", flaky_replace)
+    os_replace_with_fallback(str(p), str(p))
+
+    assert p.read_text(encoding="utf-8") == "CONTENT"
+    assert {x.name for x in tmp_path.iterdir()} == {"x.json"}
+
+
 def test_write_json_atomic_ensure_ascii_false_preserves_utf8(tmp_path):
     from graphify.paths import write_json_atomic
 

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -6,6 +6,7 @@ directory then `os.replace`s it into place; on failure the original is untouched
 """
 import json
 import os
+import sys
 
 import pytest
 
@@ -190,6 +191,40 @@ def test_write_text_atomic_windows_winerror_17_fallback(tmp_path, monkeypatch):
     assert calls["n"] == 1
     assert p.read_text() == "new-content"
     assert sorted(x.name for x in tmp_path.iterdir()) == ["graph.json"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink setup differs on Windows")
+def test_os_replace_with_fallback_replaces_a_symlink_destination_in_place(tmp_path, monkeypatch):
+    """`os.replace` replaces a symlinked destination itself rather than
+    following it -- install.py relies on exactly this for managed skill
+    symlinks (#3286). A naive `shutil.copy2(src, dst)` does the opposite when
+    dst is a symlink: opening it for writing follows the link and overwrites
+    its TARGET's content instead. The #3508 fallback must preserve replace's
+    semantics, not copy2's, or a Windows quirk that triggers the fallback
+    would silently clobber whatever a managed symlink pointed at."""
+    from graphify.paths import os_replace_with_fallback
+
+    target = tmp_path / "shared_target.txt"
+    target.write_text("ORIGINAL SHARED CONTENT", encoding="utf-8")
+    link = tmp_path / "skill_link"
+    link.symlink_to(target)
+    src = tmp_path / "tmp_new.txt"
+    src.write_text("NEW CONTENT", encoding="utf-8")
+
+    def flaky_replace(a, b):
+        exc = OSError("cannot move to a different disk drive")
+        exc.winerror = 17
+        raise exc
+
+    monkeypatch.setattr(os, "replace", flaky_replace)
+    os_replace_with_fallback(str(src), str(link))
+
+    assert not link.is_symlink(), "link must be replaced by a plain file, not left as a symlink"
+    assert link.read_text(encoding="utf-8") == "NEW CONTENT"
+    assert target.read_text(encoding="utf-8") == "ORIGINAL SHARED CONTENT", (
+        "the shared target must be untouched -- a copy2-through-the-link would have clobbered it"
+    )
+    assert not src.exists()
 
 
 def test_write_json_atomic_ensure_ascii_false_preserves_utf8(tmp_path):

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -227,6 +227,47 @@ def test_os_replace_with_fallback_replaces_a_symlink_destination_in_place(tmp_pa
     assert not src.exists()
 
 
+def test_os_replace_with_fallback_restores_destination_on_final_rename_failure(tmp_path, monkeypatch):
+    """The fallback removes the existing destination before renaming the new
+    content into place; if that final rename then fails for any reason, the
+    original content must be restored rather than leaving the destination
+    missing -- a bare unlink-then-rename with no recovery would silently
+    destroy the previous file on a mid-swap failure."""
+    from graphify.paths import os_replace_with_fallback
+
+    dst = tmp_path / "dst.json"
+    dst.write_text("ORIGINAL", encoding="utf-8")
+    src = tmp_path / "src.tmp"
+    src.write_text("NEW", encoding="utf-8")
+
+    def flaky_replace(a, b):
+        exc = OSError("cannot move to a different disk drive")
+        exc.winerror = 17
+        raise exc
+
+    real_rename = os.rename
+    calls = {"n": 0}
+
+    def flaky_rename(a, b):
+        calls["n"] += 1
+        # First rename swaps dst aside as a backup (must succeed so there's
+        # something to restore); force the second -- landing the new
+        # content -- to fail.
+        if calls["n"] == 2:
+            raise OSError("simulated failure landing the new content")
+        return real_rename(a, b)
+
+    monkeypatch.setattr(os, "replace", flaky_replace)
+    monkeypatch.setattr(os, "rename", flaky_rename)
+    with pytest.raises(OSError, match="simulated failure landing the new content"):
+        os_replace_with_fallback(str(src), str(dst))
+
+    assert dst.exists(), "destination must not be left missing after a failed swap"
+    assert dst.read_text(encoding="utf-8") == "ORIGINAL"
+    leftover = {p.name for p in tmp_path.iterdir()}
+    assert leftover == {"dst.json", "src.tmp"}, f"unexpected leftover files: {leftover}"
+
+
 def test_write_json_atomic_ensure_ascii_false_preserves_utf8(tmp_path):
     from graphify.paths import write_json_atomic
 

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -167,6 +167,31 @@ def test_write_text_atomic_windows_permission_fallback(tmp_path, monkeypatch):
     assert sorted(x.name for x in tmp_path.iterdir()) == ["graph.json"]
 
 
+def test_write_text_atomic_windows_winerror_17_fallback(tmp_path, monkeypatch):
+    """#3508: `os.replace` can raise WinError 17 ("cannot move to a different
+    disk drive") even when src/dst are the same directory on the same drive,
+    on some Windows/filesystem combinations. Unlike WinError 5/32, this is a
+    plain OSError rather than PermissionError, so the fallback must key off
+    winerror rather than the exception type alone."""
+    p = tmp_path / "graph.json"
+    p.write_text("original", encoding="utf-8")
+
+    calls = {"n": 0}
+
+    def flaky_replace(src, dst):
+        calls["n"] += 1
+        exc = OSError("cannot move to a different disk drive")
+        exc.winerror = 17
+        raise exc
+
+    monkeypatch.setattr(os, "replace", flaky_replace)
+    write_text_atomic(p, "new-content")
+
+    assert calls["n"] == 1
+    assert p.read_text() == "new-content"
+    assert sorted(x.name for x in tmp_path.iterdir()) == ["graph.json"]
+
+
 def test_write_json_atomic_ensure_ascii_false_preserves_utf8(tmp_path):
     from graphify.paths import write_json_atomic
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -221,6 +221,37 @@ def test_save_cached_relativizes_source_file(tmp_path):
     assert edge_sources == {"src/foo.py"}
 
 
+def test_save_cached_survives_a_winerror_17_replace(tmp_path, monkeypatch):
+    """#3508: on some Windows/filesystem combinations, `os.replace` raises
+    WinError 17 ("cannot move to a different disk drive") even for a temp file
+    and destination in the same directory on the same drive -- reported for
+    exactly this AST cache write path. WinError 17 is a plain OSError, not a
+    PermissionError, so it must still trigger the copy-then-delete fallback."""
+    import os
+    from graphify.cache import save_cached, file_hash, cache_dir
+
+    src = tmp_path / "foo.py"
+    src.write_text("def x(): pass\n")
+
+    real_replace = os.replace
+
+    def flaky_replace(a, b):
+        exc = OSError("cannot move to a different disk drive")
+        exc.winerror = 17
+        raise exc
+
+    monkeypatch.setattr(os, "replace", flaky_replace)
+    try:
+        save_cached(src, {"nodes": [], "edges": []}, root=tmp_path, kind="ast")
+    finally:
+        monkeypatch.setattr(os, "replace", real_replace)
+
+    h = file_hash(src, tmp_path)
+    entry = cache_dir(tmp_path, "ast") / f"{h}.json"
+    assert entry.exists()
+    assert not any(p.name.endswith(".tmp") for p in entry.parent.iterdir())
+
+
 def test_load_cached_absolutizes_source_file(tmp_path):
     """``load_cached`` returns the same absolute-path shape that a fresh
     extraction produces, so consumers don't need to special-case cache

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -40,6 +40,37 @@ def test_install_default_claude(tmp_path):
     assert (tmp_path / ".claude" / "skills" / "graphify" / "SKILL.md").exists()
 
 
+def test_install_survives_a_winerror_17_replace(tmp_path, monkeypatch):
+    """#3508: installing SKILL.md failed on some Windows setups with WinError
+    17 ("cannot move to a different disk drive") from `os.replace`, even with
+    the temp file and destination in the same directory on the same drive.
+    WinError 17 is a plain OSError, not PermissionError, so the install's
+    atomic replace must fall back to copy-then-delete for it too.
+
+    Uses "aider" (a monolith platform, no references/ sidecar) so the only
+    os.replace this install performs is the SKILL.md file replace under test
+    -- a progressive platform's separate directory replace for references/
+    isn't covered by the same fallback and would fail this test for an
+    unrelated reason.
+    """
+    real_replace = os.replace
+
+    def flaky_replace(src, dst):
+        exc = OSError("cannot move to a different disk drive")
+        exc.winerror = 17
+        raise exc
+
+    monkeypatch.setattr(os, "replace", flaky_replace)
+    try:
+        _install(tmp_path, "aider")
+    finally:
+        monkeypatch.setattr(os, "replace", real_replace)
+
+    skill = tmp_path / ".aider" / "graphify" / "SKILL.md"
+    assert skill.exists()
+    assert not any(p.name.endswith(".tmp") for p in skill.parent.iterdir())
+
+
 def test_install_claude_md_honors_claude_config_dir(tmp_path, monkeypatch):
     """#2694: with CLAUDE_CONFIG_DIR set, the always-on registration lands in
     $CLAUDE_CONFIG_DIR/CLAUDE.md — not the default ~/.claude/CLAUDE.md, which the


### PR DESCRIPTION
## Summary

Fixes #3508. On some Windows/filesystem combinations, `os.replace(src, dst)` raises `WinError 17` ("cannot move to a different disk drive") even when `src` and `dst` are in the same directory on the same drive — reproduced by the reporter both standalone and against graphify's own uv-managed Python, hitting two concrete graphify code paths: installing the Kiro skill (`SKILL.md`), and AST cache entry writes during `graphify extract`.

`WinError 17` maps to a plain `OSError` in Python, not `PermissionError`, so the existing Windows fallback (added for `WinError 5/32`, a destination transiently locked by antivirus or an open reader) never caught it — it only matched on exception type.

Adds a shared `os_replace_with_fallback(src, dst)` in `graphify/paths.py` that falls back to `shutil.copy2` + `os.unlink` for both `PermissionError` and `winerror == 17`, and re-raises anything else unchanged. Applied it to every direct `os.replace` call for a **file** across the codebase: the shared atomic writer (`paths.py`, which already had a narrower inline version of this), both cache write paths (`cache.py`), the GraphML exporter (`export.py`), and the skill/version-stamp installers (`install.py`). Left the one directory-level `os.replace` (`install.py`'s `references/` sidecar swap) untouched — `shutil.copy2` doesn't work on directories, and it wasn't part of the report; happy to add a `copytree`+`rmtree` fallback there too if it turns out to hit the same issue.

## Test plan

- [x] Unit tests for `os_replace_with_fallback` itself (simulated `WinError 17`, a bare `PermissionError` with no `winerror` set matching the existing WinError-5 test's mock shape, and an unrelated `OSError` that must still re-raise).
- [x] Regression test for the AST cache write path (`tests/test_cache.py`), matching the exact scenario from the report.
- [x] Regression test for the skill install path (`tests/test_install.py`), using a monolith platform (`aider`) so the test isolates the file replace under test from the separate, untouched directory replace.
- [x] Regression test for the shared atomic writer (`tests/test_atomic_writes.py`), alongside the existing WinError-5 test.
- [x] Full suite: `python3 -m pytest -q` — 5423 passed, only the pre-existing unrelated failures (`test_ollama_retry_cap.py` missing `openai` in this env, one flaky timing assertion in `test_ts_import_type_arguments.py`).
- [x] `python3 -m tools.skillgen --check` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qfdzgbA5KedGEjD1AayNh
