### PR TITLE
install: bound the guard hooks with a timeout (#3314)

### DIFF
--- a/graphify/install.py
+++ b/graphify/install.py
@@ -338,6 +338,14 @@ def _claude_pretooluse_hooks(strict: bool = False, project: bool = False) -> "li
     When ``strict`` is set, the read hook carries ``--strict`` so it blocks the
     first raw read per session (Claude Code only). The ``GRAPHIFY_HOOK_STRICT`` env
     var can force it on or off at runtime without a reinstall.
+
+    Each entry carries a ``timeout`` (#3314): unset, Claude Code defaults a
+    command hook to 600s, so a single wedged guard (a stuck filesystem, a
+    hung subprocess) stalls the surrounding tool call for ten minutes on
+    every Bash/Grep/Read/Glob call -- the four highest-frequency tools an
+    agent uses. The guard itself measures ~170ms warm; 10s is generous
+    headroom over that while still two orders of magnitude below the
+    unset default.
     """
     exe = _resolve_graphify_exe(project=project)
     if " " in exe and not exe.startswith('"'):
@@ -345,9 +353,9 @@ def _claude_pretooluse_hooks(strict: bool = False, project: bool = False) -> "li
     read_cmd = f"{exe} hook-guard read" + (" --strict" if strict else "")
     return [
         {"matcher": "Bash|Grep",
-         "hooks": [{"type": "command", "command": f"{exe} hook-guard search"}]},
+         "hooks": [{"type": "command", "command": f"{exe} hook-guard search", "timeout": 10}]},
         {"matcher": "Read|Glob",
-         "hooks": [{"type": "command", "command": read_cmd}]},
+         "hooks": [{"type": "command", "command": read_cmd, "timeout": 10}]},
     ]
 def _skill_registration(skill_path: str = "~/.claude/skills/graphify/SKILL.md") -> str:
     return (

--- a/tests/test_read_hook.py
+++ b/tests/test_read_hook.py
@@ -43,6 +43,16 @@ def test_matcher_targets_read_and_glob():
     assert _read_matcher()["matcher"] == "Read|Glob"
 
 
+def test_read_hook_has_a_timeout():
+    # #3314: an unset command hook defaults to Claude Code's 600s timeout, so a
+    # single wedged guard stalls a Read/Glob call -- the highest-frequency
+    # tools an agent uses -- for ten minutes. Guard measures ~170ms warm; a
+    # generous but bounded timeout must be present.
+    entry = _read_matcher()["hooks"][0]
+    assert isinstance(entry.get("timeout"), (int, float))
+    assert 0 < entry["timeout"] <= 30
+
+
 def test_command_has_no_shell_syntax():
     # #522: the command must be a plain exe invocation, not POSIX bash.
     cmd = _read_matcher()["hooks"][0]["command"]

--- a/tests/test_search_hook.py
+++ b/tests/test_search_hook.py
@@ -53,6 +53,16 @@ def test_matcher_targets_bash_and_grep():
     assert _search_matcher()["matcher"] == "Bash|Grep"
 
 
+def test_search_hook_has_a_timeout():
+    # #3314: an unset command hook defaults to Claude Code's 600s timeout, so a
+    # single wedged guard stalls a Bash/Grep call -- the highest-frequency
+    # tools an agent uses -- for ten minutes. Guard measures ~170ms warm; a
+    # generous but bounded timeout must be present.
+    entry = _search_matcher()["hooks"][0]
+    assert isinstance(entry.get("timeout"), (int, float))
+    assert 0 < entry["timeout"] <= 30
+
+
 def test_hook_command_has_no_backslashes(monkeypatch):
     # On Windows the resolved exe is a backslash path; Claude Code runs command
     # hooks through Git Bash by default, which treats an unquoted backslash as an


### PR DESCRIPTION
## Summary

Toward #3314. The generated Claude/Codebuddy `PreToolUse` guard hooks (`graphify hook-guard search` on `Bash|Grep`, `graphify hook-guard read` on `Read|Glob`) carried no `timeout`, so Claude Code's unset-hook default of 600s applied — a single wedged guard (a stuck filesystem, a hung subprocess) would stall the surrounding tool call for ten minutes, on the four highest-frequency tools an agent uses. The reporter measured the guard itself at ~170ms warm and observed dozens of transient process spawns per session on a multi-agent workstation, with the harness's own hook budget beginning to fail closed.

This PR addresses the reporter's second, lowest-risk ask in their priority order ("a `timeout` on the generated entries... a knob would be nice; a sane default would be enough") — both generated hook entries now carry `"timeout": 10`, roughly 60x the measured warm cost and still 60x below the unset default.

I deliberately left the other two asks out of scope for this PR:
- **A matcher knob** (`--hook-matchers`) requires designing a new CLI flag/config surface — a maintainer-preference decision, not a mechanical fix.
- **Skipping the Codex `hook-check` no-op entry** — the existing code already documents it as an intentional no-op with a stated reason (Codex Desktop rejects `additionalContext` on `PreToolUse`), so removing it is a bigger behavioral call than I want to make unilaterally; happy to follow up if there's a preference.

## Test plan

- [x] Added one regression test per hook (`tests/test_search_hook.py`, `tests/test_read_hook.py`) confirming a numeric `timeout` is present and stays within a small bounded range, without pinning the exact value.
- [x] Manually verified the generated hook JSON now carries `"timeout": 10` on both entries.
- [x] Full suite: `python3 -m pytest -q` — 5487 passed. Failures are all pre-existing/environmental and unrelated: `test_ollama_retry_cap.py` (missing `openai` in this env), one flaky timing assertion in `test_ts_import_type_arguments.py`, and `test_hyperedge_convex_hull_js_is_geometrically_sound` (a `NODE_OPTIONS`/sandbox artifact in this environment — confirmed it fails identically on a clean checkout with none of this PR's changes applied).
- [x] `python3 -m tools.skillgen --check` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qfdzgbA5KedGEjD1AayNh
