### PR TITLE
Surface unclassified files instead of a silent successful run (#3511)

### DIFF
--- a/graphify/report.py
+++ b/graphify/report.py
@@ -137,6 +137,21 @@ def generate(
             f"- {detection_result['total_files']} files · ~{detection_result['total_words']:,} words",
             "- Verdict: corpus is large enough that graph structure adds value.",
         ]
+        # #3511: files detect() saw but could not classify (no supported
+        # extension/shebang) were counted nowhere -- a corpus that is mostly
+        # an unsupported language reported the same "well covered" verdict as
+        # one that was actually extracted. Surface the count and its biggest
+        # extensions so a near-total miss (e.g. a Lean/Zig/whatever repo with
+        # no matching extractor) is visible here instead of silent.
+        unclassified = detection_result.get("unclassified") or []
+        if unclassified:
+            from collections import Counter as _Counter
+            ext_counts = _Counter(Path(p).suffix or "(none)" for p in unclassified)
+            top = ", ".join(f"{ext} {n}" for ext, n in ext_counts.most_common(3))
+            lines.append(
+                f"- Unclassified: {len(unclassified)} file(s) not represented in "
+                f"the graph (top: {top})"
+            )
 
     from .analyze import _is_file_node as _ifn
 

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1428,6 +1428,20 @@ def _rebuild_code(
         )
         code_files = [Path(f) for f in detected['files']['code']]
 
+        # #3511: `graphify extract` has surfaced files it saw but could not
+        # classify since #1692; this update/watch rebuild path never did,
+        # so a corpus in a language with no extractor (no supported
+        # extension or shebang) rebuilt "successfully" with those files
+        # silently absent from the graph. Same wording as the extract path.
+        _unclassified = detected.get("unclassified", []) if isinstance(detected, dict) else []
+        if _unclassified:
+            _names = ", ".join(sorted({Path(p).name for p in _unclassified})[:6])
+            _more = f" (+{len(_unclassified) - 6} more)" if len(_unclassified) > 6 else ""
+            print(
+                f"[graphify watch] {len(_unclassified)} file(s) not classified "
+                f"(no supported extension or shebang), skipped: {_names}{_more}"
+            )
+
         # #2495: hand reconcile the same ignore decisions the detect() call
         # above made, so a newly-ignored file that still exists on disk is
         # purged from the graph instead of preserved forever by the fail-closed
@@ -1876,6 +1890,7 @@ def _rebuild_code(
             "files": {"code": [str(f) for f in code_files], "document": [], "paper": [], "image": []},
             "total_files": len(code_files),
             "total_words": detected.get("total_words", 0),
+            "unclassified": detected.get("unclassified", []),
         }
 
         # Inherit the existing graph's directed flag (#2342) so `graphify

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -29,6 +29,29 @@ def test_report_contains_corpus_check():
     report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")
     assert "## Corpus Check" in report
 
+
+def test_report_surfaces_unclassified_files():
+    """#3511: detect() already tracks files it saw but could not classify
+    (no supported extension), but nothing surfaced them -- a corpus that is
+    mostly an unsupported language got the same "well covered" verdict as
+    one that was actually extracted."""
+    G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
+    detection = {
+        **detection,
+        "unclassified": ["Main.lean", "Util.lean", "a.toml", "b.toml", "c.toml", "readme"],
+    }
+    report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")
+    assert "Unclassified: 6 file(s)" in report
+    assert ".lean 2" in report
+    assert ".toml 3" in report
+
+
+def test_report_omits_unclassified_line_when_none():
+    """Backward compatible: no unclassified files, no new line."""
+    G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
+    report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")
+    assert "Unclassified:" not in report
+
 def test_report_contains_god_nodes():
     G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
     report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -133,6 +133,25 @@ def test_doc_only_deletion_full_rebuild_evicts_md_nodes(tmp_path):
     assert "run()" in labels
 
 
+def test_rebuild_code_reports_unclassified_files(tmp_path, capsys):
+    """#3511: `graphify extract` has surfaced files it saw but could not
+    classify (no supported extension/shebang) since #1692; the update/watch
+    rebuild path never did, so a corpus mostly in an unsupported language
+    (e.g. Lean, per the report) rebuilt "successfully" with those files
+    silently absent and nothing said about it."""
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "app.py").write_text("def run(): pass\n", encoding="utf-8")
+    (corpus / "Main.lean").write_text("def main := 0\n", encoding="utf-8")
+    (corpus / "Util.lean").write_text("def util := 1\n", encoding="utf-8")
+
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+    out = capsys.readouterr().out
+    assert "2 file(s) not classified" in out
+    assert "Main.lean" in out
+    assert "Util.lean" in out
+
+
 # --- watch() import error without watchdog ---
 
 def test_check_update_no_flag_returns_true(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #3511. `detect()` already computes and returns `unclassified` — every file it saw but could not classify (no supported extension or shebang) — but nothing surfaced it. On a corpus in a language graphify has no extractor for (the report's example: a 260-file Lean 4 repo), `graphify update .` exits 0, prints a normal-looking "Rebuilt: N nodes..." summary, and `GRAPH_REPORT.md`'s Corpus Check says "corpus is large enough that graph structure adds value" — describing the 4 shell scripts and 2 READMEs that happened to be classifiable, with the other 260 files invisible and unmentioned.

`graphify extract` already had this reporting, added by #1692 — the gap is specifically the `update`/watch rebuild path (`graphify/watch.py`), which never got it, plus `GRAPH_REPORT.md`'s Corpus Check section, which had no field for it at all regardless of which command wrote the graph.

- `graphify/report.py`: adds an `Unclassified: N file(s) not represented in the graph (top: .ext A, .ext B)` line to the Corpus Check section whenever `detection_result` carries any.
- `graphify/watch.py`: `_rebuild_code` now prints the same "N file(s) not classified..." line `extract` already prints, and threads the count into the local detection summary it builds for `GRAPH_REPORT.md` (which previously only carried `total_files`/`total_words`, dropping `unclassified` even though `detect()` had already computed it).

Scoped to just the reporting gap, matching the issue's own "Suggested fix" section. Left `graph.json`'s `unclassified_files` field (the issue's third suggested surface) out of this PR — threading it through would mean passing `detection_result` down through `build`/`build_from_json`/`to_json`'s call chain, which is a much larger, more invasive change than the two display-only additions here; happy to follow up separately if wanted. Also left the issue's separate "should graphify parse Lean 4" question alone — the reporter raised it explicitly as a discussion point for a maintainer architecture call, not as part of this fix.

## Test plan

- [x] `tests/test_report.py`: new tests confirming the Corpus Check section includes the unclassified line (with per-extension breakdown) when present, and omits it entirely when absent (backward compatible).
- [x] `tests/test_watch.py`: new test confirming `_rebuild_code` prints the unclassified count and filenames for a mixed `.py`/`.lean` corpus.
- [x] Manually reproduced the issue's shape end to end (a `.py` file plus several `.lean` files, `_rebuild_code` called directly): confirmed both the console line and the `GRAPH_REPORT.md` Corpus Check line appear correctly.
- [x] Full suite: `python3 -m pytest -q` — 5423 passed, only the pre-existing unrelated failures (`test_ollama_retry_cap.py` missing `openai` in this env, one flaky timing assertion in `test_ts_import_type_arguments.py`).
- [x] `python3 -m tools.skillgen --check` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qfdzgbA5KedGEjD1AayNh
