### PR TITLE
fix(lua): emit an imports edge for bare require() statements (#3320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Performance: Python symbol resolution is roughly 47% faster — path resolution is memoized, each file parses once across both resolution passes, and the tree walk is iterative rather than recursive; extraction output is unchanged (#3500 / #3501 / #3502, thanks @abhay-codes07).
 - Fix: `graphify explain` now accepts a `path::Symbol` form to disambiguate a symbol that shares its name with its file, and the ambiguity hint now shows a form the resolver actually accepts (#3485, thanks @ayushcodes10).
 - Fix: the git hook now keeps its rebuild root inside the repository — a committed `.graphify_root` pointing outside the worktree is ignored and falls back to the repo top, so a checked-in marker can't steer the hook to scan or write outside the tree (#3265, thanks @ayushcodes10).
+- Fix: a bare `require("mod")` statement with no assignment now produces an `imports` edge just like the assigned form, so Neovim/LazyVim configs — where this is the dominant idiom — graph correctly instead of coming out as a pile of disconnected files (#3320, thanks @A-Levin).
 
 ## 0.9.58 (2026-09-10)
 

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -3141,6 +3141,15 @@ def _ruby_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: st
             del ruby_namespace[-len(const_segments):]
     return True
 
+
+def _lua_is_require_call(node, source: bytes) -> bool:
+    """True if a Lua `function_call` node invokes `require`, parenthesized or not."""
+    name_node = node.child_by_field_name("name")
+    if name_node is None or name_node.type != "identifier":
+        return False
+    return _read_text(name_node, source) == "require"
+
+
 def _extract_generic(
     path: Path, config: LanguageConfig, *, source_override: bytes | None = None
 ) -> dict:
@@ -3346,6 +3355,20 @@ def _extract_generic(
 
     def walk(node, parent_class_nid: str | None = None) -> None:
         t = node.type
+
+        # Lua: `require("mod")` used as a bare statement (no assignment) is
+        # the dominant idiom in Neovim configs, but it doesn't fit any
+        # *_declaration node type — it is just a function_call. Adding
+        # function_call wholesale to import_types would swallow every plain
+        # call (e.g. `vim.keymap.set(.., function() ... end)`), skipping the
+        # walker's recursion into its callback and losing whatever is
+        # declared inside. So this only fires for a call that IS require,
+        # checked ahead of (and independently from) the import_types dispatch
+        # below (#3320).
+        if (config.ts_module == "tree_sitter_lua" and t == "function_call"
+                and config.import_handler and _lua_is_require_call(node, source)):
+            config.import_handler(node, source, file_nid, stem, edges, str_path, scope_stack)
+            return
 
         # Import types
         if t in config.import_types:

--- a/tests/test_lua_import.py
+++ b/tests/test_lua_import.py
@@ -1,0 +1,172 @@
+from pathlib import Path
+
+from graphify.build import build_from_json
+from graphify.extract import extract
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _import_edges(result: dict) -> set[tuple[str, str, str]]:
+    return {
+        (edge["source"], edge["target"], edge["relation"])
+        for edge in result["edges"]
+        if edge["relation"] == "imports"
+    }
+
+
+def test_lua_bare_require_emits_import_edge(tmp_path):
+    """A bare `require("mod")` statement (no assignment) is the common
+    Neovim-config idiom and must produce the same `imports` edge as the
+    assigned form (#3320)."""
+    _write(tmp_path / "init.lua", 'require("config.lazy")\n')
+    _write(tmp_path / "config.lazy.lua", "-- lazy\n")
+
+    result = extract(
+        [tmp_path / "init.lua", tmp_path / "config.lazy.lua"],
+        root=tmp_path,
+        cache_root=tmp_path,
+        parallel=False,
+    )
+
+    assert ("init", "config_lazy", "imports") in _import_edges(result)
+
+
+def test_lua_assigned_require_still_emits_import_edge(tmp_path):
+    """Positive control: `local x = require("mod")` must keep working exactly
+    as it did before (#3320)."""
+    _write(tmp_path / "init.lua", 'local ok = require("config.lazy")\n')
+    _write(tmp_path / "config.lazy.lua", "-- lazy\n")
+
+    result = extract(
+        [tmp_path / "init.lua", tmp_path / "config.lazy.lua"],
+        root=tmp_path,
+        cache_root=tmp_path,
+        parallel=False,
+    )
+
+    assert ("init", "config_lazy", "imports") in _import_edges(result)
+
+
+def test_lua_multiple_bare_requires_each_emit_an_import_edge(tmp_path):
+    """The realistic Neovim `init.lua` shape: several bare requires, one per
+    line, each need their own `imports` edge (#3320)."""
+    _write(
+        tmp_path / "init.lua",
+        'require("config.options")\nrequire("config.keymaps")\n',
+    )
+    _write(tmp_path / "config.options.lua", "-- options\n")
+    _write(tmp_path / "config.keymaps.lua", "-- keymaps\n")
+
+    result = extract(
+        [
+            tmp_path / "init.lua",
+            tmp_path / "config.options.lua",
+            tmp_path / "config.keymaps.lua",
+        ],
+        root=tmp_path,
+        cache_root=tmp_path,
+        parallel=False,
+    )
+
+    edges = _import_edges(result)
+    assert ("init", "config_options", "imports") in edges
+    assert ("init", "config_keymaps", "imports") in edges
+
+
+def test_lua_bare_require_resolves_lua_directory_layout(tmp_path):
+    """The standard `lua/config/lazy.lua` layout, not just the flattened
+    filename from the original repro, must resolve for a bare require — and
+    resolve to the real `lua/config/lazy.lua` node, not just to some
+    `imports` edge with any target (#3320)."""
+    _write(tmp_path / "init.lua", 'require("config.lazy")\n')
+    _write(tmp_path / "lua" / "config" / "lazy.lua", "-- lazy\n")
+
+    result = extract(
+        [tmp_path / "init.lua", tmp_path / "lua" / "config" / "lazy.lua"],
+        root=tmp_path,
+        cache_root=tmp_path,
+        parallel=False,
+    )
+
+    graph = build_from_json(result)
+    assert graph.has_edge("init", "lua_config_lazy")
+    assert graph["init"]["lua_config_lazy"]["relation"] == "imports"
+
+
+def test_lua_bare_require_without_parens_single_quotes(tmp_path):
+    """`require 'mod'` (no parens) is valid Lua and must be treated the same
+    as the parenthesized bare form (#3320)."""
+    _write(tmp_path / "init.lua", "require 'config.lazy'\n")
+    _write(tmp_path / "config.lazy.lua", "-- lazy\n")
+
+    result = extract(
+        [tmp_path / "init.lua", tmp_path / "config.lazy.lua"],
+        root=tmp_path,
+        cache_root=tmp_path,
+        parallel=False,
+    )
+
+    assert ("init", "config_lazy", "imports") in _import_edges(result)
+
+
+def test_lua_non_require_call_still_recurses_into_its_callback(tmp_path):
+    """A plain (non-`require`) Lua call must still be walked into: a
+    `local function` declared inside a callback passed to it (the
+    `vim.keymap.set`/`vim.defer_fn` idiom) must still be discovered. The
+    bare-require fix must not treat every Lua call like a require and skip
+    its children (#3320)."""
+    _write(
+        tmp_path / "init.lua",
+        'vim.keymap.set("n", "x", function()\n'
+        "  local function inner() end\n"
+        "end)\n",
+    )
+
+    result = extract([tmp_path / "init.lua"], root=tmp_path, cache_root=tmp_path, parallel=False)
+
+    node_ids = {node["id"] for node in result["nodes"]}
+    assert "init_inner" in node_ids
+    contains_edges = {
+        (edge["source"], edge["target"])
+        for edge in result["edges"]
+        if edge["relation"] == "contains"
+    }
+    assert ("init", "init_inner") in contains_edges
+
+
+def test_lua_method_style_require_is_not_an_import(tmp_path):
+    """`foo.require("mod")` / `bar:require("mod")` call something named
+    `require` on a table/object, not the global `require` builtin — the
+    bare-call check must not mistake a method-style call for a real
+    module import (#3320)."""
+    _write(tmp_path / "mod.lua", "-- mod\n")
+    _write(tmp_path / "init.lua", 'foo.require("mod")\nbar:require("mod")\n')
+
+    result = extract(
+        [tmp_path / "init.lua", tmp_path / "mod.lua"],
+        root=tmp_path,
+        cache_root=tmp_path,
+        parallel=False,
+    )
+
+    assert not _import_edges(result)
+
+
+def test_lua_bare_require_without_parens_double_quotes(tmp_path):
+    """`require "mod"` (no parens, double quotes) is valid Lua and must be
+    treated the same as the parenthesized bare form (#3320)."""
+    _write(tmp_path / "init.lua", 'require "config.lazy"\n')
+    _write(tmp_path / "config.lazy.lua", "-- lazy\n")
+
+    result = extract(
+        [tmp_path / "init.lua", tmp_path / "config.lazy.lua"],
+        root=tmp_path,
+        cache_root=tmp_path,
+        parallel=False,
+    )
+
+    assert ("init", "config_lazy", "imports") in _import_edges(result)


### PR DESCRIPTION
Fixes #3320.

## Problem

A Lua `require("mod")` written as a bare statement produces no `imports` edge. The assigned form does:

```python
# bare
(root/"init.lua").write_text('require("config.lazy")\n')
extract([...])["edges"]  # []

# assigned
(root/"init.lua").write_text('local ok = require("config.lazy")\n')
extract([...])["edges"]  # [{'source': 'init', 'target': 'config_lazy', 'relation': 'imports', ...}]
```

The bare form is the dominant idiom in Neovim configuration, where `init.lua` is typically nothing but a run of `require("config.lazy")` lines with no assignment. On a real LazyVim-style tree (`init.lua` + `lua/config/*.lua` + `lua/plugins/*.lua`) `v8` today produces **zero** import edges; every file lands in the graph disconnected.

The cause is dispatch, not parsing. `_LUA_CONFIG.import_types` is `frozenset({"variable_declaration"})` (`graphify/extract.py:1207`), and `walk()` only invokes `import_handler` for a node whose type is in that set. A bare `require(...)` parses as a `function_call` directly under `chunk`/`block`, so `_import_lua` is never called for it at all.

## Fix

`graphify/extractors/engine.py`: a new `_lua_is_require_call()` helper plus a narrow branch at the top of `walk()` that fires only for `tree_sitter_lua`, only on a `function_call`, and only when the call's `name` field is an `identifier` reading exactly `require`. It invokes the existing `_import_lua` handler unchanged.

The obvious one-line alternative — adding `function_call` to `_LUA_CONFIG.import_types` — is deliberately **not** what this does. `walk()` returns after an `import_types` match, and `function_call` is the node type for *every* Lua call, so that version would stop recursion into ordinary calls and silently drop whatever is declared inside their callbacks. Verified: under that behaviour `vim.keymap.set("n","x", function() local function inner() end end)` loses the `init_inner` node entirely, and `vim.defer_fn(function() local function deferred() end end, 10)` loses `init_deferred`. The shipped branch leaves both intact.

No double counting: `local x = require("mod")` matches `variable_declaration` first and returns before the walker descends to the nested call, so it never reaches the new branch. Confirmed with a spy on `_import_lua` — one handler invocation and one edge for both forms.

Method-style calls are rejected: `foo.require("x")` has a `dot_index_expression` name and `bar:require("x")` a `method_index_expression`, so neither produces an edge.

## Test

`tests/test_lua_import.py`, 8 tests. Five pin the defect (bare `require` in the flattened and `lua/config/` layouts, several bare requires in one file, and the no-parens `require 'm'` / `require "m"` forms); one is the assigned-form control; two guard the rationale above — that a non-`require` call still recurses into its callback, and that a method-style `require` fabricates nothing.

Each guard was checked by mutation rather than assumed:

| Mutation | Tests killed |
|---|---|
| Delete the `walk()` branch | 5 (every bare-require case) |
| `_lua_is_require_call` → `return "requires"` comparison | 5 |
| `_lua_is_require_call` → `return True` | 2 (callback recursion + method-style) |
| Drop the `ts_module == "tree_sitter_lua"` guard | 0 — equivalent mutant: `tree_sitter_lua` is the only configured grammar with a node kind named `function_call`. Kept as defensive scoping. |
| Drop the `name_node.type != "identifier"` check | 0 — equivalent mutant: the string compare already rejects `foo.require`. Kept for clarity. |

End to end on a LazyVim-shaped tree: 0 import edges before, 3 after (`init → lua_config_lazy`, `init → lua_config_options`, `lua_config_lazy → lua_plugins_tele`).

Local run of the CI jobs on this branch:

- `skillgen --check` / `--audit-coverage` / `--schema-singleton` / `--monolith-roundtrip` / `--always-on-roundtrip`: all OK
- `pytest tests/ -q` (after `uv sync --all-extras --frozen`): **5600 passed, 14 skipped, 2 failed**
- `ruff check graphify tests`: clean
- `bandit -r graphify -ll`: unchanged from baseline

The 2 failures are both `test_hooks.py::test_rebuild_bodies_survive_a_graphify_root_symlink_loop`, and they fail identically on pristine `v8` (`522ea96`) with this branch not applied — `2 failed, 111 passed` in `tests/test_hooks.py` there. Environment-specific to my machine, unrelated to Lua.

## Open question

Only literal `require("string")` / `require 'string'` is handled. A dynamic `require(var)` still produces no edge — unchanged from the assigned form's existing behaviour, since `_import_lua` has only ever matched string literals. Not addressed here; happy to file it separately if you want it covered.
