### PR TITLE
fix(dart): mint part-of ids in the caller's path space

### DIFF
--- a/graphify/extractors/dart.py
+++ b/graphify/extractors/dart.py
@@ -1,6 +1,7 @@
 """Dart extractor. Moved verbatim from graphify/extract.py."""
 from __future__ import annotations
 
+import os
 import re
 
 from pathlib import Path
@@ -49,8 +50,15 @@ def extract_dart(path: Path) -> dict:
         parent_ref = part_of_match.group(1)
         if parent_ref.endswith(".dart"):
             try:
-                parent_path = (path.parent / parent_ref).resolve()
-                if parent_path.exists():
+                # Existence is still checked on the resolved path, so symlinks and `..`
+                # behave as before. The id and stem are minted from the parent in the SAME
+                # path space the caller passed in: resolving first made a part file's
+                # symbols absolute-derived while the library's own stayed relative, so one
+                # Dart library occupied two id namespaces and its parts were stranded.
+                # It also wrote the machine's directory layout into the persisted graph
+                # (issue #3522).
+                parent_path = Path(os.path.normpath(path.parent / parent_ref))
+                if (path.parent / parent_ref).resolve().exists():
                     stem = _file_stem(parent_path)
                     file_nid = _make_id(str(parent_path))
                     is_part = True

--- a/tests/test_dart.py
+++ b/tests/test_dart.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import tempfile
 import sys
@@ -592,8 +593,12 @@ class TestDart(unittest.TestCase):
         child_node = next((n for n in nodes if n["label"] == "child_part.dart"), None)
         self.assertIsNone(child_node)
 
-        # B. Check that defines edge source is parent file ID
-        parent_fid = _make_id(str(parent_file.resolve()))
+        # B. Check that defines edge source is parent file ID.
+        # Minted from the path as PASSED, not from its resolution: the parent's own
+        # extraction below mints its file node the same way, and on a platform where the
+        # two differ (macOS /var -> /private/var) resolving here put the part's symbols in
+        # a different id namespace than the library's own (#3522).
+        parent_fid = _make_id(str(parent_file))
         child_class = next((n for n in nodes if n["label"] == "ChildClass"), None)
         self.assertIsNotNone(child_class)
 
@@ -603,6 +608,11 @@ class TestDart(unittest.TestCase):
         )
         self.assertIsNotNone(def_edge)
         self.assertEqual(def_edge["source"], parent_fid)
+        # ... and that id is the one the parent file itself produces, so the library and
+        # its parts occupy ONE namespace rather than two.
+        parent_nodes = extract_dart(parent_file)["nodes"]
+        parent_file_node = next(n for n in parent_nodes if n["label"] == "parent_lib.dart")
+        self.assertEqual(def_edge["source"], parent_file_node["id"])
 
         # C. Bug A safe generic inheritance commas split: check referenced generics
         # Bloc<Pair<UserEvent, MyState>, State> should reference 'Pair<UserEvent, MyState>' and 'State'
@@ -694,6 +704,47 @@ class TestDart(unittest.TestCase):
         result = extract_dart(path)
         inherits = next(e for e in result["edges"] if e["relation"] == "inherits")
         self.assertEqual(inherits["source_location"], "L3")
+
+
+    def test_part_of_ids_stay_in_the_callers_path_space(self):
+        """#3522: a part file's symbols must share the library's id namespace.
+
+        `extract_dart` was resolving the `part of` target to an absolute path before
+        minting ids, while every non-part file minted from the path it was called with.
+        Called with relative paths, one Dart library then occupied two id namespaces: the
+        part's symbols carried an absolute-derived prefix that encoded the machine's
+        directory layout, and `extract`'s id-canonicalization pass could not repair them
+        (its remap keys come from the item's own `source_file`, which is the child).
+        """
+        lib_dir = self.temp_path / "lib" / "core" / "settlement"
+        lib_dir.mkdir(parents=True)
+        (lib_dir / "settlement.dart").write_text(
+            "library settlement;\npart 'derive.dart';\n\nclass Settlement {}\n", encoding="utf-8")
+        (lib_dir / "derive.dart").write_text(
+            "part of 'settlement.dart';\n\nclass DeriveHelper {}\n", encoding="utf-8")
+
+        cwd = Path.cwd()
+        os.chdir(self.temp_path)
+        try:
+            rel = Path("lib/core/settlement")
+            library_nodes = extract_dart(rel / "settlement.dart")["nodes"]
+            part = extract_dart(rel / "derive.dart")
+        finally:
+            os.chdir(cwd)
+
+        library_id = next(n for n in library_nodes if n["label"] == "settlement.dart")["id"]
+        self.assertEqual(library_id, "lib_core_settlement_settlement_dart")
+
+        helper = next(n for n in part["nodes"] if n["label"] == "DeriveHelper")
+        defines = next(e for e in part["edges"]
+                       if e["target"] == helper["id"] and e["relation"] == "defines")
+        # One namespace: the part's defines edge lands on the library's own file node, and
+        # no id carries the absolute prefix.
+        self.assertEqual(defines["source"], library_id)
+        self.assertTrue(helper["id"].startswith("lib_core_settlement_settlement_"), helper["id"])
+        absolute_marker = _make_id(str(self.temp_path)).split("_")[0]
+        for node in part["nodes"]:
+            self.assertFalse(node["id"].startswith(absolute_marker + "_"), node["id"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3522.

## Reproduced

Two files, extracted from the project root with relative paths, exactly as the issue describes:

```
lib/core/settlement/settlement.dart   // part 'derive.dart';
lib/core/settlement/derive.dart       // part of 'settlement.dart';
```

Before:

```
lib_core_settlement_settlement_dart                                    | settlement.dart
lib_core_settlement_settlement_settlement                              | settlement.dart
lib_core_settlement_settlement_total                                   | settlement.dart
private_tmp_dartproj_lib_core_settlement_settlement_derivehelper       | derive.dart
private_tmp_dartproj_lib_core_settlement_settlement_derivesettlements  | derive.dart
private_tmp_dartproj_lib_core_settlement_settlement_seed               | derive.dart
private_tmp_dartproj_lib_core_settlement_settlement_xs                 | derive.dart

absolute-derived: 4   relative-derived: 5
```

After, same harness:

```
absolute-derived: 0   relative-derived: 9
```

## The change

`extract_dart` resolved the `part of` target before minting the id and stem. The existence test keeps using the resolved path, so symlinks and `..` behave as before; only the id and stem move into the path space the caller passed in:

```python
parent_path = Path(os.path.normpath(path.parent / parent_ref))
if (path.parent / parent_ref).resolve().exists():
```

This is the shape suggested in the issue, with the existence check left on `.resolve()` rather than widened to an `or`, since that is what the current code already tests and it keeps the two concerns separate.

## The existing assertion was the bug in miniature

`test_roadmap_bug_fixes` asserted `def_edge["source"] == _make_id(str(parent_file.resolve()))`. On a platform where the two spellings differ — macOS, where `TemporaryDirectory` hands out `/var/folders/...` that resolves to `/private/var/folders/...` — that is an assertion that the part's `defines` edge points at an id the parent file's own extraction never produces:

```
- var_folders_..._parent_lib_dart            <- what extracting parent_lib.dart yields
+ private_var_folders_..._parent_lib_dart    <- what the test asserted
```

which is the two-namespace split, in the test, passing only because the test never extracted the parent. It now asserts the as-passed form, and extracts the parent to check the edge lands on the id that extraction actually yields.

## Testing

- `test_part_of_ids_stay_in_the_callers_path_space` — the issue's reproduction: relative paths from the project root, the part's `defines` edge resolving to the library's own file node, and no node carrying the absolute prefix.
- `test_roadmap_bug_fixes` — corrected as above, plus the parent-extraction cross-check.

```
pytest tests/test_dart.py     9 passed
pytest tests/                 5251 passed, 14 failed, 258 skipped
```

The 14 failures are on `v8` before this branch as well (`5250 passed, 14 failed` on the unmodified tree, same files: terraform, ts scaling, and others this change does not touch). So the counts differ by exactly the one test added here.

Negative control: reverting to `(path.parent / parent_ref).resolve()` reddens both dart cases and nothing else.
