### PR TITLE
fix: surface unclassified files on the rebuild path and in GRAPH_REPORT.md

### DIFF
--- a/graphify/report.py
+++ b/graphify/report.py
@@ -138,6 +138,20 @@ def generate(
             "- Verdict: corpus is large enough that graph structure adds value.",
         ]
 
+    # A corpus whose bulk is an unsupported language produced a report that
+    # described only the classified half, with no hint the rest existed. detect()
+    # already records them; name them here so the verdict above is read against
+    # what was actually scanned.
+    unclassified = detection_result.get("unclassified") or []
+    if unclassified:
+        from collections import Counter as _Counter
+        _exts = _Counter(Path(p).suffix.lower() or "(no extension)" for p in unclassified)
+        _top = ", ".join(f"{e} {c}" for e, c in _exts.most_common(3))
+        lines.append(
+            f"- Unclassified: {len(unclassified)} file(s) skipped - no supported "
+            f"extension or shebang (top: {_top})"
+        )
+
     from .analyze import _is_file_node as _ifn
 
     def _real_count(nodes) -> int:

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1428,6 +1428,21 @@ def _rebuild_code(
         )
         code_files = [Path(f) for f in detected['files']['code']]
 
+        # Surface files the scan saw but could not classify. cli.py already does
+        # this on the `extract` path (#1692); the rebuild path used by
+        # `graphify update`, `graphify watch` and the git hook did not, so a
+        # corpus that is mostly an unsupported language rebuilt silently and
+        # reported success. Same message shape as the extract path.
+        _unclassified = detected.get("unclassified", []) or []
+        if _unclassified:
+            from collections import Counter as _Counter
+            _exts = _Counter(Path(p).suffix.lower() or "(no extension)" for p in _unclassified)
+            _top = ", ".join(f"{e} {c}" for e, c in _exts.most_common(3))
+            print(
+                f"[graphify watch] {len(_unclassified)} file(s) not classified "
+                f"(no supported extension or shebang), skipped: {_top}"
+            )
+
         # #2495: hand reconcile the same ignore decisions the detect() call
         # above made, so a newly-ignored file that still exists on disk is
         # purged from the graph instead of preserved forever by the fail-closed
@@ -1876,6 +1891,10 @@ def _rebuild_code(
             "files": {"code": [str(f) for f in code_files], "document": [], "paper": [], "image": []},
             "total_files": len(code_files),
             "total_words": detected.get("total_words", 0),
+            # Without this the Corpus Check verdict is computed from the files
+            # that WERE classified and cannot mention the ones that were not
+            # (#1692 surfaced them on the extract path only).
+            "unclassified": detected.get("unclassified", []) or [],
         }
 
         # Inherit the existing graph's directed flag (#2342) so `graphify

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -178,3 +178,23 @@ def test_report_hubs_use_wikilinks_when_obsidian():
     labels = {cid: f"Widget {cid}" for cid in communities}
     report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project", min_community_size=1, obsidian=True)
     assert "[[_COMMUNITY_" in report
+
+
+def test_report_names_unclassified_files():
+    """#1692 surfaced unclassified files on the extract path only, so a corpus
+    whose bulk is an unsupported language got a Corpus Check describing just the
+    classified half. detect() already records them; the report must name them."""
+    G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
+    detection = dict(detection)
+    detection["unclassified"] = [f"proof/Mod{i}.lean" for i in range(260)] + ["Dockerfile"]
+    report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")
+    assert "Unclassified: 261 file(s) skipped" in report
+    assert ".lean 260" in report
+
+
+def test_report_silent_when_nothing_unclassified():
+    G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
+    detection = dict(detection)
+    detection["unclassified"] = []
+    report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")
+    assert "Unclassified:" not in report

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -4343,3 +4343,29 @@ def test_rebase_relative_source_files_rebases_definition_file(tmp_path):
     node = payload["nodes"][0]
     assert node["source_file"] == "pkg/src/Foo.h"
     assert node["definition_file"] == "pkg/src/Foo.cpp"
+
+
+def test_rebuild_surfaces_unclassified_files(tmp_path, capsys):
+    """A rebuild whose corpus is mostly an unsupported language must not report
+    success in silence. cli.py does this on the extract path (#1692); the
+    rebuild path used by `graphify update`, `graphify watch` and the git hook
+    dropped the count, and the synthesized detection dict it passes to the
+    report omitted the list entirely."""
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "app.py").write_text("def run(): pass\n", encoding="utf-8")
+    for i in range(3):
+        (corpus / f"Proof{i}.lean").write_text(
+            "theorem t : True := trivial\n", encoding="utf-8"
+        )
+
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+
+    printed = capsys.readouterr().out
+    assert "3 file(s) not classified" in printed
+    assert ".lean 3" in printed
+
+    report = (corpus / "graphify-out" / "GRAPH_REPORT.md").read_text(encoding="utf-8")
+    assert "Unclassified: 3 file(s) skipped" in report


### PR DESCRIPTION
Closes #3511.

## What was wrong

`#1692` made unclassified files visible — but only on the `extract` path, in
`cli.py`. The rebuild path used by `graphify update`, `graphify watch` and the
git hook never read `detected["unclassified"]`, and the `detection` dict that
path synthesizes for the report (`watch.py`, the `total_files`/`total_words`
literal) dropped the key entirely.

So a corpus that is mostly an unsupported language rebuilt in silence, and the
report described only the classified half.

On `leanprover-community/batteries` @ `3b4ce082` — 260 `.lean` files — before:

```
$ graphify update .
[graphify watch] Rebuilt: 18 nodes, 13 edges, 7 communities
Code graph updated.
```

```
## Corpus Check
- 11 files · ~7,795 words
- Verdict: corpus is large enough that graph structure adds value.
```

Exit 0. The 18 nodes are 4 shell scripts and 2 READMEs. The verdict is about
those four shell scripts.

After:

```
[graphify watch] 268 file(s) not classified (no supported extension or shebang), skipped: .lean 260, (no extension) 4, .toml 3
[graphify watch] Rebuilt: 18 nodes, 13 edges, 7 communities
```

```
## Corpus Check
- 11 files · ~7,795 words
- Verdict: corpus is large enough that graph structure adds value.
- Unclassified: 268 file(s) skipped - no supported extension or shebang (top: .lean 260, (no extension) 4, .toml 3)
```

## The change

Three additions, 33 lines, no deletions, no behaviour change to the graph:

- `watch.py` — print the count on the rebuild path, same message shape as the
  `extract` path so the two agree.
- `watch.py` — carry `unclassified` into the `detection` dict handed to
  `report.generate`.
- `report.py` — name them in Corpus Check when the list is non-empty.

Not language-specific: any unsupported extension surfaces, `.lean` is just what
made it visible.

## Tests

Three added. The two behavioural ones fail on `v8` without the fix:

```
FAILED tests/test_report.py::test_report_names_unclassified_files
FAILED tests/test_watch.py::test_rebuild_surfaces_unclassified_files
```

`test_report_silent_when_nothing_unclassified` passes either way by design — it
is the regression guard that keeps the line off reports that have nothing to
report.

Full suite, same machine, same env, with and without the patch:

| | failed | passed |
|---|---:|---:|
| `v8` baseline | 31 | 5,193 |
| with this patch | 31 | 5,196 |

The failing set is **byte-identical** between the two runs (`diff` of the sorted
`FAILED` lines is empty), so this patch adds no failures; `+3` passed is exactly
the three new tests. The 31 pre-existing failures are all environment, not code:
`test_skillgen` (11) needs the full history that CI fetches with
`fetch-depth: 0` and my clone is `--depth 1`; `test_security` (7) and
`test_ollama_retry_cap` (4) need network; `test_terraform` (7) and
`test_languages` (1) need grammars outside the extras I installed;
`test_install_references` (1). `ruff check --config pyproject.toml` is clean on
all four changed files.

## Deliberately not in this PR

- **`total_files` in the rebuild path.** `watch.py` sets it to `len(code_files)`,
  which is why Corpus Check says `11 files` while `detect()` reports
  `total_files: 22` for the same scan. That looks wrong too, but fixing it
  changes an existing reported number, so it belongs in its own PR with its own
  discussion.
- **A `graph.json` field.** `export.to_json` does not receive the detect result,
  so adding one means threading a new parameter through the call chain. Happy to
  do it if you want it; kept out here to keep the diff reviewable.
- **Lean support.** Separate question, raised in #3511; no tree-sitter grammar
  exists for it, so it would not follow the `ARCHITECTURE.md` extractor pattern.
