### PR TITLE
fix(js): resolve calls inside exported functions, incl. aliased imports (#3346)

### DIFF
--- a/graphify/extractors/resolution.py
+++ b/graphify/extractors/resolution.py
@@ -1562,7 +1562,25 @@ def _js_default_export_name(node, source: bytes) -> str | None:
 def _js_top_level_function_bodies(path: Path, root_node, source: bytes) -> list[tuple[str, object]]:
     bodies: list[tuple[str, object]] = []
     stem = _file_stem(path)
+    # A top-level `export function f(){}` / `export const g = () => {}` is an
+    # export_statement WRAPPING the declaration, not a bare program child, so
+    # scanning only direct children missed every exported function — and the
+    # calls inside them never became `uses` facts, so an aliased-import call
+    # (`import { bar as baz }; baz()`) never resolved through the import table
+    # (#3346). Unwrap a non-re-export export_statement to its inner declaration
+    # so exported and non-exported functions are treated identically.
+    top_nodes: list = []
     for node in root_node.children:
+        if node.type == "export_statement" and not any(
+            c.type == "string" for c in node.children  # `export ... from '...'` is a re-export
+        ):
+            top_nodes.extend(
+                c for c in node.children
+                if c.type in ("function_declaration", "lexical_declaration")
+            )
+        else:
+            top_nodes.append(node)
+    for node in top_nodes:
         if node.type == "function_declaration":
             name_node = node.child_by_field_name("name")
             body = node.child_by_field_name("body")

--- a/tests/test_js_exported_fn_call_resolution.py
+++ b/tests/test_js_exported_fn_call_resolution.py
@@ -1,0 +1,83 @@
+"""Calls inside an exported function resolve through the import table (#3346).
+
+`_js_top_level_function_bodies` scanned only direct program children, so a
+top-level `export function f(){}` / `export const g = () => {}` — wrapped in an
+export_statement — was skipped, and the calls inside it never became `uses`
+facts. The visible symptom: an aliased-import call (`import { bar as baz };
+baz()`) produced no `calls` edge, because only the use-fact path consults the
+import alias table; the plain-name global resolver has no `baz` to match.
+"""
+
+from graphify.extract import extract
+
+MOD = "export function foo() { return 1; }\nexport function bar() { return 2; }\n"
+
+
+def _calls(tmp_path, files, suffix=".ts"):
+    for name, body in files.items():
+        (tmp_path / name).write_text(body, encoding="utf-8")
+    r = extract(sorted(tmp_path.glob(f"*{suffix}")), cache_root=tmp_path / ".cache")
+    labels = {n["id"]: n.get("label", "") for n in r["nodes"]}
+    return {
+        (labels.get(e["source"], ""), labels.get(e["target"], ""))
+        for e in r["edges"] if e["relation"] == "calls"
+    }
+
+
+def _has(calls, caller_sub, callee):
+    return any(caller_sub in s.lower() and t.rstrip("()") == callee for s, t in calls)
+
+
+def test_aliased_import_call_in_exported_function_resolves(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    calls = _calls(tmp_path, {
+        "m.ts": MOD,
+        "al.ts": "import { bar as baz } from './m';\n"
+                 "export function useAlias() { return baz(); }\n",
+    })
+    assert _has(calls, "usealias", "bar"), sorted(calls)
+
+
+def test_aliased_import_call_in_exported_arrow_resolves(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    calls = _calls(tmp_path, {
+        "m.ts": MOD,
+        "al.ts": "import { bar as baz } from './m';\n"
+                 "export const useArrow = () => baz();\n",
+    })
+    assert _has(calls, "usearrow", "bar"), sorted(calls)
+
+
+def test_plain_named_import_control_still_resolves(tmp_path, monkeypatch):
+    """The non-exported / plain-name path must be unaffected."""
+    monkeypatch.chdir(tmp_path)
+    calls = _calls(tmp_path, {
+        "m.ts": MOD,
+        "p.ts": "import { foo } from './m';\n"
+                "export function usePlain() { return foo(); }\n",
+    })
+    assert _has(calls, "useplain", "foo"), sorted(calls)
+
+
+def test_aliased_import_does_not_bind_to_the_alias_name(tmp_path, monkeypatch):
+    """The edge lands on the imported definition (`bar`), never a phantom
+    `baz` node (there is no such definition)."""
+    monkeypatch.chdir(tmp_path)
+    calls = _calls(tmp_path, {
+        "m.ts": MOD,
+        "al.ts": "import { bar as baz } from './m';\n"
+                 "export function useAlias() { return baz(); }\n",
+    })
+    assert not any(t.rstrip("()") == "baz" for _s, t in calls), sorted(calls)
+
+
+def test_non_exported_function_still_resolves(tmp_path, monkeypatch):
+    """A plain (non-exported) function body was always scanned; keep it working
+    alongside the exported-function fix."""
+    monkeypatch.chdir(tmp_path)
+    calls = _calls(tmp_path, {
+        "m.ts": MOD,
+        "al.ts": "import { bar as baz } from './m';\n"
+                 "function useAlias() { return baz(); }\n",
+    })
+    assert _has(calls, "usealias", "bar"), sorted(calls)


### PR DESCRIPTION
Fixes the aliased-named-import half of #3346, by fixing the root cause it shares with a broader gap: **calls inside a top-level exported function were never resolved through the import table.**

## The bug

`_js_top_level_function_bodies` scanned only the **direct** children of the program node. A top-level `export function f(){}` / `export const g = () => {}` is an `export_statement` *wrapping* the declaration, so every exported function was skipped — and the calls inside it never became `uses` facts.

That matters specifically for aliased imports. A call resolves to its target one of two ways:
- the shared resolver matches the **written** callee name against the global symbol table (this is what makes plain `import { foo }; foo()` work), or
- the symbol-resolution `uses` path maps the call's **local name** through the per-file import-alias table (`local_aliases_by_file`).

For `import { bar as baz }; baz()` only the second path can work — the global table has no `baz`, only `bar`. But because `useAlias` was an exported function, no `uses` fact was ever produced for `baz()`, so the alias mapping never ran and no edge was emitted. It fails silently: caller and callee nodes both exist, only the edge is missing.

## The fix

Unwrap a non-re-export `export_statement` to its inner `function_declaration` / `lexical_declaration` in `_js_top_level_function_bodies`, so exported and non-exported functions are collected identically. The aliased call then resolves through the existing alias table to the real definition (`bar`), function and arrow forms alike. Re-exports (`export … from '…'`) are left alone — they declare no local body.

## Scope

This fixes the **aliased named import** case (issue's second repro) and, more generally, call-through-import resolution inside any exported function. The **namespace-import** case (`import * as api; api.foo()`) is a distinct mechanism — it's a member call whose receiver is a module alias, which needs namespace-binding capture and member-call resolution rather than the local-name alias table — and is left for a follow-up so this change stays focused and low-risk.

## Tests

`tests/test_js_exported_fn_call_resolution.py` — the aliased import resolves from an exported function and an exported arrow; the edge lands on the imported definition (`bar`), never a phantom `baz`; and the plain-named-import and non-exported-function paths are unchanged. With the fix reverted, the two exported-function aliased cases fail. The JS/TS + resolution suites are otherwise unchanged (1806 passed; the four failing names fail identically on clean `v8` on this Windows machine — pre-existing/flaky, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJbLfztSxm2tH5cJwBbe9q
