### PR TITLE
fix: don't report a valid C/C++ file without a trailing newline as a syntax error (#3513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Performance: Python symbol resolution is roughly 47% faster — path resolution is memoized, each file parses once across both resolution passes, and the tree walk is iterative rather than recursive; extraction output is unchanged (#3500 / #3501 / #3502, thanks @abhay-codes07).
 - Fix: `graphify explain` now accepts a `path::Symbol` form to disambiguate a symbol that shares its name with its file, and the ambiguity hint now shows a form the resolver actually accepts (#3485, thanks @ayushcodes10).
 - Fix: the git hook now keeps its rebuild root inside the repository — a committed `.graphify_root` pointing outside the worktree is ignored and falls back to the repo top, so a checked-in marker can't steer the hook to scan or write outside the tree (#3265, thanks @ayushcodes10).
+- Fix: a valid C/C++ file that doesn't end in a newline is no longer reported as having a syntax error — not just headers, every C/C++-family extension (#3513, thanks @A-Levin).
 
 ## 0.9.58 (2026-09-10)
 

--- a/graphify/extractors/engine.py
+++ b/graphify/extractors/engine.py
@@ -3177,6 +3177,20 @@ def _extract_generic(
     try:
         parser = Parser(language)
         source = path.read_bytes() if source_override is None else source_override
+        # #3513: ISO C/C++ requires a translation unit to end in a newline,
+        # and tree-sitter-c/tree-sitter-cpp's preprocessor grammar relies on
+        # that newline to terminate a directive - without it, a file whose
+        # last line is a directive recovers with an ERROR node even though
+        # the directive is complete and legal, falsely flagging an
+        # otherwise-valid file as a syntax error. Supplying the byte the
+        # standard already requires only extends the buffer past the last
+        # real token, so no existing node's offsets change; it never
+        # introduces an error, so this isn't scoped further than "missing a
+        # trailing newline". Restricted to these two grammars because that is
+        # what has actually been verified safe here - not applied blanket to
+        # every language in the project.
+        if config.ts_module in ("tree_sitter_c", "tree_sitter_cpp") and not source.endswith(b"\n"):
+            source = source + b"\n"
         tree = parser.parse(source)
         root = tree.root_node
     except Exception as e:

--- a/tests/test_c_header_trailing_newline.py
+++ b/tests/test_c_header_trailing_newline.py
@@ -1,0 +1,178 @@
+"""A valid C/C++ file with no trailing newline must not be reported as having
+a syntax error (#3513).
+
+tree-sitter-c/tree-sitter-cpp requires a newline to terminate a preprocessor
+directive; when the directive is the last thing in the file and the file does
+not end in a newline, the grammar recovers with an ERROR node even though the
+directive itself is complete and legal. That trips the #2551 partial-extraction
+gate in ``_extract_generic`` (``root.has_error``) and reports a spurious
+syntax error on a file that compiles fine and loses no symbols.
+
+Not header-specific: reproduces for any C/C++-family extension whose last
+line is a preprocessor directive, ``.c``/``.cpp`` sources included.
+"""
+from pathlib import Path
+
+import pytest
+
+from graphify.extract import extract_c, extract_cpp
+
+pytest.importorskip("tree_sitter_c")
+pytest.importorskip("tree_sitter_cpp")
+
+# #define is not node-worthy on its own, so both variants extract exactly the
+# file node — the trailing newline changes nothing about what is recovered,
+# only whether a syntax error is (falsely) reported.
+_SOURCE = "#define A 8\n#define AA 3"
+
+_C_EXTENSIONS = (".h", ".c")
+_CPP_EXTENSIONS = (".hpp", ".cpp", ".cc", ".cxx", ".cu", ".cuh", ".metal")
+
+
+def _extract(path: Path) -> dict:
+    return extract_cpp(path) if path.suffix in _CPP_EXTENSIONS else extract_c(path)
+
+
+@pytest.mark.parametrize("ext", _C_EXTENSIONS + _CPP_EXTENSIONS)
+def test_no_trailing_newline_is_not_a_syntax_error(tmp_path, ext):
+    p = tmp_path / f"valid{ext}"
+    p.write_text(_SOURCE)  # deliberately no trailing newline
+    result = _extract(p)
+    assert result.get("parse_errors") is None, (
+        f"{ext}: valid file with no trailing newline falsely reported as "
+        f"having a syntax error: {result.get('parse_errors')!r}")
+
+
+@pytest.mark.parametrize("ext", _C_EXTENSIONS + _CPP_EXTENSIONS)
+def test_trailing_newline_is_the_positive_control(tmp_path, ext):
+    """The same content WITH a trailing newline must be clean — this pins the
+    defect to the missing newline, not to anything else about the fixture."""
+    p = tmp_path / f"valid{ext}"
+    p.write_text(_SOURCE + "\n")
+    result = _extract(p)
+    assert result.get("parse_errors") is None
+
+
+@pytest.mark.parametrize("ext,content", [
+    (".c", b"int f(void){return 1;}\n#define A 1"),
+    (".cpp", b"struct P{int x;};\nint g(void){return 0;}\n#include <a.h>"),
+])
+def test_no_trailing_newline_shifts_no_node_or_edge(tmp_path, ext, content):
+    """The fix appends the missing newline past the last real token, so the
+    supplied newline must not move a single node or edge — extracting the
+    same path with and without the trailing byte must yield byte-identical
+    nodes and edges (only ``parse_errors`` is allowed to differ)."""
+    p = tmp_path / f"f{ext}"
+    p.write_bytes(content)
+    without_nl = _extract(p)
+    p.write_bytes(content + b"\n")
+    with_nl = _extract(p)
+    without_nl.pop("parse_errors", None)
+    with_nl.pop("parse_errors", None)
+    assert without_nl["nodes"] == with_nl["nodes"]
+    assert without_nl["edges"] == with_nl["edges"]
+
+
+def test_end_to_end_warning_is_silent_for_a_header_missing_only_a_newline(
+    tmp_path, capsys,
+):
+    """The observable symptom from #3513: ``extract()`` prints the #2551
+    partial-extraction warning for a header that is otherwise completely
+    valid, purely because it lacks a trailing newline."""
+    from graphify.extract import extract
+
+    p = tmp_path / "my_file.h"
+    p.write_text(_SOURCE)
+    extract([p], root=tmp_path, cache_root=tmp_path)
+    err = capsys.readouterr().err
+    assert "syntax error" not in err and "partially extracted" not in err, (
+        f"spurious syntax-error warning for a file missing only a trailing "
+        f"newline: {err!r}")
+
+
+@pytest.mark.parametrize("ext,fn", [(".c", extract_c), (".cpp", extract_cpp)])
+def test_a_genuine_syntax_error_is_still_flagged(tmp_path, ext, fn):
+    """The fix only supplies a missing trailing newline — it must not swallow
+    an actual syntax error that happens to sit before a trailing directive."""
+    p = tmp_path / f"broken{ext}"
+    p.write_bytes(b"int f( { return 1; }\n#define A 1")
+    result = fn(p)
+    assert result.get("parse_errors") is not None, (
+        f"{ext}: a genuinely broken file is no longer flagged as having a "
+        f"syntax error")
+
+
+def test_an_unterminated_conditional_is_still_flagged(tmp_path):
+    """A trailing newline does not excuse an ``#if`` with no matching
+    ``#endif`` — this has nothing to do with the missing-newline fix and must
+    keep failing."""
+    p = tmp_path / "broken.c"
+    p.write_bytes(b"#if FOO\nint x;\n")
+    result = extract_c(p)
+    assert result.get("parse_errors") is not None
+
+
+@pytest.mark.parametrize("ext,fn", [(".c", extract_c), (".cpp", extract_cpp)])
+def test_backslash_continued_macro_at_eof_is_not_flagged(tmp_path, ext, fn):
+    """A multi-line macro via line continuation, with no trailing newline
+    after the final continuation line — a common shape for the last macro in
+    a header. The narrow "last line starts with #" guard missed this because
+    the offending line does not itself start with ``#``."""
+    p = tmp_path / f"valid{ext}"
+    p.write_bytes(b"#define MAX(a,b) \\\n  ((a) > (b) ? (a) : (b))")
+    result = fn(p)
+    assert result.get("parse_errors") is None
+
+
+def test_utf8_bom_before_trailing_directive_is_not_flagged(tmp_path):
+    """A UTF-8 BOM at the start of the file must not defeat the missing-
+    newline detection at the end of the file."""
+    p = tmp_path / "valid.c"
+    p.write_bytes(b"\xef\xbb\xbf#define A 8")
+    result = extract_c(p)
+    assert result.get("parse_errors") is None
+    # Control: the same bytes plus a trailing newline were already clean, so
+    # the BOM — not something else about this fixture — is the variable.
+    p.write_bytes(b"\xef\xbb\xbf#define A 8\n")
+    assert extract_c(p).get("parse_errors") is None
+
+
+def test_comment_before_trailing_directive_is_not_flagged(tmp_path):
+    """A block comment ahead of the final, unterminated directive must not
+    prevent the fix from recognizing the directive as the last real line."""
+    p = tmp_path / "valid.c"
+    p.write_bytes(b"int a;\n/* guard */ #define A 1")
+    result = extract_c(p)
+    assert result.get("parse_errors") is None
+
+
+def test_fix_is_scoped_to_c_and_cpp_grammars(tmp_path, monkeypatch):
+    """The #3513 fix must supply the missing trailing newline only ahead of
+    the tree_sitter_c / tree_sitter_cpp grammars. Python parsing itself does
+    not care whether the file ends in a newline, so comparing extracted nodes
+    can't tell a scoped fix from an unscoped one; spy on the bytes actually
+    handed to the parser instead, which is the one place the scoping lives."""
+    import tree_sitter
+
+    from graphify.extract import extract_python
+
+    # extract_python runs the tree-sitter-python parse twice — once in
+    # _extract_generic, once more in the docstring/rationale post-pass — so
+    # every call must be checked, not just whichever happens to run last.
+    seen: list[bytes] = []
+    orig_parse = tree_sitter.Parser.parse
+
+    def _spy_parse(self, source, *args, **kwargs):
+        seen.append(bytes(source))
+        return orig_parse(self, source, *args, **kwargs)
+
+    monkeypatch.setattr(tree_sitter.Parser, "parse", _spy_parse)
+
+    content = b"x = 1\n# trailing comment"
+    p = tmp_path / "f.py"
+    p.write_bytes(content)
+    extract_python(p)
+    assert seen, "the parse spy never fired"
+    assert all(s == content for s in seen), (
+        "a non-C/C++ file had a newline silently appended before parsing - "
+        f"the #3513 fix must stay scoped to tree_sitter_c/tree_sitter_cpp: {seen!r}")


### PR DESCRIPTION
Fixes #3513.

## Problem

A valid C/C++ file that does not end in a newline is reported as having a syntax error:

```
warning: 1 file(s) had syntax errors and may be partially extracted: my_file.h (first error at line 2, no symbols extracted)
```

The trigger is narrower than the issue title suggests, and worth stating precisely:

- **Not header-specific.** It reproduces on every C/C++-family extension routed to `extract_c`/`extract_cpp` — `.h`, `.c`, `.hpp`, `.cpp`, `.cc`, `.cxx`, `.cu`, `.cuh`, `.metal`.
- **Not "missing trailing newline" in general.** A file ending in ordinary code (`int x = 1;`) with no trailing newline is clean. It fires when the last line is a **preprocessor directive** with no terminating newline: tree-sitter-c/cpp's preproc grammar uses the newline as the directive's terminator and recovers with an ERROR node when it is absent.
- **Nothing is lost but the flag.** Node and edge sets are byte-identical with and without the newline, including on symbol-bearing files. Only `parse_errors` differs.

## Fix

`graphify/extractors/engine.py`, at the parse point in `_extract_generic`: when the grammar is `tree_sitter_c`/`tree_sitter_cpp` and the source does not end in `\n`, append one before `parser.parse`.

ISO C and C++ require a translation unit to end in a newline, so this supplies a byte the standard already mandates. It only extends the buffer past the last real token, so no existing node's offsets move — verified by diffing node dicts (`label`, `line`, `end_line`, `source_location`) and edge lists for the same fixture with and without the newline. Nothing in `engine.py` derives a value from the buffer length (`len(source)`, `source.count(`, `source.splitlines` are all absent), and the AST cache keys on `file_hash(path)`, which hashes the bytes on disk, so the in-memory buffer cannot desync a cache key.

Two notes on scope:

**Why not the post-hoc gate pattern.** The existing #2610/#2599 TypeScript carve-out gates on `len(nodes) <= 1 or multiline_error`. That cannot discriminate here: `#define`-only content yields just the file node in both the broken and the clean case, so `len(nodes) <= 1` is true either way. Rather than add a second, differently-shaped classifier beside it, this removes the mechanical cause — the grammar is simply missing its terminator token.

**Why the grammar restriction stays.** Appending is verified safe only for these two grammars, so it is scoped to them rather than applied to every language in `_extract_generic`. (Objective-C happens to be immune because `extract_objc` never sets `parse_errors` at all, but that is an accident of that extractor rather than a guarantee.)

Genuine errors are unaffected: a broken file whose last line is a directive **and** which has a real error earlier is still flagged, as is `#if` with no matching `#endif`, a lone `#`, and an unterminated block comment.

## Test

`tests/test_c_header_trailing_newline.py`, 29 tests, asserting on `result.get("parse_errors")` (matching the convention in `tests/test_cpp_nested_and_cli.py`) with one end-to-end `capsys` test for the printed warning.

Coverage: all 9 extensions with and without the newline; the three shapes a naive last-line heuristic would miss (a backslash-continued macro at EOF, a UTF-8 BOM, a comment preceding the directive); that node and edge sets are unchanged; that the append is scoped to the C/C++ grammars; and that genuine syntax errors are still reported.

Mutation results:

| Mutation | Tests killed |
|---|---|
| Delete the fix | 14 |
| Append `b" "` instead of `b"\n"` | 14 |
| Drop the `ts_module` guard | 1 (`test_fix_is_scoped_to_c_and_cpp_grammars`) |
| Blanket-suppress `parse_errors` for C/C++ instead of fixing the cause | 3 (the genuine-error tests) |

The scoping test needed a second attempt worth mentioning, in case it is useful elsewhere: comparing a Python file's extracted nodes with and without a trailing newline is structurally vacuous, because every non-C grammar I could load (python, bash, ruby, go, js, java, kotlin, rust, scala, json, elixir) is insensitive to a missing trailing newline for ordinary content — the comparison passes whether or not the guard exists. It now observes the mechanism directly, recording the bytes handed to `tree_sitter.Parser.parse`. Note `extract_python` parses twice (the main pass plus the docstring-rationale pass), and only the first goes through this code path, so the assertion checks every recorded call rather than the last.

Local run of the CI jobs on this branch:

- `skillgen --check` / `--audit-coverage` / `--schema-singleton` / `--monolith-roundtrip` / `--always-on-roundtrip`: all OK
- `pytest tests/ -q` (after `uv sync --all-extras --frozen`): **5621 passed, 14 skipped, 2 failed**
- `ruff check graphify tests`: clean
- `bandit -r graphify -ll`: unchanged from baseline

The 2 failures are both `test_hooks.py::test_rebuild_bodies_survive_a_graphify_root_symlink_loop`, and they fail identically on pristine `v8` (`522ea96`) with this branch not applied — `2 failed, 111 passed` in `tests/test_hooks.py` there. Environment-specific to my machine, unrelated to C/C++.
