### PR TITLE
fix: index keyed XAML resources

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -5816,6 +5816,11 @@ def extract_xaml(path: Path) -> dict:
             if binding_converter:
                 converter_targets = resource_nodes_by_key.get(binding_converter, [])
                 if len(converter_targets) != 1:
+                    # Keep the legacy synthetic concept only when the keyed
+                    # resource is unresolved or ambiguous. A unique resource
+                    # already has a source-backed node and receives an
+                    # `xaml_resource` edge below; emitting both would duplicate
+                    # the same converter in the graph.
                     converter_nid = _make_id("binding_converter", binding_converter)
                     add_node(converter_nid, binding_converter, line_for(value), file_type="concept")
                     add_edge(

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -5218,12 +5218,12 @@ def _xaml_split_markup_args(args: str) -> list[str]:
     return parts
 
 
-def _xaml_static_resource_key(value: str) -> str | None:
+def _xaml_resource_key(value: str, *, allow_dynamic: bool = True) -> str | None:
     markup = _xaml_markup_extension(value)
     if not markup:
         return None
     name, args = markup
-    if name != "StaticResource":
+    if name != "StaticResource" and (not allow_dynamic or name != "DynamicResource"):
         return None
     for part in _xaml_split_markup_args(args):
         if "=" not in part:
@@ -5232,6 +5232,32 @@ def _xaml_static_resource_key(value: str) -> str | None:
         if key.strip() == "ResourceKey":
             return resource.strip() or None
     return None
+
+
+def _xaml_static_resource_key(value: str) -> str | None:
+    return _xaml_resource_key(value, allow_dynamic=False)
+
+
+def _xaml_resource_keys(value: str) -> list[str]:
+    """Return resource keys used by a direct or binding markup extension."""
+    markup = _xaml_markup_extension(value)
+    if not markup:
+        return []
+    name, args = markup
+    direct_key = _xaml_resource_key(value)
+    if direct_key:
+        return [direct_key]
+    if name != "Binding":
+        return []
+
+    keys: list[str] = []
+    for part in _xaml_split_markup_args(args):
+        if "=" not in part:
+            continue
+        resource_key = _xaml_resource_key(part.split("=", 1)[1].strip())
+        if resource_key:
+            keys.append(resource_key)
+    return keys
 
 
 def _xaml_binding_refs(value: str) -> tuple[str | None, str | None]:
@@ -5706,6 +5732,31 @@ def extract_xaml(path: Path) -> dict:
             for member_edge in generated_member_edges:
                 add_existing_edge(member_edge)
 
+    resource_nodes_by_key: dict[str, list[str]] = {}
+    resource_owner_by_element: dict[int, str] = {}
+    resource_occurrences: dict[tuple[str, str], int] = {}
+    for elem in tree.iter():
+        elem_type = _xml_local_name(elem.tag)
+        resource_key = None
+        for key, value in elem.attrib.items():
+            if _xml_local_name(key) == "Key" and value:
+                resource_key = value.strip()
+                break
+        if not resource_key:
+            continue
+
+        identity = (elem_type, resource_key)
+        occurrence = resource_occurrences.get(identity, 0) + 1
+        resource_occurrences[identity] = occurrence
+        resource_parts = [stem, "resource", elem_type, resource_key]
+        if occurrence > 1:
+            resource_parts.append(str(occurrence))
+        resource_nid = _make_id(*resource_parts)
+        add_node(resource_nid, resource_key, line_for(resource_key))
+        add_edge(root_nid, resource_nid, "contains", line_for(resource_key))
+        resource_nodes_by_key.setdefault(resource_key, []).append(resource_nid)
+        resource_owner_by_element[id(elem)] = resource_nid
+
     for elem in tree.iter():
         elem_type = _xml_local_name(elem.tag)
         elem_name = None
@@ -5713,7 +5764,7 @@ def extract_xaml(path: Path) -> dict:
             if _xml_local_name(key) == "Name" and value:
                 elem_name = value.strip()
                 break
-        owner_nid = root_nid
+        owner_nid = resource_owner_by_element.get(id(elem), root_nid)
         if elem_name:
             owner_nid = _make_id(stem, elem_name)
             add_node(owner_nid, elem_name, line_for(elem_name))
@@ -5763,9 +5814,27 @@ def extract_xaml(path: Path) -> dict:
                         confidence="INFERRED",
                     )
             if binding_converter:
-                converter_nid = _make_id("binding_converter", binding_converter)
-                add_node(converter_nid, binding_converter, line_for(value), file_type="concept")
-                add_edge(owner_nid, converter_nid, "references", line_for(value), context="binding_converter")
+                converter_targets = resource_nodes_by_key.get(binding_converter, [])
+                if len(converter_targets) != 1:
+                    converter_nid = _make_id("binding_converter", binding_converter)
+                    add_node(converter_nid, binding_converter, line_for(value), file_type="concept")
+                    add_edge(
+                        owner_nid,
+                        converter_nid,
+                        "references",
+                        line_for(value),
+                        context="binding_converter",
+                    )
+            for resource_key in _xaml_resource_keys(value):
+                resource_targets = resource_nodes_by_key.get(resource_key, [])
+                if len(resource_targets) == 1:
+                    add_edge(
+                        owner_nid,
+                        resource_targets[0],
+                        "references",
+                        line_for(value),
+                        context="xaml_resource",
+                    )
             if elem_type == "Binding" and attr_local == "Path":
                 direct_path = value.strip()
                 if direct_path and "{" not in direct_path and "}" not in direct_path:
@@ -5774,10 +5843,16 @@ def extract_xaml(path: Path) -> dict:
                     add_edge(owner_nid, bind_nid, "references", line_for(value), context="binding_path")
             if elem_type == "Binding" and attr_local == "Converter":
                 direct_converter = _xaml_static_resource_key(value)
-                if direct_converter:
+                if direct_converter and len(resource_nodes_by_key.get(direct_converter, [])) != 1:
                     converter_nid = _make_id("binding_converter", direct_converter)
                     add_node(converter_nid, direct_converter, line_for(value), file_type="concept")
-                    add_edge(owner_nid, converter_nid, "references", line_for(value), context="binding_converter")
+                    add_edge(
+                        owner_nid,
+                        converter_nid,
+                        "references",
+                        line_for(value),
+                        context="binding_converter",
+                    )
 
     return {"nodes": nodes, "edges": edges}
 

--- a/tests/test_dotnet.py
+++ b/tests/test_dotnet.py
@@ -198,6 +198,99 @@ def test_xaml_named_controls_and_bindings():
     assert any(e["relation"] == "references" and e.get("context") == "binding_path" for e in r["edges"])
 
 
+def test_xaml_keyed_resources_and_references(tmp_path: Path):
+    """#3507: keyed WPF resources survive extraction and ID canonicalization."""
+    xaml = (
+        '<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"\n'
+        '        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">\n'
+        '    <Window.Resources>\n'
+        '        <Style x:Key="TabButtonStyle" TargetType="Button" />\n'
+        '        <Style x:Key="DerivedButtonStyle" BasedOn="{StaticResource TabButtonStyle}" />\n'
+        '        <SolidColorBrush x:Key="AccentBrush" Color="Blue" />\n'
+        '        <DataTemplate x:Key="CardTemplate" />\n'
+        '        <IValueConverter x:Key="TextConverter" />\n'
+        '    </Window.Resources>\n'
+        '    <Button x:Name="TabButton"\n'
+        '            Style="{StaticResource TabButtonStyle}"\n'
+        '            Background="{DynamicResource AccentBrush}"\n'
+        '            Tag="TabButtonStyle" />\n'
+        '    <ContentControl x:Name="Cards" ContentTemplate="{StaticResource ResourceKey=CardTemplate}" />\n'
+        '    <TextBlock x:Name="ConvertedText" Text="{Binding Value, Converter={StaticResource TextConverter}}" />\n'
+        '</Window>\n'
+    )
+    path = tmp_path / "Resources.xaml"
+    path.write_text(xaml, encoding="utf-8")
+
+    result = extract([path], root=tmp_path, cache_root=tmp_path, parallel=False)
+    nodes = {node["id"]: node for node in result["nodes"]}
+    resources = {
+        node["label"]: node
+        for node in result["nodes"]
+        if node["label"] in {
+            "TabButtonStyle",
+            "DerivedButtonStyle",
+            "AccentBrush",
+            "CardTemplate",
+            "TextConverter",
+        }
+    }
+
+    assert "error" not in result
+    assert set(resources) == {
+        "TabButtonStyle",
+        "DerivedButtonStyle",
+        "AccentBrush",
+        "CardTemplate",
+        "TextConverter",
+    }
+    assert all(
+        sum(node["label"] == label for node in nodes.values()) == 1
+        for label in resources
+    )
+    assert all(node["source_file"].endswith("Resources.xaml") for node in resources.values())
+
+    references = {
+        (nodes[edge["source"]]["label"], nodes[edge["target"]]["label"], edge.get("context"))
+        for edge in result["edges"]
+        if edge["relation"] == "references"
+        and edge.get("context") == "xaml_resource"
+    }
+    assert references == {
+        ("TabButton", "TabButtonStyle", "xaml_resource"),
+        ("DerivedButtonStyle", "TabButtonStyle", "xaml_resource"),
+        ("TabButton", "AccentBrush", "xaml_resource"),
+        ("Cards", "CardTemplate", "xaml_resource"),
+        ("ConvertedText", "TextConverter", "xaml_resource"),
+    }
+
+
+def test_xaml_ambiguous_or_unresolved_resources_do_not_fabricate_edges(tmp_path: Path):
+    """#3507: resource lookup must fail closed for ambiguous or missing keys."""
+    xaml = (
+        '<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"\n'
+        '        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">\n'
+        '    <Window.Resources>\n'
+        '        <Style x:Key="SharedStyle" />\n'
+        '        <Style x:Key="SharedStyle" />\n'
+        '    </Window.Resources>\n'
+        '    <Button x:Name="Ambiguous" Style="{StaticResource SharedStyle}" />\n'
+        '    <Button x:Name="Missing" Style="{StaticResource MissingStyle}" />\n'
+        '    <TextBlock x:Name="Literal" Tag="SharedStyle" />\n'
+        '</Window>\n'
+    )
+    path = tmp_path / "AmbiguousResources.xaml"
+    path.write_text(xaml, encoding="utf-8")
+
+    result = extract_xaml(path)
+    resource_references = [
+        edge for edge in result["edges"]
+        if edge["relation"] == "references" and edge.get("context") == "xaml_resource"
+    ]
+
+    assert resource_references == []
+    assert {node["label"] for node in result["nodes"]} >= {"SharedStyle", "Ambiguous", "Missing", "Literal"}
+
+
 def test_xaml_extracts_binding_paths_commands_and_converters():
     r = extract_xaml(FIXTURES / "bindings.xaml")
     labels_by_id = {n["id"]: n["label"] for n in r["nodes"]}

--- a/tests/test_dotnet.py
+++ b/tests/test_dotnet.py
@@ -262,6 +262,12 @@ def test_xaml_keyed_resources_and_references(tmp_path: Path):
         ("Cards", "CardTemplate", "xaml_resource"),
         ("ConvertedText", "TextConverter", "xaml_resource"),
     }
+    converted_id = next(node_id for node_id, node in nodes.items() if node["label"] == "ConvertedText")
+    assert not any(
+        edge.get("context") == "binding_converter"
+        for edge in result["edges"]
+        if edge["source"] == converted_id
+    )
 
 
 def test_xaml_ambiguous_or_unresolved_resources_do_not_fabricate_edges(tmp_path: Path):


### PR DESCRIPTION
## Summary

Closes #3507.

The XAML extractor currently creates graph nodes for named elements but silently omits keyed resources such as `Style`, `DataTemplate`, `ControlTemplate`, and `Brush` declarations using `x:Key`. Resource references therefore cannot resolve to the actual source declaration.

This PR:

- indexes non-empty `x:Key` resources as source-backed code nodes;
- resolves direct and binding-nested `StaticResource` and `DynamicResource` references, including `ResourceKey=` syntax;
- links resource-to-resource relationships such as `BasedOn`;
- preserves the existing converter concept fallback for unresolved or ambiguous resources;
- fails closed instead of fabricating an edge when a key is missing or duplicated.

## Tests

- `python -m pytest tests/test_dotnet.py -q`: 48 passed
- `python -m pytest tests/test_dotnet.py tests/test_extract.py tests/test_build.py tests/test_cache.py -q`: 447 passed, 4 skipped
- `python -m ruff check graphify/extract.py tests/test_dotnet.py`: passed
- `python -m tools.skillgen --check`: passed
- `python -m graphify update .`: passed

Added focused regression tests covering keyed resources, resource references, `BasedOn`, converter bindings, missing keys, and ambiguous duplicate keys.

No public API or graph schema changes are introduced.